### PR TITLE
ci: build linux arm64 artifacts in ubuntu 18.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,6 +120,7 @@ jobs:
             name: Linux x64
             cache_key: linux-artifacts
             artifact_name: linux-x64
+            build_strategy: host
             artifact_path: |
               target/release/libsurge.so
               target/release/surge
@@ -130,16 +131,14 @@ jobs:
             name: Linux arm64
             cache_key: linux-arm64-artifacts
             artifact_name: linux-arm64
-            artifact_path: |
-              target/release/libsurge.so
-              target/release/surge
-              target/release/surge-installer
-              target/release/surge-installer-ui
-              target/release/surge-supervisor
+            artifact_path: artifacts/linux-arm64
+            build_strategy: ubuntu18-container
+            glibc_max: "2.27"
           - os: windows-latest
             name: Windows x64
             cache_key: windows-artifacts
             artifact_name: win-x64
+            build_strategy: host
             artifact_path: |
               target/release/surge.dll
               target/release/surge.dll.lib
@@ -151,6 +150,7 @@ jobs:
             name: macOS
             cache_key: macos-artifacts
             artifact_name: osx-x64
+            build_strategy: host
             artifact_path: |
               target/release/libsurge.dylib
               target/release/surge
@@ -161,10 +161,34 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: true
+      - uses: actions/cache@v5
+        if: matrix.build_strategy == 'ubuntu18-container'
+        with:
+          path: |
+            .cargo-bionic
+            .rustup-bionic
+            target-bionic
+          key: ${{ runner.os }}-${{ runner.arch }}-${{ matrix.cache_key }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml', 'scripts/build-linux-arm64-ubuntu18.sh', 'scripts/check-glibc-baseline.sh', 'scripts/stage-toolchain-artifact.sh') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-${{ matrix.cache_key }}-
       - uses: Swatinem/rust-cache@v2
+        if: matrix.build_strategy != 'ubuntu18-container'
         with:
           key: ${{ matrix.cache_key }}
       - run: cargo build --release
+        if: matrix.build_strategy != 'ubuntu18-container'
+      - name: Build Linux arm64 artifacts in Ubuntu 18.04
+        if: matrix.build_strategy == 'ubuntu18-container'
+        run: ./scripts/build-linux-arm64-ubuntu18.sh --output artifacts/linux-arm64 --with-gui
+      - name: Validate Linux arm64 glibc baseline
+        if: matrix.build_strategy == 'ubuntu18-container'
+        run: |
+          ./scripts/check-glibc-baseline.sh --max "${{ matrix.glibc_max }}" \
+            artifacts/linux-arm64/surge \
+            artifacts/linux-arm64/surge-supervisor \
+            artifacts/linux-arm64/surge-installer \
+            artifacts/linux-arm64/surge-installer-ui \
+            artifacts/linux-arm64/libsurge.so
       - name: Upload artifacts
         uses: actions/upload-artifact@v7
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,6 +120,11 @@ If the local environment cannot run a listed command, document the exact gap in 
 - Keep benchmark payload descriptions anonymized and generic; do not add private product names or file names to docs, workflow labels, or benchmark fixtures.
 - Keep `.github/workflows/benchmark.yml` aligned with `docs/performance/benchmark-profiles.md` and `docs/performance/pack-policy.md`.
 
+## Anonymized Communication
+- In agent-authored issues, PRs, plans, summaries, and troubleshooting notes, use fictional placeholder names for products, customers, sites, hosts, and environments by default.
+- Do not repeat real deployment names or hostname patterns such as `*-master` in user-facing prose when a fictional placeholder will do.
+- Keep real identifiers only when technically required for literal commands, file paths, workflow names, or source references.
+
 ## Releasing
 
 Versioning is managed by GitVersion (`GitVersion.yml`). The `next-version` field controls the base version.

--- a/scripts/build-linux-arm64-ubuntu18.sh
+++ b/scripts/build-linux-arm64-ubuntu18.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Build and stage the Linux ARM64 Surge toolchain inside an Ubuntu 18.04 container.
+
+Usage:
+  build-linux-arm64-ubuntu18.sh --output <dir> [--with-gui]
+
+The output directory must live inside the Surge repository checkout so the
+container can write staged artifacts back to the host workspace.
+EOF
+}
+
+output_dir=""
+with_gui=0
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --output)
+      output_dir="${2:-}"
+      shift 2
+      ;;
+    --with-gui)
+      with_gui=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      printf 'Unknown argument: %s\n\n' "$1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [ -z "$output_dir" ]; then
+  printf -- '--output is required.\n\n' >&2
+  usage >&2
+  exit 1
+fi
+
+if [ ! -f Cargo.toml ] || [ ! -d crates/surge-core ] || [ ! -d crates/surge-cli ]; then
+  printf 'Run this script from the Surge repository root.\n' >&2
+  exit 1
+fi
+
+if ! command -v docker >/dev/null 2>&1; then
+  printf 'Docker is required to build the Ubuntu 18.04 ARM64 toolchain.\n' >&2
+  exit 1
+fi
+
+repo_root="$(pwd -P)"
+output_abs="$(python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "${output_dir}")"
+
+case "${output_abs}" in
+  "${repo_root}"/*) ;;
+  *)
+    printf 'Output directory must be inside the repository: %s\n' "${output_abs}" >&2
+    exit 1
+    ;;
+esac
+
+output_rel="${output_abs#${repo_root}/}"
+mkdir -p "${output_abs}"
+
+docker run --rm --platform linux/arm64 \
+  -e DEBIAN_FRONTEND=noninteractive \
+  -e CARGO_HOME=/work/.cargo-bionic \
+  -e RUSTUP_HOME=/work/.rustup-bionic \
+  -e CARGO_TARGET_DIR=/work/target-bionic \
+  -e OUTPUT_DIR="/work/${output_rel}" \
+  -e WITH_GUI="${with_gui}" \
+  -e HOST_UID="$(id -u)" \
+  -e HOST_GID="$(id -g)" \
+  -v "${repo_root}:/work" \
+  -w /work \
+  ubuntu:18.04 \
+  bash -lc '
+    set -euo pipefail
+    apt-get update
+    apt-get install -y --no-install-recommends \
+      build-essential \
+      ca-certificates \
+      clang \
+      curl \
+      file \
+      git \
+      libasound2-dev \
+      libegl1-mesa-dev \
+      libgl1-mesa-dev \
+      libssl-dev \
+      libudev-dev \
+      libwayland-dev \
+      libx11-dev \
+      libx11-xcb-dev \
+      libxcb-render0-dev \
+      libxcb-shape0-dev \
+      libxcb-xfixes0-dev \
+      libxcursor-dev \
+      libxi-dev \
+      libxinerama-dev \
+      libxkbcommon-dev \
+      libxrandr-dev \
+      libxxf86vm-dev \
+      pkg-config \
+      python3
+
+    export PATH="${CARGO_HOME}/bin:${PATH}"
+    if [ ! -x "${CARGO_HOME}/bin/cargo" ]; then
+      curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable
+    fi
+
+    stage_args=(--output "${OUTPUT_DIR}")
+    if [ "${WITH_GUI}" = "1" ]; then
+      stage_args+=(--with-gui)
+    fi
+
+    ./scripts/stage-toolchain-artifact.sh "${stage_args[@]}"
+
+    chown -R "${HOST_UID}:${HOST_GID}" \
+      /work/.cargo-bionic \
+      /work/.rustup-bionic \
+      /work/target-bionic \
+      "${OUTPUT_DIR}"
+  '

--- a/scripts/check-glibc-baseline.sh
+++ b/scripts/check-glibc-baseline.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Validate that ELF binaries do not require a newer glibc than the requested maximum.
+
+Usage:
+  check-glibc-baseline.sh --max <version> <file> [<file> ...]
+EOF
+}
+
+max_version=""
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --max)
+      max_version="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      break
+      ;;
+    -*)
+      printf 'Unknown argument: %s\n\n' "$1" >&2
+      usage >&2
+      exit 1
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
+
+if [ -z "${max_version}" ] || [ "$#" -eq 0 ]; then
+  usage >&2
+  exit 1
+fi
+
+status=0
+
+for path in "$@"; do
+  if [ ! -f "${path}" ]; then
+    printf 'Missing file: %s\n' "${path}" >&2
+    status=1
+    continue
+  fi
+
+  highest="$(strings "${path}" | grep -oE 'GLIBC_[0-9]+\.[0-9]+' | sed 's/^GLIBC_//' | sort -V | tail -n 1 || true)"
+  if [ -z "${highest}" ]; then
+    printf 'No glibc symbols found in %s\n' "${path}"
+    continue
+  fi
+
+  if [ "$(printf '%s\n%s\n' "${highest}" "${max_version}" | sort -V | tail -n 1)" != "${max_version}" ]; then
+    printf 'glibc requirement too new in %s: found %s, max allowed %s\n' "${path}" "${highest}" "${max_version}" >&2
+    status=1
+  else
+    printf 'glibc OK in %s: %s <= %s\n' "${path}" "${highest}" "${max_version}"
+  fi
+done
+
+exit "${status}"

--- a/scripts/stage-toolchain-artifact.sh
+++ b/scripts/stage-toolchain-artifact.sh
@@ -56,6 +56,7 @@ if [ "$with_gui" -eq 1 ]; then
 fi
 
 cargo build --release "${packages[@]}"
+target_dir="${CARGO_TARGET_DIR:-target}/release"
 
 case "$(uname -s | tr '[:upper:]' '[:lower:]')" in
   linux)
@@ -83,8 +84,8 @@ rm -rf "$output_dir"
 mkdir -p "$output_dir"
 
 for binary in "${binaries[@]}"; do
-  cp "target/release/${binary}" "$output_dir/"
+  cp "${target_dir}/${binary}" "$output_dir/"
 done
-cp "target/release/${native_runtime}" "$output_dir/"
+cp "${target_dir}/${native_runtime}" "$output_dir/"
 
 printf 'Staged Surge toolchain in %s\n' "$output_dir"


### PR DESCRIPTION
## Summary
- build the Linux ARM64 release toolchain inside an Ubuntu 18.04 container instead of linking directly against the hosted runner glibc
- add a CI gate that rejects ARM64 artifacts whose glibc requirement drifts above the intended baseline
- fix artifact staging so custom `CARGO_TARGET_DIR` builds package the correct release outputs
- document that agent-authored prose should use fictional placeholder names by default

## Testing
- ./scripts/check-version-sync.sh
- cargo fmt --all -- --check
- RUSTFLAGS="-D warnings" cargo test --workspace
- cargo clippy --all-targets --all-features -- -D warnings
- cargo clippy --workspace --lib --bins --examples -- -D warnings -D clippy::unwrap_used -D clippy::expect_used
- cargo clippy --workspace --all-targets --all-features -- -D warnings -W clippy::pedantic
- dotnet format dotnet/Surge.slnx --verify-no-changes
- dotnet test dotnet/Surge.slnx --configuration Release
- ./scripts/build-linux-arm64-ubuntu18.sh --help
- ./scripts/check-glibc-baseline.sh --max 99.99 target/release/surge target/release/surge-supervisor
- manual ARM64 Ubuntu 18.04/glibc 2.27 smoke build and baseline check on a JP4.6 device

## Notes
- this PR does not publish Cargo crates, NuGet packages, or release assets
- release-oriented artifact and publish jobs remain outside PR execution

Closes #29
