### PR TITLE
fix(core): prune old installed app snapshots

### DIFF
--- a/crates/surge-core/src/update/manager.rs
+++ b/crates/surge-core/src/update/manager.rs
@@ -16,7 +16,7 @@ use crate::error::{Result, SurgeError};
 use crate::install::{InstallProfile, RuntimeManifestMetadata, storage_provider_manifest_name, write_runtime_manifest};
 use crate::pack::builder::build_canonical_archive_from_directory;
 use crate::platform::detect::current_rid;
-use crate::platform::fs::{atomic_rename, copy_directory, write_file_atomic};
+use crate::platform::fs::{atomic_rename, copy_directory, list_directories, write_file_atomic};
 use crate::platform::process::{current_pid, spawn_detached, spawn_process, supervisor_binary_name};
 use crate::platform::shortcuts::install_shortcuts;
 use crate::releases::artifact_cache::{
@@ -193,12 +193,15 @@ pub struct UpdateInfo {
     pub apply_strategy: ApplyStrategy,
 }
 
+const DEFAULT_RELEASE_RETENTION_LIMIT: usize = 1;
+
 /// Manages checking for and applying application updates.
 pub struct UpdateManager {
     ctx: Arc<Context>,
     app_id: String,
     current_version: String,
     channel: String,
+    release_retention_limit: usize,
     install_dir: PathBuf,
     storage: Box<dyn StorageBackend>,
     cached_index: Option<ReleaseIndex>,
@@ -278,6 +281,7 @@ impl UpdateManager {
             app_id: app_id.to_string(),
             current_version: current_version.to_string(),
             channel: channel.to_string(),
+            release_retention_limit: DEFAULT_RELEASE_RETENTION_LIMIT,
             install_dir: PathBuf::from(install_dir),
             storage,
             cached_index: None,
@@ -309,6 +313,12 @@ impl UpdateManager {
         &self.current_version
     }
 
+    /// Return the number of versioned app snapshots retained after updates.
+    #[must_use]
+    pub fn release_retention_limit(&self) -> usize {
+        self.release_retention_limit
+    }
+
     /// Update the local version baseline used for update checks.
     pub fn set_current_version(&mut self, version: &str) -> Result<()> {
         let normalized = version.trim();
@@ -318,6 +328,11 @@ impl UpdateManager {
         self.current_version = normalized.to_string();
         self.cached_index = None;
         Ok(())
+    }
+
+    /// Update the number of old app snapshots retained after successful updates.
+    pub fn set_release_retention_limit(&mut self, limit: usize) {
+        self.release_retention_limit = limit;
     }
 
     /// Check for available updates on the configured channel.
@@ -1025,6 +1040,19 @@ impl UpdateManager {
                 let _ = tokio::fs::remove_dir_all(&previous_swap_dir).await;
             }
         }
+        match prune_version_snapshots(&self.install_dir, self.release_retention_limit) {
+            Ok(0) => {}
+            Ok(pruned) => {
+                debug!(
+                    pruned,
+                    retained = self.release_retention_limit,
+                    "Pruned stale installed app version snapshots"
+                );
+            }
+            Err(e) => {
+                warn!(error = %e, "Failed to prune installed app version snapshots");
+            }
+        }
 
         // Clean up staging directory
         if staging_dir.exists() {
@@ -1102,6 +1130,35 @@ fn normalize_os_label(raw: &str) -> String {
         "linux" => "linux".to_string(),
         other => other.to_string(),
     }
+}
+
+fn app_snapshot_version(dir_name: &str) -> Option<&str> {
+    let version = dir_name.strip_prefix("app-")?;
+    if version.is_empty() || !version.chars().next().is_some_and(|c| c.is_ascii_digit()) {
+        return None;
+    }
+    Some(version)
+}
+
+fn prune_version_snapshots(install_dir: &Path, keep_latest: usize) -> Result<usize> {
+    let mut snapshots: Vec<(String, PathBuf)> = list_directories(install_dir)?
+        .into_iter()
+        .filter_map(|dir_name| {
+            let version = app_snapshot_version(&dir_name)?.to_string();
+            let path = install_dir.join(&dir_name);
+            Some((version, path))
+        })
+        .collect();
+
+    snapshots.sort_by(|(left, _), (right, _)| compare_versions(right, left));
+
+    let mut pruned = 0usize;
+    for (_, path) in snapshots.into_iter().skip(keep_latest) {
+        std::fs::remove_dir_all(path)?;
+        pruned = pruned.saturating_add(1);
+    }
+
+    Ok(pruned)
 }
 
 fn find_previous_app_dir(install_dir: &Path, current_version: &str) -> Option<PathBuf> {
@@ -1610,11 +1667,14 @@ mod tests {
         let mut manager = UpdateManager::new(ctx, "app", "1.0.0", "stable", tmp.path().to_str().unwrap()).unwrap();
         assert_eq!(manager.channel(), "stable");
         assert_eq!(manager.current_version(), "1.0.0");
+        assert_eq!(manager.release_retention_limit(), 1);
 
         manager.set_channel("test").unwrap();
         manager.set_current_version("1.1.0").unwrap();
+        manager.set_release_retention_limit(0);
         assert_eq!(manager.channel(), "test");
         assert_eq!(manager.current_version(), "1.1.0");
+        assert_eq!(manager.release_retention_limit(), 0);
 
         let err = manager.set_channel("  ").unwrap_err();
         assert!(err.to_string().contains("channel cannot be empty"));
@@ -2911,6 +2971,170 @@ mod tests {
 
         assert!(!install_root.join(".surge-app-next").exists());
         assert!(!install_root.join(".surge-app-prev").exists());
+    }
+
+    #[tokio::test]
+    async fn test_download_and_apply_prunes_old_version_snapshots_to_retention_limit() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store_root = tmp.path().join("store");
+        let install_root = tmp.path().join("install");
+        std::fs::create_dir_all(&store_root).unwrap();
+        std::fs::create_dir_all(&install_root).unwrap();
+
+        let current_app_dir = install_root.join("app");
+        std::fs::create_dir_all(&current_app_dir).unwrap();
+        std::fs::write(current_app_dir.join("payload.txt"), "old payload").unwrap();
+        std::fs::create_dir_all(install_root.join("app-0.9.0")).unwrap();
+        std::fs::create_dir_all(install_root.join("app-0.8.0")).unwrap();
+        std::fs::create_dir_all(install_root.join("app-backup")).unwrap();
+
+        let rid = current_rid();
+        let full_filename = format!("test-app-1.1.0-{rid}-full.tar.zst");
+        let full_path = store_root.join(&full_filename);
+
+        let mut packer = ArchivePacker::new(3).unwrap();
+        packer.add_buffer("payload.txt", b"new payload", 0o644).unwrap();
+        packer.finalize_to_file(&full_path).unwrap();
+
+        let full_size = std::fs::metadata(&full_path).unwrap().len() as i64;
+        let full_sha256 = sha256_hex_file(&full_path).unwrap();
+
+        let index = ReleaseIndex {
+            app_id: "test-app".to_string(),
+            releases: vec![ReleaseEntry {
+                version: "1.1.0".to_string(),
+                channels: vec!["stable".to_string()],
+                os: current_os_label_for_tests(),
+                rid: rid.clone(),
+                is_genesis: true,
+                full_filename: full_filename.clone(),
+                full_size,
+                full_sha256,
+                deltas: Vec::new(),
+                preferred_delta_id: String::new(),
+                created_utc: chrono::Utc::now().to_rfc3339(),
+                release_notes: String::new(),
+                name: String::new(),
+                main_exe: "test-app".to_string(),
+                install_directory: "test-app".to_string(),
+                supervisor_id: String::new(),
+                icon: String::new(),
+                shortcuts: Vec::new(),
+                persistent_assets: Vec::new(),
+                installers: Vec::new(),
+                environment: std::collections::BTreeMap::new(),
+            }],
+            ..ReleaseIndex::default()
+        };
+
+        let compressed = compress_release_index(&index, DEFAULT_ZSTD_LEVEL).unwrap();
+        std::fs::write(store_root.join(RELEASES_FILE_COMPRESSED), compressed).unwrap();
+
+        let ctx = Arc::new(Context::new());
+        ctx.set_storage(
+            StorageProvider::Filesystem,
+            store_root.to_str().unwrap(),
+            "",
+            "",
+            "",
+            "",
+        );
+
+        let mut manager =
+            UpdateManager::new(ctx, "test-app", "1.0.0", "stable", install_root.to_str().unwrap()).unwrap();
+        manager.set_release_retention_limit(1);
+
+        let info = manager.check_for_updates().await.unwrap().unwrap();
+        manager
+            .download_and_apply(&info, None::<fn(ProgressInfo)>)
+            .await
+            .unwrap();
+
+        assert!(install_root.join("app").is_dir());
+        assert!(install_root.join("app-1.0.0").is_dir());
+        assert!(!install_root.join("app-0.9.0").exists());
+        assert!(!install_root.join("app-0.8.0").exists());
+        assert!(install_root.join("app-backup").is_dir());
+    }
+
+    #[tokio::test]
+    async fn test_download_and_apply_with_zero_retention_removes_version_snapshots() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store_root = tmp.path().join("store");
+        let install_root = tmp.path().join("install");
+        std::fs::create_dir_all(&store_root).unwrap();
+        std::fs::create_dir_all(&install_root).unwrap();
+
+        let current_app_dir = install_root.join("app");
+        std::fs::create_dir_all(&current_app_dir).unwrap();
+        std::fs::write(current_app_dir.join("payload.txt"), "old payload").unwrap();
+        std::fs::create_dir_all(install_root.join("app-0.9.0")).unwrap();
+
+        let rid = current_rid();
+        let full_filename = format!("test-app-1.1.0-{rid}-full.tar.zst");
+        let full_path = store_root.join(&full_filename);
+
+        let mut packer = ArchivePacker::new(3).unwrap();
+        packer.add_buffer("payload.txt", b"new payload", 0o644).unwrap();
+        packer.finalize_to_file(&full_path).unwrap();
+
+        let full_size = std::fs::metadata(&full_path).unwrap().len() as i64;
+        let full_sha256 = sha256_hex_file(&full_path).unwrap();
+
+        let index = ReleaseIndex {
+            app_id: "test-app".to_string(),
+            releases: vec![ReleaseEntry {
+                version: "1.1.0".to_string(),
+                channels: vec!["stable".to_string()],
+                os: current_os_label_for_tests(),
+                rid: rid.clone(),
+                is_genesis: true,
+                full_filename: full_filename.clone(),
+                full_size,
+                full_sha256,
+                deltas: Vec::new(),
+                preferred_delta_id: String::new(),
+                created_utc: chrono::Utc::now().to_rfc3339(),
+                release_notes: String::new(),
+                name: String::new(),
+                main_exe: "test-app".to_string(),
+                install_directory: "test-app".to_string(),
+                supervisor_id: String::new(),
+                icon: String::new(),
+                shortcuts: Vec::new(),
+                persistent_assets: Vec::new(),
+                installers: Vec::new(),
+                environment: std::collections::BTreeMap::new(),
+            }],
+            ..ReleaseIndex::default()
+        };
+
+        let compressed = compress_release_index(&index, DEFAULT_ZSTD_LEVEL).unwrap();
+        std::fs::write(store_root.join(RELEASES_FILE_COMPRESSED), compressed).unwrap();
+
+        let ctx = Arc::new(Context::new());
+        ctx.set_storage(
+            StorageProvider::Filesystem,
+            store_root.to_str().unwrap(),
+            "",
+            "",
+            "",
+            "",
+        );
+
+        let mut manager =
+            UpdateManager::new(ctx, "test-app", "1.0.0", "stable", install_root.to_str().unwrap()).unwrap();
+        manager.set_release_retention_limit(0);
+
+        let info = manager.check_for_updates().await.unwrap().unwrap();
+        manager
+            .download_and_apply(&info, None::<fn(ProgressInfo)>)
+            .await
+            .unwrap();
+
+        assert!(install_root.join("app").is_dir());
+        assert!(!install_root.join("app-1.0.0").exists());
+        assert!(!install_root.join("app-0.9.0").exists());
     }
 
     #[cfg(target_os = "linux")]

--- a/crates/surge-ffi/src/handles.rs
+++ b/crates/surge-ffi/src/handles.rs
@@ -114,6 +114,7 @@ pub struct SurgeUpdateManagerHandle {
     pub app_id: String,
     pub current_version: String,
     pub channel: String,
+    pub release_retention_limit: usize,
     pub install_dir: String,
 }
 

--- a/crates/surge-ffi/src/lib.rs
+++ b/crates/surge-ffi/src/lib.rs
@@ -445,6 +445,7 @@ pub unsafe extern "C" fn surge_update_manager_create(
             app_id: app_id_s,
             current_version: version_s,
             channel: channel_s,
+            release_retention_limit: 1,
             install_dir: install_s,
         });
 
@@ -520,6 +521,31 @@ pub unsafe extern "C" fn surge_update_manager_set_current_version(
     }))
 }
 
+/// Change the number of old app versions retained after successful updates.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn surge_update_manager_set_release_retention_limit(
+    mgr: *mut SurgeUpdateManagerHandle,
+    release_retention_limit: c_int,
+) -> i32 {
+    if mgr.is_null() {
+        return SURGE_ERROR;
+    }
+
+    catch_ffi(std::panic::AssertUnwindSafe(|| {
+        // SAFETY: `mgr` is checked non-null above.
+        let mgr_ref = unsafe { &mut *mgr };
+        clear_shared_error(&mgr_ref.ctx, &mgr_ref.last_error);
+
+        if release_retention_limit < 0 {
+            let e = surge_core::error::SurgeError::Config("release_retention_limit cannot be negative".into());
+            return set_shared_error(&mgr_ref.ctx, &mgr_ref.last_error, &e);
+        }
+
+        mgr_ref.release_retention_limit = usize::try_from(release_retention_limit).unwrap_or(usize::MAX);
+        SURGE_OK
+    }))
+}
+
 /// Check for available updates.
 ///
 /// Returns `SURGE_OK` if updates are available, `SURGE_NOT_FOUND` if up-to-date.
@@ -555,6 +581,7 @@ pub unsafe extern "C" fn surge_update_check(
             Ok(m) => m,
             Err(e) => return set_shared_error(&mgr_ref.ctx, &mgr_ref.last_error, &e),
         };
+        update_mgr.set_release_retention_limit(mgr_ref.release_retention_limit);
 
         let result = mgr_ref.runtime.block_on(update_mgr.check_for_updates());
 
@@ -632,7 +659,7 @@ pub unsafe extern "C" fn surge_update_download_and_apply(
             return set_shared_error(&mgr_ref.ctx, &mgr_ref.last_error, &e);
         }
 
-        let update_mgr = match UpdateManager::new(
+        let mut update_mgr = match UpdateManager::new(
             mgr_ref.ctx.clone(),
             &mgr_ref.app_id,
             &mgr_ref.current_version,
@@ -642,6 +669,7 @@ pub unsafe extern "C" fn surge_update_download_and_apply(
             Ok(m) => m,
             Err(e) => return set_shared_error(&mgr_ref.ctx, &mgr_ref.last_error, &e),
         };
+        update_mgr.set_release_retention_limit(mgr_ref.release_retention_limit);
 
         // Map core ProgressInfo → SurgeProgressFfi via the C callback.
         // Handle Some/None explicitly to give the compiler a concrete type
@@ -1528,6 +1556,44 @@ mod tests {
             .unwrap_or_default()
             .to_string();
         assert!(msg.contains("channel"));
+
+        unsafe {
+            surge_update_manager_destroy(mgr);
+            surge_context_destroy(ctx);
+        }
+    }
+
+    #[test]
+    fn manager_set_release_retention_limit_updates_context_last_error() {
+        let ctx = surge_context_create();
+        assert!(!ctx.is_null());
+
+        let app_id = CString::new("demo").unwrap();
+        let version = CString::new("1.0.0").unwrap();
+        let channel = CString::new("stable").unwrap();
+        let install_dir = CString::new("/tmp/demo").unwrap();
+
+        let mgr = unsafe {
+            surge_update_manager_create(
+                ctx,
+                app_id.as_ptr(),
+                version.as_ptr(),
+                channel.as_ptr(),
+                install_dir.as_ptr(),
+            )
+        };
+        assert!(!mgr.is_null());
+
+        let rc = unsafe { surge_update_manager_set_release_retention_limit(mgr, -1) };
+        assert_ne!(rc, SURGE_OK);
+
+        let last = unsafe { surge_context_last_error(ctx) };
+        assert!(!last.is_null());
+        let msg = unsafe { CStr::from_ptr((*last).message) }
+            .to_str()
+            .unwrap_or_default()
+            .to_string();
+        assert!(msg.contains("release_retention_limit"));
 
         unsafe {
             surge_update_manager_destroy(mgr);

--- a/dotnet/Surge.NET/NativeMethods.cs
+++ b/dotnet/Surge.NET/NativeMethods.cs
@@ -107,6 +107,9 @@ namespace Surge
         [LibraryImport(LibName, EntryPoint = "surge_update_manager_set_current_version", StringMarshalling = StringMarshalling.Utf8)]
         internal static partial int UpdateManagerSetCurrentVersion(IntPtr mgr, string currentVersion);
 
+        [LibraryImport(LibName, EntryPoint = "surge_update_manager_set_release_retention_limit")]
+        internal static partial int UpdateManagerSetReleaseRetentionLimit(IntPtr mgr, int releaseRetentionLimit);
+
         [LibraryImport(LibName, EntryPoint = "surge_update_check")]
         internal static partial int UpdateCheck(IntPtr mgr, out IntPtr info);
 
@@ -265,6 +268,9 @@ namespace Surge
 
         [DllImport(LibName, EntryPoint = "surge_update_manager_set_current_version", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
         internal static extern int UpdateManagerSetCurrentVersion(IntPtr mgr, string currentVersion);
+
+        [DllImport(LibName, EntryPoint = "surge_update_manager_set_release_retention_limit", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern int UpdateManagerSetReleaseRetentionLimit(IntPtr mgr, int releaseRetentionLimit);
 
         [DllImport(LibName, EntryPoint = "surge_update_check", CallingConvention = CallingConvention.Cdecl)]
         internal static extern int UpdateCheck(IntPtr mgr, out IntPtr info);

--- a/dotnet/Surge.NET/SurgeUpdateManager.cs
+++ b/dotnet/Surge.NET/SurgeUpdateManager.cs
@@ -16,11 +16,22 @@ namespace Surge
         private bool _disposed;
         private string _channel = "stable";
         private string _currentVersion = "0.0.0";
+        private int _releaseRetentionLimit = 1;
 
         /// <summary>
-        /// Maximum number of old releases to retain on disk after updating.
+        /// Maximum number of old installed versions to retain on disk after updating.
         /// </summary>
-        public int ReleaseRetentionLimit { get; set; } = 1;
+        public int ReleaseRetentionLimit
+        {
+            get => _releaseRetentionLimit;
+            set
+            {
+                if (value < 0)
+                    throw new ArgumentOutOfRangeException(nameof(ReleaseRetentionLimit), value, "Release retention limit cannot be negative.");
+
+                _releaseRetentionLimit = value;
+            }
+        }
 
         /// <summary>
         /// Create a new update manager. Requires that <see cref="SurgeApp.Current"/>
@@ -193,6 +204,7 @@ namespace Surge
                     try
                     {
                         cancellationToken.ThrowIfCancellationRequested();
+                        ApplyReleaseRetentionLimit();
 
                         // Build releases list
                         int count = NativeMethods.ReleasesCount(releasesInfoPtr);
@@ -360,6 +372,16 @@ namespace Surge
             }
 
             _currentVersion = version;
+        }
+
+        private void ApplyReleaseRetentionLimit()
+        {
+            int result = NativeMethods.UpdateManagerSetReleaseRetentionLimit(_nativeMgr, _releaseRetentionLimit);
+            if (result != 0)
+            {
+                var errorMsg = GetLastError();
+                throw new SurgeException(result, errorMsg ?? "Failed to set release retention limit.");
+            }
         }
 
         private static string? GetContextLastError(IntPtr nativeCtx)

--- a/include/surge/surge_api.h
+++ b/include/surge/surge_api.h
@@ -230,6 +230,15 @@ SURGE_API surge_result SURGE_CALL surge_update_manager_set_current_version(surge
                                                                            const char* current_version);
 
 /**
+ * Change how many old app versions are retained after successful updates.
+ * @param mgr                     Manager handle.
+ * @param release_retention_limit Maximum number of `app-*` snapshots to keep.
+ * @return SURGE_OK on success.
+ */
+SURGE_API surge_result SURGE_CALL surge_update_manager_set_release_retention_limit(surge_update_manager* mgr,
+                                                                                   int32_t release_retention_limit);
+
+/**
  * Check for available updates.
  * @param mgr  Manager handle.
  * @param info [out] Receives a pointer to release information.


### PR DESCRIPTION
## Summary
- wire installed-version retention through the core update manager, FFI, and .NET wrapper
- prune stale `app-*` snapshots after successful updates while keeping one rollback snapshot by default
- add regression coverage for retained and zero-retention update flows

## Behavior Impact
- successful updates now stop accumulating old `app-*` directories indefinitely
- `SurgeUpdateManager.ReleaseRetentionLimit` now affects native update behavior instead of being ignored
- default behavior retains `app/` plus one previous installed version snapshot

## Test Evidence
- `./scripts/sync-surge-core-vendor.sh --check`
- `./scripts/check-version-sync.sh`
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo test --workspace`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo clippy --workspace --lib --bins --examples -- -D warnings -D clippy::unwrap_used -D clippy::expect_used`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings -W clippy::pedantic`
- `dotnet format dotnet/Surge.slnx --verify-no-changes`
- `dotnet test dotnet/Surge.slnx --configuration Release`

## Migration Notes
- none; existing stale `app-*` directories on already-updated installs will be pruned by the next successful update with this build