### PR TITLE
Preserve persistent assets and prune stale install snapshots

### DIFF
--- a/crates/surge-cli/src/commands/install.rs
+++ b/crates/surge-cli/src/commands/install.rs
@@ -1109,6 +1109,7 @@ fn release_install_profile<'a>(app_id: &'a str, release: &'a ReleaseEntry) -> In
         &release.supervisor_id,
         &release.icon,
         &release.shortcuts,
+        &release.persistent_assets,
         &release.environment,
     )
 }

--- a/crates/surge-cli/src/commands/install.rs
+++ b/crates/surge-cli/src/commands/install.rs
@@ -2,7 +2,7 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::io::IsTerminal;
-use std::path::{Component, Path, PathBuf};
+use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
@@ -2123,7 +2123,7 @@ fn build_remote_app_copy_activation_script(
     let persistent_asset_commands = persistent_assets
         .iter()
         .map(|asset| {
-            validate_remote_persistent_asset_path(asset).map(|relative| {
+            core_install::validate_relative_persistent_asset_path(asset).map(|relative| {
                 format!(
                     "  copy_persistent_asset {}\n\\\n",
                     shell_single_quote(&relative.to_string_lossy())
@@ -2231,6 +2231,11 @@ fi\n\
 \n\
 rm -rf \"$previous_app_dir\"\n\
 \n\
+for snapshot_dir in \"$install_root\"/app-[0-9]*; do\n\
+  [ -d \"$snapshot_dir\" ] || continue\n\
+  rm -rf \"$snapshot_dir\"\n\
+done\n\
+\n\
 if [ -d \"$stage_dir/shortcuts/applications\" ]; then\n\
   mkdir -p \"$applications_dir\"\n\
   cp \"$stage_dir/shortcuts/applications/\"*.desktop \"$applications_dir/\" 2>/dev/null || true\n\
@@ -2263,47 +2268,6 @@ fi\n",
 
     Ok(script)
 }
-
-fn validate_remote_persistent_asset_path(raw: &str) -> Result<PathBuf> {
-    if raw.trim().is_empty() {
-        return Err(SurgeError::Config("Persistent asset path cannot be empty".to_string()));
-    }
-
-    let candidate = Path::new(raw);
-    if candidate.is_absolute() {
-        return Err(SurgeError::Config(format!(
-            "Persistent asset path must be relative: {raw}"
-        )));
-    }
-
-    let first_component = candidate
-        .components()
-        .next()
-        .and_then(|component| match component {
-            Component::Normal(value) => value.to_str(),
-            _ => None,
-        })
-        .unwrap_or_default();
-    if first_component.to_ascii_lowercase().starts_with("app-") {
-        return Err(SurgeError::Config(format!(
-            "Persistent asset path cannot start with 'app-': {raw}"
-        )));
-    }
-
-    for component in candidate.components() {
-        if matches!(
-            component,
-            Component::ParentDir | Component::RootDir | Component::Prefix(_)
-        ) {
-            return Err(SurgeError::Config(format!(
-                "Persistent asset path cannot contain parent/root traversal: {raw}"
-            )));
-        }
-    }
-
-    Ok(candidate.to_path_buf())
-}
-
 fn select_latest_remote_legacy_app_dir<I, S>(install_root: &Path, entries: I) -> Option<PathBuf>
 where
     I: IntoIterator<Item = S>,
@@ -3196,6 +3160,79 @@ mod tests {
         assert!(script.contains("--surge-first-run \"$version\""));
         assert!(script.contains("kill_matching \"$install_root/$main_exe\""));
         assert!(script.contains("kill_matching \"$install_root/app-\""));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn build_remote_app_copy_activation_script_preserves_persistent_assets_and_prunes_snapshots() {
+        let tmp = tempfile::tempdir().expect("temp dir should exist");
+        let install_root = tmp.path().join("install-root");
+        let active_app_dir = install_root.join("app");
+        let stage_app_dir = install_root.join(".surge-transfer-stage").join("app");
+        let stale_snapshot = install_root.join("app-1.0.0");
+        let older_snapshot = install_root.join("app-0.9.0");
+        let persistent_assets = vec!["settings.json".to_string(), "state".to_string()];
+
+        std::fs::create_dir_all(active_app_dir.join("state")).expect("state dir should exist");
+        std::fs::create_dir_all(&stage_app_dir).expect("stage app dir should exist");
+        std::fs::create_dir_all(&stale_snapshot).expect("stale snapshot should exist");
+        std::fs::create_dir_all(&older_snapshot).expect("older snapshot should exist");
+        std::fs::write(active_app_dir.join("settings.json"), "persisted settings").expect("settings should exist");
+        std::fs::write(active_app_dir.join("state").join("cache.bin"), "persisted cache").expect("state should exist");
+        std::fs::write(active_app_dir.join("old.txt"), "remove me").expect("old file should exist");
+        std::fs::write(stage_app_dir.join("demoapp"), "#!/bin/sh\nexit 0\n").expect("demoapp should exist");
+        std::fs::write(stage_app_dir.join("settings.json"), "packaged settings").expect("settings should exist");
+        std::fs::create_dir_all(stage_app_dir.join("state")).expect("packaged state dir should exist");
+        std::fs::write(stage_app_dir.join("state").join("cache.bin"), "packaged cache")
+            .expect("packaged state should exist");
+        std::fs::write(stage_app_dir.join("payload.txt"), "new payload").expect("payload should exist");
+
+        let script = build_remote_app_copy_activation_script(
+            &install_root,
+            "demoapp",
+            "1.2.3",
+            &BTreeMap::new(),
+            &persistent_assets,
+            None,
+            true,
+        )
+        .expect("script should build");
+
+        let status = std::process::Command::new("sh")
+            .arg("-c")
+            .arg(script)
+            .env("HOME", tmp.path())
+            .status()
+            .expect("script should run");
+        assert!(status.success(), "script should succeed");
+
+        let active_app_dir = install_root.join("app");
+        assert_eq!(
+            std::fs::read_to_string(active_app_dir.join("settings.json")).expect("settings should exist"),
+            "persisted settings"
+        );
+        assert_eq!(
+            std::fs::read_to_string(active_app_dir.join("state").join("cache.bin")).expect("state should exist"),
+            "persisted cache"
+        );
+        assert_eq!(
+            std::fs::read_to_string(active_app_dir.join("payload.txt")).expect("payload should exist"),
+            "new payload"
+        );
+        assert!(
+            !active_app_dir.join("old.txt").exists(),
+            "undeclared assets should be removed"
+        );
+        assert!(!stale_snapshot.exists(), "stale snapshot should be pruned");
+        assert!(!older_snapshot.exists(), "older snapshot should be pruned");
+        assert!(
+            !install_root.join(".surge-transfer-stage").exists(),
+            "transfer stage should be cleaned up"
+        );
+        assert!(
+            !install_root.join(".surge-app-prev").exists(),
+            "previous app dir should be removed"
+        );
     }
 
     #[test]

--- a/crates/surge-cli/src/commands/setup.rs
+++ b/crates/surge-cli/src/commands/setup.rs
@@ -465,6 +465,75 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn execute_preserves_persistent_assets_and_prunes_stale_snapshots() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let installer_dir = temp_dir.path().join("installer");
+        let payload_dir = installer_dir.join("payload");
+        let install_root = temp_dir.path().join("installed-app");
+        let active_app_dir = install_root.join("app");
+        let store_root = temp_dir.path().join("store");
+        let full_filename = "demo-app-1.2.3-full.tar.zst";
+
+        std::fs::create_dir_all(active_app_dir.join("state")).expect("state dir should exist");
+        std::fs::create_dir_all(payload_dir.parent().expect("payload parent")).expect("payload parent should exist");
+        std::fs::create_dir_all(install_root.join("app-1.0.0")).expect("stale snapshot should exist");
+        std::fs::create_dir_all(install_root.join("app-0.9.0")).expect("stale snapshot should exist");
+        std::fs::write(active_app_dir.join("settings.json"), "persisted settings").expect("settings should exist");
+        std::fs::write(active_app_dir.join("state").join("cache.bin"), "persisted cache").expect("state should exist");
+        std::fs::write(active_app_dir.join("old.txt"), "remove me").expect("old file should exist");
+
+        let mut manifest = make_manifest(&install_root, &store_root, full_filename, "offline");
+        manifest.runtime.persistent_assets = vec!["settings.json".to_string(), "state".to_string()];
+        let installer_yaml = serde_yaml::to_string(&manifest).expect("installer yaml");
+        std::fs::write(installer_dir.join("installer.yml"), installer_yaml).expect("installer manifest");
+
+        let mut packer = ArchivePacker::new(3).expect("archive packer");
+        packer
+            .add_buffer("demoapp", b"#!/bin/sh\necho demo\n", 0o755)
+            .expect("demoapp entry");
+        packer
+            .add_buffer("settings.json", b"packaged settings", 0o644)
+            .expect("settings entry");
+        packer
+            .add_buffer("state/cache.bin", b"packaged cache", 0o644)
+            .expect("state entry");
+        packer
+            .add_buffer("payload.txt", b"bundled payload", 0o644)
+            .expect("payload entry");
+        packer
+            .finalize_to_file(&payload_dir.join(full_filename))
+            .expect("archive file");
+
+        execute(&installer_dir, true).await.expect("setup should succeed");
+
+        let active_app_dir = install_root.join("app");
+        assert_eq!(
+            std::fs::read_to_string(active_app_dir.join("settings.json")).expect("settings should exist"),
+            "persisted settings"
+        );
+        assert_eq!(
+            std::fs::read_to_string(active_app_dir.join("state").join("cache.bin")).expect("state should exist"),
+            "persisted cache"
+        );
+        assert_eq!(
+            std::fs::read_to_string(active_app_dir.join("payload.txt")).expect("payload should exist"),
+            "bundled payload"
+        );
+        assert!(
+            !active_app_dir.join("old.txt").exists(),
+            "undeclared assets should be removed"
+        );
+        assert!(
+            !install_root.join("app-1.0.0").exists(),
+            "stale snapshot should be pruned"
+        );
+        assert!(
+            !install_root.join("app-0.9.0").exists(),
+            "stale snapshot should be pruned"
+        );
+    }
+
+    #[tokio::test]
     async fn resolve_package_downloads_when_bundled_payload_is_missing() {
         let temp_dir = tempfile::tempdir().expect("temp dir");
         let installer_dir = temp_dir.path().join("installer");

--- a/crates/surge-core/src/install.rs
+++ b/crates/surge-core/src/install.rs
@@ -340,10 +340,10 @@ pub fn install_package_locally_at_root_with_progress(
     } else {
         fallback_previous_app_dir.as_deref()
     };
-    if !profile.persistent_assets.is_empty() {
-        if let Some(previous) = previous_app_dir_for_assets {
-            copy_persistent_assets(previous, &active_app_dir, profile.persistent_assets)?;
-        }
+    if !profile.persistent_assets.is_empty()
+        && let Some(previous) = previous_app_dir_for_assets
+    {
+        copy_persistent_assets(previous, &active_app_dir, profile.persistent_assets)?;
     }
 
     if !profile.shortcuts.is_empty() {

--- a/crates/surge-core/src/install.rs
+++ b/crates/surge-core/src/install.rs
@@ -1,17 +1,21 @@
 use std::collections::BTreeMap;
-use std::path::Path;
+use std::path::{Component, Path, PathBuf};
 use std::time::Duration;
 
 use serde::Serialize;
+use tracing::warn;
 
 use crate::archive::extractor::extract_file_to_with_progress;
 use crate::config::installer::InstallerManifest;
 use crate::config::manifest::ShortcutLocation;
 use crate::context::StorageProvider;
 use crate::error::{Result, SurgeError};
+use crate::platform::fs::{copy_directory, list_directories};
 use crate::platform::paths::default_install_root;
 use crate::platform::process::{ProcessHandle, spawn_detached};
 use crate::platform::shortcuts::install_shortcuts;
+use crate::releases::version::compare_versions;
+use crate::supervisor::stub::find_latest_app_dir;
 
 pub const RUNTIME_MANIFEST_RELATIVE_PATH: &str = ".surge/runtime.yml";
 pub const LEGACY_RUNTIME_MANIFEST_RELATIVE_PATH: &str = ".surge/surge.yml";
@@ -51,6 +55,7 @@ pub struct InstallProfile<'a> {
     pub supervisor_id: &'a str,
     pub icon: &'a str,
     pub shortcuts: &'a [ShortcutLocation],
+    pub persistent_assets: &'a [String],
     pub environment: &'a BTreeMap<String, String>,
 }
 
@@ -112,6 +117,7 @@ impl<'a> InstallProfile<'a> {
         supervisor_id: &'a str,
         icon: &'a str,
         shortcuts: &'a [ShortcutLocation],
+        persistent_assets: &'a [String],
         environment: &'a BTreeMap<String, String>,
     ) -> Self {
         Self {
@@ -122,6 +128,7 @@ impl<'a> InstallProfile<'a> {
             supervisor_id,
             icon,
             shortcuts,
+            persistent_assets,
             environment,
         }
     }
@@ -136,6 +143,7 @@ impl<'a> InstallProfile<'a> {
             &manifest.runtime.supervisor_id,
             &manifest.runtime.icon,
             shortcuts,
+            &manifest.runtime.persistent_assets,
             &manifest.runtime.environment,
         )
     }
@@ -237,6 +245,11 @@ pub fn install_package_locally_at_root_with_progress(
     let active_app_dir = install_root.join("app");
     let next_app_dir = install_root.join(".surge-app-next");
     let previous_app_dir = install_root.join(".surge-app-prev");
+    let fallback_previous_app_dir = if active_app_dir.is_dir() {
+        None
+    } else {
+        find_latest_app_dir(install_root).ok()
+    };
 
     if next_app_dir.is_dir() {
         std::fs::remove_dir_all(&next_app_dir)?;
@@ -322,6 +335,17 @@ pub fn install_package_locally_at_root_with_progress(
         },
     );
 
+    let previous_app_dir_for_assets = if previous_app_dir.is_dir() {
+        Some(previous_app_dir.as_path())
+    } else {
+        fallback_previous_app_dir.as_deref()
+    };
+    if !profile.persistent_assets.is_empty() {
+        if let Some(previous) = previous_app_dir_for_assets {
+            copy_persistent_assets(previous, &active_app_dir, profile.persistent_assets)?;
+        }
+    }
+
     if !profile.shortcuts.is_empty() {
         emit_install_progress(
             progress,
@@ -367,8 +391,112 @@ pub fn install_package_locally_at_root_with_progress(
     if previous_app_dir.is_dir() {
         std::fs::remove_dir_all(previous_app_dir)?;
     }
+    if let Err(err) = prune_version_snapshots(install_root, 0) {
+        warn!(error = %err, "Failed to prune installed app version snapshots after install");
+    }
 
     Ok(())
+}
+
+fn app_snapshot_version(dir_name: &str) -> Option<&str> {
+    let version = dir_name.strip_prefix("app-")?;
+    if version.is_empty() || !version.chars().next().is_some_and(|c| c.is_ascii_digit()) {
+        return None;
+    }
+    Some(version)
+}
+
+pub fn prune_version_snapshots(install_dir: &Path, keep_latest: usize) -> Result<usize> {
+    let mut snapshots: Vec<(String, PathBuf)> = list_directories(install_dir)?
+        .into_iter()
+        .filter_map(|dir_name| {
+            let version = app_snapshot_version(&dir_name)?.to_string();
+            let path = install_dir.join(&dir_name);
+            Some((version, path))
+        })
+        .collect();
+
+    snapshots.sort_by(|(left, _), (right, _)| compare_versions(right, left));
+
+    let mut pruned = 0usize;
+    for (_, path) in snapshots.into_iter().skip(keep_latest) {
+        std::fs::remove_dir_all(path)?;
+        pruned = pruned.saturating_add(1);
+    }
+
+    Ok(pruned)
+}
+
+pub fn copy_persistent_assets(previous_app_dir: &Path, new_app_dir: &Path, assets: &[String]) -> Result<()> {
+    for asset in assets {
+        let relative = validate_relative_persistent_asset_path(asset)?;
+        let source = previous_app_dir.join(&relative);
+        if !source.exists() {
+            continue;
+        }
+
+        let destination = new_app_dir.join(&relative);
+        if source.is_dir() {
+            if destination.exists() {
+                if destination.is_dir() {
+                    std::fs::remove_dir_all(&destination)?;
+                } else {
+                    std::fs::remove_file(&destination)?;
+                }
+            }
+            copy_directory(&source, &destination)?;
+        } else {
+            if let Some(parent) = destination.parent() {
+                std::fs::create_dir_all(parent)?;
+            }
+            if destination.exists() && destination.is_dir() {
+                std::fs::remove_dir_all(&destination)?;
+            }
+            std::fs::copy(&source, &destination)?;
+        }
+    }
+
+    Ok(())
+}
+
+pub fn validate_relative_persistent_asset_path(raw: &str) -> Result<PathBuf> {
+    if raw.trim().is_empty() {
+        return Err(SurgeError::Update("Persistent asset path cannot be empty".to_string()));
+    }
+
+    let candidate = Path::new(raw);
+    if candidate.is_absolute() {
+        return Err(SurgeError::Update(format!(
+            "Persistent asset path must be relative: {raw}"
+        )));
+    }
+
+    let first_component = candidate
+        .components()
+        .next()
+        .and_then(|component| match component {
+            Component::Normal(value) => value.to_str(),
+            _ => None,
+        })
+        .unwrap_or_default();
+    if first_component.to_ascii_lowercase().starts_with("app-") {
+        return Err(SurgeError::Update(format!(
+            "Persistent asset path cannot start with 'app-': {raw}"
+        )));
+    }
+
+    for component in candidate.components() {
+        if matches!(
+            component,
+            Component::ParentDir | Component::RootDir | Component::Prefix(_)
+        ) {
+            return Err(SurgeError::Update(format!(
+                "Persistent asset path cannot contain parent/root traversal: {raw}"
+            )));
+        }
+    }
+
+    Ok(candidate.to_path_buf())
 }
 
 /// Start the installed application, using the supervisor if configured.
@@ -534,6 +662,7 @@ fn verify_process_stays_running(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::archive::packer::ArchivePacker;
 
     #[test]
     fn storage_provider_manifest_name_maps_expected_values() {
@@ -559,6 +688,7 @@ mod tests {
         let tmp = tempfile::tempdir().expect("temp dir should exist");
         let environment = BTreeMap::new();
         let shortcuts: [ShortcutLocation; 0] = [];
+        let persistent_assets: [String; 0] = [];
         let profile = InstallProfile::new(
             "demo-app",
             "Demo App",
@@ -567,6 +697,7 @@ mod tests {
             "demo-supervisor",
             "",
             &shortcuts,
+            &persistent_assets,
             &environment,
         );
         let metadata =
@@ -586,5 +717,84 @@ mod tests {
         assert!(raw.contains("endpoint: https://example.invalid"));
         assert!(!raw.contains("region:"));
         assert_eq!(raw, legacy_raw);
+    }
+
+    #[test]
+    fn install_package_locally_preserves_declared_persistent_assets_and_prunes_snapshots() {
+        let tmp = tempfile::tempdir().expect("temp dir should exist");
+        let install_root = tmp.path().join("install-root");
+        let active_app_dir = install_root.join("app");
+        let package_path = tmp.path().join("package.tar.zst");
+        let environment = BTreeMap::new();
+        let shortcuts: [ShortcutLocation; 0] = [];
+        let persistent_assets = vec!["settings.json".to_string(), "state".to_string()];
+
+        std::fs::create_dir_all(active_app_dir.join("state")).expect("state dir should exist");
+        std::fs::create_dir_all(install_root.join("app-1.0.0")).expect("snapshot should exist");
+        std::fs::create_dir_all(install_root.join("app-0.9.0")).expect("snapshot should exist");
+        std::fs::write(active_app_dir.join("settings.json"), "persisted settings").expect("settings should exist");
+        std::fs::write(active_app_dir.join("state").join("cache.bin"), "persisted cache").expect("state should exist");
+        std::fs::write(active_app_dir.join("old.txt"), "remove me").expect("old file should exist");
+
+        let mut packer = ArchivePacker::new(3).expect("archive packer should be created");
+        packer
+            .add_buffer("demo", b"#!/bin/sh\necho demo\n", 0o755)
+            .expect("main executable should be added");
+        packer
+            .add_buffer("settings.json", b"packaged settings", 0o644)
+            .expect("settings should be added");
+        packer
+            .add_buffer("state/cache.bin", b"packaged cache", 0o644)
+            .expect("state should be added");
+        packer
+            .add_buffer("payload.txt", b"new payload", 0o644)
+            .expect("payload should be added");
+        packer
+            .finalize_to_file(&package_path)
+            .expect("archive should be written");
+
+        let profile = InstallProfile::new(
+            "demo-app",
+            "Demo App",
+            "demo",
+            "demo-install",
+            "",
+            "",
+            &shortcuts,
+            &persistent_assets,
+            &environment,
+        );
+
+        install_package_locally_at_root(&profile, &package_path, &install_root).expect("install should succeed");
+
+        let active_app_dir = install_root.join("app");
+        assert_eq!(
+            std::fs::read_to_string(active_app_dir.join("settings.json")).expect("settings should exist"),
+            "persisted settings"
+        );
+        assert_eq!(
+            std::fs::read_to_string(active_app_dir.join("state").join("cache.bin")).expect("state should exist"),
+            "persisted cache"
+        );
+        assert_eq!(
+            std::fs::read_to_string(active_app_dir.join("payload.txt")).expect("payload should exist"),
+            "new payload"
+        );
+        assert!(
+            !active_app_dir.join("old.txt").exists(),
+            "undeclared assets should be removed"
+        );
+        assert!(
+            !install_root.join("app-1.0.0").exists(),
+            "stale snapshot should be pruned"
+        );
+        assert!(
+            !install_root.join("app-0.9.0").exists(),
+            "stale snapshot should be pruned"
+        );
+        assert!(
+            !install_root.join(".surge-app-prev").exists(),
+            "temporary previous dir should be removed"
+        );
     }
 }

--- a/crates/surge-core/src/update/manager.rs
+++ b/crates/surge-core/src/update/manager.rs
@@ -1,7 +1,7 @@
 //! Update manager: check for updates, download, verify, and apply them.
 
 use std::collections::{BTreeMap, BTreeSet};
-use std::path::{Component, Path, PathBuf};
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
@@ -13,10 +13,13 @@ use crate::config::constants::RELEASES_FILE_COMPRESSED;
 use crate::context::Context;
 use crate::crypto::sha256::{sha256_hex, sha256_hex_file};
 use crate::error::{Result, SurgeError};
-use crate::install::{InstallProfile, RuntimeManifestMetadata, storage_provider_manifest_name, write_runtime_manifest};
+use crate::install::{
+    InstallProfile, RuntimeManifestMetadata, copy_persistent_assets, prune_version_snapshots,
+    storage_provider_manifest_name, write_runtime_manifest,
+};
 use crate::pack::builder::build_canonical_archive_from_directory;
 use crate::platform::detect::current_rid;
-use crate::platform::fs::{atomic_rename, copy_directory, list_directories, write_file_atomic};
+use crate::platform::fs::{atomic_rename, write_file_atomic};
 use crate::platform::process::{current_pid, spawn_detached, spawn_process, supervisor_binary_name};
 use crate::platform::shortcuts::install_shortcuts;
 use crate::releases::artifact_cache::{
@@ -985,6 +988,7 @@ impl UpdateManager {
             &latest.supervisor_id,
             &latest.icon,
             &latest.shortcuts,
+            &latest.persistent_assets,
             &latest.environment,
         );
         let runtime_manifest_metadata = RuntimeManifestMetadata::new(
@@ -1130,35 +1134,6 @@ fn normalize_os_label(raw: &str) -> String {
         "linux" => "linux".to_string(),
         other => other.to_string(),
     }
-}
-
-fn app_snapshot_version(dir_name: &str) -> Option<&str> {
-    let version = dir_name.strip_prefix("app-")?;
-    if version.is_empty() || !version.chars().next().is_some_and(|c| c.is_ascii_digit()) {
-        return None;
-    }
-    Some(version)
-}
-
-fn prune_version_snapshots(install_dir: &Path, keep_latest: usize) -> Result<usize> {
-    let mut snapshots: Vec<(String, PathBuf)> = list_directories(install_dir)?
-        .into_iter()
-        .filter_map(|dir_name| {
-            let version = app_snapshot_version(&dir_name)?.to_string();
-            let path = install_dir.join(&dir_name);
-            Some((version, path))
-        })
-        .collect();
-
-    snapshots.sort_by(|(left, _), (right, _)| compare_versions(right, left));
-
-    let mut pruned = 0usize;
-    for (_, path) in snapshots.into_iter().skip(keep_latest) {
-        std::fs::remove_dir_all(path)?;
-        pruned = pruned.saturating_add(1);
-    }
-
-    Ok(pruned)
 }
 
 fn find_previous_app_dir(install_dir: &Path, current_version: &str) -> Option<PathBuf> {
@@ -1448,78 +1423,6 @@ fn restart_supervisor_after_update(install_dir: &Path, active_app_dir: &Path, la
             );
         }
     }
-}
-
-fn copy_persistent_assets(previous_app_dir: &Path, new_app_dir: &Path, assets: &[String]) -> Result<()> {
-    for asset in assets {
-        let relative = validate_relative_persistent_asset_path(asset)?;
-        let source = previous_app_dir.join(&relative);
-        if !source.exists() {
-            continue;
-        }
-
-        let destination = new_app_dir.join(&relative);
-        if source.is_dir() {
-            if destination.exists() {
-                if destination.is_dir() {
-                    std::fs::remove_dir_all(&destination)?;
-                } else {
-                    std::fs::remove_file(&destination)?;
-                }
-            }
-            copy_directory(&source, &destination)?;
-        } else {
-            if let Some(parent) = destination.parent() {
-                std::fs::create_dir_all(parent)?;
-            }
-            if destination.exists() && destination.is_dir() {
-                std::fs::remove_dir_all(&destination)?;
-            }
-            std::fs::copy(&source, &destination)?;
-        }
-    }
-
-    Ok(())
-}
-
-fn validate_relative_persistent_asset_path(raw: &str) -> Result<PathBuf> {
-    if raw.trim().is_empty() {
-        return Err(SurgeError::Update("Persistent asset path cannot be empty".to_string()));
-    }
-
-    let candidate = Path::new(raw);
-    if candidate.is_absolute() {
-        return Err(SurgeError::Update(format!(
-            "Persistent asset path must be relative: {raw}"
-        )));
-    }
-
-    let first_component = candidate
-        .components()
-        .next()
-        .and_then(|component| match component {
-            Component::Normal(value) => value.to_str(),
-            _ => None,
-        })
-        .unwrap_or_default();
-    if first_component.to_ascii_lowercase().starts_with("app-") {
-        return Err(SurgeError::Update(format!(
-            "Persistent asset path cannot start with 'app-': {raw}"
-        )));
-    }
-
-    for component in candidate.components() {
-        if matches!(
-            component,
-            Component::ParentDir | Component::RootDir | Component::Prefix(_)
-        ) {
-            return Err(SurgeError::Update(format!(
-                "Persistent asset path cannot contain parent/root traversal: {raw}"
-            )));
-        }
-    }
-
-    Ok(candidate.to_path_buf())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## What changed
- moved explicit install persistence rules into the shared install path used by `surge install`, `surge setup`, and the installer UI
- preserved only declared `persistent_assets` when replacing `app/` during explicit installs
- pruned stale `app-*` version snapshots after explicit installs, matching the newer updater behavior
- updated the direct remote app-copy activation path used for host-mismatch remote installs so it also preserves declared assets and removes stale snapshots
- added regressions for shared install, setup, and remote activation flows

## Why
Explicit install paths still behaved differently from the in-app updater. A fresh install/update through setup or remote install would replace `app/` but drop declared persistent assets, while stale `app-*` snapshots could accumulate indefinitely.

## Root cause
The recent snapshot-pruning fix only ran in the update-manager path. The shared explicit install primitive and the direct remote activation script did not carry over `persistent_assets`, and they did not prune legacy `app-*` snapshots after activation.

## Impact
- explicit installs now keep declared persistent state while still removing undeclared app-local files
- remote Linux installs follow the same persistence rules as local installs
- stale versioned snapshots are cleaned up instead of accumulating on long-lived nodes

## Validation
- `cargo test -p surge-core install_package_locally_preserves_declared_persistent_assets_and_prunes_snapshots`
- `cargo test -p surge-cli preserves_persistent_assets`
- `cargo test -p surge-core test_download_and_apply_prunes_old_version_snapshots_to_retention_limit`
- `cargo test -p surge-cli build_remote_app_copy_activation_script_exports_env_and_lifecycle_hooks`
