### PR TITLE
Fix promote when a release full artifact is missing

### DIFF
--- a/crates/surge-cli/src/commands/compact.rs
+++ b/crates/surge-cli/src/commands/compact.rs
@@ -9,9 +9,9 @@ use surge_core::config::constants::{DEFAULT_ZSTD_LEVEL, RELEASES_FILE_COMPRESSED
 use surge_core::config::manifest::SurgeManifest;
 use surge_core::error::{Result, SurgeError};
 use surge_core::releases::manifest::{compress_release_index, decompress_release_index};
-use surge_core::releases::restore::{required_artifacts_for_index, restore_full_archive_for_version};
+use surge_core::releases::restore::required_artifacts_for_index;
 use surge_core::releases::version::compare_versions;
-use surge_core::storage::{self, StorageBackend};
+use surge_core::storage;
 
 /// Compact a channel to a single latest full release and prune stale artifacts.
 ///
@@ -147,7 +147,7 @@ async fn compact_single(
     print_stage_done(theme, 3, TOTAL_STAGES, &format!("v{latest_version}"));
 
     print_stage(theme, 4, TOTAL_STAGES, "Ensuring latest full artifact exists");
-    let full_materialized = ensure_release_full_artifact(&*backend, &index, rid, &latest_version).await?;
+    let full_materialized = super::ensure_release_full_artifact(&*backend, &index, rid, &latest_version).await?;
     print_stage_done(
         theme,
         4,
@@ -316,37 +316,6 @@ fn referenced_artifacts(index: &surge_core::releases::manifest::ReleaseIndex) ->
         }
     }
     keys
-}
-
-async fn ensure_release_full_artifact(
-    backend: &dyn StorageBackend,
-    index: &surge_core::releases::manifest::ReleaseIndex,
-    rid: &str,
-    version: &str,
-) -> Result<bool> {
-    let release = index
-        .releases
-        .iter()
-        .find(|release| release.rid == rid && release.version == version)
-        .ok_or_else(|| SurgeError::NotFound(format!("Release {version} ({rid}) not found in index")))?;
-    let full_filename = release.full_filename.trim();
-    if full_filename.is_empty() {
-        return Err(SurgeError::Storage(format!(
-            "Release {version} ({rid}) has no full artifact descriptor"
-        )));
-    }
-
-    match backend.head_object(full_filename).await {
-        Ok(_) => Ok(false),
-        Err(SurgeError::NotFound(_)) => {
-            let archive = restore_full_archive_for_version(backend, index, rid, version).await?;
-            backend
-                .put_object(full_filename, &archive, "application/octet-stream")
-                .await?;
-            Ok(true)
-        }
-        Err(e) => Err(e),
-    }
 }
 
 #[cfg(test)]

--- a/crates/surge-cli/src/commands/mod.rs
+++ b/crates/surge-cli/src/commands/mod.rs
@@ -19,11 +19,15 @@ pub(crate) use crate::prompts::{resolve_app_id, resolve_app_id_with_rid_hint, re
 
 use std::path::Path;
 
+use surge_core::config::constants::RELEASES_FILE_COMPRESSED;
 #[cfg(test)]
 use surge_core::config::installer::InstallerManifest;
 use surge_core::config::manifest::SurgeManifest;
 use surge_core::context::{Context, StorageConfig, StorageProvider};
 use surge_core::error::{Result, SurgeError};
+use surge_core::releases::manifest::{ReleaseIndex, decompress_release_index};
+use surge_core::releases::restore::restore_full_archive_for_version;
+use surge_core::storage::StorageBackend;
 
 pub(crate) fn build_storage_config(
     manifest: &SurgeManifest,
@@ -90,6 +94,42 @@ pub(crate) fn ensure_mutating_storage_access(config: &StorageConfig, action: &st
         StorageProvider::GitHubReleases => Err(SurgeError::Config(format!(
             "Cannot {action}: GitHub Releases write access requires GITHUB_TOKEN or GH_TOKEN"
         ))),
+    }
+}
+
+pub(crate) async fn fetch_release_index(backend: &dyn StorageBackend) -> Result<ReleaseIndex> {
+    let data = backend.get_object(RELEASES_FILE_COMPRESSED).await?;
+    decompress_release_index(&data)
+}
+
+pub(crate) async fn ensure_release_full_artifact(
+    backend: &dyn StorageBackend,
+    index: &ReleaseIndex,
+    rid: &str,
+    version: &str,
+) -> Result<bool> {
+    let release = index
+        .releases
+        .iter()
+        .find(|release| release.rid == rid && release.version == version)
+        .ok_or_else(|| SurgeError::NotFound(format!("Release {version} ({rid}) not found in index")))?;
+    let full_filename = release.full_filename.trim();
+    if full_filename.is_empty() {
+        return Err(SurgeError::Storage(format!(
+            "Release {version} ({rid}) has no full artifact descriptor"
+        )));
+    }
+
+    match backend.head_object(full_filename).await {
+        Ok(_) => Ok(false),
+        Err(SurgeError::NotFound(_)) => {
+            let archive = restore_full_archive_for_version(backend, index, rid, version).await?;
+            backend
+                .put_object(full_filename, &archive, "application/octet-stream")
+                .await?;
+            Ok(true)
+        }
+        Err(err) => Err(err),
     }
 }
 

--- a/crates/surge-cli/src/commands/promote.rs
+++ b/crates/surge-cli/src/commands/promote.rs
@@ -7,8 +7,8 @@ use crate::ui::UiTheme;
 use surge_core::config::constants::{DEFAULT_ZSTD_LEVEL, RELEASES_FILE_COMPRESSED};
 use surge_core::config::manifest::SurgeManifest;
 use surge_core::error::{Result, SurgeError};
-use surge_core::releases::manifest::{compress_release_index, decompress_release_index};
-use surge_core::storage::{self, StorageBackend};
+use surge_core::releases::manifest::compress_release_index;
+use surge_core::storage;
 
 /// Promote a release version to a target channel.
 pub async fn execute(
@@ -18,7 +18,7 @@ pub async fn execute(
     rid: Option<&str>,
     channel: &str,
 ) -> Result<()> {
-    const TOTAL_STAGES: usize = 4;
+    const TOTAL_STAGES: usize = 5;
 
     let theme = UiTheme::global();
     let started = Instant::now();
@@ -28,11 +28,12 @@ pub async fn execute(
     let app_id = super::resolve_app_id_with_rid_hint(&manifest, app_id, rid)?;
     let rid = super::resolve_rid(&manifest, &app_id, rid)?;
     let storage_config = super::build_app_scoped_storage_config(&manifest, manifest_path, &app_id)?;
+    super::ensure_mutating_storage_access(&storage_config, "promote release")?;
     let backend = storage::create_storage_backend(&storage_config)?;
     print_stage_done(theme, 1, TOTAL_STAGES, &format!("Target: {app_id}/{rid} v{version}"));
 
     print_stage(theme, 2, TOTAL_STAGES, "Loading release index");
-    let mut index = fetch_release_index(&*backend).await?;
+    let mut index = super::fetch_release_index(&*backend).await?;
     if !index.app_id.is_empty() && index.app_id != app_id {
         return Err(SurgeError::NotFound(format!(
             "Release index belongs to app '{}' not '{}'",
@@ -41,14 +42,18 @@ pub async fn execute(
     }
     print_stage_done(theme, 2, TOTAL_STAGES, "Release index loaded");
 
-    print_stage(theme, 3, TOTAL_STAGES, "Updating channel membership");
-    let release = index
+    let release_idx = index
         .releases
-        .iter_mut()
-        .find(|release| release.version == version && release.rid == rid)
+        .iter()
+        .position(|release| release.version == version && release.rid == rid)
         .ok_or_else(|| SurgeError::NotFound(format!("Release {version} not found for {app_id}/{rid}")))?;
 
-    if release.channels.iter().any(|existing| existing == channel) {
+    if index.releases[release_idx]
+        .channels
+        .iter()
+        .any(|existing| existing == channel)
+    {
+        print_stage(theme, 3, TOTAL_STAGES, "Updating channel membership");
         print_stage_done(
             theme,
             3,
@@ -64,6 +69,22 @@ pub async fn execute(
         );
         return Ok(());
     }
+
+    print_stage(theme, 3, TOTAL_STAGES, "Ensuring release full artifact exists");
+    let full_materialized = super::ensure_release_full_artifact(&*backend, &index, &rid, version).await?;
+    print_stage_done(
+        theme,
+        3,
+        TOTAL_STAGES,
+        if full_materialized {
+            "Rebuilt and uploaded missing full artifact"
+        } else {
+            "Release full artifact already present"
+        },
+    );
+
+    print_stage(theme, 4, TOTAL_STAGES, "Updating channel membership");
+    let release = &mut index.releases[release_idx];
     release.channels.push(channel.to_string());
     release.channels.sort();
     release.channels.dedup();
@@ -73,12 +94,12 @@ pub async fn execute(
     backend
         .put_object(RELEASES_FILE_COMPRESSED, &compressed, "application/octet-stream")
         .await?;
-    print_stage_done(theme, 3, TOTAL_STAGES, &format!("Added channel '{channel}' to release"));
+    print_stage_done(theme, 4, TOTAL_STAGES, &format!("Added channel '{channel}' to release"));
 
-    print_stage(theme, 4, TOTAL_STAGES, "Finalize promote summary");
+    print_stage(theme, 5, TOTAL_STAGES, "Finalize promote summary");
     print_stage_done(
         theme,
-        4,
+        5,
         TOTAL_STAGES,
         &format!(
             "Promoted {app_id} v{version} ({rid}) -> {channel} in {}",
@@ -86,11 +107,6 @@ pub async fn execute(
         ),
     );
     Ok(())
-}
-
-async fn fetch_release_index(backend: &dyn StorageBackend) -> Result<surge_core::releases::manifest::ReleaseIndex> {
-    let data = backend.get_object(RELEASES_FILE_COMPRESSED).await?;
-    decompress_release_index(&data)
 }
 
 fn print_stage(theme: UiTheme, stage: usize, total: usize, text: &str) {
@@ -107,8 +123,10 @@ fn print_stage_done(theme: UiTheme, stage: usize, total: usize, text: &str) {
 mod tests {
     use super::*;
     use surge_core::config::constants::DEFAULT_ZSTD_LEVEL;
+    use surge_core::crypto::sha256::sha256_hex;
+    use surge_core::diff::wrapper::bsdiff_buffers;
     use surge_core::platform::detect::current_rid;
-    use surge_core::releases::manifest::{ReleaseEntry, ReleaseIndex};
+    use surge_core::releases::manifest::{DeltaArtifact, ReleaseEntry, ReleaseIndex, decompress_release_index};
 
     fn write_manifest(path: &Path, store_dir: &Path, app_id: &str, rid: &str) {
         let yaml = format!(
@@ -171,6 +189,8 @@ mod tests {
                 ..ReleaseIndex::default()
             },
         );
+        std::fs::write(store_dir.join(format!("demo-1.2.3-{rid}-full.tar.zst")), b"payload")
+            .expect("full artifact should be present");
 
         execute(&manifest_path, Some("demo"), "1.2.3", Some(&rid), "beta")
             .await
@@ -213,5 +233,136 @@ mod tests {
             vec!["beta".to_string(), "stable".to_string()]
         );
         assert_eq!(index.last_write_utc, "unchanged");
+    }
+
+    #[tokio::test]
+    async fn execute_materializes_missing_full_before_adding_channel() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let store_dir = temp_dir.path().join("store");
+        let manifest_path = temp_dir.path().join("surge.yml");
+        let rid = current_rid();
+
+        std::fs::create_dir_all(&store_dir).expect("store dir");
+        write_manifest(&manifest_path, &store_dir, "demo", &rid);
+
+        let v1 = b"demo-v1-full".to_vec();
+        let v2 = b"demo-v2-full".to_vec();
+        let delta = zstd::encode_all(bsdiff_buffers(&v1, &v2).unwrap().as_slice(), 3).unwrap();
+
+        let v1_full_key = format!("demo-1.0.0-{rid}-full.tar.zst");
+        let v2_full_key = format!("demo-1.1.0-{rid}-full.tar.zst");
+        let v2_delta_key = format!("demo-1.1.0-{rid}-delta.tar.zst");
+
+        std::fs::write(store_dir.join(&v1_full_key), &v1).expect("base full should be present");
+        std::fs::write(store_dir.join(&v2_delta_key), &delta).expect("delta artifact should be present");
+
+        write_index(
+            &store_dir,
+            &ReleaseIndex {
+                app_id: "demo".to_string(),
+                releases: vec![
+                    ReleaseEntry {
+                        version: "1.0.0".to_string(),
+                        channels: vec!["stable".to_string()],
+                        os: "linux".to_string(),
+                        rid: rid.clone(),
+                        is_genesis: true,
+                        full_filename: v1_full_key.clone(),
+                        full_size: i64::try_from(v1.len()).unwrap(),
+                        full_sha256: sha256_hex(&v1),
+                        deltas: Vec::new(),
+                        preferred_delta_id: String::new(),
+                        created_utc: chrono::Utc::now().to_rfc3339(),
+                        release_notes: String::new(),
+                        name: String::new(),
+                        main_exe: "demoapp".to_string(),
+                        install_directory: "demoapp".to_string(),
+                        supervisor_id: String::new(),
+                        icon: String::new(),
+                        shortcuts: Vec::new(),
+                        persistent_assets: Vec::new(),
+                        installers: Vec::new(),
+                        environment: std::collections::BTreeMap::new(),
+                    },
+                    ReleaseEntry {
+                        version: "1.1.0".to_string(),
+                        channels: vec!["stable".to_string()],
+                        os: "linux".to_string(),
+                        rid: rid.clone(),
+                        is_genesis: false,
+                        full_filename: v2_full_key.clone(),
+                        full_size: i64::try_from(v2.len()).unwrap(),
+                        full_sha256: sha256_hex(&v2),
+                        deltas: vec![DeltaArtifact::bsdiff_zstd(
+                            "primary",
+                            "1.0.0",
+                            &v2_delta_key,
+                            i64::try_from(delta.len()).unwrap(),
+                            &sha256_hex(&delta),
+                        )],
+                        preferred_delta_id: "primary".to_string(),
+                        created_utc: chrono::Utc::now().to_rfc3339(),
+                        release_notes: String::new(),
+                        name: String::new(),
+                        main_exe: "demoapp".to_string(),
+                        install_directory: "demoapp".to_string(),
+                        supervisor_id: String::new(),
+                        icon: String::new(),
+                        shortcuts: Vec::new(),
+                        persistent_assets: Vec::new(),
+                        installers: Vec::new(),
+                        environment: std::collections::BTreeMap::new(),
+                    },
+                ],
+                ..ReleaseIndex::default()
+            },
+        );
+
+        execute(&manifest_path, Some("demo"), "1.1.0", Some(&rid), "beta")
+            .await
+            .expect("promote should materialize and succeed");
+
+        let index = read_index(&store_dir);
+        let promoted = index
+            .releases
+            .iter()
+            .find(|release| release.version == "1.1.0" && release.rid == rid)
+            .expect("promoted release should exist");
+        assert_eq!(promoted.channels, vec!["beta".to_string(), "stable".to_string()]);
+        assert_eq!(std::fs::read(store_dir.join(v2_full_key)).unwrap(), v2);
+    }
+
+    #[tokio::test]
+    async fn execute_rejects_promotion_when_missing_full_cannot_be_restored() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let store_dir = temp_dir.path().join("store");
+        let manifest_path = temp_dir.path().join("surge.yml");
+        let rid = current_rid();
+
+        std::fs::create_dir_all(&store_dir).expect("store dir");
+        write_manifest(&manifest_path, &store_dir, "demo", &rid);
+        write_index(
+            &store_dir,
+            &ReleaseIndex {
+                app_id: "demo".to_string(),
+                last_write_utc: "unchanged".to_string(),
+                releases: vec![release("1.2.3", &rid, &["stable"])],
+                ..ReleaseIndex::default()
+            },
+        );
+
+        let err = execute(&manifest_path, Some("demo"), "1.2.3", Some(&rid), "beta")
+            .await
+            .expect_err("promote should fail when full cannot be restored");
+        let err = err.to_string();
+        assert!(
+            err.contains("No reconstructable full archive found"),
+            "unexpected error: {err}"
+        );
+
+        let index = read_index(&store_dir);
+        assert_eq!(index.releases[0].channels, vec!["stable".to_string()]);
+        assert_eq!(index.last_write_utc, "unchanged");
+        assert!(!store_dir.join(format!("demo-1.2.3-{rid}-full.tar.zst")).exists());
     }
 }


### PR DESCRIPTION
## Summary
- factor release-index loading and full-artifact materialization into shared `surge-cli` command helpers
- make `surge promote` ensure the target release full artifact exists before adding channel membership
- keep `surge compact` behavior unchanged by reusing the same helper
- add regression tests for successful promote, no-op promote, materialized promote, and unreconstructable promote failure

## Why
A release could be promoted onto a channel even when its referenced full artifact was missing from storage. That left clients on some install/update paths unable to reinstall or switch channels successfully.

## Root Cause
`promote` only edited channel membership in the release index. It did not verify that the promoted release's `full_filename` actually existed in storage or materialize it from the retained release graph first.

## Impact
Promoting a release now either:
- succeeds with the full artifact already present
- rebuilds and uploads the missing full artifact before promotion
- fails without mutating channel membership if the full artifact cannot be reconstructed

## Validation
- `./scripts/sync-surge-core-vendor.sh --check`
- `./scripts/check-version-sync.sh`
- `cargo fmt --all --check`
- `RUSTFLAGS="-D warnings" cargo test --workspace`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo clippy --workspace --lib --bins --examples -- -D warnings -D clippy::unwrap_used -D clippy::expect_used`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings -W clippy::pedantic`
- `dotnet format dotnet/Surge.slnx --verify-no-changes`
- `dotnet test dotnet/Surge.slnx --configuration Release`

## Operational Note
The already-broken `2925.0.0` full blobs were repaired separately in storage after verifying the reconstruction path.