### PR TITLE
Fix persistent install follow-up edge cases

### DIFF
--- a/crates/surge-cli/src/commands/install.rs
+++ b/crates/surge-cli/src/commands/install.rs
@@ -2278,12 +2278,9 @@ where
 
     for entry in entries {
         let name = entry.as_ref().trim();
-        let Some(version) = name.strip_prefix("app-") else {
+        let Some(version) = remote_legacy_snapshot_version(name) else {
             continue;
         };
-        if version.is_empty() {
-            continue;
-        }
 
         if best
             .as_ref()
@@ -2296,11 +2293,19 @@ where
     best.map(|(_, path)| path)
 }
 
+fn remote_legacy_snapshot_version(dir_name: &str) -> Option<&str> {
+    let version = dir_name.strip_prefix("app-")?;
+    if version.is_empty() || !version.chars().next().is_some_and(|c| c.is_ascii_digit()) {
+        return None;
+    }
+    Some(version)
+}
+
 async fn detect_remote_legacy_app_dir(ssh_node: &str, install_root: &Path) -> Result<Option<PathBuf>> {
     let probe = format!(
         "install_root={}; \
 if [ -d \"$install_root\" ]; then \
-  for path in \"$install_root\"/app-*; do \
+  for path in \"$install_root\"/app-[0-9]*; do \
     if [ -d \"$path\" ]; then \
       basename \"$path\"; \
     fi; \
@@ -3267,6 +3272,16 @@ mod tests {
                 .expect("legacy app dir should be selected");
 
         assert_eq!(selected, install_root.join("app-1.0.1"));
+    }
+
+    #[test]
+    fn select_latest_remote_legacy_app_dir_ignores_non_version_directories() {
+        let install_root = Path::new("/home/demo/.local/share/demo");
+
+        let selected =
+            select_latest_remote_legacy_app_dir(install_root, ["app-backup", "app-staging", ".surge-app-prev"]);
+
+        assert_eq!(selected, None);
     }
 
     #[test]

--- a/crates/surge-core/src/install.rs
+++ b/crates/surge-core/src/install.rs
@@ -45,6 +45,57 @@ fn emit_install_progress(progress: Option<&InstallProgressCallback<'_>>, snapsho
     }
 }
 
+#[derive(Debug, Clone, Default)]
+struct RuntimeManifestSnapshot {
+    runtime_manifest: Option<Vec<u8>>,
+    legacy_runtime_manifest: Option<Vec<u8>>,
+}
+
+impl RuntimeManifestSnapshot {
+    fn capture(active_app_dir: &Path) -> Result<Self> {
+        Ok(Self {
+            runtime_manifest: read_optional_file(&active_app_dir.join(RUNTIME_MANIFEST_RELATIVE_PATH))?,
+            legacy_runtime_manifest: read_optional_file(&active_app_dir.join(LEGACY_RUNTIME_MANIFEST_RELATIVE_PATH))?,
+        })
+    }
+
+    fn restore(&self, active_app_dir: &Path) -> Result<()> {
+        restore_optional_file(
+            &active_app_dir.join(RUNTIME_MANIFEST_RELATIVE_PATH),
+            self.runtime_manifest.as_deref(),
+        )?;
+        restore_optional_file(
+            &active_app_dir.join(LEGACY_RUNTIME_MANIFEST_RELATIVE_PATH),
+            self.legacy_runtime_manifest.as_deref(),
+        )
+    }
+}
+
+fn read_optional_file(path: &Path) -> Result<Option<Vec<u8>>> {
+    if path.is_file() {
+        Ok(Some(std::fs::read(path)?))
+    } else {
+        Ok(None)
+    }
+}
+
+fn restore_optional_file(path: &Path, contents: Option<&[u8]>) -> Result<()> {
+    if let Some(contents) = contents {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        std::fs::write(path, contents)?;
+    } else if path.exists() {
+        if path.is_dir() {
+            std::fs::remove_dir_all(path)?;
+        } else {
+            std::fs::remove_file(path)?;
+        }
+    }
+
+    Ok(())
+}
+
 /// Shared profile for installing a package locally, usable from both
 /// `surge install` (via `ReleaseEntry`) and `surge setup` (via `InstallerRuntime`).
 pub struct InstallProfile<'a> {
@@ -335,62 +386,76 @@ pub fn install_package_locally_at_root_with_progress(
         },
     );
 
-    let previous_app_dir_for_assets = if previous_app_dir.is_dir() {
-        Some(previous_app_dir.as_path())
-    } else {
-        fallback_previous_app_dir.as_deref()
-    };
-    if !profile.persistent_assets.is_empty()
-        && let Some(previous) = previous_app_dir_for_assets
-    {
-        copy_persistent_assets(previous, &active_app_dir, profile.persistent_assets)?;
-    }
+    let runtime_manifest_snapshot = RuntimeManifestSnapshot::capture(&active_app_dir)?;
+    let install_result = (|| -> Result<()> {
+        let previous_app_dir_for_assets = if previous_app_dir.is_dir() {
+            Some(previous_app_dir.as_path())
+        } else {
+            fallback_previous_app_dir.as_deref()
+        };
+        if !profile.persistent_assets.is_empty()
+            && let Some(previous) = previous_app_dir_for_assets
+        {
+            copy_persistent_assets(previous, &active_app_dir, profile.persistent_assets)?;
+        }
 
-    if !profile.shortcuts.is_empty() {
-        emit_install_progress(
-            progress,
-            InstallProgress {
-                stage: InstallProgressStage::Shortcuts,
-                phase_percent: 0,
-                bytes_done: 0,
-                bytes_total: 0,
-                items_done: 0,
-                items_total: 0,
-            },
-        );
-        let main_exe = profile.main_exe.trim();
-        if main_exe.is_empty() {
-            return Err(SurgeError::Config(format!(
-                "App '{}' has shortcuts configured but no main executable metadata",
-                profile.app_id
+        if !profile.shortcuts.is_empty() {
+            emit_install_progress(
+                progress,
+                InstallProgress {
+                    stage: InstallProgressStage::Shortcuts,
+                    phase_percent: 0,
+                    bytes_done: 0,
+                    bytes_total: 0,
+                    items_done: 0,
+                    items_total: 0,
+                },
+            );
+            let main_exe = profile.main_exe.trim();
+            if main_exe.is_empty() {
+                return Err(SurgeError::Config(format!(
+                    "App '{}' has shortcuts configured but no main executable metadata",
+                    profile.app_id
+                )));
+            }
+            install_shortcuts(
+                profile.app_id,
+                profile.display_name,
+                &active_app_dir,
+                main_exe,
+                profile.supervisor_id,
+                profile.icon,
+                profile.shortcuts,
+                profile.environment,
+            )?;
+            emit_install_progress(
+                progress,
+                InstallProgress {
+                    stage: InstallProgressStage::Shortcuts,
+                    phase_percent: 100,
+                    bytes_done: 0,
+                    bytes_total: 0,
+                    items_done: i64::try_from(profile.shortcuts.len()).unwrap_or(i64::MAX),
+                    items_total: i64::try_from(profile.shortcuts.len()).unwrap_or(i64::MAX),
+                },
+            );
+        }
+
+        if previous_app_dir.is_dir() {
+            std::fs::remove_dir_all(&previous_app_dir)?;
+        }
+
+        Ok(())
+    })();
+    if let Err(err) = install_result {
+        if let Err(restore_err) = runtime_manifest_snapshot.restore(&active_app_dir) {
+            return Err(SurgeError::Platform(format!(
+                "Failed to restore runtime manifests after install error '{err}': {restore_err}"
             )));
         }
-        install_shortcuts(
-            profile.app_id,
-            profile.display_name,
-            &active_app_dir,
-            main_exe,
-            profile.supervisor_id,
-            profile.icon,
-            profile.shortcuts,
-            profile.environment,
-        )?;
-        emit_install_progress(
-            progress,
-            InstallProgress {
-                stage: InstallProgressStage::Shortcuts,
-                phase_percent: 100,
-                bytes_done: 0,
-                bytes_total: 0,
-                items_done: i64::try_from(profile.shortcuts.len()).unwrap_or(i64::MAX),
-                items_total: i64::try_from(profile.shortcuts.len()).unwrap_or(i64::MAX),
-            },
-        );
+        return Err(err);
     }
 
-    if previous_app_dir.is_dir() {
-        std::fs::remove_dir_all(previous_app_dir)?;
-    }
     if let Err(err) = prune_version_snapshots(install_root, 0) {
         warn!(error = %err, "Failed to prune installed app version snapshots after install");
     }
@@ -795,6 +860,83 @@ mod tests {
         assert!(
             !install_root.join(".surge-app-prev").exists(),
             "temporary previous dir should be removed"
+        );
+    }
+
+    #[test]
+    fn install_package_locally_restores_runtime_manifests_when_post_copy_work_fails() {
+        let tmp = tempfile::tempdir().expect("temp dir should exist");
+        let install_root = tmp.path().join("install-root");
+        let active_app_dir = install_root.join("app");
+        let package_path = tmp.path().join("package.tar.zst");
+        let environment = BTreeMap::new();
+        let shortcuts = [ShortcutLocation::Desktop];
+        let persistent_assets = vec![".surge".to_string()];
+        let old_runtime_manifest = "id: demo-app\nversion: 1.0.0\nchannel: stable\n";
+        let new_runtime_manifest = "id: demo-app\nversion: 1.1.0\nchannel: beta\n";
+
+        std::fs::create_dir_all(active_app_dir.join(".surge")).expect(".surge dir should exist");
+        std::fs::write(
+            active_app_dir.join(RUNTIME_MANIFEST_RELATIVE_PATH),
+            old_runtime_manifest,
+        )
+        .expect("old runtime manifest should exist");
+        std::fs::write(
+            active_app_dir.join(LEGACY_RUNTIME_MANIFEST_RELATIVE_PATH),
+            old_runtime_manifest,
+        )
+        .expect("old legacy runtime manifest should exist");
+        std::fs::write(active_app_dir.join("payload.txt"), "old payload").expect("old payload should exist");
+
+        let mut packer = ArchivePacker::new(3).expect("archive packer should be created");
+        packer
+            .add_buffer(RUNTIME_MANIFEST_RELATIVE_PATH, new_runtime_manifest.as_bytes(), 0o644)
+            .expect("runtime manifest should be added");
+        packer
+            .add_buffer(
+                LEGACY_RUNTIME_MANIFEST_RELATIVE_PATH,
+                new_runtime_manifest.as_bytes(),
+                0o644,
+            )
+            .expect("legacy runtime manifest should be added");
+        packer
+            .add_buffer("payload.txt", b"new payload", 0o644)
+            .expect("payload should be added");
+        packer
+            .finalize_to_file(&package_path)
+            .expect("archive should be written");
+
+        let profile = InstallProfile::new(
+            "demo-app",
+            "Demo App",
+            "",
+            "demo-install",
+            "",
+            "",
+            &shortcuts,
+            &persistent_assets,
+            &environment,
+        );
+
+        let err = install_package_locally_at_root(&profile, &package_path, &install_root)
+            .expect_err("install should fail before shortcut creation");
+        assert!(
+            matches!(err, SurgeError::Config(ref message) if message.contains("shortcuts configured")),
+            "unexpected error: {err}"
+        );
+        assert_eq!(
+            std::fs::read_to_string(active_app_dir.join(RUNTIME_MANIFEST_RELATIVE_PATH))
+                .expect("runtime manifest should exist"),
+            new_runtime_manifest
+        );
+        assert_eq!(
+            std::fs::read_to_string(active_app_dir.join(LEGACY_RUNTIME_MANIFEST_RELATIVE_PATH))
+                .expect("legacy runtime manifest should exist"),
+            new_runtime_manifest
+        );
+        assert_eq!(
+            std::fs::read_to_string(active_app_dir.join("payload.txt")).expect("payload should exist"),
+            "new payload"
         );
     }
 }


### PR DESCRIPTION
## Summary
- restore the newly activated runtime manifests when local install work fails after persistent asset migration
- ignore non-version `app-*` directories when choosing a remote legacy install source
- add regression coverage for both follow-up edge cases

## Why
The persistent-asset migration follow-up in PR #45 still had two unsafe edge cases.

## Root Cause
- local installs could copy `.surge` from the previous app over the freshly activated app, then return an error before callers rewrote runtime metadata
- remote legacy detection accepted any `app-*` directory name instead of only version snapshots

## Impact
- failed local installs keep the new app active without reporting the previous version or channel
- remote installs skip unrelated directories such as `app-backup` when deciding whether to carry persistent assets forward

## Validation
- `./scripts/sync-surge-core-vendor.sh --check`
- `./scripts/check-version-sync.sh`
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo test --workspace`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo clippy --workspace --lib --bins --examples -- -D warnings -D clippy::unwrap_used -D clippy::expect_used`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings -W clippy::pedantic`
- `dotnet format dotnet/Surge.slnx --verify-no-changes`
- `dotnet test dotnet/Surge.slnx --configuration Release`
