### PR TITLE
fix staged tailscale installs

### DIFF
--- a/crates/surge-bench/src/runner.rs
+++ b/crates/surge-bench/src/runner.rs
@@ -226,6 +226,7 @@ fn installer_manifest(
         },
         release: InstallerRelease {
             full_filename: full_filename.to_string(),
+            full_sha256: String::new(),
             delta_filename: String::new(),
             delta_algorithm: String::new(),
             delta_patch_format: String::new(),

--- a/crates/surge-cli/src/commands/install.rs
+++ b/crates/surge-cli/src/commands/install.rs
@@ -41,19 +41,24 @@ pub struct InstallBehavior {
     pub plan_only: bool,
     pub no_start: bool,
     pub force: bool,
-    pub stage: StageBehavior,
+    pub mode: InstallMode,
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-pub enum StageBehavior {
+pub enum InstallMode {
     #[default]
     Install,
     StageOnly,
+    VerifyStage,
 }
 
-impl StageBehavior {
+impl InstallMode {
     fn is_stage(self) -> bool {
         matches!(self, Self::StageOnly)
+    }
+
+    fn is_verify_stage(self) -> bool {
+        matches!(self, Self::VerifyStage)
     }
 }
 
@@ -135,7 +140,50 @@ enum RemoteInstallerMode {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum RemoteTailscaleTransferStrategy {
     AppCopy,
+    StagedInstallerCache,
     Installer { prefer_published: bool },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RemoteHostInstallerAvailability {
+    Available,
+    Unavailable,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RemoteTailscaleOperation {
+    Stage,
+    Install,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RemoteTailscaleCachedState {
+    None,
+    AppCopyPayload,
+    InstallerCache,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum VerifiedRemoteStage {
+    AppCopyPayload,
+    InstallerCache,
+}
+
+impl VerifiedRemoteStage {
+    fn description(self) -> &'static str {
+        match self {
+            Self::AppCopyPayload => "staged app payload",
+            Self::InstallerCache => "staged installer cache",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct RemoteTailscaleTransferInputs {
+    host_installer_availability: RemoteHostInstallerAvailability,
+    installer_mode: RemoteInstallerMode,
+    operation: RemoteTailscaleOperation,
+    cached_state: RemoteTailscaleCachedState,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -413,6 +461,39 @@ pub async fn execute(
         )));
     }
 
+    if behavior.mode.is_verify_stage() {
+        match &install_target {
+            InstallTarget::Local => {
+                return Err(SurgeError::Config(
+                    "--verify-stage requires 'tailscale' install method".to_string(),
+                ));
+            }
+            InstallTarget::Tailscale {
+                ssh_target,
+                file_target,
+            } => {
+                let verified_stage = verify_remote_stage_readiness(
+                    ssh_target,
+                    file_target,
+                    &app_id,
+                    &selected_rid,
+                    release,
+                    &channel,
+                    &storage_config,
+                )
+                .await?;
+                logline::success(&format!(
+                    "Verified {} is ready for '{}' v{} on '{}'.",
+                    verified_stage.description(),
+                    app_id,
+                    release.version,
+                    file_target
+                ));
+                return Ok(());
+            }
+        }
+    }
+
     if behavior.plan_only {
         match &install_target {
             InstallTarget::Local => {
@@ -532,21 +613,42 @@ pub async fn execute(
                     );
                 }
                 let host_can_build_installer = host_can_build_installer_locally(&selected_rid);
-                let has_matching_pre_staged_payload = if host_can_build_installer
+                let has_matching_pre_staged_app_copy_payload = if host_can_build_installer
                     && installer_mode == RemoteInstallerMode::Offline
-                    && !behavior.stage.is_stage()
+                    && !behavior.mode.is_stage()
                 {
                     remote_staged_payload_matches_release(ssh_target, &app_id, release, &channel, &storage_config)
                         .await?
                 } else {
                     false
                 };
-                let transfer_strategy = select_remote_tailscale_transfer_strategy(
-                    host_can_build_installer,
+                let has_matching_pre_staged_installer_cache =
+                    if installer_mode == RemoteInstallerMode::Online && !behavior.mode.is_stage() {
+                        remote_staged_installer_matches_release(ssh_target, &app_id, release, &channel, &storage_config)
+                            .await?
+                    } else {
+                        false
+                    };
+                let transfer_strategy = select_remote_tailscale_transfer_strategy(RemoteTailscaleTransferInputs {
+                    host_installer_availability: if host_can_build_installer {
+                        RemoteHostInstallerAvailability::Available
+                    } else {
+                        RemoteHostInstallerAvailability::Unavailable
+                    },
                     installer_mode,
-                    behavior.stage.is_stage(),
-                    has_matching_pre_staged_payload,
-                );
+                    operation: if behavior.mode.is_stage() {
+                        RemoteTailscaleOperation::Stage
+                    } else {
+                        RemoteTailscaleOperation::Install
+                    },
+                    cached_state: if has_matching_pre_staged_installer_cache {
+                        RemoteTailscaleCachedState::InstallerCache
+                    } else if has_matching_pre_staged_app_copy_payload {
+                        RemoteTailscaleCachedState::AppCopyPayload
+                    } else {
+                        RemoteTailscaleCachedState::None
+                    },
+                });
                 if matches!(transfer_strategy, RemoteTailscaleTransferStrategy::AppCopy) {
                     deploy_remote_app_copy_for_tailscale(
                         &*backend,
@@ -563,13 +665,13 @@ pub async fn execute(
                         &rid_candidates,
                         full_filename,
                         behavior.no_start,
-                        behavior.stage.is_stage(),
+                        behavior.mode.is_stage(),
                     )
                     .await?;
-                    if !behavior.stage.is_stage() {
+                    if !behavior.mode.is_stage() {
                         warn_if_remote_stage_cleanup_fails(ssh_target, &app_id, release).await;
                     }
-                    if behavior.stage.is_stage() {
+                    if behavior.mode.is_stage() {
                         logline::success(&format!(
                             "Staged '{app_id}' v{} on tailscale node '{file_target}'.",
                             release.version
@@ -577,6 +679,12 @@ pub async fn execute(
                     } else {
                         logline::success(&format!("Installed '{app_id}' on tailscale node '{file_target}'."));
                     }
+                    return Ok(());
+                }
+                if matches!(transfer_strategy, RemoteTailscaleTransferStrategy::StagedInstallerCache) {
+                    run_remote_staged_installer_setup(ssh_target, file_target, &app_id, release, behavior.no_start)
+                        .await?;
+                    logline::success(&format!("Installed '{app_id}' on tailscale node '{file_target}'."));
                     return Ok(());
                 }
                 let published_installer_plan = if let Some(manifest) = manifest.as_ref() {
@@ -705,20 +813,20 @@ pub async fn execute(
                 .await?;
 
                 let no_start_flag = if behavior.no_start { " --no-start" } else { "" };
-                let stage_flag = if behavior.stage.is_stage() { " --stage" } else { "" };
+                let stage_flag = if behavior.mode.is_stage() { " --stage" } else { "" };
                 let run_cmd =
                     format!("/tmp/.surge-installer{no_start_flag}{stage_flag} && rm -f /tmp/.surge-installer");
                 let ssh_command = format!("sh -lc {}", shell_single_quote(&run_cmd));
-                if behavior.stage.is_stage() {
+                if behavior.mode.is_stage() {
                     logline::info(&format!("Running installer in stage mode on '{file_target}'..."));
                 } else {
                     logline::info(&format!("Running installer on '{file_target}'..."));
                 }
                 run_tailscale_streaming(&["ssh", ssh_target, ssh_command.as_str()], "remote").await?;
-                if !behavior.stage.is_stage() {
+                if !behavior.mode.is_stage() {
                     warn_if_remote_stage_cleanup_fails(ssh_target, &app_id, release).await;
                 }
-                if behavior.stage.is_stage() {
+                if behavior.mode.is_stage() {
                     logline::success(&format!(
                         "Staged '{app_id}' v{} on tailscale node '{file_target}'.",
                         release.version
@@ -2009,6 +2117,7 @@ fn build_remote_installer_manifest(
         },
         release: InstallerRelease {
             full_filename: release.full_filename.clone(),
+            full_sha256: release.full_sha256.clone(),
             delta_filename: String::new(),
             delta_algorithm: String::new(),
             delta_patch_format: String::new(),
@@ -2692,19 +2801,23 @@ fn select_remote_installer_mode(storage_config: &surge_core::context::StorageCon
     }
 }
 
-fn select_remote_tailscale_transfer_strategy(
-    host_can_build_installer: bool,
-    installer_mode: RemoteInstallerMode,
-    stage: bool,
-    has_matching_pre_staged_payload: bool,
-) -> RemoteTailscaleTransferStrategy {
-    if !host_can_build_installer
-        || matches!(installer_mode, RemoteInstallerMode::Offline) && (stage || has_matching_pre_staged_payload)
+fn select_remote_tailscale_transfer_strategy(inputs: RemoteTailscaleTransferInputs) -> RemoteTailscaleTransferStrategy {
+    if inputs.operation == RemoteTailscaleOperation::Install
+        && inputs.installer_mode == RemoteInstallerMode::Online
+        && inputs.cached_state == RemoteTailscaleCachedState::InstallerCache
+    {
+        return RemoteTailscaleTransferStrategy::StagedInstallerCache;
+    }
+
+    if inputs.host_installer_availability == RemoteHostInstallerAvailability::Unavailable
+        || matches!(inputs.installer_mode, RemoteInstallerMode::Offline)
+            && (inputs.operation == RemoteTailscaleOperation::Stage
+                || inputs.cached_state == RemoteTailscaleCachedState::AppCopyPayload)
     {
         RemoteTailscaleTransferStrategy::AppCopy
     } else {
         RemoteTailscaleTransferStrategy::Installer {
-            prefer_published: !stage,
+            prefer_published: inputs.operation == RemoteTailscaleOperation::Install,
         }
     }
 }
@@ -2897,6 +3010,21 @@ async fn check_remote_staged_payload_identity(
     }
 }
 
+async fn check_remote_staged_installer_identity(
+    ssh_node: &str,
+    install_root: &Path,
+) -> Option<RemoteStagedPayloadIdentity> {
+    let probe = format!(
+        "cat {}/.surge-cache/staged-installer/.surge-staged-release.json 2>/dev/null",
+        shell_single_quote(&install_root.to_string_lossy())
+    );
+    let command = format!("sh -c {}", shell_single_quote(&probe));
+    match run_tailscale_capture(&["ssh", ssh_node, command.as_str()]).await {
+        Ok(output) => parse_remote_staged_payload_identity(&output),
+        Err(_) => None,
+    }
+}
+
 async fn remote_staged_payload_matches_release(
     ssh_node: &str,
     app_id: &str,
@@ -2908,6 +3036,98 @@ async fn remote_staged_payload_matches_release(
     let install_root = remote_install_root(&remote_home, app_id, &release.install_directory)?;
     let expected = remote_staged_payload_identity(app_id, release, channel, storage_config);
     Ok(check_remote_staged_payload_identity(ssh_node, &install_root).await == Some(expected))
+}
+
+async fn remote_staged_installer_matches_release(
+    ssh_node: &str,
+    app_id: &str,
+    release: &ReleaseEntry,
+    channel: &str,
+    storage_config: &surge_core::context::StorageConfig,
+) -> Result<bool> {
+    let remote_home = detect_remote_home_directory(ssh_node).await?;
+    let install_root = remote_install_root(&remote_home, app_id, &release.install_directory)?;
+    let expected = remote_staged_payload_identity(app_id, release, channel, storage_config);
+    Ok(check_remote_staged_installer_identity(ssh_node, &install_root).await == Some(expected))
+}
+
+async fn verify_remote_stage_readiness(
+    ssh_node: &str,
+    file_target: &str,
+    app_id: &str,
+    selected_rid: &str,
+    release: &ReleaseEntry,
+    channel: &str,
+    storage_config: &surge_core::context::StorageConfig,
+) -> Result<VerifiedRemoteStage> {
+    let remote_home = detect_remote_home_directory(ssh_node).await?;
+    let install_root = remote_install_root(&remote_home, app_id, &release.install_directory)?;
+    let expected = remote_staged_payload_identity(app_id, release, channel, storage_config);
+    let app_copy_matches =
+        check_remote_staged_payload_identity(ssh_node, &install_root).await == Some(expected.clone());
+    let app_copy_ready = if app_copy_matches {
+        remote_staged_app_copy_files_exist(ssh_node, &install_root).await?
+    } else {
+        false
+    };
+    let installer_cache_matches =
+        check_remote_staged_installer_identity(ssh_node, &install_root).await == Some(expected.clone());
+    let installer_cache_ready = if installer_cache_matches {
+        remote_staged_installer_cache_files_exist(ssh_node, &install_root, release).await?
+    } else {
+        false
+    };
+
+    match select_remote_installer_mode(storage_config) {
+        RemoteInstallerMode::Offline => {
+            if app_copy_ready {
+                return Ok(VerifiedRemoteStage::AppCopyPayload);
+            }
+        }
+        RemoteInstallerMode::Online => {
+            if installer_cache_ready {
+                return Ok(VerifiedRemoteStage::InstallerCache);
+            }
+            if !host_can_build_installer_locally(selected_rid) && app_copy_ready {
+                return Ok(VerifiedRemoteStage::AppCopyPayload);
+            }
+        }
+    }
+
+    let selected_rid = if selected_rid.trim().is_empty() {
+        "<generic>"
+    } else {
+        selected_rid
+    };
+    if app_copy_matches || installer_cache_matches {
+        return Err(SurgeError::NotFound(format!(
+            "Node '{file_target}' has a staged marker for '{app_id}' v{} on channel '{channel}' (rid '{selected_rid}'), but the staged payload is incomplete or would not be reused by the next install from this host.",
+            release.version
+        )));
+    }
+
+    Err(SurgeError::NotFound(format!(
+        "Node '{file_target}' is not staged for '{app_id}' v{} on channel '{channel}' (rid '{selected_rid}').",
+        release.version
+    )))
+}
+
+async fn run_remote_staged_installer_setup(
+    ssh_node: &str,
+    file_target: &str,
+    app_id: &str,
+    release: &ReleaseEntry,
+    no_start: bool,
+) -> Result<()> {
+    let remote_home = detect_remote_home_directory(ssh_node).await?;
+    let install_root = remote_install_root(&remote_home, app_id, &release.install_directory)?;
+    let setup_command = build_remote_staged_installer_setup_command(&install_root, no_start);
+    let ssh_command = format!("sh -lc {}", shell_single_quote(&setup_command));
+    logline::info(&format!(
+        "Using pre-staged installer cache for '{app_id}' v{} on '{file_target}'.",
+        release.version
+    ));
+    run_tailscale_streaming(&["ssh", ssh_node, ssh_command.as_str()], "remote").await
 }
 
 async fn warn_if_remote_stage_cleanup_fails(ssh_node: &str, app_id: &str, release: &ReleaseEntry) {
@@ -2944,6 +3164,64 @@ fn build_remote_stage_cleanup_command(install_root: &Path) -> String {
     )
 }
 
+async fn remote_staged_app_copy_files_exist(ssh_node: &str, install_root: &Path) -> Result<bool> {
+    let stage_root = install_root.join(".surge-transfer-stage");
+    let marker = stage_root.join(".surge-staged-release.json");
+    let app_dir = stage_root.join("app");
+    remote_paths_exist(ssh_node, &[app_dir.as_path()], &[marker.as_path()]).await
+}
+
+async fn remote_staged_installer_cache_files_exist(
+    ssh_node: &str,
+    install_root: &Path,
+    release: &ReleaseEntry,
+) -> Result<bool> {
+    let stage_dir = install_root.join(".surge-cache").join("staged-installer");
+    let marker = stage_dir.join(".surge-staged-release.json");
+    let installer_manifest = stage_dir.join("installer.yml");
+    let surge_bin = stage_dir.join("surge");
+    let artifact_cache_dir = install_root.join(".surge-cache").join("artifacts");
+    let cached_package = cache_path_for_key(&artifact_cache_dir, release.full_filename.trim())?;
+    remote_paths_exist(
+        ssh_node,
+        &[stage_dir.as_path()],
+        &[
+            marker.as_path(),
+            installer_manifest.as_path(),
+            surge_bin.as_path(),
+            cached_package.as_path(),
+        ],
+    )
+    .await
+}
+
+async fn remote_paths_exist(ssh_node: &str, required_dirs: &[&Path], required_files: &[&Path]) -> Result<bool> {
+    let probe = build_remote_paths_exist_probe(required_dirs, required_files);
+    let command = format!("sh -c {}", shell_single_quote(&probe));
+    Ok(run_tailscale_capture(&["ssh", ssh_node, command.as_str()])
+        .await?
+        .trim()
+        == "ready")
+}
+
+fn build_remote_paths_exist_probe(required_dirs: &[&Path], required_files: &[&Path]) -> String {
+    let mut checks = Vec::new();
+    for path in required_dirs {
+        checks.push(format!("[ -d {} ]", shell_single_quote(&path.to_string_lossy())));
+    }
+    for path in required_files {
+        checks.push(format!("[ -f {} ]", shell_single_quote(&path.to_string_lossy())));
+    }
+    if checks.is_empty() {
+        "printf 'ready'".to_string()
+    } else {
+        format!(
+            "if {}; then printf 'ready'; else printf 'missing'; fi",
+            checks.join(" && ")
+        )
+    }
+}
+
 fn build_remote_stop_supervisor_command(install_root: &Path, supervisor_id: &str) -> Option<String> {
     let supervisor_id = supervisor_id.trim();
     if supervisor_id.is_empty() {
@@ -2965,6 +3243,23 @@ done",
         shell_single_quote(&install_root.to_string_lossy()),
         shell_single_quote(supervisor_id)
     ))
+}
+
+fn build_remote_staged_installer_setup_command(install_root: &Path, no_start: bool) -> String {
+    let no_start_flag = if no_start { " --no-start" } else { "" };
+    format!(
+        "install_root={}; \
+stage_dir=\"$install_root/.surge-cache/staged-installer\"; \
+surge_bin=\"$stage_dir/surge\"; \
+if [ ! -d \"$stage_dir\" ] || [ ! -f \"$stage_dir/installer.yml\" ] || [ ! -f \"$surge_bin\" ]; then \
+  echo \"Remote staged installer cache is missing required files\" >&2; \
+  exit 1; \
+fi; \
+chmod +x \"$surge_bin\" || true; \
+cd \"$stage_dir\"; \
+\"$surge_bin\" setup \"$stage_dir\"{no_start_flag}",
+        shell_single_quote(&install_root.to_string_lossy())
+    )
 }
 
 async fn detect_remote_launch_environment(ssh_node: &str) -> RemoteLaunchEnvironment {
@@ -3559,15 +3854,30 @@ mod tests {
     #[test]
     fn select_remote_tailscale_transfer_strategy_uses_app_copy_when_stage_reduces_transfer() {
         assert_eq!(
-            select_remote_tailscale_transfer_strategy(true, RemoteInstallerMode::Offline, true, false),
+            select_remote_tailscale_transfer_strategy(RemoteTailscaleTransferInputs {
+                host_installer_availability: RemoteHostInstallerAvailability::Available,
+                installer_mode: RemoteInstallerMode::Offline,
+                operation: RemoteTailscaleOperation::Stage,
+                cached_state: RemoteTailscaleCachedState::None,
+            }),
             RemoteTailscaleTransferStrategy::AppCopy
         );
         assert_eq!(
-            select_remote_tailscale_transfer_strategy(true, RemoteInstallerMode::Offline, false, true),
+            select_remote_tailscale_transfer_strategy(RemoteTailscaleTransferInputs {
+                host_installer_availability: RemoteHostInstallerAvailability::Available,
+                installer_mode: RemoteInstallerMode::Offline,
+                operation: RemoteTailscaleOperation::Install,
+                cached_state: RemoteTailscaleCachedState::AppCopyPayload,
+            }),
             RemoteTailscaleTransferStrategy::AppCopy
         );
         assert_eq!(
-            select_remote_tailscale_transfer_strategy(false, RemoteInstallerMode::Online, false, false),
+            select_remote_tailscale_transfer_strategy(RemoteTailscaleTransferInputs {
+                host_installer_availability: RemoteHostInstallerAvailability::Unavailable,
+                installer_mode: RemoteInstallerMode::Online,
+                operation: RemoteTailscaleOperation::Install,
+                cached_state: RemoteTailscaleCachedState::None,
+            }),
             RemoteTailscaleTransferStrategy::AppCopy
         );
     }
@@ -3575,14 +3885,37 @@ mod tests {
     #[test]
     fn select_remote_tailscale_transfer_strategy_disables_published_installers_for_stage_mode() {
         assert_eq!(
-            select_remote_tailscale_transfer_strategy(true, RemoteInstallerMode::Online, true, false),
+            select_remote_tailscale_transfer_strategy(RemoteTailscaleTransferInputs {
+                host_installer_availability: RemoteHostInstallerAvailability::Available,
+                installer_mode: RemoteInstallerMode::Online,
+                operation: RemoteTailscaleOperation::Stage,
+                cached_state: RemoteTailscaleCachedState::None,
+            }),
             RemoteTailscaleTransferStrategy::Installer {
                 prefer_published: false
             }
         );
         assert_eq!(
-            select_remote_tailscale_transfer_strategy(true, RemoteInstallerMode::Online, false, false),
+            select_remote_tailscale_transfer_strategy(RemoteTailscaleTransferInputs {
+                host_installer_availability: RemoteHostInstallerAvailability::Available,
+                installer_mode: RemoteInstallerMode::Online,
+                operation: RemoteTailscaleOperation::Install,
+                cached_state: RemoteTailscaleCachedState::None,
+            }),
             RemoteTailscaleTransferStrategy::Installer { prefer_published: true }
+        );
+    }
+
+    #[test]
+    fn select_remote_tailscale_transfer_strategy_prefers_staged_online_installer_cache() {
+        assert_eq!(
+            select_remote_tailscale_transfer_strategy(RemoteTailscaleTransferInputs {
+                host_installer_availability: RemoteHostInstallerAvailability::Available,
+                installer_mode: RemoteInstallerMode::Online,
+                operation: RemoteTailscaleOperation::Install,
+                cached_state: RemoteTailscaleCachedState::InstallerCache,
+            }),
+            RemoteTailscaleTransferStrategy::StagedInstallerCache
         );
     }
 
@@ -3594,6 +3927,30 @@ mod tests {
             command,
             "install_root='/home/demo/apps/customer'\"'\"'s app'; rm -rf \"$install_root/.surge-transfer-stage\""
         );
+    }
+
+    #[test]
+    fn build_remote_staged_installer_setup_command_quotes_install_root() {
+        let command = build_remote_staged_installer_setup_command(Path::new("/home/demo/apps/customer's app"), true);
+
+        assert!(command.contains("install_root='/home/demo/apps/customer'\"'\"'s app'"));
+        assert!(command.contains("stage_dir=\"$install_root/.surge-cache/staged-installer\""));
+        assert!(command.contains("\"$surge_bin\" setup \"$stage_dir\" --no-start"));
+    }
+
+    #[test]
+    fn build_remote_paths_exist_probe_quotes_paths() {
+        let dir = Path::new("/home/demo/apps/customer's app/.surge-transfer-stage/app");
+        let file = Path::new("/home/demo/apps/customer's app/.surge-transfer-stage/.surge-staged-release.json");
+
+        let probe = build_remote_paths_exist_probe(&[dir], &[file]);
+
+        assert!(probe.contains("[ -d '/home/demo/apps/customer'\"'\"'s app/.surge-transfer-stage/app' ]"));
+        assert!(probe.contains(
+            "[ -f '/home/demo/apps/customer'\"'\"'s app/.surge-transfer-stage/.surge-staged-release.json' ]"
+        ));
+        assert!(probe.contains("printf 'ready'"));
+        assert!(probe.contains("printf 'missing'"));
     }
 
     #[test]
@@ -3727,6 +4084,7 @@ mod tests {
             },
             release: InstallerRelease {
                 full_filename: "demo.tar.zst".to_string(),
+                full_sha256: String::new(),
                 delta_filename: String::new(),
                 delta_algorithm: String::new(),
                 delta_patch_format: String::new(),
@@ -3920,7 +4278,7 @@ mod tests {
                 plan_only: false,
                 no_start: true,
                 force: false,
-                stage: StageBehavior::Install,
+                mode: InstallMode::Install,
             },
             &download_dir,
             StorageOverrides::default(),

--- a/crates/surge-cli/src/commands/install.rs
+++ b/crates/surge-cli/src/commands/install.rs
@@ -10,6 +10,7 @@ use std::time::Instant;
 use crate::logline;
 use crate::prompts;
 use indicatif::{ProgressBar, ProgressStyle};
+use serde::{Deserialize, Serialize};
 use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncReadExt, AsyncWriteExt, BufReader};
 use tokio::process::Command;
 
@@ -154,6 +155,22 @@ struct AppInstallTargetOption {
 struct RemoteInstallState {
     version: String,
     channel: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct RemoteStagedPayloadIdentity {
+    app_id: String,
+    version: String,
+    channel: String,
+    rid: String,
+    full_filename: String,
+    full_sha256: String,
+    install_directory: String,
+    supervisor_id: String,
+    storage_provider: String,
+    storage_bucket: String,
+    storage_region: String,
+    storage_endpoint: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -515,11 +532,12 @@ pub async fn execute(
                     );
                 }
                 let host_can_build_installer = host_can_build_installer_locally(&selected_rid);
-                let has_matching_pre_staged_version = if host_can_build_installer
+                let has_matching_pre_staged_payload = if host_can_build_installer
                     && installer_mode == RemoteInstallerMode::Offline
                     && !behavior.stage.is_stage()
                 {
-                    remote_staged_version_matches_release(ssh_target, &app_id, release).await?
+                    remote_staged_payload_matches_release(ssh_target, &app_id, release, &channel, &storage_config)
+                        .await?
                 } else {
                     false
                 };
@@ -527,7 +545,7 @@ pub async fn execute(
                     host_can_build_installer,
                     installer_mode,
                     behavior.stage.is_stage(),
-                    has_matching_pre_staged_version,
+                    has_matching_pre_staged_payload,
                 );
                 if matches!(transfer_strategy, RemoteTailscaleTransferStrategy::AppCopy) {
                     deploy_remote_app_copy_for_tailscale(
@@ -2531,6 +2549,7 @@ async fn deploy_remote_app_copy_for_tailscale(
     let install_root = remote_install_root(&remote_home, app_id, &release.install_directory)?;
     let active_app_dir = install_root.join("app");
     let runtime_environment = build_remote_runtime_environment(release, launch_env);
+    let staged_payload_identity = remote_staged_payload_identity(app_id, release, channel, storage_config);
     let main_exe_name = if release.main_exe.trim().is_empty() {
         app_id
     } else {
@@ -2540,13 +2559,14 @@ async fn deploy_remote_app_copy_for_tailscale(
     // When not staging, check if a previous --stage run already transferred
     // the correct version. If so, skip re-transfer and go straight to activation.
     if !stage
-        && let Some(staged_version) = check_remote_staged_version(ssh_target, &install_root).await
-        && staged_version == release.version
+        && let Some(remote_staged_payload) = check_remote_staged_payload_identity(ssh_target, &install_root).await
+        && remote_staged_payload == staged_payload_identity
     {
         logline::success(&format!(
             "Using pre-staged payload for '{app_id}' v{} on '{file_target}'.",
             release.version
         ));
+        stop_remote_supervisor_if_running(ssh_target, &install_root, &release.supervisor_id).await?;
         let legacy_app_dir = if release.persistent_assets.is_empty() {
             None
         } else {
@@ -2602,6 +2622,11 @@ async fn deploy_remote_app_copy_for_tailscale(
     let install_profile = release_install_profile(app_id, release);
     let runtime_manifest = release_runtime_manifest_metadata(release, channel, storage_config);
     core_install::write_runtime_manifest(&stage_app_dir, &install_profile, &runtime_manifest)?;
+    std::fs::write(
+        stage_root.join(".surge-staged-release.json"),
+        serde_json::to_vec(&staged_payload_identity)
+            .map_err(|e| SurgeError::Config(format!("Failed to serialize remote staged payload identity: {e}")))?,
+    )?;
     let legacy_app_dir = if release.persistent_assets.is_empty() {
         None
     } else {
@@ -2636,17 +2661,10 @@ mkdir -p \"$install_root\"; rm -rf \"$stage_dir\"; mkdir -p \"$stage_dir\"; tar 
     stream_directory_to_tailscale_node_with_command(ssh_target, &stage_root, &transfer_command).await?;
 
     if stage {
-        // Write a version marker so the next install can detect what was staged
-        let marker_cmd = format!(
-            "echo {} > {}/.surge-transfer-stage/.surge-staged-version",
-            shell_single_quote(&release.version),
-            shell_single_quote(&install_root.to_string_lossy())
-        );
-        let ssh_command = format!("sh -lc {}", shell_single_quote(&marker_cmd));
-        run_tailscale_streaming(&["ssh", ssh_target, ssh_command.as_str()], "remote").await?;
         return Ok(());
     }
 
+    stop_remote_supervisor_if_running(ssh_target, &install_root, &release.supervisor_id).await?;
     let activation_script = build_remote_app_copy_activation_script(
         &install_root,
         main_exe_name,
@@ -2678,10 +2696,10 @@ fn select_remote_tailscale_transfer_strategy(
     host_can_build_installer: bool,
     installer_mode: RemoteInstallerMode,
     stage: bool,
-    has_matching_pre_staged_version: bool,
+    has_matching_pre_staged_payload: bool,
 ) -> RemoteTailscaleTransferStrategy {
     if !host_can_build_installer
-        || matches!(installer_mode, RemoteInstallerMode::Offline) && (stage || has_matching_pre_staged_version)
+        || matches!(installer_mode, RemoteInstallerMode::Offline) && (stage || has_matching_pre_staged_payload)
     {
         RemoteTailscaleTransferStrategy::AppCopy
     } else {
@@ -2838,25 +2856,58 @@ fn parse_remote_install_state(output: &str) -> Option<RemoteInstallState> {
     version.map(|version| RemoteInstallState { version, channel })
 }
 
-async fn check_remote_staged_version(ssh_node: &str, install_root: &Path) -> Option<String> {
+fn remote_staged_payload_identity(
+    app_id: &str,
+    release: &ReleaseEntry,
+    channel: &str,
+    storage_config: &surge_core::context::StorageConfig,
+) -> RemoteStagedPayloadIdentity {
+    RemoteStagedPayloadIdentity {
+        app_id: app_id.trim().to_string(),
+        version: release.version.trim().to_string(),
+        channel: channel.trim().to_string(),
+        rid: release.rid.trim().to_string(),
+        full_filename: release.full_filename.trim().to_string(),
+        full_sha256: release.full_sha256.trim().to_string(),
+        install_directory: release.install_directory.trim().to_string(),
+        supervisor_id: release.supervisor_id.trim().to_string(),
+        storage_provider: core_install::storage_provider_manifest_name(storage_config.provider).to_string(),
+        storage_bucket: storage_config.bucket.trim().to_string(),
+        storage_region: storage_config.region.trim().to_string(),
+        storage_endpoint: storage_config.endpoint.trim().to_string(),
+    }
+}
+
+fn parse_remote_staged_payload_identity(output: &str) -> Option<RemoteStagedPayloadIdentity> {
+    serde_json::from_str(output.trim()).ok()
+}
+
+async fn check_remote_staged_payload_identity(
+    ssh_node: &str,
+    install_root: &Path,
+) -> Option<RemoteStagedPayloadIdentity> {
     let probe = format!(
-        "cat {}/.surge-transfer-stage/.surge-staged-version 2>/dev/null",
+        "cat {}/.surge-transfer-stage/.surge-staged-release.json 2>/dev/null",
         shell_single_quote(&install_root.to_string_lossy())
     );
     let command = format!("sh -c {}", shell_single_quote(&probe));
     match run_tailscale_capture(&["ssh", ssh_node, command.as_str()]).await {
-        Ok(output) => {
-            let version = output.trim().to_string();
-            if version.is_empty() { None } else { Some(version) }
-        }
+        Ok(output) => parse_remote_staged_payload_identity(&output),
         Err(_) => None,
     }
 }
 
-async fn remote_staged_version_matches_release(ssh_node: &str, app_id: &str, release: &ReleaseEntry) -> Result<bool> {
+async fn remote_staged_payload_matches_release(
+    ssh_node: &str,
+    app_id: &str,
+    release: &ReleaseEntry,
+    channel: &str,
+    storage_config: &surge_core::context::StorageConfig,
+) -> Result<bool> {
     let remote_home = detect_remote_home_directory(ssh_node).await?;
     let install_root = remote_install_root(&remote_home, app_id, &release.install_directory)?;
-    Ok(check_remote_staged_version(ssh_node, &install_root).await.as_deref() == Some(release.version.as_str()))
+    let expected = remote_staged_payload_identity(app_id, release, channel, storage_config);
+    Ok(check_remote_staged_payload_identity(ssh_node, &install_root).await == Some(expected))
 }
 
 async fn warn_if_remote_stage_cleanup_fails(ssh_node: &str, app_id: &str, release: &ReleaseEntry) {
@@ -2873,11 +2924,47 @@ async fn cleanup_remote_staged_payload(ssh_node: &str, app_id: &str, release: &R
     run_tailscale_streaming(&["ssh", ssh_node, ssh_command.as_str()], "remote").await
 }
 
+async fn stop_remote_supervisor_if_running(ssh_node: &str, install_root: &Path, supervisor_id: &str) -> Result<()> {
+    let Some(stop_command) = build_remote_stop_supervisor_command(install_root, supervisor_id) else {
+        return Ok(());
+    };
+
+    logline::info(&format!(
+        "Stopping remote supervisor '{}' before activation...",
+        supervisor_id.trim()
+    ));
+    let ssh_command = format!("sh -lc {}", shell_single_quote(&stop_command));
+    run_tailscale_streaming(&["ssh", ssh_node, ssh_command.as_str()], "remote").await
+}
+
 fn build_remote_stage_cleanup_command(install_root: &Path) -> String {
     format!(
         "install_root={}; rm -rf \"$install_root/.surge-transfer-stage\"",
         shell_single_quote(&install_root.to_string_lossy())
     )
+}
+
+fn build_remote_stop_supervisor_command(install_root: &Path, supervisor_id: &str) -> Option<String> {
+    let supervisor_id = supervisor_id.trim();
+    if supervisor_id.is_empty() {
+        return None;
+    }
+
+    Some(format!(
+        "install_root={}; supervisor_id={}; pid_file=\"$install_root/.surge-supervisor-$supervisor_id.pid\"; \
+if [ ! -d \"$install_root\" ] || [ ! -f \"$pid_file\" ]; then exit 0; fi; \
+pid=\"$(tr -d '[:space:]' < \"$pid_file\")\"; \
+case \"$pid\" in ''|*[!0-9]*) echo \"Invalid PID in supervisor PID file: $pid_file\" >&2; exit 1 ;; esac; \
+kill \"$pid\"; \
+i=0; \
+while [ -f \"$pid_file\" ]; do \
+  if [ \"$i\" -ge 200 ]; then echo \"Timed out waiting for supervisor '$supervisor_id' to exit\" >&2; exit 1; fi; \
+  sleep 0.1; \
+  i=$((i + 1)); \
+done",
+        shell_single_quote(&install_root.to_string_lossy()),
+        shell_single_quote(supervisor_id)
+    ))
 }
 
 async fn detect_remote_launch_environment(ssh_node: &str) -> RemoteLaunchEnvironment {
@@ -3507,6 +3594,50 @@ mod tests {
             command,
             "install_root='/home/demo/apps/customer'\"'\"'s app'; rm -rf \"$install_root/.surge-transfer-stage\""
         );
+    }
+
+    #[test]
+    fn remote_staged_payload_identity_changes_when_channel_or_artifact_changes() {
+        let mut entry = release("1.2.3", "stable", "linux-arm64", "demo.tar.zst");
+        entry.full_sha256 = "sha256-a".to_string();
+        entry.install_directory = "demo".to_string();
+        entry.supervisor_id = "demo-supervisor".to_string();
+
+        let baseline = remote_staged_payload_identity("demo", &entry, "stable", &storage_config("/srv/releases"));
+        let promoted = remote_staged_payload_identity("demo", &entry, "beta", &storage_config("/srv/releases"));
+
+        let mut rebuilt_release = entry.clone();
+        rebuilt_release.full_sha256 = "sha256-b".to_string();
+        let rebuilt =
+            remote_staged_payload_identity("demo", &rebuilt_release, "stable", &storage_config("/srv/releases"));
+
+        assert_ne!(baseline, promoted);
+        assert_ne!(baseline, rebuilt);
+    }
+
+    #[test]
+    fn parse_remote_staged_payload_identity_round_trips_json() {
+        let mut entry = release("1.2.3", "stable", "linux-arm64", "demo.tar.zst");
+        entry.full_sha256 = "sha256-a".to_string();
+        entry.install_directory = "demo".to_string();
+        entry.supervisor_id = "demo-supervisor".to_string();
+
+        let identity = remote_staged_payload_identity("demo", &entry, "stable", &storage_config("/srv/releases"));
+        let encoded = serde_json::to_string(&identity).expect("staged identity should serialize");
+
+        assert_eq!(parse_remote_staged_payload_identity(&encoded), Some(identity));
+        assert_eq!(parse_remote_staged_payload_identity("not-json"), None);
+    }
+
+    #[test]
+    fn build_remote_stop_supervisor_command_quotes_install_root() {
+        let command =
+            build_remote_stop_supervisor_command(Path::new("/home/demo/apps/customer's app"), "demo-supervisor")
+                .expect("supervisor command should exist");
+
+        assert!(command.contains("install_root='/home/demo/apps/customer'\"'\"'s app'"));
+        assert!(command.contains("supervisor_id='demo-supervisor'"));
+        assert!(command.contains("pid_file=\"$install_root/.surge-supervisor-$supervisor_id.pid\""));
     }
 
     #[test]

--- a/crates/surge-cli/src/commands/install.rs
+++ b/crates/surge-cli/src/commands/install.rs
@@ -35,6 +35,27 @@ pub struct StorageOverrides<'a> {
     pub prefix: Option<&'a str>,
 }
 
+#[derive(Debug, Clone, Copy, Default)]
+pub struct InstallBehavior {
+    pub plan_only: bool,
+    pub no_start: bool,
+    pub force: bool,
+    pub stage: StageBehavior,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum StageBehavior {
+    #[default]
+    Install,
+    StageOnly,
+}
+
+impl StageBehavior {
+    fn is_stage(self) -> bool {
+        matches!(self, Self::StageOnly)
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct RuntimeProfile {
     os: String,
@@ -110,6 +131,12 @@ enum RemoteInstallerMode {
     Offline,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RemoteTailscaleTransferStrategy {
+    AppCopy,
+    Installer { prefer_published: bool },
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct InstallSelection {
     app_id: String,
@@ -144,9 +171,7 @@ pub async fn execute(
     channel: Option<&str>,
     rid: Option<&str>,
     version: Option<&str>,
-    plan_only: bool,
-    no_start: bool,
-    force: bool,
+    behavior: InstallBehavior,
     download_dir: &Path,
     overrides: StorageOverrides<'_>,
 ) -> Result<()> {
@@ -371,7 +396,7 @@ pub async fn execute(
         )));
     }
 
-    if plan_only {
+    if behavior.plan_only {
         match &install_target {
             InstallTarget::Local => {
                 logline::warn("Plan only mode: no download performed. Remove --plan-only to fetch the package.");
@@ -431,7 +456,7 @@ pub async fn execute(
                 active_app_dir.display()
             ));
 
-            if !no_start && !plan_only {
+            if !behavior.no_start && !behavior.plan_only {
                 let display_name = release.display_name(&app_id);
                 match auto_start_after_install(release, &app_id, &install_root, &active_app_dir) {
                     Ok(pid) => {
@@ -455,7 +480,7 @@ pub async fn execute(
             };
             let remote_state = check_remote_install_state(ssh_target, install_dir).await;
             let install_matches = remote_install_matches(remote_state.as_ref(), &release.version, &channel);
-            if should_skip_remote_install(install_matches, force) {
+            if should_skip_remote_install(install_matches, behavior.force) {
                 logline::success(&format!(
                     "'{app_id}' v{} ({channel}) is already installed on '{file_target}', skipping.",
                     release.version
@@ -489,7 +514,22 @@ pub async fn execute(
                         "No remote graphical session environment detected; install will default to headless startup.",
                     );
                 }
-                if !host_can_build_installer_locally(&selected_rid) {
+                let host_can_build_installer = host_can_build_installer_locally(&selected_rid);
+                let has_matching_pre_staged_version = if host_can_build_installer
+                    && installer_mode == RemoteInstallerMode::Offline
+                    && !behavior.stage.is_stage()
+                {
+                    remote_staged_version_matches_release(ssh_target, &app_id, release).await?
+                } else {
+                    false
+                };
+                let transfer_strategy = select_remote_tailscale_transfer_strategy(
+                    host_can_build_installer,
+                    installer_mode,
+                    behavior.stage.is_stage(),
+                    has_matching_pre_staged_version,
+                );
+                if matches!(transfer_strategy, RemoteTailscaleTransferStrategy::AppCopy) {
                     deploy_remote_app_copy_for_tailscale(
                         &*backend,
                         &index,
@@ -504,10 +544,18 @@ pub async fn execute(
                         &launch_env,
                         &rid_candidates,
                         full_filename,
-                        no_start,
+                        behavior.no_start,
+                        behavior.stage.is_stage(),
                     )
                     .await?;
-                    logline::success(&format!("Installed '{app_id}' on tailscale node '{file_target}'."));
+                    if behavior.stage.is_stage() {
+                        logline::success(&format!(
+                            "Staged '{app_id}' v{} on tailscale node '{file_target}'.",
+                            release.version
+                        ));
+                    } else {
+                        logline::success(&format!("Installed '{app_id}' on tailscale node '{file_target}'."));
+                    }
                     return Ok(());
                 }
                 let published_installer_plan = if let Some(manifest) = manifest.as_ref() {
@@ -528,22 +576,29 @@ pub async fn execute(
                         installer_mode,
                     )
                 };
-                let installer_path = if let Some(installer_path) = try_prepare_published_installer_for_tailscale(
-                    &*backend,
-                    download_dir,
-                    &published_installer_plan,
-                    &app_id,
-                    release,
-                    &channel,
-                    &storage_config,
-                    &launch_env,
-                    installer_mode,
-                )
-                .await?
-                {
+                let published_installer_path = if matches!(
+                    transfer_strategy,
+                    RemoteTailscaleTransferStrategy::Installer { prefer_published: true }
+                ) {
+                    try_prepare_published_installer_for_tailscale(
+                        &*backend,
+                        download_dir,
+                        &published_installer_plan,
+                        &app_id,
+                        release,
+                        &channel,
+                        &storage_config,
+                        &launch_env,
+                        installer_mode,
+                    )
+                    .await?
+                } else {
+                    None
+                };
+                let installer_path = if let Some(installer_path) = published_installer_path {
                     installer_path
                 } else if installer_mode == RemoteInstallerMode::Offline {
-                    if !host_can_build_installer_locally(&selected_rid) {
+                    if !host_can_build_installer {
                         return Err(missing_remote_installer_error(
                             &selected_rid,
                             &published_installer_plan,
@@ -596,7 +651,7 @@ pub async fn execute(
                         installer_mode,
                     )?
                 } else {
-                    if !host_can_build_installer_locally(&selected_rid) {
+                    if !host_can_build_installer {
                         return Err(missing_remote_installer_error(
                             &selected_rid,
                             &published_installer_plan,
@@ -628,12 +683,25 @@ pub async fn execute(
                 )
                 .await?;
 
-                let no_start_flag = if no_start { " --no-start" } else { "" };
-                let run_cmd = format!("/tmp/.surge-installer{no_start_flag} && rm -f /tmp/.surge-installer");
+                let no_start_flag = if behavior.no_start { " --no-start" } else { "" };
+                let stage_flag = if behavior.stage.is_stage() { " --stage" } else { "" };
+                let run_cmd =
+                    format!("/tmp/.surge-installer{no_start_flag}{stage_flag} && rm -f /tmp/.surge-installer");
                 let ssh_command = format!("sh -lc {}", shell_single_quote(&run_cmd));
-                logline::info(&format!("Running installer on '{file_target}'..."));
+                if behavior.stage.is_stage() {
+                    logline::info(&format!("Running installer in stage mode on '{file_target}'..."));
+                } else {
+                    logline::info(&format!("Running installer on '{file_target}'..."));
+                }
                 run_tailscale_streaming(&["ssh", ssh_target, ssh_command.as_str()], "remote").await?;
-                logline::success(&format!("Installed '{app_id}' on tailscale node '{file_target}'."));
+                if behavior.stage.is_stage() {
+                    logline::success(&format!(
+                        "Staged '{app_id}' v{} on tailscale node '{file_target}'.",
+                        release.version
+                    ));
+                } else {
+                    logline::success(&format!("Installed '{app_id}' on tailscale node '{file_target}'."));
+                }
             }
         }
     }
@@ -2451,7 +2519,47 @@ async fn deploy_remote_app_copy_for_tailscale(
     rid_candidates: &[String],
     full_filename: &str,
     no_start: bool,
+    stage: bool,
 ) -> Result<()> {
+    let remote_home = detect_remote_home_directory(ssh_target).await?;
+    let install_root = remote_install_root(&remote_home, app_id, &release.install_directory)?;
+    let active_app_dir = install_root.join("app");
+    let runtime_environment = build_remote_runtime_environment(release, launch_env);
+    let main_exe_name = if release.main_exe.trim().is_empty() {
+        app_id
+    } else {
+        release.main_exe.trim()
+    };
+
+    // When not staging, check if a previous --stage run already transferred
+    // the correct version. If so, skip re-transfer and go straight to activation.
+    if !stage
+        && let Some(staged_version) = check_remote_staged_version(ssh_target, &install_root).await
+        && staged_version == release.version
+    {
+        logline::success(&format!(
+            "Using pre-staged payload for '{app_id}' v{} on '{file_target}'.",
+            release.version
+        ));
+        let legacy_app_dir = if release.persistent_assets.is_empty() {
+            None
+        } else {
+            detect_remote_legacy_app_dir(ssh_target, &install_root).await?
+        };
+        let activation_script = build_remote_app_copy_activation_script(
+            &install_root,
+            main_exe_name,
+            &release.version,
+            &runtime_environment,
+            &release.persistent_assets,
+            legacy_app_dir.as_deref(),
+            no_start,
+        )?;
+        let ssh_command = format!("sh -lc {}", shell_single_quote(&activation_script));
+        logline::info(&format!("Activating pre-staged install on '{file_target}'..."));
+        return run_tailscale_streaming(&["ssh", ssh_target, ssh_command.as_str()], "remote").await;
+    }
+
     std::fs::create_dir_all(download_dir)?;
     let local_package = download_dir.join(Path::new(full_filename).file_name().unwrap_or_default());
     let acquisition =
@@ -2478,16 +2586,6 @@ async fn deploy_remote_app_copy_for_tailscale(
             ));
         }
     }
-
-    let remote_home = detect_remote_home_directory(ssh_target).await?;
-    let install_root = remote_install_root(&remote_home, app_id, &release.install_directory)?;
-    let active_app_dir = install_root.join("app");
-    let runtime_environment = build_remote_runtime_environment(release, launch_env);
-    let main_exe_name = if release.main_exe.trim().is_empty() {
-        app_id
-    } else {
-        release.main_exe.trim()
-    };
 
     let staging_dir =
         tempfile::tempdir().map_err(|e| SurgeError::Platform(format!("Failed to create staging directory: {e}")))?;
@@ -2531,6 +2629,18 @@ mkdir -p \"$install_root\"; rm -rf \"$stage_dir\"; mkdir -p \"$stage_dir\"; tar 
     ));
     stream_directory_to_tailscale_node_with_command(ssh_target, &stage_root, &transfer_command).await?;
 
+    if stage {
+        // Write a version marker so the next install can detect what was staged
+        let marker_cmd = format!(
+            "echo {} > {}/.surge-transfer-stage/.surge-staged-version",
+            shell_single_quote(&release.version),
+            shell_single_quote(&install_root.to_string_lossy())
+        );
+        let ssh_command = format!("sh -lc {}", shell_single_quote(&marker_cmd));
+        run_tailscale_streaming(&["ssh", ssh_target, ssh_command.as_str()], "remote").await?;
+        return Ok(());
+    }
+
     let activation_script = build_remote_app_copy_activation_script(
         &install_root,
         main_exe_name,
@@ -2555,6 +2665,23 @@ fn select_remote_installer_mode(storage_config: &surge_core::context::StorageCon
         | surge_core::context::StorageProvider::AzureBlob
         | surge_core::context::StorageProvider::Gcs
         | surge_core::context::StorageProvider::GitHubReleases => RemoteInstallerMode::Online,
+    }
+}
+
+fn select_remote_tailscale_transfer_strategy(
+    host_can_build_installer: bool,
+    installer_mode: RemoteInstallerMode,
+    stage: bool,
+    has_matching_pre_staged_version: bool,
+) -> RemoteTailscaleTransferStrategy {
+    if !host_can_build_installer
+        || matches!(installer_mode, RemoteInstallerMode::Offline) && (stage || has_matching_pre_staged_version)
+    {
+        RemoteTailscaleTransferStrategy::AppCopy
+    } else {
+        RemoteTailscaleTransferStrategy::Installer {
+            prefer_published: !stage,
+        }
     }
 }
 
@@ -2703,6 +2830,27 @@ fn parse_remote_install_state(output: &str) -> Option<RemoteInstallState> {
     }
 
     version.map(|version| RemoteInstallState { version, channel })
+}
+
+async fn check_remote_staged_version(ssh_node: &str, install_root: &Path) -> Option<String> {
+    let probe = format!(
+        "cat {}/.surge-transfer-stage/.surge-staged-version 2>/dev/null",
+        shell_single_quote(&install_root.to_string_lossy())
+    );
+    let command = format!("sh -c {}", shell_single_quote(&probe));
+    match run_tailscale_capture(&["ssh", ssh_node, command.as_str()]).await {
+        Ok(output) => {
+            let version = output.trim().to_string();
+            if version.is_empty() { None } else { Some(version) }
+        }
+        Err(_) => None,
+    }
+}
+
+async fn remote_staged_version_matches_release(ssh_node: &str, app_id: &str, release: &ReleaseEntry) -> Result<bool> {
+    let remote_home = detect_remote_home_directory(ssh_node).await?;
+    let install_root = remote_install_root(&remote_home, app_id, &release.install_directory)?;
+    Ok(check_remote_staged_version(ssh_node, &install_root).await.as_deref() == Some(release.version.as_str()))
 }
 
 async fn detect_remote_launch_environment(ssh_node: &str) -> RemoteLaunchEnvironment {
@@ -3295,6 +3443,36 @@ mod tests {
     }
 
     #[test]
+    fn select_remote_tailscale_transfer_strategy_uses_app_copy_when_stage_reduces_transfer() {
+        assert_eq!(
+            select_remote_tailscale_transfer_strategy(true, RemoteInstallerMode::Offline, true, false),
+            RemoteTailscaleTransferStrategy::AppCopy
+        );
+        assert_eq!(
+            select_remote_tailscale_transfer_strategy(true, RemoteInstallerMode::Offline, false, true),
+            RemoteTailscaleTransferStrategy::AppCopy
+        );
+        assert_eq!(
+            select_remote_tailscale_transfer_strategy(false, RemoteInstallerMode::Online, false, false),
+            RemoteTailscaleTransferStrategy::AppCopy
+        );
+    }
+
+    #[test]
+    fn select_remote_tailscale_transfer_strategy_disables_published_installers_for_stage_mode() {
+        assert_eq!(
+            select_remote_tailscale_transfer_strategy(true, RemoteInstallerMode::Online, true, false),
+            RemoteTailscaleTransferStrategy::Installer {
+                prefer_published: false
+            }
+        );
+        assert_eq!(
+            select_remote_tailscale_transfer_strategy(true, RemoteInstallerMode::Online, false, false),
+            RemoteTailscaleTransferStrategy::Installer { prefer_published: true }
+        );
+    }
+
+    #[test]
     fn plan_remote_published_installer_uses_default_channel_key() {
         let manifest = remote_manifest("demo", "linux-arm64", &["test", "production"], &["online"]);
         let mut entry = release("1.2.3", "test", "linux-arm64", "demo.tar.zst");
@@ -3570,9 +3748,12 @@ mod tests {
             Some("stable"),
             Some(&rid),
             Some("1.2.3"),
-            false,
-            true,
-            false,
+            InstallBehavior {
+                plan_only: false,
+                no_start: true,
+                force: false,
+                stage: StageBehavior::Install,
+            },
             &download_dir,
             StorageOverrides::default(),
         )

--- a/crates/surge-cli/src/commands/install.rs
+++ b/crates/surge-cli/src/commands/install.rs
@@ -548,6 +548,9 @@ pub async fn execute(
                         behavior.stage.is_stage(),
                     )
                     .await?;
+                    if !behavior.stage.is_stage() {
+                        warn_if_remote_stage_cleanup_fails(ssh_target, &app_id, release).await;
+                    }
                     if behavior.stage.is_stage() {
                         logline::success(&format!(
                             "Staged '{app_id}' v{} on tailscale node '{file_target}'.",
@@ -694,6 +697,9 @@ pub async fn execute(
                     logline::info(&format!("Running installer on '{file_target}'..."));
                 }
                 run_tailscale_streaming(&["ssh", ssh_target, ssh_command.as_str()], "remote").await?;
+                if !behavior.stage.is_stage() {
+                    warn_if_remote_stage_cleanup_fails(ssh_target, &app_id, release).await;
+                }
                 if behavior.stage.is_stage() {
                     logline::success(&format!(
                         "Staged '{app_id}' v{} on tailscale node '{file_target}'.",
@@ -2853,6 +2859,27 @@ async fn remote_staged_version_matches_release(ssh_node: &str, app_id: &str, rel
     Ok(check_remote_staged_version(ssh_node, &install_root).await.as_deref() == Some(release.version.as_str()))
 }
 
+async fn warn_if_remote_stage_cleanup_fails(ssh_node: &str, app_id: &str, release: &ReleaseEntry) {
+    if let Err(error) = cleanup_remote_staged_payload(ssh_node, app_id, release).await {
+        logline::warn(&format!("Could not remove stale remote staged payload: {error}"));
+    }
+}
+
+async fn cleanup_remote_staged_payload(ssh_node: &str, app_id: &str, release: &ReleaseEntry) -> Result<()> {
+    let remote_home = detect_remote_home_directory(ssh_node).await?;
+    let install_root = remote_install_root(&remote_home, app_id, &release.install_directory)?;
+    let cleanup_command = build_remote_stage_cleanup_command(&install_root);
+    let ssh_command = format!("sh -lc {}", shell_single_quote(&cleanup_command));
+    run_tailscale_streaming(&["ssh", ssh_node, ssh_command.as_str()], "remote").await
+}
+
+fn build_remote_stage_cleanup_command(install_root: &Path) -> String {
+    format!(
+        "install_root={}; rm -rf \"$install_root/.surge-transfer-stage\"",
+        shell_single_quote(&install_root.to_string_lossy())
+    )
+}
+
 async fn detect_remote_launch_environment(ssh_node: &str) -> RemoteLaunchEnvironment {
     let probe = remote_launch_environment_probe();
     let command = format!("sh -c {}", shell_single_quote(probe));
@@ -3469,6 +3496,16 @@ mod tests {
         assert_eq!(
             select_remote_tailscale_transfer_strategy(true, RemoteInstallerMode::Online, false, false),
             RemoteTailscaleTransferStrategy::Installer { prefer_published: true }
+        );
+    }
+
+    #[test]
+    fn build_remote_stage_cleanup_command_quotes_install_root() {
+        let command = build_remote_stage_cleanup_command(Path::new("/home/demo/apps/customer's app"));
+
+        assert_eq!(
+            command,
+            "install_root='/home/demo/apps/customer'\"'\"'s app'; rm -rf \"$install_root/.surge-transfer-stage\""
         );
     }
 

--- a/crates/surge-cli/src/commands/mod.rs
+++ b/crates/surge-cli/src/commands/mod.rs
@@ -563,6 +563,7 @@ apps:
                     },
                     release: InstallerRelease {
                         full_filename: "demo-full.tar.zst".to_string(),
+                        full_sha256: String::new(),
                         delta_filename: String::new(),
                         delta_algorithm: String::new(),
                         delta_patch_format: String::new(),

--- a/crates/surge-cli/src/commands/pack.rs
+++ b/crates/surge-cli/src/commands/pack.rs
@@ -17,6 +17,7 @@ use surge_core::config::installer::{
 };
 use surge_core::config::manifest::{AppConfig, InstallerType, SurgeManifest, TargetConfig};
 use surge_core::context::Context;
+use surge_core::crypto::sha256::sha256_hex_file;
 use surge_core::error::{Result, SurgeError};
 use surge_core::installer_bundle;
 use surge_core::pack::builder::PackBuilder;
@@ -698,6 +699,7 @@ fn build_installers_with_launcher(
         } else {
             InstallerUi::Console
         };
+        let full_sha256 = sha256_hex_file(full_package_path)?;
         let manifest_payload = InstallerManifest {
             schema: 1,
             format: "surge-installer-v1".to_string(),
@@ -719,6 +721,7 @@ fn build_installers_with_launcher(
             },
             release: InstallerRelease {
                 full_filename: full_filename.clone(),
+                full_sha256: full_sha256.clone(),
                 delta_filename: delta_filename.clone(),
                 delta_algorithm: if delta_filename.is_empty() {
                     String::new()

--- a/crates/surge-cli/src/commands/setup.rs
+++ b/crates/surge-cli/src/commands/setup.rs
@@ -295,7 +295,7 @@ fn persist_staged_installer_cache(dir: &Path, manifest: &InstallerManifest, inst
         return Ok(());
     }
 
-    let surge_binary_name = if cfg!(windows) { "surge.exe" } else { "surge" };
+    let surge_binary_name = staged_installer_binary_name();
     let surge_binary_path = dir.join(surge_binary_name);
     if !surge_binary_path.is_file() {
         return Err(SurgeError::Config(format!(
@@ -349,6 +349,10 @@ fn persist_staged_installer_cache(dir: &Path, manifest: &InstallerManifest, inst
     ));
 
     Ok(())
+}
+
+fn staged_installer_binary_name() -> &'static str {
+    if cfg!(windows) { "surge.exe" } else { "surge" }
 }
 
 /// Kill any running process whose executable lives in the app directory.
@@ -859,8 +863,9 @@ mod tests {
         write_release_index(&store_root, &manifest, &stored_archive);
         let installer_yaml = serde_yaml::to_string(&manifest).expect("installer yaml");
         std::fs::write(installer_dir.join("installer.yml"), installer_yaml).expect("installer manifest");
-        std::fs::write(installer_dir.join("surge"), b"#!/bin/sh\nexit 0\n").expect("surge stub");
-        make_executable(&installer_dir.join("surge")).expect("surge stub should be executable");
+        let surge_binary = installer_dir.join(staged_installer_binary_name());
+        std::fs::write(&surge_binary, b"#!/bin/sh\nexit 0\n").expect("surge stub");
+        make_executable(&surge_binary).expect("surge stub should be executable");
 
         execute(&installer_dir, true, true)
             .await
@@ -868,7 +873,7 @@ mod tests {
 
         let staged_installer_dir = install_root.join(".surge-cache").join("staged-installer");
         assert!(
-            staged_installer_dir.join("surge").is_file(),
+            staged_installer_dir.join(staged_installer_binary_name()).is_file(),
             "online stage should persist the surge helper"
         );
         assert!(

--- a/crates/surge-cli/src/commands/setup.rs
+++ b/crates/surge-cli/src/commands/setup.rs
@@ -7,10 +7,11 @@ use surge_core::config::installer::InstallerManifest;
 use surge_core::error::{Result, SurgeError};
 use surge_core::install::{self as core_install, InstallProfile};
 use surge_core::installer_package::{
-    InstallerPackageAcquisition, ResolveInstallerPackageOptions, ResolvedInstallerPackage,
+    InstallerPackageAcquisition, ResolveInstallerPackageOptions, ResolvedInstallerPackage, install_artifact_cache_dir,
     prune_install_artifact_cache, resolve_installer_package,
 };
 use surge_core::platform::paths::default_install_root;
+use surge_core::releases::artifact_cache::cache_path_for_key;
 use surge_core::releases::restore::RestoreProgress;
 
 const PACKAGE_PROGRESS_LOG_INTERVAL: Duration = Duration::from_secs(10);
@@ -107,7 +108,7 @@ fn percent(done: u64, total: u64) -> u64 {
 ///
 /// This is called either directly via `surge setup [dir]` or auto-detected when
 /// warp extracts the bundle and runs `surge` with no arguments.
-pub async fn execute(dir: &Path, no_start: bool) -> Result<()> {
+pub async fn execute(dir: &Path, no_start: bool, stage: bool) -> Result<()> {
     let manifest_path = dir.join("installer.yml");
     if !manifest_path.is_file() {
         return Err(SurgeError::Config(format!(
@@ -125,6 +126,18 @@ pub async fn execute(dir: &Path, no_start: bool) -> Result<()> {
     ));
 
     let install_root = default_install_root(&manifest.app_id, &manifest.runtime.install_directory)?;
+
+    if stage {
+        let package = resolve_package(dir, &manifest, &install_root).await?;
+        ensure_stage_cache_entry(&package, &manifest, &install_root)?;
+        logline::success(&format!(
+            "Staged '{}' v{} in artifact cache at '{}'",
+            manifest.app_id,
+            manifest.version,
+            install_root.display()
+        ));
+        return Ok(());
+    }
 
     if let Err(e) = super::stop_supervisor(&install_root, &manifest.runtime.supervisor_id).await {
         logline::warn(&format!("Could not stop supervisor: {e}"));
@@ -253,6 +266,26 @@ async fn resolve_package(dir: &Path, manifest: &InstallerManifest, install_root:
     }
 
     Ok(package)
+}
+
+fn ensure_stage_cache_entry(
+    package: &ResolvedPackage,
+    manifest: &InstallerManifest,
+    install_root: &Path,
+) -> Result<()> {
+    if package.acquisition != InstallerPackageAcquisition::BundledPayload {
+        return Ok(());
+    }
+
+    let artifact_cache_dir = install_artifact_cache_dir(install_root);
+    std::fs::create_dir_all(&artifact_cache_dir)?;
+    let cached_package_path = cache_path_for_key(&artifact_cache_dir, manifest.release.full_filename.trim())?;
+    std::fs::copy(package.path(), &cached_package_path)?;
+    logline::info(&format!(
+        "Copied bundled payload into artifact cache: {}",
+        cached_package_path.display()
+    ));
+    Ok(())
 }
 
 /// Kill any running process whose executable lives in the app directory.
@@ -446,7 +479,9 @@ mod tests {
         std::fs::write(installer_dir.join("installer.yml"), installer_yaml).expect("installer manifest");
         write_archive(&payload_dir.join(full_filename), b"bundled payload");
 
-        execute(&installer_dir, true).await.expect("setup should succeed");
+        execute(&installer_dir, true, false)
+            .await
+            .expect("setup should succeed");
 
         let active_app_dir = install_root.join("app");
         assert_eq!(
@@ -504,7 +539,9 @@ mod tests {
             .finalize_to_file(&payload_dir.join(full_filename))
             .expect("archive file");
 
-        execute(&installer_dir, true).await.expect("setup should succeed");
+        execute(&installer_dir, true, false)
+            .await
+            .expect("setup should succeed");
 
         let active_app_dir = install_root.join("app");
         assert_eq!(
@@ -581,7 +618,9 @@ mod tests {
         let installer_yaml = serde_yaml::to_string(&manifest).expect("installer yaml");
         std::fs::write(installer_dir.join("installer.yml"), installer_yaml).expect("installer manifest");
 
-        execute(&installer_dir, true).await.expect("setup should succeed");
+        execute(&installer_dir, true, false)
+            .await
+            .expect("setup should succeed");
 
         assert!(!stale_path.exists(), "stale cache entry should be pruned");
         assert!(
@@ -681,7 +720,9 @@ mod tests {
 
         write_release_index_entries(&store_root, &manifest.app_id, vec![base_release, target_release]);
 
-        execute(&installer_dir, true).await.expect("setup should succeed");
+        execute(&installer_dir, true, false)
+            .await
+            .expect("setup should succeed");
 
         let artifact_cache = install_root.join(".surge-cache").join("artifacts");
         assert!(
@@ -695,6 +736,44 @@ mod tests {
         assert!(
             artifact_cache.join(target_full_filename).is_file(),
             "installed target full should remain as a warm cache entry"
+        );
+    }
+
+    #[tokio::test]
+    async fn execute_stage_persists_bundled_payload_in_artifact_cache_without_installing() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let installer_dir = temp_dir.path().join("installer");
+        let payload_dir = installer_dir.join("payload");
+        let install_root = temp_dir.path().join("installed-app");
+        let store_root = temp_dir.path().join("store");
+        let full_filename = "demo-app-1.2.3-full.tar.zst";
+        let bundled_payload = payload_dir.join(full_filename);
+
+        std::fs::create_dir_all(&payload_dir).expect("payload dir");
+        std::fs::create_dir_all(&store_root).expect("store dir");
+
+        let manifest = make_manifest(&install_root, &store_root, full_filename, "offline");
+        let installer_yaml = serde_yaml::to_string(&manifest).expect("installer yaml");
+        std::fs::write(installer_dir.join("installer.yml"), installer_yaml).expect("installer manifest");
+        write_archive(&bundled_payload, b"bundled payload");
+        let bundled_archive = std::fs::read(&bundled_payload).expect("bundled payload should exist");
+
+        execute(&installer_dir, true, true)
+            .await
+            .expect("setup stage should succeed");
+
+        let cached_package = install_root.join(".surge-cache").join("artifacts").join(full_filename);
+        assert!(
+            cached_package.is_file(),
+            "bundled payload should be copied into the artifact cache"
+        );
+        assert_eq!(
+            std::fs::read(&cached_package).expect("cached package should exist"),
+            bundled_archive
+        );
+        assert!(
+            !install_root.join("app").exists(),
+            "stage mode should not activate the install"
         );
     }
 }

--- a/crates/surge-cli/src/commands/setup.rs
+++ b/crates/surge-cli/src/commands/setup.rs
@@ -10,6 +10,7 @@ use surge_core::installer_package::{
     InstallerPackageAcquisition, ResolveInstallerPackageOptions, ResolvedInstallerPackage, install_artifact_cache_dir,
     prune_install_artifact_cache, resolve_installer_package,
 };
+use surge_core::platform::fs::make_executable;
 use surge_core::platform::paths::default_install_root;
 use surge_core::releases::artifact_cache::cache_path_for_key;
 use surge_core::releases::restore::RestoreProgress;
@@ -130,6 +131,7 @@ pub async fn execute(dir: &Path, no_start: bool, stage: bool) -> Result<()> {
     if stage {
         let package = resolve_package(dir, &manifest, &install_root).await?;
         ensure_stage_cache_entry(&package, &manifest, &install_root)?;
+        persist_staged_installer_cache(dir, &manifest, &install_root)?;
         logline::success(&format!(
             "Staged '{}' v{} in artifact cache at '{}'",
             manifest.app_id,
@@ -288,6 +290,67 @@ fn ensure_stage_cache_entry(
     Ok(())
 }
 
+fn persist_staged_installer_cache(dir: &Path, manifest: &InstallerManifest, install_root: &Path) -> Result<()> {
+    if !manifest.installer_type.trim().eq_ignore_ascii_case("online") {
+        return Ok(());
+    }
+
+    let surge_binary_name = if cfg!(windows) { "surge.exe" } else { "surge" };
+    let surge_binary_path = dir.join(surge_binary_name);
+    if !surge_binary_path.is_file() {
+        return Err(SurgeError::Config(format!(
+            "Online stage cache is missing embedded surge binary '{}'",
+            surge_binary_path.display()
+        )));
+    }
+
+    let installer_manifest_path = dir.join("installer.yml");
+    if !installer_manifest_path.is_file() {
+        return Err(SurgeError::Config(format!(
+            "Online stage cache is missing installer manifest '{}'",
+            installer_manifest_path.display()
+        )));
+    }
+
+    let staged_installer_dir = install_root.join(".surge-cache").join("staged-installer");
+    if staged_installer_dir.exists() {
+        std::fs::remove_dir_all(&staged_installer_dir)?;
+    }
+    std::fs::create_dir_all(&staged_installer_dir)?;
+
+    let cached_surge_binary = staged_installer_dir.join(surge_binary_name);
+    std::fs::copy(&surge_binary_path, &cached_surge_binary)?;
+    make_executable(&cached_surge_binary)?;
+    std::fs::copy(&installer_manifest_path, staged_installer_dir.join("installer.yml"))?;
+
+    let staged_identity = serde_json::json!({
+        "app_id": manifest.app_id.trim(),
+        "version": manifest.version.trim(),
+        "channel": manifest.channel.trim(),
+        "rid": manifest.rid.trim(),
+        "full_filename": manifest.release.full_filename.trim(),
+        "full_sha256": manifest.release.full_sha256.trim(),
+        "install_directory": manifest.runtime.install_directory.trim(),
+        "supervisor_id": manifest.runtime.supervisor_id.trim(),
+        "storage_provider": manifest.storage.provider.trim(),
+        "storage_bucket": manifest.storage.bucket.trim(),
+        "storage_region": manifest.storage.region.trim(),
+        "storage_endpoint": manifest.storage.endpoint.trim(),
+    });
+    std::fs::write(
+        staged_installer_dir.join(".surge-staged-release.json"),
+        serde_json::to_vec(&staged_identity)
+            .map_err(|e| SurgeError::Config(format!("Failed to serialize staged installer identity: {e}")))?,
+    )?;
+
+    logline::info(&format!(
+        "Persisted staged installer support files in '{}'.",
+        staged_installer_dir.display()
+    ));
+
+    Ok(())
+}
+
 /// Kill any running process whose executable lives in the app directory.
 /// This catches orphaned app processes that outlived their supervisor.
 fn stop_running_app(install_root: &Path, main_exe: &str) {
@@ -367,6 +430,7 @@ mod tests {
             },
             release: InstallerRelease {
                 full_filename: full_filename.to_string(),
+                full_sha256: String::new(),
                 delta_filename: String::new(),
                 delta_algorithm: String::new(),
                 delta_patch_format: String::new(),
@@ -771,6 +835,50 @@ mod tests {
             std::fs::read(&cached_package).expect("cached package should exist"),
             bundled_archive
         );
+        assert!(
+            !install_root.join("app").exists(),
+            "stage mode should not activate the install"
+        );
+    }
+
+    #[tokio::test]
+    async fn execute_stage_persists_online_installer_cache_without_installing() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let installer_dir = temp_dir.path().join("installer");
+        let install_root = temp_dir.path().join("installed-app");
+        let store_root = temp_dir.path().join("store");
+        let full_filename = "demo-app-1.2.3-full.tar.zst";
+        let stored_archive = store_root.join(full_filename);
+
+        std::fs::create_dir_all(&installer_dir).expect("installer dir");
+        std::fs::create_dir_all(&store_root).expect("store dir");
+        write_archive(&stored_archive, b"downloaded payload");
+
+        let mut manifest = make_manifest(&install_root, &store_root, full_filename, "online");
+        manifest.release.full_sha256 = sha256_hex(&std::fs::read(&stored_archive).expect("stored bytes"));
+        write_release_index(&store_root, &manifest, &stored_archive);
+        let installer_yaml = serde_yaml::to_string(&manifest).expect("installer yaml");
+        std::fs::write(installer_dir.join("installer.yml"), installer_yaml).expect("installer manifest");
+        std::fs::write(installer_dir.join("surge"), b"#!/bin/sh\nexit 0\n").expect("surge stub");
+        make_executable(&installer_dir.join("surge")).expect("surge stub should be executable");
+
+        execute(&installer_dir, true, true)
+            .await
+            .expect("setup stage should succeed");
+
+        let staged_installer_dir = install_root.join(".surge-cache").join("staged-installer");
+        assert!(
+            staged_installer_dir.join("surge").is_file(),
+            "online stage should persist the surge helper"
+        );
+        assert!(
+            staged_installer_dir.join("installer.yml").is_file(),
+            "online stage should persist the installer manifest"
+        );
+        let staged_identity = std::fs::read_to_string(staged_installer_dir.join(".surge-staged-release.json"))
+            .expect("staged identity should exist");
+        assert!(staged_identity.contains("\"version\":\"1.2.3\""));
+        assert!(staged_identity.contains(&manifest.release.full_sha256));
         assert!(
             !install_root.join("app").exists(),
             "stage mode should not activate the install"

--- a/crates/surge-cli/src/main.rs
+++ b/crates/surge-cli/src/main.rs
@@ -260,6 +260,10 @@ enum Commands {
         /// Do not start the application after installation
         #[arg(long)]
         no_start: bool,
+
+        /// Only cache the package locally without installing (used by --stage)
+        #[arg(long)]
+        stage: bool,
     },
 
     /// Print SHA-256 hash of a file
@@ -390,6 +394,9 @@ struct InstallOptions {
     #[arg(long)]
     no_start: bool,
 
+    #[command(flatten)]
+    stage_options: InstallStageOptions,
+
     /// Reinstall even if the selected version/channel is already installed on the target
     #[arg(long)]
     force: bool,
@@ -417,6 +424,13 @@ struct InstallOptions {
     /// Override storage prefix from application manifest
     #[arg(long)]
     prefix: Option<String>,
+}
+
+#[derive(Args, Clone)]
+struct InstallStageOptions {
+    /// Pre-stage packages on remote nodes without activating (tailscale method only)
+    #[arg(long)]
+    stage: bool,
 }
 
 fn init_tracing(verbose: bool) {
@@ -456,7 +470,7 @@ fn main() -> ExitCode {
                         return ExitCode::FAILURE;
                     }
                 };
-                return match rt.block_on(commands::setup::execute(&installer_dir, false)) {
+                return match rt.block_on(commands::setup::execute(&installer_dir, false, false)) {
                     Ok(()) => ExitCode::SUCCESS,
                     Err(e) => {
                         logline::error_chain(&e);
@@ -737,7 +751,7 @@ async fn run(cli: Cli) -> surge_core::error::Result<()> {
             }
         }
 
-        Commands::Setup { dir, no_start } => commands::setup::execute(&dir, no_start).await,
+        Commands::Setup { dir, no_start, stage } => commands::setup::execute(&dir, no_start, stage).await,
 
         Commands::Sha256 { file } => {
             let hash = surge_core::crypto::sha256::sha256_hex_file(&file)?;
@@ -760,6 +774,11 @@ async fn run(cli: Cli) -> surge_core::error::Result<()> {
                             "--node/--node-user require 'tailscale' install method".to_string(),
                         ));
                     }
+                    if options.stage_options.stage {
+                        return Err(surge_core::error::SurgeError::Config(
+                            "--stage requires 'tailscale' install method".to_string(),
+                        ));
+                    }
                     None
                 }
                 InstallMethod::Tailscale => Some(node.as_deref().ok_or_else(|| {
@@ -778,9 +797,16 @@ async fn run(cli: Cli) -> surge_core::error::Result<()> {
                 options.channel.as_deref(),
                 options.rid.as_deref(),
                 options.version.as_deref(),
-                options.plan_only,
-                options.no_start,
-                options.force,
+                commands::install::InstallBehavior {
+                    plan_only: options.plan_only,
+                    no_start: options.no_start,
+                    force: options.force,
+                    stage: if options.stage_options.stage {
+                        commands::install::StageBehavior::StageOnly
+                    } else {
+                        commands::install::StageBehavior::Install
+                    },
+                },
                 &options.download_dir,
                 commands::install::StorageOverrides {
                     provider: options.provider.as_deref(),

--- a/crates/surge-cli/src/main.rs
+++ b/crates/surge-cli/src/main.rs
@@ -431,6 +431,10 @@ struct InstallStageOptions {
     /// Pre-stage packages on remote nodes without activating (tailscale method only)
     #[arg(long)]
     stage: bool,
+
+    /// Verify that the selected release is already staged and ready for the next tailscale install
+    #[arg(long, conflicts_with = "stage")]
+    verify_stage: bool,
 }
 
 fn init_tracing(verbose: bool) {
@@ -779,6 +783,11 @@ async fn run(cli: Cli) -> surge_core::error::Result<()> {
                             "--stage requires 'tailscale' install method".to_string(),
                         ));
                     }
+                    if options.stage_options.verify_stage {
+                        return Err(surge_core::error::SurgeError::Config(
+                            "--verify-stage requires 'tailscale' install method".to_string(),
+                        ));
+                    }
                     None
                 }
                 InstallMethod::Tailscale => Some(node.as_deref().ok_or_else(|| {
@@ -801,10 +810,12 @@ async fn run(cli: Cli) -> surge_core::error::Result<()> {
                     plan_only: options.plan_only,
                     no_start: options.no_start,
                     force: options.force,
-                    stage: if options.stage_options.stage {
-                        commands::install::StageBehavior::StageOnly
+                    mode: if options.stage_options.verify_stage {
+                        commands::install::InstallMode::VerifyStage
+                    } else if options.stage_options.stage {
+                        commands::install::InstallMode::StageOnly
                     } else {
-                        commands::install::StageBehavior::Install
+                        commands::install::InstallMode::Install
                     },
                 },
                 &options.download_dir,
@@ -869,5 +880,27 @@ mod tests {
         };
 
         assert!(options.force);
+    }
+
+    #[test]
+    fn install_verify_stage_flag_parses() {
+        let cli = Cli::try_parse_from(["surge", "install", "tailscale", "my-node", "--verify-stage"])
+            .expect("install command with --verify-stage should parse");
+
+        let Commands::Install { options, .. } = cli.command else {
+            panic!("expected install command");
+        };
+
+        assert!(options.stage_options.verify_stage);
+    }
+
+    #[test]
+    fn install_verify_stage_conflicts_with_stage() {
+        let Err(err) = Cli::try_parse_from(["surge", "install", "tailscale", "my-node", "--stage", "--verify-stage"])
+        else {
+            panic!("--verify-stage should conflict with --stage");
+        };
+
+        assert!(err.to_string().contains("--stage"));
     }
 }

--- a/crates/surge-core/src/config/installer.rs
+++ b/crates/surge-core/src/config/installer.rs
@@ -46,6 +46,8 @@ pub struct InstallerStorage {
 pub struct InstallerRelease {
     pub full_filename: String,
     #[serde(default)]
+    pub full_sha256: String,
+    #[serde(default)]
     pub delta_filename: String,
     #[serde(default)]
     pub delta_algorithm: String,

--- a/crates/surge-installer-ui/src/install.rs
+++ b/crates/surge-installer-ui/src/install.rs
@@ -492,6 +492,7 @@ mod tests {
             },
             release: InstallerRelease {
                 full_filename: full_filename.to_string(),
+                full_sha256: String::new(),
                 delta_filename: String::new(),
                 delta_algorithm: String::new(),
                 delta_patch_format: String::new(),


### PR DESCRIPTION
## What changed
- persist bundled offline payloads into `.surge-cache` during `surge setup --stage`
- prefer remote app-copy when offline tailscale staging should reduce the next transfer, and check for a matching pre-staged payload before downloading anything locally
- avoid published installers for `--stage` so remote stage mode always runs a stage-capable `surge` binary
- replace the new positional stage bool with typed install/stage options and update the affected tests

## Why
The previous `--stage` patch added the flag but left two runtime gaps:
- offline installers only resolved the bundled payload from the extracted installer tempdir, so `setup --stage` did not leave anything reusable behind once the installer process exited
- remote stage mode could hand `--stage` to an older published installer whose embedded `surge` binary did not know that flag, and offline/tailscale staging could still miss the low-transfer activation path on the next install

## Impact
- `surge setup --stage` now produces a durable staged cache entry for offline installers
- `surge install --stage --node ...` now stages remote tailscale installs in a way the next install can reuse with minimal transfer, especially for offline payloads and persistent-asset updates
- stage mode no longer depends on legacy published installers accepting the new flag

## Validation
- `./scripts/sync-surge-core-vendor.sh --check`
- `./scripts/check-version-sync.sh`
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo test --workspace`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo clippy --workspace --lib --bins --examples -- -D warnings -D clippy::unwrap_used -D clippy::expect_used`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings -W clippy::pedantic`
- `dotnet format dotnet/Surge.slnx --verify-no-changes`
- `dotnet test dotnet/Surge.slnx --configuration Release`