### PR TITLE
docs: add maintainability guardrails for source file size and module boundaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,17 @@ jobs:
       - run: rustup component add rustfmt
       - run: cargo fmt --all -- --check
 
+  maintainability:
+    name: maintainability (advisory)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Run maintainability guardrail (non-blocking)
+        run: |
+          ./scripts/check-maintainability.sh || {
+            echo "::warning::Maintainability guardrail detected a new oversized Rust source file or growth in an existing hotspot."
+          }
+
   clippy:
     name: clippy
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,7 @@ If the local environment cannot run a listed command, document the exact gap in 
 - Prefer self-documenting code: clear types, names, and small functions over explanatory comments.
 - Use comments sparingly; add them only for invariants, non-obvious tradeoffs, or safety contracts.
 - Keep modules cohesive and APIs explicit (`Result<T, E>`, typed structs/enums instead of ad-hoc tuples).
+- Treat roughly 600 production lines as the point to split a Rust source file; keep module roots orchestration-focused and move detailed behavior into focused leaf modules.
 - Prefer typed error enums (`thiserror`) over `Box<dyn Error>` in binaries/crates where error cases are known.
 - Consolidate repeated crate-local helpers (for example mutex poison recovery and C-string sanitization) into a shared internal module.
 - Prefer `unwrap_or_else(std::sync::PoisonError::into_inner)` over manual `match` when recovering poisoned mutexes.
@@ -171,4 +172,5 @@ For a major release (e.g. `1.0.0`), manually set `[workspace.package].version` a
 - Use concise imperative commit messages, optionally scoped (examples: `feat(cli): ...`, `fix(core): ...`, `ci: ...`).
 - Keep commits focused (one logical change per commit).
 - PRs should include: purpose, behavior impact, test evidence (commands run), and migration notes if applicable.
+- Agent-authored or agent-managed PRs must use GitHub `Squash and merge`; do not use merge commits or rebase merge.
 - Ensure GitHub Actions are green before merge.

--- a/docs/architecture/maintainability-baseline.txt
+++ b/docs/architecture/maintainability-baseline.txt
@@ -1,0 +1,18 @@
+# Maximum allowed production-line counts for current oversized Rust source files.
+# Format: <max_lines> <path>
+605 crates/surge-bench/src/payload.rs
+1013 crates/surge-bench/src/runner.rs
+3455 crates/surge-cli/src/commands/install.rs
+1189 crates/surge-cli/src/commands/pack.rs
+835 crates/surge-cli/src/main.rs
+861 crates/surge-core/src/config/manifest.rs
+727 crates/surge-core/src/install.rs
+990 crates/surge-core/src/pack/builder.rs
+1130 crates/surge-core/src/platform/shortcuts.rs
+782 crates/surge-core/src/releases/delta.rs
+625 crates/surge-core/src/releases/restore.rs
+604 crates/surge-core/src/storage/azure.rs
+840 crates/surge-core/src/storage/gcs.rs
+1428 crates/surge-core/src/update/manager.rs
+1491 crates/surge-ffi/src/lib.rs
+760 crates/surge-installer-ui/src/app.rs

--- a/docs/architecture/maintainability.md
+++ b/docs/architecture/maintainability.md
@@ -1,0 +1,78 @@
+# Maintainability Guardrails
+
+This document describes the module boundaries and file-size guardrails for the
+ongoing Surge refactor campaign. The goal is to stop large multi-purpose source
+files from growing further while the existing hotspots are split incrementally.
+
+## Module Boundaries
+
+### `surge-core`
+
+- Owns shared domain logic, manifest normalization and validation, release graph
+  planning, storage-facing workflows, install/update orchestration, and
+  platform abstractions.
+- Keep module roots orchestration-focused. Split detailed behavior into leaf
+  modules by responsibility, such as restore planning vs restore execution,
+  update progress vs supervisor handoff, and per-platform shortcut handling.
+- If CLI, installer, or FFI code needs shared release, manifest, or runtime
+  logic, move that logic into `surge-core` instead of duplicating it.
+
+### `surge-cli`
+
+- Owns command orchestration, user-facing prompts, logline output, and
+  command-specific progress reporting.
+- Large commands should become module trees where the root coordinates flow and
+  sibling modules handle focused concerns such as manifest resolution, target
+  selection, remote staging, or installer upload.
+- Do not mix prompt collection, manifest parsing, remote execution, and output
+  formatting in one growing file when they can live in separate modules.
+
+### `surge-ffi`
+
+- Owns the explicit unsafe boundary and C ABI surface.
+- Split the root by API surface: context/configuration, update manager,
+  releases, diff/pack, and shared pointer or callback helpers.
+- Preserve exported symbol names and signatures while moving implementation
+  details behind focused internal modules.
+
+### Platform and Provider Surfaces
+
+- Keep platform-specific behavior in per-platform modules instead of
+  `cfg`-heavy monoliths.
+- Keep storage-provider-specific behavior isolated by backend. Shared retry,
+  auth, or upload helpers belong in common internal helpers instead of being
+  reimplemented per backend.
+
+## File Size Policy
+
+- Start splitting Rust source files before they reach roughly `600` production
+  lines.
+- Production lines are measured up to the inline `#[cfg(test)] mod tests { ... }`
+  block at the end of a file.
+- Inline tests should stay at the end of the file. When tests dominate a large
+  source file, move them into a colocated `tests/` tree next to the module.
+- `#[allow(clippy::too_many_lines)]` is temporary debt and should not be added
+  to new code as a substitute for decomposition.
+
+## Advisory Guardrail
+
+- `./scripts/check-maintainability.sh` enforces the `600`-line target in
+  advisory mode during the refactor campaign.
+- The script uses [`maintainability-baseline.txt`](./maintainability-baseline.txt)
+  to record the current oversized-file debt. CI warns when:
+  - a new Rust source file crosses the threshold
+  - an already oversized file grows beyond its recorded baseline
+- Once the current hotspots are split, the guardrail can move from advisory to
+  blocking.
+
+## Review Heuristics
+
+Use these checks while refactoring or reviewing:
+
+- Does this file have one reason to change?
+- Should this root file delegate to a small module tree instead of gaining one
+  more helper?
+- Is shared manifest, release, install, or runtime logic duplicated outside
+  `surge-core`?
+- Would moving tests into a neighboring `tests/` tree keep the production file
+  focused?

--- a/scripts/check-maintainability.sh
+++ b/scripts/check-maintainability.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SOFT_MAX_LINES=600
+BASELINE_FILE="$ROOT_DIR/docs/architecture/maintainability-baseline.txt"
+status=0
+
+declare -A baseline_limits=()
+declare -A baseline_seen=()
+
+run_self_tests() {
+  local tmpdir
+  tmpdir="$(mktemp -d)"
+  trap 'rm -rf "$tmpdir"' RETURN
+
+  cat >"$tmpdir/inline-tests-at-end.rs" <<'EOF'
+fn alpha() {}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn works() {}
+}
+EOF
+
+  cat >"$tmpdir/test_helpers_before_prod.rs" <<'EOF'
+#[cfg(test)]
+fn helper() {}
+
+fn alpha() {}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn works() {}
+}
+EOF
+
+  local measured
+  measured="$(measure_production_lines "$tmpdir/inline-tests-at-end.rs")"
+  if [[ "$measured" != "3" ]]; then
+    printf 'maintainability self-test failed: expected 3 lines before inline tests, got %s\n' "$measured" >&2
+    status=1
+  fi
+
+  measured="$(measure_production_lines "$tmpdir/test_helpers_before_prod.rs")"
+  if [[ "$measured" != "6" ]]; then
+    printf 'maintainability self-test failed: expected 6 lines including helper spacing before inline tests, got %s\n' \
+      "$measured" >&2
+    status=1
+  fi
+}
+
+measure_production_lines() {
+  local file="$1"
+  awk '
+    function flush_pending_attr() {
+      if (pending_test_attr) {
+        count += 1
+        pending_test_attr = 0
+      }
+    }
+
+    /^[[:space:]]*#\[cfg\(test\)\][[:space:]]*$/ {
+      flush_pending_attr()
+      pending_test_attr = 1
+      next
+    }
+
+    pending_test_attr && /^[[:space:]]*(\/\/.*)?$/ {
+      next
+    }
+
+    pending_test_attr && /^[[:space:]]*mod[[:space:]]+tests[[:space:]]*\{/ {
+      exit
+    }
+
+    {
+      flush_pending_attr()
+      count += 1
+    }
+
+    END {
+      flush_pending_attr()
+      print count + 0
+    }
+  ' "$file"
+}
+
+load_baseline() {
+  if [[ ! -f "$BASELINE_FILE" ]]; then
+    printf 'maintainability check misconfigured: missing baseline file %s\n' "${BASELINE_FILE#"$ROOT_DIR"/}" >&2
+    status=1
+    return
+  fi
+
+  local line limit path
+  while IFS= read -r line; do
+    [[ -z "$line" || "$line" =~ ^# ]] && continue
+    limit="${line%% *}"
+    path="${line#* }"
+
+    if [[ -z "$limit" || -z "$path" || "$limit" == "$line" || ! "$limit" =~ ^[0-9]+$ ]]; then
+      printf 'maintainability check misconfigured: invalid baseline entry "%s"\n' "$line" >&2
+      status=1
+      continue
+    fi
+
+    baseline_limits["$path"]="$limit"
+  done <"$BASELINE_FILE"
+}
+
+check_file_length() {
+  local file="$1"
+  local rel_path lines baseline_limit
+
+  rel_path="${file#"$ROOT_DIR"/}"
+  lines="$(measure_production_lines "$file")"
+
+  if (( lines <= SOFT_MAX_LINES )); then
+    return
+  fi
+
+  baseline_limit="${baseline_limits[$rel_path]-}"
+  if [[ -z "$baseline_limit" ]]; then
+    printf 'maintainability regression: %s has %d production lines and is above the %d-line target without a baseline entry\n' \
+      "$rel_path" "$lines" "$SOFT_MAX_LINES" >&2
+    status=1
+    return
+  fi
+
+  baseline_seen["$rel_path"]=1
+  if (( lines > baseline_limit )); then
+    printf 'maintainability regression: %s grew from %d to %d production lines (target: %d)\n' \
+      "$rel_path" "$baseline_limit" "$lines" "$SOFT_MAX_LINES" >&2
+    status=1
+  fi
+}
+
+report_stale_baseline_entries() {
+  local rel_path file lines
+
+  for rel_path in "${!baseline_limits[@]}"; do
+    if [[ -n "${baseline_seen[$rel_path]-}" ]]; then
+      continue
+    fi
+
+    file="$ROOT_DIR/$rel_path"
+    if [[ ! -f "$file" ]]; then
+      printf 'maintainability note: baseline entry %s no longer exists; update %s\n' \
+        "$rel_path" "${BASELINE_FILE#"$ROOT_DIR"/}" >&2
+      continue
+    fi
+
+    lines="$(measure_production_lines "$file")"
+    if (( lines <= SOFT_MAX_LINES )); then
+      printf 'maintainability note: %s is down to %d production lines; update %s\n' \
+        "$rel_path" "$lines" "${BASELINE_FILE#"$ROOT_DIR"/}" >&2
+    fi
+  done
+}
+
+run_self_tests
+load_baseline
+
+while IFS= read -r -d '' file; do
+  check_file_length "$file"
+done < <(
+  find \
+    "$ROOT_DIR/crates" \
+    -path '*/src/*' \
+    -type f \
+    -name '*.rs' \
+    -print0 \
+    | sort -z
+)
+
+report_stale_baseline_entries
+
+exit "$status"


### PR DESCRIPTION
## What changed
- add `docs/architecture/maintainability.md` to capture the new module-boundary and file-size guardrails, adapted from the Horizon maintainability guidance
- add `scripts/check-maintainability.sh`, including self-tests and a baseline file for the current oversized Rust source files so the guardrail catches new oversize regressions without failing on existing debt
- add an advisory CI job that emits warnings when a new oversized Rust source file appears or a known hotspot grows
- update `AGENTS.md` to record the new 600-line split guideline and require `Squash and merge` for agent-managed PRs

## Why
The refactor campaign needs a guardrail before the large module splits begin. Without a baseline-aware check, the oversized files can keep growing while the cleanup work is in flight, and the merge policy for the rollout needs to be explicit in the repository guidance.

## Impact
- maintainability expectations are now documented in-repo instead of living only in the rollout plan
- CI warns on new maintainability regressions while leaving the current oversized-file backlog in advisory mode
- the follow-up refactor PRs can reduce the baseline incrementally until the guardrail is ready to become blocking

## Validation
- `git submodule update --init --recursive`
- `./scripts/sync-surge-core-vendor.sh --check`
- `./scripts/check-version-sync.sh`
- `cargo fmt --all -- --check`
- `./scripts/check-maintainability.sh`
- `RUSTFLAGS="-D warnings" cargo test --workspace`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo clippy --workspace --lib --bins --examples -- -D warnings -D clippy::unwrap_used -D clippy::expect_used`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings -W clippy::pedantic`
- `dotnet format dotnet/Surge.slnx --verify-no-changes`
- `dotnet test dotnet/Surge.slnx --configuration Release`