### PR TITLE
refactor(core): extract update download and apply pipeline helpers

### DIFF
--- a/crates/surge-core/src/update/manager.rs
+++ b/crates/surge-core/src/update/manager.rs
@@ -1,48 +1,36 @@
 //! Update manager: check for updates, download, verify, and apply them.
 
+mod apply;
+mod artifacts;
 mod progress;
 mod release_index;
 
-use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, Mutex};
-use std::time::{Duration, Instant};
+use std::sync::Arc;
+use std::time::Duration;
 
-use futures_util::stream::{self, StreamExt};
 use tracing::{debug, info, warn};
 
-use crate::archive::extractor::extract_file_to_with_progress;
 use crate::config::constants::RELEASES_FILE_COMPRESSED;
 use crate::context::Context;
-use crate::crypto::sha256::{sha256_hex, sha256_hex_file};
 use crate::error::{Result, SurgeError};
 use crate::install::{
     InstallProfile, RuntimeManifestMetadata, copy_persistent_assets, prune_version_snapshots,
     storage_provider_manifest_name, write_runtime_manifest,
 };
-use crate::pack::builder::build_canonical_archive_from_directory;
-use crate::platform::detect::current_rid;
-use crate::platform::fs::{atomic_rename, write_file_atomic};
+use crate::platform::fs::atomic_rename;
 use crate::platform::process::{current_pid, spawn_detached, spawn_process, supervisor_binary_name};
 use crate::platform::shortcuts::install_shortcuts;
-use crate::releases::artifact_cache::{
-    CacheFetchOutcome, cache_path_for_key, fetch_or_reuse_file, prune_cached_artifacts,
-};
-use crate::releases::delta::{apply_delta_patch, decode_delta_patch, is_supported_delta};
+use crate::releases::artifact_cache::prune_cached_artifacts;
 use crate::releases::manifest::{ReleaseEntry, ReleaseIndex, decompress_release_index};
-use crate::releases::restore::{
-    RestoreOptions, find_release_for_version_rid, local_checkpoint_artifacts_for_index, required_artifacts_for_index,
-    restore_full_archive_for_version_with_options,
-};
+use crate::releases::restore::{local_checkpoint_artifacts_for_index, required_artifacts_for_index};
 use crate::storage::{StorageBackend, create_storage_backend};
 use crate::supervisor::state::{read_restart_args, supervisor_pid_file, supervisor_stop_file};
-use crate::supervisor::stub::find_latest_app_dir;
 
+use self::apply::materialize_update_payload;
+use self::artifacts::prepare_update_artifacts;
 pub use self::progress::ProgressInfo;
-use self::progress::{
-    ArtifactDownload, DownloadProgressState, average_speed_bytes_per_sec, clamp_progress_percent,
-    clamp_progress_percent_u64, emit_progress, phase_total_percent, saturating_i64_from_u64,
-};
+use self::progress::emit_progress;
 use self::release_index::{load_release_index as load_release_index_impl, resolve_update_info};
 
 /// Strategy used when applying an update.
@@ -203,8 +191,6 @@ impl UpdateManager {
     where
         F: Fn(ProgressInfo) + Send + Sync,
     {
-        const DOWNLOAD_CONCURRENCY: usize = 4;
-
         self.ctx.check_cancelled()?;
         let progress = progress.map(Arc::new);
 
@@ -249,422 +235,19 @@ impl UpdateManager {
 
         let artifact_cache_dir = self.install_dir.join(".surge-cache").join("artifacts");
         tokio::fs::create_dir_all(&artifact_cache_dir).await?;
-
-        let artifacts: Vec<ArtifactDownload> = if matches!(info.apply_strategy, ApplyStrategy::Delta) {
-            info.apply_releases
-                .iter()
-                .filter_map(ReleaseEntry::selected_delta)
-                .map(|delta| ArtifactDownload {
-                    key: delta.filename.clone(),
-                    sha256: delta.sha256.clone(),
-                    size: delta.size,
-                })
-                .collect()
-        } else {
-            let latest = info
-                .apply_releases
-                .last()
-                .ok_or_else(|| SurgeError::Update("No latest release".to_string()))?;
-            vec![ArtifactDownload {
-                key: latest.full_filename.clone(),
-                sha256: latest.full_sha256.clone(),
-                size: latest.full_size,
-            }]
-        };
-        if artifacts.is_empty() {
-            return Err(SurgeError::Update("No artifacts selected for download".to_string()));
-        }
-
-        let total_items = i64::try_from(artifacts.len()).unwrap_or(i64::MAX);
-        let total_bytes = artifacts
-            .iter()
-            .fold(0i64, |acc, artifact| acc.saturating_add(artifact.size.max(0)));
-        let total_bytes_u64 = u64::try_from(total_bytes).unwrap_or(u64::MAX);
-
-        let storage = self.storage.as_ref();
-        let staging_dir_ref = &staging_dir;
-        let cache_dir_ref = &artifact_cache_dir;
-
-        let download_progress_state = Arc::new(Mutex::new(DownloadProgressState::new()));
-        let mut download_stream = stream::iter(artifacts.into_iter())
-            .map(|artifact| {
-                let download_progress_state = Arc::clone(&download_progress_state);
-                let progress = progress.clone();
-                async move {
-                    let cache_path = cache_path_for_key(cache_dir_ref, &artifact.key)?;
-                    let artifact_key_for_progress = artifact.key.clone();
-                    let progress_callback = move |done: u64, _total: u64| {
-                        let snapshot = {
-                            let mut state = download_progress_state
-                                .lock()
-                                .unwrap_or_else(std::sync::PoisonError::into_inner);
-                            state.observe_artifact_bytes(&artifact_key_for_progress, done);
-                            state.snapshot(total_bytes_u64, total_items)
-                        };
-                        emit_progress(progress.as_ref(), snapshot);
-                    };
-                    let outcome = fetch_or_reuse_file(
-                        storage,
-                        &artifact.key,
-                        &cache_path,
-                        &artifact.sha256,
-                        Some(&progress_callback),
-                    )
-                    .await?;
-
-                    let stage_path = staging_dir_ref.join(&artifact.key);
-                    if let Some(parent) = stage_path.parent() {
-                        tokio::fs::create_dir_all(parent).await?;
-                    }
-                    tokio::fs::copy(&cache_path, &stage_path).await?;
-
-                    Ok::<(ArtifactDownload, CacheFetchOutcome), SurgeError>((artifact, outcome))
-                }
-            })
-            .buffer_unordered(DOWNLOAD_CONCURRENCY);
-
-        while let Some(result) = download_stream.next().await {
-            self.ctx.check_cancelled()?;
-            let (artifact, outcome) = result?;
-
-            debug!(key = %artifact.key, ?outcome, "Prepared artifact for update application");
-
-            let snapshot = {
-                let mut state = download_progress_state
-                    .lock()
-                    .unwrap_or_else(std::sync::PoisonError::into_inner);
-                state.finish_artifact(&artifact.key, u64::try_from(artifact.size.max(0)).unwrap_or(u64::MAX));
-                state.snapshot(total_bytes_u64, total_items)
-            };
-            emit_progress(progress.as_ref(), snapshot);
-        }
-
-        emit_progress(
-            progress.as_ref(),
-            ProgressInfo {
-                phase: 2,
-                phase_percent: 100,
-                total_percent: 40,
-                bytes_done: total_bytes,
-                bytes_total: total_bytes,
-                items_done: total_items,
-                items_total: total_items,
-                speed_bytes_per_sec: {
-                    let state = download_progress_state
-                        .lock()
-                        .unwrap_or_else(std::sync::PoisonError::into_inner);
-                    average_speed_bytes_per_sec(state.bytes_done(), state.started_at())
-                },
-            },
-        );
-
-        // Phase 3: Verify
-        emit_progress(
-            progress.as_ref(),
-            ProgressInfo {
-                phase: 3,
-                total_percent: 45,
-                items_total: total_items,
-                ..ProgressInfo::default()
-            },
-        );
-
-        if matches!(info.apply_strategy, ApplyStrategy::Delta) {
-            for release in &info.apply_releases {
-                self.ctx.check_cancelled()?;
-
-                let Some(delta) = release.selected_delta() else {
-                    continue;
-                };
-
-                let path = staging_dir.join(&delta.filename);
-                let hash = sha256_hex_file(&path)?;
-                if !delta.sha256.is_empty() && hash != delta.sha256 {
-                    return Err(SurgeError::Update(format!(
-                        "SHA-256 mismatch for {}: expected {}, got {hash}",
-                        delta.filename, delta.sha256
-                    )));
-                }
-            }
-        } else {
-            let latest = info
-                .apply_releases
-                .last()
-                .ok_or_else(|| SurgeError::Update("No latest release".to_string()))?;
-            let path = staging_dir.join(&latest.full_filename);
-            let hash = sha256_hex_file(&path)?;
-            if !latest.full_sha256.is_empty() && hash != latest.full_sha256 {
-                return Err(SurgeError::Update(format!(
-                    "SHA-256 mismatch for {}: expected {}, got {hash}",
-                    latest.full_filename, latest.full_sha256
-                )));
-            }
-        }
-
-        emit_progress(
-            progress.as_ref(),
-            ProgressInfo {
-                phase: 3,
-                phase_percent: 100,
-                total_percent: 55,
-                items_done: total_items,
-                items_total: total_items,
-                ..ProgressInfo::default()
-            },
-        );
+        prepare_update_artifacts(self, info, &staging_dir, &artifact_cache_dir, progress.as_ref()).await?;
 
         let extract_dir = staging_dir.join("extracted");
         tokio::fs::create_dir_all(&extract_dir).await?;
-
-        if matches!(info.apply_strategy, ApplyStrategy::Delta) {
-            // Phase 5: Apply delta
-            let apply_delta_started_at = Instant::now();
-            let apply_delta_total_items = i64::try_from(info.apply_releases.len()).unwrap_or(i64::MAX);
-            let apply_delta_total_bytes = info
-                .apply_releases
-                .iter()
-                .filter_map(ReleaseEntry::selected_delta)
-                .fold(0i64, |acc, delta| acc.saturating_add(delta.size.max(0)));
-
-            emit_progress(
-                progress.as_ref(),
-                ProgressInfo {
-                    phase: 5,
-                    total_percent: 60,
-                    bytes_total: apply_delta_total_bytes,
-                    items_total: apply_delta_total_items,
-                    ..ProgressInfo::default()
-                },
-            );
-
-            // Restore the current full archive (direct or reconstructed from
-            // earlier full + deltas), then apply the downloaded delta chain.
-            let index = if let Some(cached) = &self.cached_index {
-                cached.clone()
-            } else {
-                let data = self.storage.get_object(RELEASES_FILE_COMPRESSED).await?;
-                decompress_release_index(&data)?
-            };
-            let rid = current_rid();
-            let current_release =
-                find_release_for_version_rid(&index, &rid, &self.current_version).ok_or_else(|| {
-                    SurgeError::Update(format!(
-                        "Current release {} ({rid}) was not found in the release index",
-                        self.current_version
-                    ))
-                })?;
-            let mut rebuilt_archive = match restore_full_archive_for_version_with_options(
-                self.storage.as_ref(),
-                &index,
-                &rid,
-                &self.current_version,
-                RestoreOptions {
-                    cache_dir: Some(&artifact_cache_dir),
-                    progress: None,
-                },
-            )
-            .await
-            {
-                Ok(archive) => archive,
-                Err(restore_err) => synthesize_current_full_archive_from_installed_app(
-                    &self.install_dir,
-                    &self.current_version,
-                    current_release,
-                    &artifact_cache_dir,
-                    &self.ctx,
-                )
-                .map_err(|fallback_err| {
-                    SurgeError::Update(format!(
-                        "Failed to restore base full archive for {}: {restore_err}; installed-app fallback failed: {fallback_err}",
-                        self.current_version
-                    ))
-                })?,
-            };
-
-            let mut apply_delta_items_done = 0i64;
-            let mut apply_delta_bytes_done = 0i64;
-            for release in &info.apply_releases {
-                self.ctx.check_cancelled()?;
-
-                let Some(delta) = release.selected_delta() else {
-                    return Err(SurgeError::Update(format!(
-                        "Delta update path is missing delta filename for {}",
-                        release.version
-                    )));
-                };
-
-                if !is_supported_delta(&delta) {
-                    return Err(SurgeError::Update(format!(
-                        "Delta {} for {} uses unsupported descriptor (algorithm='{}', format='{}', compression='{}')",
-                        delta.filename, release.version, delta.algorithm, delta.patch_format, delta.compression
-                    )));
-                }
-
-                let delta_path = staging_dir.join(&delta.filename);
-                let delta_compressed = tokio::fs::read(&delta_path).await?;
-                let patch = decode_delta_patch(delta_compressed.as_slice(), &delta)
-                    .map_err(|e| SurgeError::Archive(format!("Failed to decompress delta {}: {e}", delta.filename)))?;
-                rebuilt_archive = apply_delta_patch(&rebuilt_archive, &patch, &delta)
-                    .map_err(|e| SurgeError::Update(format!("Failed to apply delta {}: {e}", delta.filename)))?;
-
-                if !release.full_sha256.is_empty() {
-                    let hash = sha256_hex(&rebuilt_archive);
-                    if hash != release.full_sha256 {
-                        return Err(SurgeError::Update(format!(
-                            "SHA-256 mismatch for rebuilt full archive {}: expected {}, got {hash}",
-                            release.version, release.full_sha256
-                        )));
-                    }
-                }
-
-                apply_delta_items_done = apply_delta_items_done.saturating_add(1);
-                apply_delta_bytes_done = apply_delta_bytes_done.saturating_add(delta.size.max(0));
-                let phase_percent = clamp_progress_percent(apply_delta_items_done, apply_delta_total_items.max(1));
-                emit_progress(
-                    progress.as_ref(),
-                    ProgressInfo {
-                        phase: 5,
-                        phase_percent,
-                        total_percent: phase_total_percent(60, 20, phase_percent),
-                        bytes_done: apply_delta_bytes_done,
-                        bytes_total: apply_delta_total_bytes,
-                        items_done: apply_delta_items_done,
-                        items_total: apply_delta_total_items,
-                        speed_bytes_per_sec: average_speed_bytes_per_sec(
-                            u64::try_from(apply_delta_bytes_done.max(0)).unwrap_or(u64::MAX),
-                            apply_delta_started_at,
-                        ),
-                    },
-                );
-            }
-
-            emit_progress(
-                progress.as_ref(),
-                ProgressInfo {
-                    phase: 5,
-                    phase_percent: 100,
-                    total_percent: 80,
-                    bytes_done: apply_delta_total_bytes,
-                    bytes_total: apply_delta_total_bytes,
-                    items_done: apply_delta_total_items,
-                    items_total: apply_delta_total_items,
-                    speed_bytes_per_sec: average_speed_bytes_per_sec(
-                        u64::try_from(apply_delta_total_bytes.max(0)).unwrap_or(u64::MAX),
-                        apply_delta_started_at,
-                    ),
-                },
-            );
-
-            let rebuilt_archive_path = staging_dir.join("rebuilt-full.tar.zst");
-            tokio::fs::write(&rebuilt_archive_path, &rebuilt_archive).await?;
-            // Phase 4: Extract the rebuilt archive into place.
-            emit_progress(
-                progress.as_ref(),
-                ProgressInfo {
-                    phase: 4,
-                    total_percent: 80,
-                    ..ProgressInfo::default()
-                },
-            );
-            let extract_started_at = Instant::now();
-            let progress_for_extract = progress.clone();
-            let extract_progress = move |items_done: u64, items_total: u64, bytes_done: u64, bytes_total: u64| {
-                let phase_percent = if bytes_total > 0 {
-                    clamp_progress_percent_u64(bytes_done, bytes_total)
-                } else {
-                    clamp_progress_percent_u64(items_done, items_total)
-                };
-                emit_progress(
-                    progress_for_extract.as_ref(),
-                    ProgressInfo {
-                        phase: 4,
-                        phase_percent,
-                        total_percent: phase_total_percent(80, 10, phase_percent),
-                        bytes_done: saturating_i64_from_u64(bytes_done),
-                        bytes_total: saturating_i64_from_u64(bytes_total),
-                        items_done: saturating_i64_from_u64(items_done),
-                        items_total: saturating_i64_from_u64(items_total),
-                        speed_bytes_per_sec: average_speed_bytes_per_sec(bytes_done, extract_started_at),
-                    },
-                );
-            };
-            extract_file_to_with_progress(&rebuilt_archive_path, &extract_dir, Some(&extract_progress))?;
-            emit_progress(
-                progress.as_ref(),
-                ProgressInfo {
-                    phase: 4,
-                    phase_percent: 100,
-                    total_percent: 90,
-                    ..ProgressInfo::default()
-                },
-            );
-        } else {
-            // Phase 4: Extract
-            emit_progress(
-                progress.as_ref(),
-                ProgressInfo {
-                    phase: 4,
-                    total_percent: 60,
-                    ..ProgressInfo::default()
-                },
-            );
-            let extract_started_at = Instant::now();
-            let progress_for_extract = progress.clone();
-            let extract_progress = move |items_done: u64, items_total: u64, bytes_done: u64, bytes_total: u64| {
-                let phase_percent = if bytes_total > 0 {
-                    clamp_progress_percent_u64(bytes_done, bytes_total)
-                } else {
-                    clamp_progress_percent_u64(items_done, items_total)
-                };
-                emit_progress(
-                    progress_for_extract.as_ref(),
-                    ProgressInfo {
-                        phase: 4,
-                        phase_percent,
-                        total_percent: phase_total_percent(60, 15, phase_percent),
-                        bytes_done: saturating_i64_from_u64(bytes_done),
-                        bytes_total: saturating_i64_from_u64(bytes_total),
-                        items_done: saturating_i64_from_u64(items_done),
-                        items_total: saturating_i64_from_u64(items_total),
-                        speed_bytes_per_sec: average_speed_bytes_per_sec(bytes_done, extract_started_at),
-                    },
-                );
-            };
-            let latest = info
-                .apply_releases
-                .last()
-                .ok_or_else(|| SurgeError::Update("No latest release".to_string()))?;
-            let archive_path = staging_dir.join(&latest.full_filename);
-            extract_file_to_with_progress(&archive_path, &extract_dir, Some(&extract_progress))?;
-            emit_progress(
-                progress.as_ref(),
-                ProgressInfo {
-                    phase: 4,
-                    phase_percent: 100,
-                    total_percent: 75,
-                    ..ProgressInfo::default()
-                },
-            );
-
-            // Phase 5: Apply delta (if applicable)
-            emit_progress(
-                progress.as_ref(),
-                ProgressInfo {
-                    phase: 5,
-                    total_percent: 80,
-                    ..ProgressInfo::default()
-                },
-            );
-            emit_progress(
-                progress.as_ref(),
-                ProgressInfo {
-                    phase: 5,
-                    phase_percent: 100,
-                    total_percent: 85,
-                    ..ProgressInfo::default()
-                },
-            );
-        }
+        let extracted_final_dir = materialize_update_payload(
+            self,
+            info,
+            &staging_dir,
+            &artifact_cache_dir,
+            &extract_dir,
+            progress.as_ref(),
+        )
+        .await?;
 
         // Phase 6: Finalize
         emit_progress(
@@ -698,15 +281,9 @@ impl UpdateManager {
         let fallback_previous_app_dir = if active_app_dir.is_dir() {
             None
         } else {
-            find_previous_app_dir(&self.install_dir, &self.current_version)
+            apply::find_previous_app_dir(&self.install_dir, &self.current_version)
         };
 
-        let extracted_final_dir = if matches!(info.apply_strategy, ApplyStrategy::Delta) {
-            let source = extract_dir.join(&info.latest_version);
-            if source.exists() { source } else { extract_dir.clone() }
-        } else {
-            extract_dir.clone()
-        };
         atomic_rename(&extracted_final_dir, &next_app_dir)?;
 
         if active_app_dir.is_dir() {
@@ -875,112 +452,6 @@ impl UpdateManager {
 
         Ok(())
     }
-}
-
-fn find_previous_app_dir(install_dir: &Path, current_version: &str) -> Option<PathBuf> {
-    let active = install_dir.join("app");
-    if active.is_dir() {
-        return Some(active);
-    }
-
-    let explicit = install_dir.join(format!("app-{current_version}"));
-    if explicit.is_dir() {
-        return Some(explicit);
-    }
-
-    find_latest_app_dir(install_dir).ok()
-}
-
-fn synthesize_current_full_archive_from_installed_app(
-    install_dir: &Path,
-    current_version: &str,
-    current_release: &ReleaseEntry,
-    artifact_cache_dir: &Path,
-    ctx: &Arc<Context>,
-) -> Result<Vec<u8>> {
-    let app_dir = find_previous_app_dir(install_dir, current_version).ok_or_else(|| {
-        SurgeError::NotFound(format!(
-            "No active installed app directory was found for current version {current_version}"
-        ))
-    })?;
-
-    let mut excluded_relative_paths = BTreeSet::new();
-    excluded_relative_paths.insert(crate::install::RUNTIME_MANIFEST_RELATIVE_PATH.to_string());
-    excluded_relative_paths.insert(crate::install::LEGACY_RUNTIME_MANIFEST_RELATIVE_PATH.to_string());
-    if runtime_state_dir_contains_only_manifests(&app_dir)? {
-        excluded_relative_paths.insert(".surge".to_string());
-    }
-
-    let budget = ctx.resource_budget();
-    let archive = build_canonical_archive_from_directory(
-        &app_dir,
-        budget.zstd_compression_level,
-        budget.effective_zstd_workers(),
-        &excluded_relative_paths,
-    )?;
-
-    let mut cache_path = None;
-    if !current_release.full_sha256.trim().is_empty() {
-        let actual_sha256 = sha256_hex(&archive);
-        if actual_sha256 == current_release.full_sha256 {
-            cache_path = Some(cache_path_for_key(artifact_cache_dir, &current_release.full_filename)?);
-        } else {
-            warn!(
-                version = %current_release.version,
-                expected_sha256 = %current_release.full_sha256,
-                actual_sha256 = %actual_sha256,
-                "Installed app content reproduced the current package payload but not the original compressed full archive bytes; using synthesized archive for in-flight delta application without caching it"
-            );
-        }
-    }
-
-    if let Some(cache_path) = cache_path {
-        write_file_atomic(&cache_path, &archive)?;
-        debug!(
-            version = %current_release.version,
-            app_dir = %app_dir.display(),
-            cache_path = %cache_path.display(),
-            "Rebuilt current full archive from installed app content"
-        );
-    }
-    Ok(archive)
-}
-
-fn runtime_state_dir_contains_only_manifests(app_dir: &Path) -> Result<bool> {
-    let surge_dir = app_dir.join(".surge");
-    if !surge_dir.exists() {
-        return Ok(false);
-    }
-    if !surge_dir.is_dir() {
-        return Ok(false);
-    }
-
-    let allowed = BTreeSet::from([
-        crate::install::RUNTIME_MANIFEST_RELATIVE_PATH.to_string(),
-        crate::install::LEGACY_RUNTIME_MANIFEST_RELATIVE_PATH.to_string(),
-    ]);
-    let mut stack = vec![surge_dir];
-    while let Some(dir) = stack.pop() {
-        let entries = std::fs::read_dir(&dir)?.collect::<std::result::Result<Vec<_>, std::io::Error>>()?;
-        for entry in entries {
-            let path = entry.path();
-            let metadata = std::fs::symlink_metadata(&path)?;
-            if metadata.is_dir() {
-                stack.push(path);
-                continue;
-            }
-
-            let relative = path
-                .strip_prefix(app_dir)
-                .map_err(|e| SurgeError::Update(format!("Failed to relativize installed app path: {e}")))?;
-            let relative = relative.to_string_lossy().replace('\\', "/");
-            if !allowed.contains(&relative) {
-                return Ok(false);
-            }
-        }
-    }
-
-    Ok(true)
 }
 
 async fn request_supervisor_shutdown(install_dir: &Path, supervisor_id: &str) -> Result<()> {
@@ -1170,20 +641,25 @@ fn restart_supervisor_after_update(install_dir: &Path, active_app_dir: &Path, la
 mod tests {
     #![allow(clippy::cast_possible_wrap)]
 
+    use std::sync::Mutex;
+
     use super::*;
     use crate::archive::packer::ArchivePacker;
     use crate::config::constants::DEFAULT_ZSTD_LEVEL;
     #[cfg(target_os = "linux")]
     use crate::config::manifest::ShortcutLocation;
     use crate::context::StorageProvider;
+    use crate::crypto::sha256::{sha256_hex, sha256_hex_file};
     use crate::diff::chunked::ChunkedDiffOptions;
     use crate::diff::wrapper::bsdiff_buffers;
+    use crate::platform::detect::current_rid;
     #[cfg(target_os = "linux")]
     use crate::platform::shortcuts::{
         clear_test_shortcut_paths_override, lock_test_shortcut_environment_async, set_test_shortcut_paths_override,
     };
-    use crate::releases::delta::build_sparse_file_patch;
+    use crate::releases::delta::{apply_delta_patch, build_sparse_file_patch, decode_delta_patch};
     use crate::releases::manifest::{DeltaArtifact, ReleaseEntry, ReleaseIndex, compress_release_index};
+    use crate::releases::restore::find_release_for_version_rid;
 
     #[cfg(target_os = "linux")]
     struct ShortcutPathsOverrideGuard;
@@ -1953,7 +1429,7 @@ mod tests {
             UpdateManager::new(ctx, "test-app", "1.0.0", "stable", install_root.to_str().unwrap()).unwrap();
         let info = manager.check_for_updates().await.unwrap().unwrap();
 
-        let observed = Arc::new(Mutex::new(Vec::new()));
+        let observed = Arc::new(Mutex::new(Vec::<ProgressInfo>::new()));
         let observed_for_progress = Arc::clone(&observed);
 
         manager
@@ -2183,7 +1659,7 @@ mod tests {
         let info = manager.check_for_updates().await.unwrap().unwrap();
         assert_eq!(info.apply_strategy, ApplyStrategy::Delta);
 
-        let observed = Arc::new(Mutex::new(Vec::new()));
+        let observed = Arc::new(Mutex::new(Vec::<ProgressInfo>::new()));
         let observed_for_progress = Arc::clone(&observed);
         manager
             .download_and_apply(
@@ -2490,7 +1966,7 @@ mod tests {
 
         let current_release = find_release_for_version_rid(&index, &rid, "1.1.0").unwrap();
         let artifact_cache_dir = install_root.join(".surge-cache").join("artifacts");
-        let synthesized = synthesize_current_full_archive_from_installed_app(
+        let synthesized = apply::synthesize_current_full_archive_from_installed_app(
             &install_root,
             "1.1.0",
             current_release,

--- a/crates/surge-core/src/update/manager/apply.rs
+++ b/crates/surge-core/src/update/manager/apply.rs
@@ -1,0 +1,412 @@
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::Instant;
+
+use tracing::{debug, warn};
+
+use crate::archive::extractor::extract_file_to_with_progress;
+use crate::config::constants::RELEASES_FILE_COMPRESSED;
+use crate::context::Context;
+use crate::crypto::sha256::sha256_hex;
+use crate::error::{Result, SurgeError};
+use crate::pack::builder::build_canonical_archive_from_directory;
+use crate::platform::detect::current_rid;
+use crate::platform::fs::write_file_atomic;
+use crate::releases::artifact_cache::cache_path_for_key;
+use crate::releases::delta::{apply_delta_patch, decode_delta_patch, is_supported_delta};
+use crate::releases::manifest::{ReleaseEntry, decompress_release_index};
+use crate::releases::restore::{
+    RestoreOptions, find_release_for_version_rid, restore_full_archive_for_version_with_options,
+};
+use crate::supervisor::stub::find_latest_app_dir;
+
+use super::progress::{
+    ProgressInfo, average_speed_bytes_per_sec, clamp_progress_percent, clamp_progress_percent_u64, emit_progress,
+    phase_total_percent, saturating_i64_from_u64,
+};
+use super::{ApplyStrategy, UpdateInfo, UpdateManager};
+
+pub(super) async fn materialize_update_payload<F>(
+    manager: &UpdateManager,
+    info: &UpdateInfo,
+    staging_dir: &Path,
+    artifact_cache_dir: &Path,
+    extract_dir: &Path,
+    progress: Option<&Arc<F>>,
+) -> Result<PathBuf>
+where
+    F: Fn(ProgressInfo) + Send + Sync,
+{
+    if matches!(info.apply_strategy, ApplyStrategy::Delta) {
+        materialize_delta_payload(manager, info, staging_dir, artifact_cache_dir, extract_dir, progress).await
+    } else {
+        materialize_full_payload(info, staging_dir, extract_dir, progress)
+    }
+}
+
+fn materialize_full_payload<F>(
+    info: &UpdateInfo,
+    staging_dir: &Path,
+    extract_dir: &Path,
+    progress: Option<&Arc<F>>,
+) -> Result<PathBuf>
+where
+    F: Fn(ProgressInfo) + Send + Sync,
+{
+    let latest = info
+        .apply_releases
+        .last()
+        .ok_or_else(|| SurgeError::Update("No latest release".to_string()))?;
+    let archive_path = staging_dir.join(&latest.full_filename);
+    extract_archive_with_progress(&archive_path, extract_dir, progress, 60, 75)?;
+
+    emit_progress(
+        progress,
+        ProgressInfo {
+            phase: 5,
+            total_percent: 80,
+            ..ProgressInfo::default()
+        },
+    );
+    emit_progress(
+        progress,
+        ProgressInfo {
+            phase: 5,
+            phase_percent: 100,
+            total_percent: 85,
+            ..ProgressInfo::default()
+        },
+    );
+
+    Ok(extract_dir.to_path_buf())
+}
+
+async fn materialize_delta_payload<F>(
+    manager: &UpdateManager,
+    info: &UpdateInfo,
+    staging_dir: &Path,
+    artifact_cache_dir: &Path,
+    extract_dir: &Path,
+    progress: Option<&Arc<F>>,
+) -> Result<PathBuf>
+where
+    F: Fn(ProgressInfo) + Send + Sync,
+{
+    let apply_delta_started_at = Instant::now();
+    let apply_delta_total_items = i64::try_from(info.apply_releases.len()).unwrap_or(i64::MAX);
+    let apply_delta_total_bytes = info
+        .apply_releases
+        .iter()
+        .filter_map(ReleaseEntry::selected_delta)
+        .fold(0i64, |acc, delta| acc.saturating_add(delta.size.max(0)));
+
+    emit_progress(
+        progress,
+        ProgressInfo {
+            phase: 5,
+            total_percent: 60,
+            bytes_total: apply_delta_total_bytes,
+            items_total: apply_delta_total_items,
+            ..ProgressInfo::default()
+        },
+    );
+
+    let mut rebuilt_archive = restore_base_full_archive(manager, artifact_cache_dir).await?;
+    let mut apply_delta_items_done = 0i64;
+    let mut apply_delta_bytes_done = 0i64;
+
+    for release in &info.apply_releases {
+        manager.ctx.check_cancelled()?;
+
+        let Some(delta) = release.selected_delta() else {
+            return Err(SurgeError::Update(format!(
+                "Delta update path is missing delta filename for {}",
+                release.version
+            )));
+        };
+
+        if !is_supported_delta(&delta) {
+            return Err(SurgeError::Update(format!(
+                "Delta {} for {} uses unsupported descriptor (algorithm='{}', format='{}', compression='{}')",
+                delta.filename, release.version, delta.algorithm, delta.patch_format, delta.compression
+            )));
+        }
+
+        let delta_path = staging_dir.join(&delta.filename);
+        let delta_compressed = tokio::fs::read(&delta_path).await?;
+        let patch = decode_delta_patch(delta_compressed.as_slice(), &delta)
+            .map_err(|e| SurgeError::Archive(format!("Failed to decompress delta {}: {e}", delta.filename)))?;
+        rebuilt_archive = apply_delta_patch(&rebuilt_archive, &patch, &delta)
+            .map_err(|e| SurgeError::Update(format!("Failed to apply delta {}: {e}", delta.filename)))?;
+
+        if !release.full_sha256.is_empty() {
+            let hash = sha256_hex(&rebuilt_archive);
+            if hash != release.full_sha256 {
+                return Err(SurgeError::Update(format!(
+                    "SHA-256 mismatch for rebuilt full archive {}: expected {}, got {hash}",
+                    release.version, release.full_sha256
+                )));
+            }
+        }
+
+        apply_delta_items_done = apply_delta_items_done.saturating_add(1);
+        apply_delta_bytes_done = apply_delta_bytes_done.saturating_add(delta.size.max(0));
+        let phase_percent = clamp_progress_percent(apply_delta_items_done, apply_delta_total_items.max(1));
+        emit_progress(
+            progress,
+            ProgressInfo {
+                phase: 5,
+                phase_percent,
+                total_percent: phase_total_percent(60, 20, phase_percent),
+                bytes_done: apply_delta_bytes_done,
+                bytes_total: apply_delta_total_bytes,
+                items_done: apply_delta_items_done,
+                items_total: apply_delta_total_items,
+                speed_bytes_per_sec: average_speed_bytes_per_sec(
+                    u64::try_from(apply_delta_bytes_done.max(0)).unwrap_or(u64::MAX),
+                    apply_delta_started_at,
+                ),
+            },
+        );
+    }
+
+    emit_progress(
+        progress,
+        ProgressInfo {
+            phase: 5,
+            phase_percent: 100,
+            total_percent: 80,
+            bytes_done: apply_delta_total_bytes,
+            bytes_total: apply_delta_total_bytes,
+            items_done: apply_delta_total_items,
+            items_total: apply_delta_total_items,
+            speed_bytes_per_sec: average_speed_bytes_per_sec(
+                u64::try_from(apply_delta_total_bytes.max(0)).unwrap_or(u64::MAX),
+                apply_delta_started_at,
+            ),
+        },
+    );
+
+    let rebuilt_archive_path = staging_dir.join("rebuilt-full.tar.zst");
+    tokio::fs::write(&rebuilt_archive_path, &rebuilt_archive).await?;
+    extract_archive_with_progress(&rebuilt_archive_path, extract_dir, progress, 80, 90)?;
+
+    let source = extract_dir.join(&info.latest_version);
+    if source.exists() {
+        Ok(source)
+    } else {
+        Ok(extract_dir.to_path_buf())
+    }
+}
+
+async fn restore_base_full_archive(manager: &UpdateManager, artifact_cache_dir: &Path) -> Result<Vec<u8>> {
+    let index = if let Some(cached) = &manager.cached_index {
+        cached.clone()
+    } else {
+        let data = manager.storage.get_object(RELEASES_FILE_COMPRESSED).await?;
+        decompress_release_index(&data)?
+    };
+    let rid = current_rid();
+    let current_release = find_release_for_version_rid(&index, &rid, &manager.current_version).ok_or_else(|| {
+        SurgeError::Update(format!(
+            "Current release {} ({rid}) was not found in the release index",
+            manager.current_version
+        ))
+    })?;
+
+    match restore_full_archive_for_version_with_options(
+        manager.storage.as_ref(),
+        &index,
+        &rid,
+        &manager.current_version,
+        RestoreOptions {
+            cache_dir: Some(artifact_cache_dir),
+            progress: None,
+        },
+    )
+    .await
+    {
+        Ok(archive) => Ok(archive),
+        Err(restore_err) => synthesize_current_full_archive_from_installed_app(
+            &manager.install_dir,
+            &manager.current_version,
+            current_release,
+            artifact_cache_dir,
+            &manager.ctx,
+        )
+        .map_err(|fallback_err| {
+            SurgeError::Update(format!(
+                "Failed to restore base full archive for {}: {restore_err}; installed-app fallback failed: {fallback_err}",
+                manager.current_version
+            ))
+        }),
+    }
+}
+
+fn extract_archive_with_progress<F>(
+    archive_path: &Path,
+    extract_dir: &Path,
+    progress: Option<&Arc<F>>,
+    total_percent_start: i32,
+    total_percent_end: i32,
+) -> Result<()>
+where
+    F: Fn(ProgressInfo) + Send + Sync,
+{
+    emit_progress(
+        progress,
+        ProgressInfo {
+            phase: 4,
+            total_percent: total_percent_start,
+            ..ProgressInfo::default()
+        },
+    );
+
+    let extract_started_at = Instant::now();
+    let progress_for_extract = progress.cloned();
+    let extract_progress = move |items_done: u64, items_total: u64, bytes_done: u64, bytes_total: u64| {
+        let phase_percent = if bytes_total > 0 {
+            clamp_progress_percent_u64(bytes_done, bytes_total)
+        } else {
+            clamp_progress_percent_u64(items_done, items_total)
+        };
+        emit_progress(
+            progress_for_extract.as_ref(),
+            ProgressInfo {
+                phase: 4,
+                phase_percent,
+                total_percent: phase_total_percent(
+                    total_percent_start,
+                    total_percent_end - total_percent_start,
+                    phase_percent,
+                ),
+                bytes_done: saturating_i64_from_u64(bytes_done),
+                bytes_total: saturating_i64_from_u64(bytes_total),
+                items_done: saturating_i64_from_u64(items_done),
+                items_total: saturating_i64_from_u64(items_total),
+                speed_bytes_per_sec: average_speed_bytes_per_sec(bytes_done, extract_started_at),
+            },
+        );
+    };
+
+    extract_file_to_with_progress(archive_path, extract_dir, Some(&extract_progress))?;
+
+    emit_progress(
+        progress,
+        ProgressInfo {
+            phase: 4,
+            phase_percent: 100,
+            total_percent: total_percent_end,
+            ..ProgressInfo::default()
+        },
+    );
+
+    Ok(())
+}
+
+pub(super) fn synthesize_current_full_archive_from_installed_app(
+    install_dir: &Path,
+    current_version: &str,
+    current_release: &ReleaseEntry,
+    artifact_cache_dir: &Path,
+    ctx: &Arc<Context>,
+) -> Result<Vec<u8>> {
+    let app_dir = find_previous_app_dir(install_dir, current_version).ok_or_else(|| {
+        SurgeError::NotFound(format!(
+            "No active installed app directory was found for current version {current_version}"
+        ))
+    })?;
+
+    let mut excluded_relative_paths = BTreeSet::new();
+    excluded_relative_paths.insert(crate::install::RUNTIME_MANIFEST_RELATIVE_PATH.to_string());
+    excluded_relative_paths.insert(crate::install::LEGACY_RUNTIME_MANIFEST_RELATIVE_PATH.to_string());
+    if runtime_state_dir_contains_only_manifests(&app_dir)? {
+        excluded_relative_paths.insert(".surge".to_string());
+    }
+
+    let budget = ctx.resource_budget();
+    let archive = build_canonical_archive_from_directory(
+        &app_dir,
+        budget.zstd_compression_level,
+        budget.effective_zstd_workers(),
+        &excluded_relative_paths,
+    )?;
+
+    let mut cache_path = None;
+    if !current_release.full_sha256.trim().is_empty() {
+        let actual_sha256 = sha256_hex(&archive);
+        if actual_sha256 == current_release.full_sha256 {
+            cache_path = Some(cache_path_for_key(artifact_cache_dir, &current_release.full_filename)?);
+        } else {
+            warn!(
+                version = %current_release.version,
+                expected_sha256 = %current_release.full_sha256,
+                actual_sha256 = %actual_sha256,
+                "Installed app content reproduced the current package payload but not the original compressed full archive bytes; using synthesized archive for in-flight delta application without caching it"
+            );
+        }
+    }
+
+    if let Some(cache_path) = cache_path {
+        write_file_atomic(&cache_path, &archive)?;
+        debug!(
+            version = %current_release.version,
+            app_dir = %app_dir.display(),
+            cache_path = %cache_path.display(),
+            "Rebuilt current full archive from installed app content"
+        );
+    }
+    Ok(archive)
+}
+
+pub(super) fn find_previous_app_dir(install_dir: &Path, current_version: &str) -> Option<PathBuf> {
+    let active = install_dir.join("app");
+    if active.is_dir() {
+        return Some(active);
+    }
+
+    let explicit = install_dir.join(format!("app-{current_version}"));
+    if explicit.is_dir() {
+        return Some(explicit);
+    }
+
+    find_latest_app_dir(install_dir).ok()
+}
+
+fn runtime_state_dir_contains_only_manifests(app_dir: &Path) -> Result<bool> {
+    let surge_dir = app_dir.join(".surge");
+    if !surge_dir.exists() {
+        return Ok(false);
+    }
+    if !surge_dir.is_dir() {
+        return Ok(false);
+    }
+
+    let allowed = BTreeSet::from([
+        crate::install::RUNTIME_MANIFEST_RELATIVE_PATH.to_string(),
+        crate::install::LEGACY_RUNTIME_MANIFEST_RELATIVE_PATH.to_string(),
+    ]);
+    let mut stack = vec![surge_dir];
+    while let Some(dir) = stack.pop() {
+        let entries = std::fs::read_dir(&dir)?.collect::<std::result::Result<Vec<_>, std::io::Error>>()?;
+        for entry in entries {
+            let path = entry.path();
+            let metadata = std::fs::symlink_metadata(&path)?;
+            if metadata.is_dir() {
+                stack.push(path);
+                continue;
+            }
+
+            let relative = path
+                .strip_prefix(app_dir)
+                .map_err(|e| SurgeError::Update(format!("Failed to relativize installed app path: {e}")))?;
+            let relative = relative.to_string_lossy().replace('\\', "/");
+            if !allowed.contains(&relative) {
+                return Ok(false);
+            }
+        }
+    }
+
+    Ok(true)
+}

--- a/crates/surge-core/src/update/manager/artifacts.rs
+++ b/crates/surge-core/src/update/manager/artifacts.rs
@@ -1,0 +1,217 @@
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+
+use futures_util::stream::{self, StreamExt};
+use tracing::debug;
+
+use crate::crypto::sha256::sha256_hex_file;
+use crate::error::{Result, SurgeError};
+use crate::releases::artifact_cache::{CacheFetchOutcome, cache_path_for_key, fetch_or_reuse_file};
+use crate::releases::manifest::ReleaseEntry;
+
+use super::progress::{
+    ArtifactDownload, DownloadProgressState, ProgressInfo, average_speed_bytes_per_sec, emit_progress,
+};
+use super::{ApplyStrategy, UpdateInfo, UpdateManager};
+
+const DOWNLOAD_CONCURRENCY: usize = 4;
+
+pub(super) async fn prepare_update_artifacts<F>(
+    manager: &UpdateManager,
+    info: &UpdateInfo,
+    staging_dir: &Path,
+    artifact_cache_dir: &Path,
+    progress: Option<&Arc<F>>,
+) -> Result<()>
+where
+    F: Fn(ProgressInfo) + Send + Sync,
+{
+    let progress = progress.cloned();
+    let artifacts = selected_artifacts(info)?;
+    let total_items = i64::try_from(artifacts.len()).unwrap_or(i64::MAX);
+    let total_bytes = artifacts
+        .iter()
+        .fold(0i64, |acc, artifact| acc.saturating_add(artifact.size.max(0)));
+    let total_bytes_u64 = u64::try_from(total_bytes).unwrap_or(u64::MAX);
+
+    emit_progress(
+        progress.as_ref(),
+        ProgressInfo {
+            phase: 2,
+            total_percent: 10,
+            bytes_total: total_bytes,
+            items_total: total_items,
+            ..ProgressInfo::default()
+        },
+    );
+
+    let storage = manager.storage.as_ref();
+    let download_progress_state = Arc::new(Mutex::new(DownloadProgressState::new()));
+    let mut download_stream = stream::iter(artifacts.into_iter())
+        .map(|artifact| {
+            let download_progress_state = Arc::clone(&download_progress_state);
+            let progress = progress.clone();
+            async move {
+                let cache_path = cache_path_for_key(artifact_cache_dir, &artifact.key)?;
+                let artifact_key_for_progress = artifact.key.clone();
+                let progress_callback = move |done: u64, _total: u64| {
+                    let snapshot = {
+                        let mut state = download_progress_state
+                            .lock()
+                            .unwrap_or_else(std::sync::PoisonError::into_inner);
+                        state.observe_artifact_bytes(&artifact_key_for_progress, done);
+                        state.snapshot(total_bytes_u64, total_items)
+                    };
+                    emit_progress(progress.as_ref(), snapshot);
+                };
+                let outcome = fetch_or_reuse_file(
+                    storage,
+                    &artifact.key,
+                    &cache_path,
+                    &artifact.sha256,
+                    Some(&progress_callback),
+                )
+                .await?;
+
+                let stage_path = staging_dir.join(&artifact.key);
+                if let Some(parent) = stage_path.parent() {
+                    tokio::fs::create_dir_all(parent).await?;
+                }
+                tokio::fs::copy(&cache_path, &stage_path).await?;
+
+                Ok::<(ArtifactDownload, CacheFetchOutcome), SurgeError>((artifact, outcome))
+            }
+        })
+        .buffer_unordered(DOWNLOAD_CONCURRENCY);
+
+    while let Some(result) = download_stream.next().await {
+        manager.ctx.check_cancelled()?;
+        let (artifact, outcome) = result?;
+
+        debug!(key = %artifact.key, ?outcome, "Prepared artifact for update application");
+
+        let snapshot = {
+            let mut state = download_progress_state
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            state.finish_artifact(&artifact.key, u64::try_from(artifact.size.max(0)).unwrap_or(u64::MAX));
+            state.snapshot(total_bytes_u64, total_items)
+        };
+        emit_progress(progress.as_ref(), snapshot);
+    }
+
+    emit_progress(
+        progress.as_ref(),
+        ProgressInfo {
+            phase: 2,
+            phase_percent: 100,
+            total_percent: 40,
+            bytes_done: total_bytes,
+            bytes_total: total_bytes,
+            items_done: total_items,
+            items_total: total_items,
+            speed_bytes_per_sec: {
+                let state = download_progress_state
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner);
+                average_speed_bytes_per_sec(state.bytes_done(), state.started_at())
+            },
+        },
+    );
+
+    verify_update_artifacts(info, staging_dir, total_items, progress.as_ref())
+}
+
+fn selected_artifacts(info: &UpdateInfo) -> Result<Vec<ArtifactDownload>> {
+    let artifacts = if matches!(info.apply_strategy, ApplyStrategy::Delta) {
+        info.apply_releases
+            .iter()
+            .filter_map(ReleaseEntry::selected_delta)
+            .map(|delta| ArtifactDownload {
+                key: delta.filename.clone(),
+                sha256: delta.sha256.clone(),
+                size: delta.size,
+            })
+            .collect()
+    } else {
+        let latest = info
+            .apply_releases
+            .last()
+            .ok_or_else(|| SurgeError::Update("No latest release".to_string()))?;
+        vec![ArtifactDownload {
+            key: latest.full_filename.clone(),
+            sha256: latest.full_sha256.clone(),
+            size: latest.full_size,
+        }]
+    };
+
+    if artifacts.is_empty() {
+        return Err(SurgeError::Update("No artifacts selected for download".to_string()));
+    }
+
+    Ok(artifacts)
+}
+
+fn verify_update_artifacts<F>(
+    info: &UpdateInfo,
+    staging_dir: &Path,
+    total_items: i64,
+    progress: Option<&Arc<F>>,
+) -> Result<()>
+where
+    F: Fn(ProgressInfo) + Send + Sync,
+{
+    emit_progress(
+        progress,
+        ProgressInfo {
+            phase: 3,
+            total_percent: 45,
+            items_total: total_items,
+            ..ProgressInfo::default()
+        },
+    );
+
+    if matches!(info.apply_strategy, ApplyStrategy::Delta) {
+        for release in &info.apply_releases {
+            let Some(delta) = release.selected_delta() else {
+                continue;
+            };
+
+            let path = staging_dir.join(&delta.filename);
+            let hash = sha256_hex_file(&path)?;
+            if !delta.sha256.is_empty() && hash != delta.sha256 {
+                return Err(SurgeError::Update(format!(
+                    "SHA-256 mismatch for {}: expected {}, got {hash}",
+                    delta.filename, delta.sha256
+                )));
+            }
+        }
+    } else {
+        let latest = info
+            .apply_releases
+            .last()
+            .ok_or_else(|| SurgeError::Update("No latest release".to_string()))?;
+        let path = staging_dir.join(&latest.full_filename);
+        let hash = sha256_hex_file(&path)?;
+        if !latest.full_sha256.is_empty() && hash != latest.full_sha256 {
+            return Err(SurgeError::Update(format!(
+                "SHA-256 mismatch for {}: expected {}, got {hash}",
+                latest.full_filename, latest.full_sha256
+            )));
+        }
+    }
+
+    emit_progress(
+        progress,
+        ProgressInfo {
+            phase: 3,
+            phase_percent: 100,
+            total_percent: 55,
+            items_done: total_items,
+            items_total: total_items,
+            ..ProgressInfo::default()
+        },
+    );
+
+    Ok(())
+}

--- a/docs/architecture/maintainability-baseline.txt
+++ b/docs/architecture/maintainability-baseline.txt
@@ -14,5 +14,5 @@
 625 crates/surge-core/src/releases/restore.rs
 604 crates/surge-core/src/storage/azure.rs
 840 crates/surge-core/src/storage/gcs.rs
-1169 crates/surge-core/src/update/manager.rs
+640 crates/surge-core/src/update/manager.rs
 760 crates/surge-installer-ui/src/app.rs


### PR DESCRIPTION
## Summary
- extract update artifact selection, download, and verification into `update/manager/artifacts.rs`
- extract full-vs-delta payload materialization and base-archive reconstruction into `update/manager/apply.rs`
- keep `UpdateManager::download_and_apply` as orchestration and tighten the maintainability baseline for `manager.rs` from 1169 to 640 production lines

## Why
`crates/surge-core/src/update/manager.rs` was still carrying most of the update application pipeline in one file after phase 1. This split isolates the download/verify path from the full-vs-delta materialization path so the remaining root file can focus on orchestration and finalize/lifecycle behavior in the next phase.

## Impact
- no public API changes to `UpdateManager`, `UpdateInfo`, or `ApplyStrategy`
- no intended behavior changes to update application, delta restoration, or progress reporting
- follow-up phase can now target finalize and supervisor lifecycle helpers without mixing artifact logic back in

## Validation
- `git submodule update --init --recursive`
- `cargo check -p surge-core`
- `cargo test -p surge-core update::manager`
- `cargo clippy -p surge-core --all-targets --all-features -- -D warnings -W clippy::pedantic`
- `./scripts/sync-surge-core-vendor.sh --check`
- `./scripts/check-version-sync.sh`
- `cargo fmt --all -- --check`
- `./scripts/check-maintainability.sh`
- `RUSTFLAGS="-D warnings" cargo test --workspace`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo clippy --workspace --lib --bins --examples -- -D warnings -D clippy::unwrap_used -D clippy::expect_used`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings -W clippy::pedantic`
- `dotnet format dotnet/Surge.slnx --verify-no-changes`
- `dotnet test dotnet/Surge.slnx --configuration Release`