### PR TITLE
refactor(core): split azure storage backend helpers

### DIFF
--- a/crates/surge-core/src/storage/azure/auth.rs
+++ b/crates/surge-core/src/storage/azure/auth.rs
@@ -1,0 +1,141 @@
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD as BASE64;
+use chrono::Utc;
+use tracing::trace;
+
+use crate::crypto::hmac_sha256::hmac_sha256;
+use crate::error::{Result, SurgeError};
+
+use super::{AZURE_API_VERSION, AzureBlobBackend};
+
+impl AzureBlobBackend {
+    /// Returns `true` when credentials are available for signing requests.
+    pub(super) fn has_credentials(&self) -> bool {
+        !self.key_bytes.is_empty()
+    }
+
+    /// Return an error when a write is attempted without credentials.
+    pub(super) fn require_credentials(&self, operation: &str) -> Result<()> {
+        if self.has_credentials() {
+            Ok(())
+        } else {
+            Err(SurgeError::Config(format!(
+                "Azure Blob {operation} requires account credentials"
+            )))
+        }
+    }
+
+    /// Produce an RFC 1123 date string (e.g. `Mon, 02 Mar 2026 12:34:56 GMT`).
+    fn rfc1123_date(now: &chrono::DateTime<Utc>) -> String {
+        now.format("%a, %d %b %Y %H:%M:%S GMT").to_string()
+    }
+
+    /// Sign a request using SharedKey authentication and return the headers
+    /// that must be attached to the request.
+    ///
+    /// The string-to-sign format for Blob service:
+    /// ```text
+    /// VERB\n
+    /// Content-Encoding\n
+    /// Content-Language\n
+    /// Content-Length\n
+    /// Content-MD5\n
+    /// Content-Type\n
+    /// Date\n
+    /// If-Modified-Since\n
+    /// If-Match\n
+    /// If-None-Match\n
+    /// If-Unmodified-Since\n
+    /// Range\n
+    /// CanonicalizedHeaders\n
+    /// CanonicalizedResource
+    /// ```
+    #[allow(clippy::too_many_arguments)]
+    pub(super) fn sign_request(
+        &self,
+        method: &str,
+        resource_path: &str,
+        query_params: &[(String, String)],
+        content_length: Option<usize>,
+        content_type: &str,
+        extra_headers: &[(String, String)],
+    ) -> Vec<(String, String)> {
+        let now = Utc::now();
+        let date = Self::rfc1123_date(&now);
+
+        let mut ms_headers: Vec<(String, String)> = vec![
+            ("x-ms-date".to_string(), date.clone()),
+            ("x-ms-version".to_string(), AZURE_API_VERSION.to_string()),
+        ];
+        for (k, v) in extra_headers {
+            if k.starts_with("x-ms-") {
+                ms_headers.push((k.clone(), v.clone()));
+            }
+        }
+        ms_headers.sort_by(|a, b| a.0.cmp(&b.0));
+        ms_headers.dedup_by(|a, b| a.0 == b.0);
+
+        let canonicalized_headers = ms_headers
+            .iter()
+            .map(|(k, v)| format!("{k}:{v}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        let mut canonicalized_resource = format!("/{}{}", self.account, resource_path);
+        if !query_params.is_empty() {
+            let mut sorted_params = query_params.to_vec();
+            sorted_params.sort_by(|a, b| a.0.cmp(&b.0));
+            for (k, v) in &sorted_params {
+                canonicalized_resource.push('\n');
+                canonicalized_resource.push_str(k);
+                canonicalized_resource.push(':');
+                canonicalized_resource.push_str(v);
+            }
+        }
+
+        let content_length_str = match content_length {
+            Some(n) if n > 0 => n.to_string(),
+            _ => String::new(),
+        };
+
+        let string_to_sign = format!(
+            "{method}\n\
+             \n\
+             \n\
+             {content_length_str}\n\
+             \n\
+             {content_type}\n\
+             \n\
+             \n\
+             \n\
+             \n\
+             \n\
+             \n\
+             {canonicalized_headers}\n\
+             {canonicalized_resource}"
+        );
+
+        trace!(string_to_sign = %string_to_sign, "Azure string to sign");
+
+        let signature = BASE64.encode(hmac_sha256(&self.key_bytes, string_to_sign.as_bytes()));
+        let authorization = format!("SharedKey {}:{signature}", self.account);
+
+        let mut headers: Vec<(String, String)> = ms_headers;
+        headers.push(("Authorization".to_string(), authorization));
+        if !content_type.is_empty() {
+            headers.push(("Content-Type".to_string(), content_type.to_string()));
+        }
+
+        headers
+    }
+}
+
+pub(super) fn decode_account_key(account_key: &str) -> Result<Vec<u8>> {
+    if account_key.is_empty() {
+        Ok(Vec::new())
+    } else {
+        BASE64
+            .decode(account_key)
+            .map_err(|e| SurgeError::Config(format!("Azure account key is not valid base64: {e}")))
+    }
+}

--- a/crates/surge-core/src/storage/azure/listing.rs
+++ b/crates/surge-core/src/storage/azure/listing.rs
@@ -1,0 +1,149 @@
+use quick_xml::Reader;
+use quick_xml::events::Event;
+use tracing::debug;
+
+use crate::error::{Result, SurgeError};
+use crate::storage::{ListEntry, ListResult};
+
+/// Parse an Azure List Blobs XML response into a `ListResult`.
+///
+/// Azure response structure:
+/// ```xml
+/// <EnumerationResults>
+///   <Blobs>
+///     <Blob>
+///       <Name>key</Name>
+///       <Properties>
+///         <Content-Length>123</Content-Length>
+///       </Properties>
+///     </Blob>
+///   </Blobs>
+///   <NextMarker>...</NextMarker>
+/// </EnumerationResults>
+/// ```
+pub(super) fn parse_azure_list_blobs_xml(xml: &str) -> Result<ListResult> {
+    let mut reader = Reader::from_str(xml);
+    let mut buf = Vec::new();
+    let mut entries = Vec::new();
+    let mut next_marker: Option<String> = None;
+
+    let mut in_blob = false;
+    let mut in_properties = false;
+    let mut current_name: Option<String> = None;
+    let mut current_size: Option<i64> = None;
+    let mut current_tag = String::new();
+
+    loop {
+        match reader.read_event_into(&mut buf) {
+            Ok(Event::Start(ref e)) => {
+                let tag = String::from_utf8_lossy(e.name().as_ref()).to_string();
+                match tag.as_str() {
+                    "Blob" => {
+                        in_blob = true;
+                        current_name = None;
+                        current_size = None;
+                    }
+                    "Properties" if in_blob => {
+                        in_properties = true;
+                    }
+                    _ => {}
+                }
+                current_tag = tag;
+            }
+            Ok(Event::End(ref e)) => {
+                let tag = String::from_utf8_lossy(e.name().as_ref()).to_string();
+                match tag.as_str() {
+                    "Blob" => {
+                        if let Some(name) = current_name.take() {
+                            entries.push(ListEntry {
+                                key: name,
+                                size: current_size.unwrap_or(0),
+                            });
+                        }
+                        in_blob = false;
+                        in_properties = false;
+                    }
+                    "Properties" => {
+                        in_properties = false;
+                    }
+                    _ => {}
+                }
+                current_tag.clear();
+            }
+            Ok(Event::Text(ref e)) => {
+                let text = String::from_utf8_lossy(e.as_ref()).to_string();
+                if in_blob && !in_properties && current_tag == "Name" {
+                    current_name = Some(text);
+                } else if in_properties && current_tag == "Content-Length" {
+                    current_size = text.parse::<i64>().ok();
+                } else if !in_blob && current_tag == "NextMarker" && !text.is_empty() {
+                    next_marker = Some(text);
+                }
+            }
+            Ok(Event::Eof) => break,
+            Err(e) => {
+                return Err(SurgeError::Storage(format!("Failed to parse Azure list response: {e}")));
+            }
+            _ => {}
+        }
+        buf.clear();
+    }
+
+    let is_truncated = next_marker.is_some();
+    debug!(count = entries.len(), is_truncated, "Azure LIST parsed");
+    Ok(ListResult {
+        entries,
+        next_marker,
+        is_truncated,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_azure_list_blobs_xml;
+
+    #[test]
+    fn parse_azure_list_blobs_xml_reads_entries_and_marker() {
+        let xml = r#"<?xml version="1.0" encoding="utf-8"?>
+<EnumerationResults>
+  <Blobs>
+    <Blob>
+      <Name>prefix/app-1.0.0.zip</Name>
+      <Properties>
+        <Content-Length>123</Content-Length>
+      </Properties>
+    </Blob>
+    <Blob>
+      <Name>prefix/app-1.1.0.zip</Name>
+      <Properties>
+        <Content-Length>456</Content-Length>
+      </Properties>
+    </Blob>
+  </Blobs>
+  <NextMarker>opaque-marker</NextMarker>
+</EnumerationResults>"#;
+
+        let result = parse_azure_list_blobs_xml(xml).expect("azure list xml should parse");
+        assert_eq!(result.entries.len(), 2);
+        assert_eq!(result.entries[0].key, "prefix/app-1.0.0.zip");
+        assert_eq!(result.entries[0].size, 123);
+        assert_eq!(result.entries[1].key, "prefix/app-1.1.0.zip");
+        assert_eq!(result.entries[1].size, 456);
+        assert_eq!(result.next_marker.as_deref(), Some("opaque-marker"));
+        assert!(result.is_truncated);
+    }
+
+    #[test]
+    fn parse_azure_list_blobs_xml_handles_empty_listing() {
+        let xml = r#"<?xml version="1.0" encoding="utf-8"?>
+<EnumerationResults>
+  <Blobs />
+  <NextMarker></NextMarker>
+</EnumerationResults>"#;
+
+        let result = parse_azure_list_blobs_xml(xml).expect("empty azure list xml should parse");
+        assert!(result.entries.is_empty());
+        assert_eq!(result.next_marker, None);
+        assert!(!result.is_truncated);
+    }
+}

--- a/crates/surge-core/src/storage/azure/mod.rs
+++ b/crates/surge-core/src/storage/azure/mod.rs
@@ -1,0 +1,21 @@
+//! Azure Blob Storage backend with SharedKey authentication.
+
+mod auth;
+mod listing;
+mod requests;
+
+use reqwest::Client;
+
+/// Azure Blob Storage REST API version.
+pub(super) const AZURE_API_VERSION: &str = "2024-08-04";
+
+/// Azure Blob Storage backend using SharedKey authentication.
+pub struct AzureBlobBackend {
+    pub(super) client: Client,
+    pub(super) account: String,
+    /// Base64-decoded account key (raw bytes) for HMAC signing.
+    pub(super) key_bytes: Vec<u8>,
+    pub(super) container: String,
+    pub(super) endpoint: String,
+    pub(super) prefix: String,
+}

--- a/crates/surge-core/src/storage/azure/requests.rs
+++ b/crates/surge-core/src/storage/azure/requests.rs
@@ -1,32 +1,16 @@
-//! Azure Blob Storage backend with SharedKey authentication.
-
-use async_trait::async_trait;
 use std::path::Path;
 
-use base64::Engine;
-use base64::engine::general_purpose::STANDARD as BASE64;
-use chrono::Utc;
+use async_trait::async_trait;
 use reqwest::Client;
-use tracing::{debug, trace};
+use tracing::debug;
 
 use crate::context::StorageConfig;
-use crate::crypto::hmac_sha256::hmac_sha256;
 use crate::error::{Result, SurgeError};
-use crate::storage::{ListEntry, ListResult, ObjectInfo, StorageBackend, TransferProgress, download_response_to_file};
+use crate::storage::{ListResult, ObjectInfo, StorageBackend, TransferProgress, download_response_to_file};
 
-/// Azure Blob Storage REST API version.
-const AZURE_API_VERSION: &str = "2024-08-04";
-
-/// Azure Blob Storage backend using SharedKey authentication.
-pub struct AzureBlobBackend {
-    client: Client,
-    account: String,
-    /// Base64-decoded account key (raw bytes) for HMAC signing.
-    key_bytes: Vec<u8>,
-    container: String,
-    endpoint: String,
-    prefix: String,
-}
+use super::AzureBlobBackend;
+use super::auth::decode_account_key;
+use super::listing::parse_azure_list_blobs_xml;
 
 impl AzureBlobBackend {
     /// Create a new Azure Blob Storage backend from configuration.
@@ -59,14 +43,6 @@ impl AzureBlobBackend {
             ));
         }
 
-        let key_bytes = if account_key.is_empty() {
-            Vec::new()
-        } else {
-            BASE64
-                .decode(&account_key)
-                .map_err(|e| SurgeError::Config(format!("Azure account key is not valid base64: {e}")))?
-        };
-
         let endpoint = if config.endpoint.is_empty() {
             format!("https://{account_name}.blob.core.windows.net")
         } else {
@@ -87,27 +63,11 @@ impl AzureBlobBackend {
         Ok(Self {
             client,
             account: account_name,
-            key_bytes,
+            key_bytes: decode_account_key(&account_key)?,
             container: config.bucket.clone(),
             endpoint,
             prefix: config.prefix.clone(),
         })
-    }
-
-    /// Returns `true` when credentials are available for signing requests.
-    fn has_credentials(&self) -> bool {
-        !self.key_bytes.is_empty()
-    }
-
-    /// Return an error when a write is attempted without credentials.
-    fn require_credentials(&self, operation: &str) -> Result<()> {
-        if self.has_credentials() {
-            Ok(())
-        } else {
-            Err(SurgeError::Config(format!(
-                "Azure Blob {operation} requires account credentials"
-            )))
-        }
     }
 
     /// Build the full blob name, prepending the configured prefix.
@@ -132,124 +92,6 @@ impl AzureBlobBackend {
     /// Build the container-level URL (for list operations).
     fn container_url(&self) -> String {
         format!("{}/{}", self.endpoint.trim_end_matches('/'), self.container)
-    }
-
-    /// Produce an RFC 1123 date string (e.g. `Mon, 02 Mar 2026 12:34:56 GMT`).
-    fn rfc1123_date(now: &chrono::DateTime<Utc>) -> String {
-        now.format("%a, %d %b %Y %H:%M:%S GMT").to_string()
-    }
-
-    /// Sign a request using SharedKey authentication and return the headers
-    /// that must be attached to the request.
-    ///
-    /// The string-to-sign format for Blob service:
-    /// ```text
-    /// VERB\n
-    /// Content-Encoding\n
-    /// Content-Language\n
-    /// Content-Length\n
-    /// Content-MD5\n
-    /// Content-Type\n
-    /// Date\n
-    /// If-Modified-Since\n
-    /// If-Match\n
-    /// If-None-Match\n
-    /// If-Unmodified-Since\n
-    /// Range\n
-    /// CanonicalizedHeaders\n
-    /// CanonicalizedResource
-    /// ```
-    #[allow(clippy::too_many_arguments)]
-    fn sign_request(
-        &self,
-        method: &str,
-        resource_path: &str,
-        query_params: &[(String, String)],
-        content_length: Option<usize>,
-        content_type: &str,
-        extra_headers: &[(String, String)],
-    ) -> Vec<(String, String)> {
-        let now = Utc::now();
-        let date = Self::rfc1123_date(&now);
-
-        // Collect all x-ms-* headers (sorted).
-        let mut ms_headers: Vec<(String, String)> = vec![
-            ("x-ms-date".to_string(), date.clone()),
-            ("x-ms-version".to_string(), AZURE_API_VERSION.to_string()),
-        ];
-        for (k, v) in extra_headers {
-            if k.starts_with("x-ms-") {
-                ms_headers.push((k.clone(), v.clone()));
-            }
-        }
-        ms_headers.sort_by(|a, b| a.0.cmp(&b.0));
-        // Deduplicate on key, keeping later values.
-        ms_headers.dedup_by(|a, b| {
-            if a.0 == b.0 {
-                // Keep value from `b` (the earlier one after sort is stable).
-                true
-            } else {
-                false
-            }
-        });
-
-        let canonicalized_headers = ms_headers
-            .iter()
-            .map(|(k, v)| format!("{k}:{v}"))
-            .collect::<Vec<_>>()
-            .join("\n");
-
-        // Canonicalized resource: /account/container/blob?\ncomp:list\n...
-        let mut canonicalized_resource = format!("/{}{}", self.account, resource_path);
-        if !query_params.is_empty() {
-            let mut sorted_params = query_params.to_vec();
-            sorted_params.sort_by(|a, b| a.0.cmp(&b.0));
-            for (k, v) in &sorted_params {
-                canonicalized_resource.push('\n');
-                canonicalized_resource.push_str(k);
-                canonicalized_resource.push(':');
-                canonicalized_resource.push_str(v);
-            }
-        }
-
-        // Content-Length: omit for 0 or absent.
-        let content_length_str = match content_length {
-            Some(n) if n > 0 => n.to_string(),
-            _ => String::new(),
-        };
-
-        // String to sign.
-        let string_to_sign = format!(
-            "{method}\n\
-             \n\
-             \n\
-             {content_length_str}\n\
-             \n\
-             {content_type}\n\
-             \n\
-             \n\
-             \n\
-             \n\
-             \n\
-             \n\
-             {canonicalized_headers}\n\
-             {canonicalized_resource}"
-        );
-
-        trace!(string_to_sign = %string_to_sign, "Azure string to sign");
-
-        // HMAC-SHA256 with the account key.
-        let signature = BASE64.encode(hmac_sha256(&self.key_bytes, string_to_sign.as_bytes()));
-
-        let authorization = format!("SharedKey {}:{signature}", self.account);
-
-        let mut headers: Vec<(String, String)> = ms_headers;
-        headers.push(("Authorization".to_string(), authorization));
-        if !content_type.is_empty() {
-            headers.push(("Content-Type".to_string(), content_type.to_string()));
-        }
-
-        headers
     }
 
     /// Map an HTTP response status to a `SurgeError`.
@@ -392,7 +234,6 @@ impl StorageBackend for AzureBlobBackend {
 
         let resp = req.send().await?;
         let status = resp.status();
-        // Azure returns 202 Accepted for deletes, and 404 if already gone.
         if !status.is_success() && status != reqwest::StatusCode::ACCEPTED && status != reqwest::StatusCode::NOT_FOUND {
             let body = resp.text().await.unwrap_or_default();
             Self::check_response_status(status, &full_key, &body)?;
@@ -406,7 +247,6 @@ impl StorageBackend for AzureBlobBackend {
         let full_prefix = self.full_key(prefix);
         let container_url = self.container_url();
 
-        // Query parameters for List Blobs.
         let mut query_params: Vec<(String, String)> = vec![
             ("comp".to_string(), "list".to_string()),
             ("restype".to_string(), "container".to_string()),
@@ -501,104 +341,4 @@ impl StorageBackend for AzureBlobBackend {
         }
         Ok(())
     }
-}
-
-// ---------------------------------------------------------------------------
-// XML parsing for Azure List Blobs response
-// ---------------------------------------------------------------------------
-
-/// Parse an Azure List Blobs XML response into a `ListResult`.
-///
-/// Azure response structure:
-/// ```xml
-/// <EnumerationResults>
-///   <Blobs>
-///     <Blob>
-///       <Name>key</Name>
-///       <Properties>
-///         <Content-Length>123</Content-Length>
-///       </Properties>
-///     </Blob>
-///   </Blobs>
-///   <NextMarker>...</NextMarker>
-/// </EnumerationResults>
-/// ```
-fn parse_azure_list_blobs_xml(xml: &str) -> Result<ListResult> {
-    use quick_xml::Reader;
-    use quick_xml::events::Event;
-
-    let mut reader = Reader::from_str(xml);
-    let mut buf = Vec::new();
-    let mut entries = Vec::new();
-    let mut next_marker: Option<String> = None;
-
-    let mut in_blob = false;
-    let mut in_properties = false;
-    let mut current_name: Option<String> = None;
-    let mut current_size: Option<i64> = None;
-    let mut current_tag = String::new();
-
-    loop {
-        match reader.read_event_into(&mut buf) {
-            Ok(Event::Start(ref e)) => {
-                let tag = String::from_utf8_lossy(e.name().as_ref()).to_string();
-                match tag.as_str() {
-                    "Blob" => {
-                        in_blob = true;
-                        current_name = None;
-                        current_size = None;
-                    }
-                    "Properties" if in_blob => {
-                        in_properties = true;
-                    }
-                    _ => {}
-                }
-                current_tag = tag;
-            }
-            Ok(Event::End(ref e)) => {
-                let tag = String::from_utf8_lossy(e.name().as_ref()).to_string();
-                match tag.as_str() {
-                    "Blob" => {
-                        if let Some(name) = current_name.take() {
-                            entries.push(ListEntry {
-                                key: name,
-                                size: current_size.unwrap_or(0),
-                            });
-                        }
-                        in_blob = false;
-                        in_properties = false;
-                    }
-                    "Properties" => {
-                        in_properties = false;
-                    }
-                    _ => {}
-                }
-                current_tag.clear();
-            }
-            Ok(Event::Text(ref e)) => {
-                let text = String::from_utf8_lossy(e.as_ref()).to_string();
-                if in_blob && !in_properties && current_tag == "Name" {
-                    current_name = Some(text);
-                } else if in_properties && current_tag == "Content-Length" {
-                    current_size = text.parse::<i64>().ok();
-                } else if !in_blob && current_tag == "NextMarker" && !text.is_empty() {
-                    next_marker = Some(text);
-                }
-            }
-            Ok(Event::Eof) => break,
-            Err(e) => {
-                return Err(SurgeError::Storage(format!("Failed to parse Azure list response: {e}")));
-            }
-            _ => {}
-        }
-        buf.clear();
-    }
-
-    let is_truncated = next_marker.is_some();
-    debug!(count = entries.len(), is_truncated, "Azure LIST parsed");
-    Ok(ListResult {
-        entries,
-        next_marker,
-        is_truncated,
-    })
 }

--- a/docs/architecture/cleanup-plan.md
+++ b/docs/architecture/cleanup-plan.md
@@ -35,36 +35,36 @@ These PRs are already merged:
 - `#63` `refactor(core): split release restore planning and artifact recovery`
 - `#64` `refactor(core): split shortcut installation by platform`
 - `#65` `refactor(core): split manifest module responsibilities`
+- `#66` `refactor(core): split install module responsibilities`
 
 ## Active Phase
 
-### `refactor/install-phase-1`
+### `refactor/storage-azure-phase-1`
 
 Current goal:
 
-- split [`crates/surge-core/src/install/mod.rs`](../../crates/surge-core/src/install/mod.rs)
+- split [`crates/surge-core/src/storage/azure/mod.rs`](../../crates/surge-core/src/storage/azure/mod.rs)
   into:
-  - `install/runtime_manifest.rs`
-  - `install/activation.rs`
-  - `install/persistent_assets.rs`
-  - `install/launch.rs`
+  - `storage/azure/auth.rs`
+  - `storage/azure/requests.rs`
+  - `storage/azure/listing.rs`
 
 Current checkpoint:
 
 - the leaf modules have been created
-- the root module has been reduced to install-facing types, entrypoints, and tests
+- the root module has been reduced to the backend type and module wiring
 - targeted compile of `surge-core` passes
-- focused `install` tests pass
+- focused `storage::azure` tests pass
 - focused `surge-core` clippy passes
-- the install baseline entry has been removed
+- the azure baseline entry has been removed
 - the full pre-push suite passes on the branch
 
 Exit criteria:
 
-- `cargo test -p surge-core install` passes
+- `cargo test -p surge-core storage::azure` passes
 - `cargo clippy -p surge-core --all-targets --all-features -- -D warnings -W clippy::pedantic` passes
 - `./scripts/check-maintainability.sh` reports the file below the target so the
-  install baseline entry can be removed
+  azure baseline entry can be removed
 - the full pre-push suite passes
 - the PR is merged with squash, local cleanup is done, and merged-`main` CI is green
 
@@ -72,14 +72,13 @@ Exit criteria:
 
 These are the remaining planned PRs from the original Rust-first campaign.
 
-### 1. `refactor/install-phase-1`
+### 1. `refactor/storage-azure-phase-1`
 
-- split [`crates/surge-core/src/install/mod.rs`](../../crates/surge-core/src/install/mod.rs)
+- split [`crates/surge-core/src/storage/azure/mod.rs`](../../crates/surge-core/src/storage/azure/mod.rs)
   into focused modules for:
-  - runtime manifest handling
-  - activation and snapshot pruning
-  - persistent asset copying and validation
-  - launch and post-install lifecycle helpers
+  - shared-key signing and credential checks
+  - request construction and backend operations
+  - list-response XML parsing
 
 ### 2. `refactor/maintainability-phase-2`
 
@@ -103,7 +102,6 @@ be decomposed to fully retire the baseline.
 ### Core surfaces
 
 - [`crates/surge-core/src/releases/delta.rs`](../../crates/surge-core/src/releases/delta.rs)
-- [`crates/surge-core/src/storage/azure.rs`](../../crates/surge-core/src/storage/azure.rs)
 - [`crates/surge-core/src/storage/gcs.rs`](../../crates/surge-core/src/storage/gcs.rs)
 
 ### Bench debt

--- a/docs/architecture/maintainability-baseline.txt
+++ b/docs/architecture/maintainability-baseline.txt
@@ -6,6 +6,5 @@
 1860 crates/surge-cli/src/commands/install/remote.rs
 835 crates/surge-cli/src/main.rs
 782 crates/surge-core/src/releases/delta.rs
-604 crates/surge-core/src/storage/azure.rs
 840 crates/surge-core/src/storage/gcs.rs
 760 crates/surge-installer-ui/src/app.rs


### PR DESCRIPTION
## Purpose
- split `surge-core` Azure storage support into focused modules for signing, requests, and XML listing parsing
- keep `surge_core::storage::azure::AzureBlobBackend` and its behavior stable while reducing the root module below the maintainability threshold
- remove the Azure baseline entry and advance `docs/architecture/cleanup-plan.md` to the next active slice

## Behavior Impact
- no intended user-visible behavior change
- Azure credential resolution, SharedKey signing, object operations, and list parsing keep the same request and response semantics
- the public backend constructor and storage trait implementation remain at the existing path

## Test Evidence
- `cargo check -p surge-core`
- `cargo test -p surge-core storage::azure`
- `cargo clippy -p surge-core --all-targets --all-features -- -D warnings -W clippy::pedantic`
- `./scripts/check-maintainability.sh`
- `./scripts/sync-surge-core-vendor.sh --check`
- `./scripts/check-version-sync.sh`
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo test --workspace`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo clippy --workspace --lib --bins --examples -- -D warnings -D clippy::unwrap_used -D clippy::expect_used`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings -W clippy::pedantic`
- `dotnet format dotnet/Surge.slnx --verify-no-changes`
- `dotnet test dotnet/Surge.slnx --configuration Release`

## Migration Notes
- none