### PR TITLE
refactor(core): split gcs storage backend helpers

### DIFF
--- a/crates/surge-core/src/storage/gcs/auth.rs
+++ b/crates/surge-core/src/storage/gcs/auth.rs
@@ -1,0 +1,113 @@
+use std::sync::Arc;
+
+use chrono::Utc;
+use tokio::sync::RwLock;
+use tracing::trace;
+
+use crate::context::StorageConfig;
+use crate::crypto::hmac_sha256::hmac_sha256;
+use crate::crypto::sha256::sha256_hex;
+use crate::error::{Result, SurgeError};
+
+use super::{AuthMode, GcsBackend};
+
+pub(super) fn auth_mode_from_config(config: &StorageConfig) -> AuthMode {
+    if !config.access_key.is_empty() && !config.secret_key.is_empty() {
+        AuthMode::Hmac {
+            access_key: config.access_key.clone(),
+            secret_key: config.secret_key.clone(),
+        }
+    } else {
+        let token = if config.secret_key.is_empty() {
+            std::env::var("GOOGLE_ACCESS_TOKEN").unwrap_or_default()
+        } else {
+            config.secret_key.clone()
+        };
+        if token.is_empty() {
+            AuthMode::Anonymous
+        } else {
+            AuthMode::OAuth2 {
+                token: Arc::new(RwLock::new(token)),
+            }
+        }
+    }
+}
+
+impl GcsBackend {
+    /// Update the OAuth2 bearer token (for token refresh).
+    pub async fn set_oauth2_token(&self, new_token: &str) -> Result<()> {
+        match &self.auth {
+            AuthMode::OAuth2 { token } => {
+                let mut t = token.write().await;
+                *t = new_token.to_string();
+                Ok(())
+            }
+            AuthMode::Anonymous | AuthMode::Hmac { .. } => Err(SurgeError::Config(
+                "Cannot set OAuth2 token on non-OAuth2 backend".to_string(),
+            )),
+        }
+    }
+
+    /// Return an error when a write is attempted without credentials.
+    pub(super) fn require_credentials(&self, operation: &str) -> Result<()> {
+        match &self.auth {
+            AuthMode::Anonymous => Err(SurgeError::Config(format!("GCS {operation} requires credentials"))),
+            _ => Ok(()),
+        }
+    }
+
+    /// Derive HMAC signing key, similar to AWS Signature V4 but for GCS.
+    /// GCS HMAC keys use the same signing algorithm as AWS SigV4.
+    fn hmac_signing_key(secret_key: &str, date_stamp: &str, region: &str) -> Vec<u8> {
+        let k_date = hmac_sha256(format!("AWS4{secret_key}").as_bytes(), date_stamp.as_bytes());
+        let k_region = hmac_sha256(&k_date, region.as_bytes());
+        let k_service = hmac_sha256(&k_region, b"s3");
+        hmac_sha256(&k_service, b"aws4_request")
+    }
+
+    /// Sign a request using HMAC (SigV4-compatible) for the GCS XML API.
+    pub(super) fn hmac_sign_request(
+        &self,
+        method: &str,
+        canonical_uri: &str,
+        canonical_querystring: &str,
+        payload_hash: &str,
+        access_key: &str,
+        secret_key: &str,
+    ) -> Vec<(String, String)> {
+        let now = Utc::now();
+        let amz_date = now.format("%Y%m%dT%H%M%SZ").to_string();
+        let date_stamp = now.format("%Y%m%d").to_string();
+        let host = self.xml_host();
+        let region = "auto";
+
+        let canonical_headers = format!("host:{host}\nx-amz-content-sha256:{payload_hash}\nx-amz-date:{amz_date}\n");
+        let signed_headers = "host;x-amz-content-sha256;x-amz-date";
+
+        let canonical_request = format!(
+            "{method}\n{canonical_uri}\n{canonical_querystring}\n{canonical_headers}\n{signed_headers}\n{payload_hash}"
+        );
+
+        trace!(canonical_request = %canonical_request, "GCS HMAC canonical request");
+
+        let credential_scope = format!("{date_stamp}/{region}/s3/aws4_request");
+        let string_to_sign = format!(
+            "AWS4-HMAC-SHA256\n{amz_date}\n{credential_scope}\n{}",
+            sha256_hex(canonical_request.as_bytes())
+        );
+
+        let signing_key = Self::hmac_signing_key(secret_key, &date_stamp, region);
+        let signature = hex::encode(hmac_sha256(&signing_key, string_to_sign.as_bytes()));
+
+        let authorization = format!(
+            "AWS4-HMAC-SHA256 Credential={access_key}/{credential_scope}, SignedHeaders={signed_headers}, Signature={signature}"
+        );
+
+        vec![
+            ("Host".to_string(), host),
+            ("x-amz-content-sha256".to_string(), payload_hash.to_string()),
+            ("x-amz-date".to_string(), amz_date),
+            ("Authorization".to_string(), authorization),
+        ]
+    }
+}

--- a/crates/surge-core/src/storage/gcs/json_listing.rs
+++ b/crates/surge-core/src/storage/gcs/json_listing.rs
@@ -1,0 +1,68 @@
+use tracing::debug;
+
+use crate::error::{Result, SurgeError};
+use crate::storage::{ListEntry, ListResult};
+
+/// Parse a GCS JSON API list-objects response into a `ListResult`.
+///
+/// Response format:
+/// ```json
+/// {
+///   "items": [{"name": "key", "size": "123"}, ...],
+///   "nextPageToken": "..."
+/// }
+/// ```
+pub(super) fn parse_gcs_json_list_response(json_str: &str) -> Result<ListResult> {
+    let json: serde_json::Value = serde_json::from_str(json_str)
+        .map_err(|e| SurgeError::Storage(format!("Failed to parse GCS JSON list response: {e}")))?;
+
+    let mut entries = Vec::new();
+    if let Some(items) = json.get("items").and_then(|v| v.as_array()) {
+        for item in items {
+            let key = item.get("name").and_then(|v| v.as_str()).unwrap_or("").to_string();
+            let size = item
+                .get("size")
+                .and_then(|v| v.as_str())
+                .and_then(|v| v.parse::<i64>().ok())
+                .unwrap_or(0);
+            if !key.is_empty() {
+                entries.push(ListEntry { key, size });
+            }
+        }
+    }
+
+    let next_marker = json.get("nextPageToken").and_then(|v| v.as_str()).map(String::from);
+    let is_truncated = next_marker.is_some();
+
+    debug!(count = entries.len(), is_truncated, "GCS JSON LIST parsed");
+    Ok(ListResult {
+        entries,
+        next_marker,
+        is_truncated,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_gcs_json_list_response;
+
+    #[test]
+    fn parse_gcs_json_list_response_reads_entries_and_next_page_token() {
+        let json = r#"{
+  "items": [
+    {"name": "prefix/app-1.0.0.zip", "size": "123"},
+    {"name": "prefix/app-1.1.0.zip", "size": "456"}
+  ],
+  "nextPageToken": "next-token"
+}"#;
+
+        let result = parse_gcs_json_list_response(json).expect("gcs json list response should parse");
+        assert_eq!(result.entries.len(), 2);
+        assert_eq!(result.entries[0].key, "prefix/app-1.0.0.zip");
+        assert_eq!(result.entries[0].size, 123);
+        assert_eq!(result.entries[1].key, "prefix/app-1.1.0.zip");
+        assert_eq!(result.entries[1].size, 456);
+        assert_eq!(result.next_marker.as_deref(), Some("next-token"));
+        assert!(result.is_truncated);
+    }
+}

--- a/crates/surge-core/src/storage/gcs/mod.rs
+++ b/crates/surge-core/src/storage/gcs/mod.rs
@@ -1,0 +1,52 @@
+//! Google Cloud Storage backend with HMAC (S3-interop XML API) and OAuth2 bearer token auth.
+
+mod auth;
+mod json_listing;
+mod requests;
+mod xml_listing;
+
+use std::sync::Arc;
+
+use percent_encoding::{AsciiSet, NON_ALPHANUMERIC};
+use reqwest::Client;
+use tokio::sync::RwLock;
+
+/// Characters that must NOT be percent-encoded in URI paths.
+pub(super) const URI_ENCODE_SET: &AsciiSet = &NON_ALPHANUMERIC.remove(b'-').remove(b'.').remove(b'_').remove(b'~');
+
+/// Same set but preserves '/'.
+pub(super) const URI_ENCODE_PATH_SET: &AsciiSet = &NON_ALPHANUMERIC
+    .remove(b'-')
+    .remove(b'.')
+    .remove(b'_')
+    .remove(b'~')
+    .remove(b'/');
+
+/// GCS XML API endpoint (S3-interop).
+pub(super) const GCS_XML_ENDPOINT: &str = "https://storage.googleapis.com";
+
+/// GCS JSON API endpoint (used for OAuth2 bearer-token auth).
+pub(super) const GCS_JSON_ENDPOINT: &str = "https://storage.googleapis.com/storage/v1";
+
+/// GCS JSON API upload endpoint.
+pub(super) const GCS_UPLOAD_ENDPOINT: &str = "https://storage.googleapis.com/upload/storage/v1";
+
+/// Authentication mode for GCS.
+#[derive(Debug, Clone)]
+pub(super) enum AuthMode {
+    /// No credentials — only anonymous (public) reads are possible.
+    Anonymous,
+    /// HMAC-based authentication using the S3-interop XML API.
+    Hmac { access_key: String, secret_key: String },
+    /// OAuth2 bearer token authentication using the JSON API.
+    OAuth2 { token: Arc<RwLock<String>> },
+}
+
+/// Google Cloud Storage backend.
+pub struct GcsBackend {
+    pub(super) client: Client,
+    pub(super) bucket: String,
+    pub(super) prefix: String,
+    pub(super) endpoint: String,
+    pub(super) auth: AuthMode,
+}

--- a/crates/surge-core/src/storage/gcs/requests.rs
+++ b/crates/surge-core/src/storage/gcs/requests.rs
@@ -1,64 +1,21 @@
-//! Google Cloud Storage backend with HMAC (S3-interop XML API) and OAuth2 bearer token auth.
+use std::path::Path;
 
 use async_trait::async_trait;
-use std::path::Path;
-use std::sync::Arc;
-
-use chrono::Utc;
-use percent_encoding::{AsciiSet, NON_ALPHANUMERIC, utf8_percent_encode};
+use percent_encoding::utf8_percent_encode;
 use reqwest::Client;
-use tokio::sync::RwLock;
-use tracing::{debug, trace};
+use tracing::debug;
 
 use crate::context::StorageConfig;
-use crate::crypto::hmac_sha256::hmac_sha256;
 use crate::crypto::sha256::sha256_hex;
 use crate::error::{Result, SurgeError};
-use crate::storage::{ListEntry, ListResult, ObjectInfo, StorageBackend, TransferProgress, download_response_to_file};
+use crate::storage::{ListResult, ObjectInfo, StorageBackend, TransferProgress, download_response_to_file};
 
-/// Characters that must NOT be percent-encoded in URI paths.
-const URI_ENCODE_SET: &AsciiSet = &NON_ALPHANUMERIC.remove(b'-').remove(b'.').remove(b'_').remove(b'~');
-
-/// Same set but preserves '/'.
-const URI_ENCODE_PATH_SET: &AsciiSet = &NON_ALPHANUMERIC
-    .remove(b'-')
-    .remove(b'.')
-    .remove(b'_')
-    .remove(b'~')
-    .remove(b'/');
-
-/// GCS XML API endpoint (S3-interop).
-const GCS_XML_ENDPOINT: &str = "https://storage.googleapis.com";
-
-/// GCS JSON API endpoint (used for OAuth2 bearer-token auth).
-const GCS_JSON_ENDPOINT: &str = "https://storage.googleapis.com/storage/v1";
-
-/// GCS JSON API upload endpoint.
-const GCS_UPLOAD_ENDPOINT: &str = "https://storage.googleapis.com/upload/storage/v1";
-
-/// Authentication mode for GCS.
-#[derive(Debug, Clone)]
-enum AuthMode {
-    /// No credentials — only anonymous (public) reads are possible.
-    Anonymous,
-    /// HMAC-based authentication using the S3-interop XML API.
-    Hmac { access_key: String, secret_key: String },
-    /// OAuth2 bearer token authentication using the JSON API.
-    OAuth2 {
-        /// Current bearer token. Wrapped in `Arc<RwLock>` for interior
-        /// mutability across `&self` calls and thread safety.
-        token: Arc<RwLock<String>>,
-    },
-}
-
-/// Google Cloud Storage backend.
-pub struct GcsBackend {
-    client: Client,
-    bucket: String,
-    prefix: String,
-    endpoint: String,
-    auth: AuthMode,
-}
+use super::auth::auth_mode_from_config;
+use super::json_listing::parse_gcs_json_list_response;
+use super::xml_listing::parse_gcs_xml_list_response;
+use super::{
+    AuthMode, GCS_JSON_ENDPOINT, GCS_UPLOAD_ENDPOINT, GCS_XML_ENDPOINT, GcsBackend, URI_ENCODE_PATH_SET, URI_ENCODE_SET,
+};
 
 impl GcsBackend {
     /// Create a new GCS backend from configuration.
@@ -74,27 +31,7 @@ impl GcsBackend {
             return Err(SurgeError::Config("GCS storage requires a bucket name".to_string()));
         }
 
-        let auth = if !config.access_key.is_empty() && !config.secret_key.is_empty() {
-            AuthMode::Hmac {
-                access_key: config.access_key.clone(),
-                secret_key: config.secret_key.clone(),
-            }
-        } else {
-            // Try secret_key first, then environment variable.
-            let token = if config.secret_key.is_empty() {
-                std::env::var("GOOGLE_ACCESS_TOKEN").unwrap_or_default()
-            } else {
-                config.secret_key.clone()
-            };
-            if token.is_empty() {
-                AuthMode::Anonymous
-            } else {
-                AuthMode::OAuth2 {
-                    token: Arc::new(RwLock::new(token)),
-                }
-            }
-        };
-
+        let auth = auth_mode_from_config(config);
         let endpoint = if config.endpoint.is_empty() {
             GCS_XML_ENDPOINT.to_string()
         } else {
@@ -125,28 +62,6 @@ impl GcsBackend {
         })
     }
 
-    /// Update the OAuth2 bearer token (for token refresh).
-    pub async fn set_oauth2_token(&self, new_token: &str) -> Result<()> {
-        match &self.auth {
-            AuthMode::OAuth2 { token } => {
-                let mut t = token.write().await;
-                *t = new_token.to_string();
-                Ok(())
-            }
-            AuthMode::Anonymous | AuthMode::Hmac { .. } => Err(SurgeError::Config(
-                "Cannot set OAuth2 token on non-OAuth2 backend".to_string(),
-            )),
-        }
-    }
-
-    /// Return an error when a write is attempted without credentials.
-    fn require_credentials(&self, operation: &str) -> Result<()> {
-        match &self.auth {
-            AuthMode::Anonymous => Err(SurgeError::Config(format!("GCS {operation} requires credentials"))),
-            _ => Ok(()),
-        }
-    }
-
     /// Build the full object key, prepending the configured prefix.
     fn full_key(&self, key: &str) -> String {
         if self.prefix.is_empty() {
@@ -169,10 +84,6 @@ impl GcsBackend {
         )))
     }
 
-    // -----------------------------------------------------------------------
-    // HMAC (S3-interop XML API) helpers
-    // -----------------------------------------------------------------------
-
     /// Build the URL for an object using the XML API (path-style).
     fn xml_object_url(&self, key: &str) -> String {
         let encoded = utf8_percent_encode(key, URI_ENCODE_PATH_SET);
@@ -185,68 +96,12 @@ impl GcsBackend {
     }
 
     /// Host for the XML API endpoint.
-    fn xml_host(&self) -> String {
+    pub(super) fn xml_host(&self) -> String {
         self.endpoint
             .trim_start_matches("https://")
             .trim_start_matches("http://")
             .trim_end_matches('/')
             .to_string()
-    }
-
-    /// Derive HMAC signing key, similar to AWS Signature V4 but for GCS.
-    /// GCS HMAC keys use the same signing algorithm as AWS SigV4.
-    fn hmac_signing_key(secret_key: &str, date_stamp: &str, region: &str) -> Vec<u8> {
-        let k_date = hmac_sha256(format!("AWS4{secret_key}").as_bytes(), date_stamp.as_bytes());
-        let k_region = hmac_sha256(&k_date, region.as_bytes());
-        let k_service = hmac_sha256(&k_region, b"s3");
-        hmac_sha256(&k_service, b"aws4_request")
-    }
-
-    /// Sign a request using HMAC (SigV4-compatible) for the GCS XML API.
-    fn hmac_sign_request(
-        &self,
-        method: &str,
-        canonical_uri: &str,
-        canonical_querystring: &str,
-        payload_hash: &str,
-        access_key: &str,
-        secret_key: &str,
-    ) -> Vec<(String, String)> {
-        let now = Utc::now();
-        let amz_date = now.format("%Y%m%dT%H%M%SZ").to_string();
-        let date_stamp = now.format("%Y%m%d").to_string();
-        let host = self.xml_host();
-        // GCS HMAC uses "auto" as the region for the signing scope.
-        let region = "auto";
-
-        let canonical_headers = format!("host:{host}\nx-amz-content-sha256:{payload_hash}\nx-amz-date:{amz_date}\n");
-        let signed_headers = "host;x-amz-content-sha256;x-amz-date";
-
-        let canonical_request = format!(
-            "{method}\n{canonical_uri}\n{canonical_querystring}\n{canonical_headers}\n{signed_headers}\n{payload_hash}"
-        );
-
-        trace!(canonical_request = %canonical_request, "GCS HMAC canonical request");
-
-        let credential_scope = format!("{date_stamp}/{region}/s3/aws4_request");
-        let string_to_sign = format!(
-            "AWS4-HMAC-SHA256\n{amz_date}\n{credential_scope}\n{}",
-            sha256_hex(canonical_request.as_bytes())
-        );
-
-        let signing_key = Self::hmac_signing_key(secret_key, &date_stamp, region);
-        let signature = hex::encode(hmac_sha256(&signing_key, string_to_sign.as_bytes()));
-
-        let authorization = format!(
-            "AWS4-HMAC-SHA256 Credential={access_key}/{credential_scope}, SignedHeaders={signed_headers}, Signature={signature}"
-        );
-
-        vec![
-            ("Host".to_string(), host),
-            ("x-amz-content-sha256".to_string(), payload_hash.to_string()),
-            ("x-amz-date".to_string(), amz_date),
-            ("Authorization".to_string(), authorization),
-        ]
     }
 
     /// URI-encode a path (preserves '/').
@@ -258,10 +113,6 @@ impl GcsBackend {
     fn encode_uri_component(value: &str) -> String {
         utf8_percent_encode(value, URI_ENCODE_SET).to_string()
     }
-
-    // -----------------------------------------------------------------------
-    // OAuth2 (JSON API) helpers
-    // -----------------------------------------------------------------------
 
     /// Build the JSON API URL for an object.
     fn json_object_url(&self, key: &str) -> String {
@@ -335,7 +186,6 @@ impl StorageBackend for GcsBackend {
 
         let bytes = match &self.auth {
             AuthMode::Anonymous | AuthMode::Hmac { .. } => {
-                // Both Anonymous and HMAC use the XML API; only signing differs.
                 let url = self.xml_object_url(&full_key);
                 let mut req = self.client.get(&url);
                 if let AuthMode::Hmac { access_key, secret_key } = &self.auth {
@@ -390,7 +240,6 @@ impl StorageBackend for GcsBackend {
 
         match &self.auth {
             AuthMode::Anonymous | AuthMode::Hmac { .. } => {
-                // Both Anonymous and HMAC use the XML API; only signing differs.
                 let url = self.xml_object_url(&full_key);
                 let mut req = self.client.head(&url);
                 if let AuthMode::Hmac { access_key, secret_key } = &self.auth {
@@ -442,7 +291,6 @@ impl StorageBackend for GcsBackend {
                 })
             }
             AuthMode::OAuth2 { token } => {
-                // JSON API: GET object metadata.
                 let url = self.json_object_url(&full_key);
                 let bearer = token.read().await.clone();
 
@@ -509,7 +357,6 @@ impl StorageBackend for GcsBackend {
                 let status = resp.status();
                 if !status.is_success() && status != reqwest::StatusCode::NO_CONTENT {
                     let body = resp.text().await.unwrap_or_default();
-                    // Don't error on 404 - object already deleted.
                     if status != reqwest::StatusCode::NOT_FOUND {
                         Self::check_response_status(status, &full_key, &body)?;
                     }
@@ -546,7 +393,6 @@ impl StorageBackend for GcsBackend {
 
         match &self.auth {
             AuthMode::Anonymous | AuthMode::Hmac { .. } => {
-                // Both Anonymous and HMAC use the XML API; only signing differs.
                 let bucket_url = self.xml_bucket_url();
 
                 let mut query_parts: Vec<(String, String)> = vec![
@@ -659,7 +505,7 @@ impl StorageBackend for GcsBackend {
 
         download_response_to_file(resp, dest, progress).await?;
 
-        debug!(key = %self.full_key(key), dest = %dest.display(), "GCS download completed");
+        debug!(key = %full_key, dest = %dest.display(), "GCS download completed");
         Ok(())
     }
 
@@ -714,127 +560,4 @@ impl StorageBackend for GcsBackend {
         }
         Ok(())
     }
-}
-
-// ---------------------------------------------------------------------------
-// XML parsing for GCS XML API (S3-compatible ListBucketResult)
-// ---------------------------------------------------------------------------
-
-/// Parse a GCS XML API ListBucketResult into a `ListResult`.
-/// The format matches S3's `ListBucketResult` (v1).
-fn parse_gcs_xml_list_response(xml: &str) -> Result<ListResult> {
-    use quick_xml::Reader;
-    use quick_xml::events::Event;
-
-    let mut reader = Reader::from_str(xml);
-    let mut buf = Vec::new();
-    let mut entries = Vec::new();
-    let mut next_marker: Option<String> = None;
-    let mut is_truncated = false;
-
-    let mut in_contents = false;
-    let mut current_key: Option<String> = None;
-    let mut current_size: Option<i64> = None;
-    let mut current_tag = String::new();
-
-    loop {
-        match reader.read_event_into(&mut buf) {
-            Ok(Event::Start(ref e)) => {
-                let tag = String::from_utf8_lossy(e.name().as_ref()).to_string();
-                if tag == "Contents" {
-                    in_contents = true;
-                    current_key = None;
-                    current_size = None;
-                }
-                current_tag = tag;
-            }
-            Ok(Event::End(ref e)) => {
-                let tag = String::from_utf8_lossy(e.name().as_ref()).to_string();
-                if tag == "Contents" {
-                    if let Some(key) = current_key.take() {
-                        entries.push(ListEntry {
-                            key,
-                            size: current_size.unwrap_or(0),
-                        });
-                    }
-                    in_contents = false;
-                }
-                current_tag.clear();
-            }
-            Ok(Event::Text(ref e)) => {
-                let text = String::from_utf8_lossy(e.as_ref()).to_string();
-                if in_contents {
-                    match current_tag.as_str() {
-                        "Key" => current_key = Some(text),
-                        "Size" => current_size = text.parse::<i64>().ok(),
-                        _ => {}
-                    }
-                } else {
-                    match current_tag.as_str() {
-                        "IsTruncated" => is_truncated = text == "true",
-                        "NextMarker" => next_marker = Some(text),
-                        _ => {}
-                    }
-                }
-            }
-            Ok(Event::Eof) => break,
-            Err(e) => {
-                return Err(SurgeError::Storage(format!(
-                    "Failed to parse GCS XML list response: {e}"
-                )));
-            }
-            _ => {}
-        }
-        buf.clear();
-    }
-
-    debug!(count = entries.len(), is_truncated, "GCS XML LIST parsed");
-    Ok(ListResult {
-        entries,
-        next_marker,
-        is_truncated,
-    })
-}
-
-// ---------------------------------------------------------------------------
-// JSON parsing for GCS JSON API
-// ---------------------------------------------------------------------------
-
-/// Parse a GCS JSON API list-objects response into a `ListResult`.
-///
-/// Response format:
-/// ```json
-/// {
-///   "items": [{"name": "key", "size": "123"}, ...],
-///   "nextPageToken": "..."
-/// }
-/// ```
-fn parse_gcs_json_list_response(json_str: &str) -> Result<ListResult> {
-    let json: serde_json::Value = serde_json::from_str(json_str)
-        .map_err(|e| SurgeError::Storage(format!("Failed to parse GCS JSON list response: {e}")))?;
-
-    let mut entries = Vec::new();
-    if let Some(items) = json.get("items").and_then(|v| v.as_array()) {
-        for item in items {
-            let key = item.get("name").and_then(|v| v.as_str()).unwrap_or("").to_string();
-            let size = item
-                .get("size")
-                .and_then(|v| v.as_str())
-                .and_then(|v| v.parse::<i64>().ok())
-                .unwrap_or(0);
-            if !key.is_empty() {
-                entries.push(ListEntry { key, size });
-            }
-        }
-    }
-
-    let next_marker = json.get("nextPageToken").and_then(|v| v.as_str()).map(String::from);
-    let is_truncated = next_marker.is_some();
-
-    debug!(count = entries.len(), is_truncated, "GCS JSON LIST parsed");
-    Ok(ListResult {
-        entries,
-        next_marker,
-        is_truncated,
-    })
 }

--- a/crates/surge-core/src/storage/gcs/xml_listing.rs
+++ b/crates/surge-core/src/storage/gcs/xml_listing.rs
@@ -1,0 +1,110 @@
+use quick_xml::Reader;
+use quick_xml::events::Event;
+use tracing::debug;
+
+use crate::error::{Result, SurgeError};
+use crate::storage::{ListEntry, ListResult};
+
+/// Parse a GCS XML API ListBucketResult into a `ListResult`.
+/// The format matches S3's `ListBucketResult` (v1).
+pub(super) fn parse_gcs_xml_list_response(xml: &str) -> Result<ListResult> {
+    let mut reader = Reader::from_str(xml);
+    let mut buf = Vec::new();
+    let mut entries = Vec::new();
+    let mut next_marker: Option<String> = None;
+    let mut is_truncated = false;
+
+    let mut in_contents = false;
+    let mut current_key: Option<String> = None;
+    let mut current_size: Option<i64> = None;
+    let mut current_tag = String::new();
+
+    loop {
+        match reader.read_event_into(&mut buf) {
+            Ok(Event::Start(ref e)) => {
+                let tag = String::from_utf8_lossy(e.name().as_ref()).to_string();
+                if tag == "Contents" {
+                    in_contents = true;
+                    current_key = None;
+                    current_size = None;
+                }
+                current_tag = tag;
+            }
+            Ok(Event::End(ref e)) => {
+                let tag = String::from_utf8_lossy(e.name().as_ref()).to_string();
+                if tag == "Contents" {
+                    if let Some(key) = current_key.take() {
+                        entries.push(ListEntry {
+                            key,
+                            size: current_size.unwrap_or(0),
+                        });
+                    }
+                    in_contents = false;
+                }
+                current_tag.clear();
+            }
+            Ok(Event::Text(ref e)) => {
+                let text = String::from_utf8_lossy(e.as_ref()).to_string();
+                if in_contents {
+                    match current_tag.as_str() {
+                        "Key" => current_key = Some(text),
+                        "Size" => current_size = text.parse::<i64>().ok(),
+                        _ => {}
+                    }
+                } else {
+                    match current_tag.as_str() {
+                        "IsTruncated" => is_truncated = text == "true",
+                        "NextMarker" => next_marker = Some(text),
+                        _ => {}
+                    }
+                }
+            }
+            Ok(Event::Eof) => break,
+            Err(e) => {
+                return Err(SurgeError::Storage(format!(
+                    "Failed to parse GCS XML list response: {e}"
+                )));
+            }
+            _ => {}
+        }
+        buf.clear();
+    }
+
+    debug!(count = entries.len(), is_truncated, "GCS XML LIST parsed");
+    Ok(ListResult {
+        entries,
+        next_marker,
+        is_truncated,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_gcs_xml_list_response;
+
+    #[test]
+    fn parse_gcs_xml_list_response_reads_entries_and_marker() {
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<ListBucketResult>
+  <Contents>
+    <Key>prefix/app-1.0.0.zip</Key>
+    <Size>123</Size>
+  </Contents>
+  <Contents>
+    <Key>prefix/app-1.1.0.zip</Key>
+    <Size>456</Size>
+  </Contents>
+  <IsTruncated>true</IsTruncated>
+  <NextMarker>next-marker</NextMarker>
+</ListBucketResult>"#;
+
+        let result = parse_gcs_xml_list_response(xml).expect("gcs xml list response should parse");
+        assert_eq!(result.entries.len(), 2);
+        assert_eq!(result.entries[0].key, "prefix/app-1.0.0.zip");
+        assert_eq!(result.entries[0].size, 123);
+        assert_eq!(result.entries[1].key, "prefix/app-1.1.0.zip");
+        assert_eq!(result.entries[1].size, 456);
+        assert_eq!(result.next_marker.as_deref(), Some("next-marker"));
+        assert!(result.is_truncated);
+    }
+}

--- a/docs/architecture/cleanup-plan.md
+++ b/docs/architecture/cleanup-plan.md
@@ -36,35 +36,37 @@ These PRs are already merged:
 - `#64` `refactor(core): split shortcut installation by platform`
 - `#65` `refactor(core): split manifest module responsibilities`
 - `#66` `refactor(core): split install module responsibilities`
+- `#67` `refactor(core): split azure storage backend helpers`
 
 ## Active Phase
 
-### `refactor/storage-azure-phase-1`
+### `refactor/storage-gcs-phase-1`
 
 Current goal:
 
-- split [`crates/surge-core/src/storage/azure/mod.rs`](../../crates/surge-core/src/storage/azure/mod.rs)
+- split [`crates/surge-core/src/storage/gcs/mod.rs`](../../crates/surge-core/src/storage/gcs/mod.rs)
   into:
-  - `storage/azure/auth.rs`
-  - `storage/azure/requests.rs`
-  - `storage/azure/listing.rs`
+  - `storage/gcs/auth.rs`
+  - `storage/gcs/requests.rs`
+  - `storage/gcs/xml_listing.rs`
+  - `storage/gcs/json_listing.rs`
 
 Current checkpoint:
 
 - the leaf modules have been created
 - the root module has been reduced to the backend type and module wiring
 - targeted compile of `surge-core` passes
-- focused `storage::azure` tests pass
+- focused `storage::gcs` tests pass
 - focused `surge-core` clippy passes
-- the azure baseline entry has been removed
+- the gcs baseline entry has been removed
 - the full pre-push suite passes on the branch
 
 Exit criteria:
 
-- `cargo test -p surge-core storage::azure` passes
+- `cargo test -p surge-core storage::gcs` passes
 - `cargo clippy -p surge-core --all-targets --all-features -- -D warnings -W clippy::pedantic` passes
 - `./scripts/check-maintainability.sh` reports the file below the target so the
-  azure baseline entry can be removed
+  gcs baseline entry can be removed
 - the full pre-push suite passes
 - the PR is merged with squash, local cleanup is done, and merged-`main` CI is green
 
@@ -72,13 +74,14 @@ Exit criteria:
 
 These are the remaining planned PRs from the original Rust-first campaign.
 
-### 1. `refactor/storage-azure-phase-1`
+### 1. `refactor/storage-gcs-phase-1`
 
-- split [`crates/surge-core/src/storage/azure/mod.rs`](../../crates/surge-core/src/storage/azure/mod.rs)
+- split [`crates/surge-core/src/storage/gcs/mod.rs`](../../crates/surge-core/src/storage/gcs/mod.rs)
   into focused modules for:
-  - shared-key signing and credential checks
+  - auth-mode selection and signing helpers
   - request construction and backend operations
-  - list-response XML parsing
+  - XML list parsing
+  - JSON list parsing
 
 ### 2. `refactor/maintainability-phase-2`
 
@@ -102,7 +105,6 @@ be decomposed to fully retire the baseline.
 ### Core surfaces
 
 - [`crates/surge-core/src/releases/delta.rs`](../../crates/surge-core/src/releases/delta.rs)
-- [`crates/surge-core/src/storage/gcs.rs`](../../crates/surge-core/src/storage/gcs.rs)
 
 ### Bench debt
 

--- a/docs/architecture/maintainability-baseline.txt
+++ b/docs/architecture/maintainability-baseline.txt
@@ -6,5 +6,4 @@
 1860 crates/surge-cli/src/commands/install/remote.rs
 835 crates/surge-cli/src/main.rs
 782 crates/surge-core/src/releases/delta.rs
-840 crates/surge-core/src/storage/gcs.rs
 760 crates/surge-installer-ui/src/app.rs


### PR DESCRIPTION
## Purpose
- split `surge-core` GCS storage support into focused modules for auth handling, request construction, and XML/JSON list parsing
- keep `surge_core::storage::gcs::GcsBackend` and its behavior stable while reducing the root module below the maintainability threshold
- remove the GCS baseline entry and advance `docs/architecture/cleanup-plan.md` to the next active slice

## Behavior Impact
- no intended user-visible behavior change
- GCS auth-mode selection, HMAC signing, OAuth2 request flow, and XML/JSON list parsing keep the same semantics
- the public backend constructor and `set_oauth2_token` surface remain at the existing path

## Test Evidence
- `cargo check -p surge-core`
- `cargo test -p surge-core storage::gcs`
- `cargo clippy -p surge-core --all-targets --all-features -- -D warnings -W clippy::pedantic`
- `./scripts/check-maintainability.sh`
- `./scripts/sync-surge-core-vendor.sh --check`
- `./scripts/check-version-sync.sh`
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo test --workspace`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo clippy --workspace --lib --bins --examples -- -D warnings -D clippy::unwrap_used -D clippy::expect_used`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings -W clippy::pedantic`
- `dotnet format dotnet/Surge.slnx --verify-no-changes`
- `dotnet test dotnet/Surge.slnx --configuration Release`

## Migration Notes
- none