### PR TITLE
feat: enforce strict SemVer 2.0 and type Surge.NET versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2826,9 +2826,9 @@ checksum = "b12e76d157a900eb52e81bc6e9f3069344290341720e9178cde2407113ac8d89"
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -3157,6 +3157,7 @@ dependencies = [
  "percent-encoding",
  "quick-xml 0.39.2",
  "reqwest",
+ "semver",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ surge-core = { path = "crates/surge-core", version = "1.0.0" }
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.9"
 serde_json = "1.0"
+semver = "1.0.28"
 sha2 = "0.11"
 hex = "0.4"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "stream", "json"] }

--- a/crates/surge-cli/src/commands/demote.rs
+++ b/crates/surge-cli/src/commands/demote.rs
@@ -8,6 +8,7 @@ use surge_core::config::constants::{DEFAULT_ZSTD_LEVEL, RELEASES_FILE_COMPRESSED
 use surge_core::config::manifest::SurgeManifest;
 use surge_core::error::{Result, SurgeError};
 use surge_core::releases::manifest::{compress_release_index, decompress_release_index};
+use surge_core::releases::version::canonicalize_version;
 use surge_core::storage::{self, StorageBackend};
 
 /// Demote (remove) a release version from a channel.
@@ -19,6 +20,7 @@ pub async fn execute(
     channel: &str,
 ) -> Result<()> {
     const TOTAL_STAGES: usize = 4;
+    let version = canonicalize_version(version, "release version")?;
 
     let theme = UiTheme::global();
     let started = Instant::now();

--- a/crates/surge-cli/src/commands/pack.rs
+++ b/crates/surge-cli/src/commands/pack.rs
@@ -35,6 +35,7 @@ use surge_core::releases::artifact_cache::{CacheFetchOutcome, fetch_or_reuse_fil
 use surge_core::releases::restore::{
     RestoreOptions, plan_full_archive_restore, restore_full_archive_for_version_with_options,
 };
+use surge_core::releases::version::canonicalize_version;
 use surge_core::storage_config::build_storage_config;
 
 /// Build release packages (full + delta) for a given app version and RID.
@@ -47,6 +48,7 @@ pub async fn execute(
     output_dir: &Path,
 ) -> Result<()> {
     const TOTAL_STAGES: usize = 5;
+    let version = canonicalize_version(version, "release version")?;
 
     let theme = UiTheme::global();
     let started = Instant::now();
@@ -62,7 +64,7 @@ pub async fn execute(
 
     print_stage(theme, 2, TOTAL_STAGES, "Validating artifacts and output directories");
     let artifacts_dir = artifacts_dir.map_or_else(
-        || default_artifacts_dir(manifest_path, &app_id, &rid, version),
+        || default_artifacts_dir(manifest_path, &app_id, &rid, &version),
         PathBuf::from,
     );
     if !artifacts_dir.is_dir() {
@@ -96,7 +98,7 @@ pub async fn execute(
         ))
     })?;
 
-    let mut builder = PackBuilder::new(ctx, manifest_path_s, &app_id, &rid, version, artifacts_dir_s)?;
+    let mut builder = PackBuilder::new(ctx, manifest_path_s, &app_id, &rid, &version, artifacts_dir_s)?;
     let build_started = Instant::now();
     let build_running = Arc::new(AtomicBool::new(true));
     let build_step = Arc::new(AtomicI32::new(0));
@@ -168,7 +170,7 @@ pub async fn execute(
         &target,
         &app_id,
         &rid,
-        version,
+        &version,
         &self::resolution::default_channel_for_app(&manifest, app),
         manifest_path.parent().unwrap_or_else(|| Path::new(".")),
         artifacts_dir.as_path(),

--- a/crates/surge-cli/src/commands/pack/installers.rs
+++ b/crates/surge-cli/src/commands/pack/installers.rs
@@ -193,6 +193,7 @@ pub(super) fn build_installers_with_launcher(
                 environment: target.environment.clone(),
             },
         };
+        manifest_payload.validate()?;
         let manifest_yaml = serde_yaml::to_string(&manifest_payload)?;
         std::fs::write(staging.join("installer.yml"), manifest_yaml.as_bytes())?;
 

--- a/crates/surge-cli/src/commands/promote.rs
+++ b/crates/surge-cli/src/commands/promote.rs
@@ -8,6 +8,7 @@ use surge_core::config::constants::{DEFAULT_ZSTD_LEVEL, RELEASES_FILE_COMPRESSED
 use surge_core::config::manifest::SurgeManifest;
 use surge_core::error::{Result, SurgeError};
 use surge_core::releases::manifest::compress_release_index;
+use surge_core::releases::version::canonicalize_version;
 use surge_core::storage;
 
 /// Promote a release version to a target channel.
@@ -19,6 +20,7 @@ pub async fn execute(
     channel: &str,
 ) -> Result<()> {
     const TOTAL_STAGES: usize = 5;
+    let version = canonicalize_version(version, "release version")?;
 
     let theme = UiTheme::global();
     let started = Instant::now();
@@ -71,7 +73,7 @@ pub async fn execute(
     }
 
     print_stage(theme, 3, TOTAL_STAGES, "Ensuring release full artifact exists");
-    let full_materialized = super::ensure_release_full_artifact(&*backend, &index, &rid, version).await?;
+    let full_materialized = super::ensure_release_full_artifact(&*backend, &index, &rid, &version).await?;
     print_stage_done(
         theme,
         3,

--- a/crates/surge-cli/src/commands/push.rs
+++ b/crates/surge-cli/src/commands/push.rs
@@ -27,7 +27,9 @@ use surge_core::releases::manifest::{
     DeltaArtifact, PATCH_FORMAT_BSDIFF4, PATCH_FORMAT_CHUNKED_BSDIFF_V1, PATCH_FORMAT_SPARSE_FILE_OPS_V1, ReleaseEntry,
     ReleaseIndex, compress_release_index, decompress_release_index,
 };
+use surge_core::releases::restore::find_previous_release_for_rid;
 use surge_core::releases::restore::required_artifacts_for_index;
+use surge_core::releases::version::canonicalize_version;
 use surge_core::releases::version::compare_versions;
 use surge_core::storage::{self, StorageBackend};
 
@@ -41,6 +43,7 @@ pub async fn execute(
     packages_dir: &Path,
 ) -> Result<()> {
     const TOTAL_STAGES: usize = 5;
+    let version = canonicalize_version(version, "release version")?;
 
     let theme = UiTheme::global();
     let started = Instant::now();
@@ -159,7 +162,7 @@ pub async fn execute(
     let pruned = update_release_index(
         &*backend,
         &app_id,
-        version,
+        &version,
         &rid,
         channel,
         full_filename,
@@ -290,6 +293,19 @@ async fn update_release_index(
         .releases
         .iter()
         .any(|release| release.rid == rid || release.rid.is_empty());
+    let delta_from_version = if delta_filename.trim().is_empty() {
+        None
+    } else {
+        Some(
+            find_previous_release_for_rid(&index, rid, version)
+                .map(|release| release.version.clone())
+                .ok_or_else(|| {
+                    SurgeError::Config(format!(
+                        "Cannot publish delta artifact for {app_id}/{rid} v{version} without a previous release baseline"
+                    ))
+                })?,
+        )
+    };
 
     index
         .releases
@@ -318,41 +334,43 @@ async fn update_release_index(
         installers,
         environment,
     };
-    let primary_delta = if delta_filename.trim().is_empty() {
-        None
-    } else if delta_patch_format.eq_ignore_ascii_case(PATCH_FORMAT_SPARSE_FILE_OPS_V1) {
-        Some(DeltaArtifact::sparse_file_ops_zstd(
+    let primary_delta = match delta_from_version.as_deref() {
+        None => None,
+        Some(delta_from_version) if delta_patch_format.eq_ignore_ascii_case(PATCH_FORMAT_SPARSE_FILE_OPS_V1) => {
+            Some(DeltaArtifact::sparse_file_ops_zstd(
+                "primary",
+                delta_from_version,
+                &delta_filename,
+                delta_size,
+                &delta_sha256,
+            ))
+        }
+        Some(delta_from_version) if delta_patch_format.eq_ignore_ascii_case(PATCH_FORMAT_CHUNKED_BSDIFF_V1) => {
+            Some(DeltaArtifact::chunked_bsdiff_zstd(
+                "primary",
+                delta_from_version,
+                &delta_filename,
+                delta_size,
+                &delta_sha256,
+            ))
+        }
+        Some(delta_from_version) if delta_patch_format.eq_ignore_ascii_case(PATCH_FORMAT_BSDIFF4) => {
+            Some(DeltaArtifact::bsdiff_zstd(
+                "primary",
+                delta_from_version,
+                &delta_filename,
+                delta_size,
+                &delta_sha256,
+            ))
+        }
+        Some(delta_from_version) => Some(DeltaArtifact::with_patch_format(
             "primary",
-            "",
-            &delta_filename,
-            delta_size,
-            &delta_sha256,
-        ))
-    } else if delta_patch_format.eq_ignore_ascii_case(PATCH_FORMAT_CHUNKED_BSDIFF_V1) {
-        Some(DeltaArtifact::chunked_bsdiff_zstd(
-            "primary",
-            "",
-            &delta_filename,
-            delta_size,
-            &delta_sha256,
-        ))
-    } else if delta_patch_format.eq_ignore_ascii_case(PATCH_FORMAT_BSDIFF4) {
-        Some(DeltaArtifact::bsdiff_zstd(
-            "primary",
-            "",
-            &delta_filename,
-            delta_size,
-            &delta_sha256,
-        ))
-    } else {
-        Some(DeltaArtifact::with_patch_format(
-            "primary",
-            "",
+            delta_from_version,
             &delta_patch_format,
             &delta_filename,
             delta_size,
             &delta_sha256,
-        ))
+        )),
     };
     entry.set_primary_delta(primary_delta);
     index.releases.push(entry);

--- a/crates/surge-cli/src/commands/setup.rs
+++ b/crates/surge-cli/src/commands/setup.rs
@@ -120,6 +120,7 @@ pub async fn execute(dir: &Path, no_start: bool, stage: bool) -> Result<()> {
 
     let manifest_bytes = std::fs::read(&manifest_path)?;
     let manifest: InstallerManifest = serde_yaml::from_slice(&manifest_bytes)?;
+    manifest.validate()?;
 
     logline::info(&format!(
         "Setting up {} v{} ({}/{})",

--- a/crates/surge-core/Cargo.toml
+++ b/crates/surge-core/Cargo.toml
@@ -36,6 +36,7 @@ quick-xml = { workspace = true }
 async-trait = { workspace = true }
 futures-util = { workspace = true }
 tempfile = { workspace = true }
+semver = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
 nix = { version = "0.31", features = ["signal", "process", "fs"] }

--- a/crates/surge-core/src/config/installer.rs
+++ b/crates/surge-core/src/config/installer.rs
@@ -3,6 +3,8 @@ use std::collections::BTreeMap;
 use serde::{Deserialize, Serialize};
 
 use crate::config::manifest::ShortcutLocation;
+use crate::error::Result;
+use crate::releases::version::validate_version_string;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -75,4 +77,10 @@ pub struct InstallerRuntime {
     pub installers: Vec<String>,
     #[serde(default)]
     pub environment: BTreeMap<String, String>,
+}
+
+impl InstallerManifest {
+    pub fn validate(&self) -> Result<()> {
+        validate_version_string(&self.version, "installer manifest version")
+    }
 }

--- a/crates/surge-core/src/install/activation.rs
+++ b/crates/surge-core/src/install/activation.rs
@@ -7,7 +7,7 @@ use crate::error::{Result, SurgeError};
 use crate::platform::fs::list_directories;
 use crate::platform::paths::default_install_root;
 use crate::platform::shortcuts::install_shortcuts;
-use crate::releases::version::compare_versions;
+use crate::releases::version::{compare_versions, is_valid_version_string};
 use crate::supervisor::stub::find_latest_app_dir;
 
 use super::persistent_assets::copy_persistent_assets;
@@ -211,7 +211,7 @@ pub fn install_package_locally_at_root_with_progress(
 
 fn app_snapshot_version(dir_name: &str) -> Option<&str> {
     let version = dir_name.strip_prefix("app-")?;
-    if version.is_empty() || !version.chars().next().is_some_and(|c| c.is_ascii_digit()) {
+    if !is_valid_version_string(version) {
         return None;
     }
     Some(version)

--- a/crates/surge-core/src/install/runtime_manifest.rs
+++ b/crates/surge-core/src/install/runtime_manifest.rs
@@ -4,6 +4,7 @@ use serde::Serialize;
 
 use crate::context::StorageProvider;
 use crate::error::{Result, SurgeError};
+use crate::releases::version::canonicalize_version;
 
 use super::InstallProfile;
 
@@ -125,9 +126,11 @@ pub fn write_runtime_manifest(
     profile: &InstallProfile<'_>,
     metadata: &RuntimeManifestMetadata<'_>,
 ) -> Result<PathBuf> {
+    let version = canonicalize_version(metadata.version, "runtime manifest version")?;
+
     let manifest = RuntimeManifestFile {
         id: profile.app_id.trim(),
-        version: metadata.version.trim(),
+        version: &version,
         channel: metadata.channel.trim(),
         install_directory: profile.install_directory.trim(),
         supervisor_id: profile.supervisor_id.trim(),

--- a/crates/surge-core/src/pack/builder.rs
+++ b/crates/surge-core/src/pack/builder.rs
@@ -17,6 +17,7 @@ use crate::config::manifest::{PackPolicy, ShortcutLocation, SurgeManifest};
 use crate::context::Context;
 use crate::error::{Result, SurgeError};
 use crate::platform::fs::write_file_atomic;
+use crate::releases::version::canonicalize_version;
 use crate::storage::{StorageBackend, create_storage_backend};
 
 pub(crate) use self::staging::build_canonical_archive_from_directory;
@@ -114,6 +115,7 @@ impl PackBuilder {
         version: &str,
         artifacts_dir: &str,
     ) -> Result<Self> {
+        let version = canonicalize_version(version, "release version")?;
         let manifest = SurgeManifest::from_file(Path::new(manifest_path))?;
         let pack_policy = manifest.effective_pack_policy();
         let (app, target) = manifest
@@ -157,7 +159,7 @@ impl PackBuilder {
             ctx,
             app_id: app_id.to_string(),
             rid: rid.to_string(),
-            version: version.to_string(),
+            version,
             name: app.effective_name(),
             main_exe,
             install_directory: app.effective_install_directory(),

--- a/crates/surge-core/src/releases/channel.rs
+++ b/crates/surge-core/src/releases/channel.rs
@@ -6,6 +6,7 @@ use crate::config::constants::RELEASES_FILE_COMPRESSED;
 use crate::context::Context;
 use crate::error::{Result, SurgeError};
 use crate::releases::manifest::{ReleaseEntry, ReleaseIndex, compress_release_index, decompress_release_index};
+use crate::releases::version::canonicalize_version;
 
 /// Manages release channels: fetching, saving, promoting, and demoting releases.
 pub struct ChannelManager {
@@ -46,6 +47,7 @@ impl ChannelManager {
     /// not on the source channel.
     pub async fn promote(&self, version: &str, source_channel: &str, target_channel: &str) -> Result<()> {
         self.ctx.check_cancelled()?;
+        let version = canonicalize_version(version, "release version")?;
 
         let mut index = self.fetch_index().await?;
         let mut found = false;
@@ -82,6 +84,7 @@ impl ChannelManager {
     /// if the version is not found or not on the channel.
     pub async fn demote(&self, version: &str, channel: &str) -> Result<()> {
         self.ctx.check_cancelled()?;
+        let version = canonicalize_version(version, "release version")?;
 
         let mut index = self.fetch_index().await?;
         let mut found = false;

--- a/crates/surge-core/src/releases/manifest.rs
+++ b/crates/surge-core/src/releases/manifest.rs
@@ -5,7 +5,7 @@ use std::collections::BTreeMap;
 
 use crate::config::manifest::ShortcutLocation;
 use crate::error::{Result, SurgeError};
-use crate::releases::version::compare_versions;
+use crate::releases::version::{compare_versions, validate_version_string};
 
 pub const DIFF_ALGORITHM_BSDIFF: &str = "bsdiff";
 pub const DIFF_ALGORITHM_FILE_OPS: &str = "file-ops";
@@ -186,6 +186,16 @@ pub struct ReleaseEntry {
 }
 
 impl ReleaseEntry {
+    fn validate_versions(&self) -> Result<()> {
+        validate_version_string(&self.version, "release version")?;
+
+        for delta in &self.deltas {
+            validate_version_string(&delta.from_version, "delta base version")?;
+        }
+
+        Ok(())
+    }
+
     /// Returns the best display name, falling back through `name → main_exe → app_id`.
     #[must_use]
     pub fn display_name<'a>(&'a self, app_id: &'a str) -> &'a str {
@@ -280,14 +290,26 @@ impl Default for ReleaseIndex {
     }
 }
 
+impl ReleaseIndex {
+    fn validate_versions(&self) -> Result<()> {
+        for release in &self.releases {
+            release.validate_versions()?;
+        }
+
+        Ok(())
+    }
+}
+
 /// Parse a release index from YAML bytes.
 pub fn parse_release_index(data: &[u8]) -> Result<ReleaseIndex> {
     let index: ReleaseIndex = serde_yaml::from_slice(data)?;
+    index.validate_versions()?;
     Ok(index)
 }
 
 /// Serialize a release index to YAML bytes.
 pub fn serialize_release_index(index: &ReleaseIndex) -> Result<Vec<u8>> {
+    index.validate_versions()?;
     let yaml = serde_yaml::to_string(index)?;
     Ok(yaml.into_bytes())
 }
@@ -386,7 +408,7 @@ mod tests {
         let delta = if has_delta {
             Some(DeltaArtifact::bsdiff_zstd(
                 "primary",
-                "",
+                "0.0.0",
                 &format!("app-{version}-delta.tar.zst"),
                 200,
                 "def456",

--- a/crates/surge-core/src/releases/restore.rs
+++ b/crates/surge-core/src/releases/restore.rs
@@ -62,7 +62,7 @@ mod tests {
             full_sha256: String::new(),
             deltas: vec![DeltaArtifact::bsdiff_zstd(
                 "primary",
-                "",
+                "0.0.0",
                 &format!("demo-{version}-linux-x64-delta.tar.zst"),
                 0,
                 "",

--- a/crates/surge-core/src/releases/version.rs
+++ b/crates/surge-core/src/releases/version.rs
@@ -1,130 +1,57 @@
-//! Semantic version comparison for dotted-integer version strings.
+//! Strict Semantic Versioning 2.0 parsing and comparison helpers.
 
 use std::cmp::Ordering;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-enum PrereleaseIdentifier<'a> {
-    Numeric(u64),
-    Text(&'a str),
-}
+use semver::Version;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct ParsedVersion<'a> {
-    core: Vec<u64>,
-    prerelease: Option<Vec<PrereleaseIdentifier<'a>>>,
-}
+use crate::error::{Result, SurgeError};
 
-fn parse_core_version(version: &str) -> Vec<u64> {
-    let parts: Vec<u64> = version
-        .split('.')
-        .filter_map(|p| p.trim().parse::<u64>().ok())
-        .collect();
-
-    let mut result = parts;
-    while result.len() < 3 {
-        result.push(0);
+fn parse_semver(version: &str, label: &str) -> Result<Version> {
+    if version.is_empty() {
+        return Err(SurgeError::Config(format!("{label} cannot be empty")));
     }
-    result
+
+    if version.trim() != version {
+        return Err(SurgeError::Config(format!(
+            "{label} must not contain leading or trailing whitespace: '{version}'"
+        )));
+    }
+
+    Version::parse(version)
+        .map_err(|error| SurgeError::Config(format!("Invalid {label} semantic version '{version}': {error}")))
 }
 
-fn parse_prerelease(version: &str) -> Option<Vec<PrereleaseIdentifier<'_>>> {
-    let (_, raw_prerelease) = version.split_once('-')?;
-    let identifiers = raw_prerelease
-        .split('.')
-        .filter(|segment| !segment.is_empty())
-        .map(|segment| {
-            segment
-                .parse::<u64>()
-                .map_or(PrereleaseIdentifier::Text(segment), PrereleaseIdentifier::Numeric)
-        })
-        .collect::<Vec<_>>();
-
-    if identifiers.is_empty() {
-        None
-    } else {
-        Some(identifiers)
+fn parse_semver_for_compare(version: &str) -> Version {
+    match parse_semver(version, "version") {
+        Ok(version) => version,
+        Err(error) => panic!("internal semantic-version invariant violated: {error}"),
     }
 }
 
-fn parse_version(version: &str) -> ParsedVersion<'_> {
-    let without_build_metadata = version.split_once('+').map_or(version, |(base, _)| base);
-    let core = without_build_metadata
-        .split_once('-')
-        .map_or(without_build_metadata, |(base, _)| base);
-
-    ParsedVersion {
-        core: parse_core_version(core),
-        prerelease: parse_prerelease(without_build_metadata),
-    }
+/// Parse and validate a strict Semantic Versioning 2.0 version string.
+pub fn validate_version_string(version: &str, label: &str) -> Result<()> {
+    parse_semver(version, label).map(|_| ())
 }
 
-fn compare_prerelease_identifiers(a: &[PrereleaseIdentifier<'_>], b: &[PrereleaseIdentifier<'_>]) -> Ordering {
-    let max_len = a.len().max(b.len());
-
-    for i in 0..max_len {
-        match (a.get(i), b.get(i)) {
-            (Some(PrereleaseIdentifier::Numeric(lhs)), Some(PrereleaseIdentifier::Numeric(rhs))) => {
-                let ordering = lhs.cmp(rhs);
-                if ordering != Ordering::Equal {
-                    return ordering;
-                }
-            }
-            (Some(PrereleaseIdentifier::Text(lhs)), Some(PrereleaseIdentifier::Text(rhs))) => {
-                let ordering = lhs.cmp(rhs);
-                if ordering != Ordering::Equal {
-                    return ordering;
-                }
-            }
-            (Some(PrereleaseIdentifier::Numeric(_)), Some(PrereleaseIdentifier::Text(_))) | (None, Some(_)) => {
-                return Ordering::Less;
-            }
-            (Some(PrereleaseIdentifier::Text(_)), Some(PrereleaseIdentifier::Numeric(_))) => {
-                return Ordering::Greater;
-            }
-            (Some(_), None) => return Ordering::Greater,
-            (None, None) => return Ordering::Equal,
-        }
-    }
-
-    Ordering::Equal
+/// Parse and canonicalize a strict Semantic Versioning 2.0 version string.
+pub fn canonicalize_version(version: &str, label: &str) -> Result<String> {
+    parse_semver(version, label).map(|parsed| parsed.to_string())
 }
 
-/// Compare two dotted-integer version strings.
+/// Return whether the provided string is a valid strict Semantic Versioning 2.0 value.
+#[must_use]
+pub fn is_valid_version_string(version: &str) -> bool {
+    parse_semver(version, "version").is_ok()
+}
+
+/// Compare two validated semantic versions by precedence.
 ///
-/// Parses "major.minor.patch" format, filling missing parts with 0.
-/// Supports versions with more than 3 parts (e.g., "1.2.3.4").
-///
-/// # Examples
-///
-/// ```
-/// use surge_core::releases::version::compare_versions;
-/// use std::cmp::Ordering;
-///
-/// assert_eq!(compare_versions("1.2.3", "1.2.3"), Ordering::Equal);
-/// assert_eq!(compare_versions("2.0.0", "1.9.9"), Ordering::Greater);
-/// assert_eq!(compare_versions("1.0", "1.0.0"), Ordering::Equal);
-/// ```
+/// This ignores build metadata as required by SemVer 2.0 precedence rules.
 #[must_use]
 pub fn compare_versions(a: &str, b: &str) -> Ordering {
-    let parts_a = parse_version(a);
-    let parts_b = parse_version(b);
-
-    let max_len = parts_a.core.len().max(parts_b.core.len());
-
-    for i in 0..max_len {
-        let va = parts_a.core.get(i).copied().unwrap_or(0);
-        let vb = parts_b.core.get(i).copied().unwrap_or(0);
-        if va != vb {
-            return va.cmp(&vb);
-        }
-    }
-
-    match (&parts_a.prerelease, &parts_b.prerelease) {
-        (None, None) => Ordering::Equal,
-        (None, Some(_)) => Ordering::Greater,
-        (Some(_), None) => Ordering::Less,
-        (Some(lhs), Some(rhs)) => compare_prerelease_identifiers(lhs, rhs),
-    }
+    let left = parse_semver_for_compare(a);
+    let right = parse_semver_for_compare(b);
+    left.cmp_precedence(&right)
 }
 
 #[cfg(test)]
@@ -132,66 +59,34 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_equal_versions() {
-        assert_eq!(compare_versions("1.0.0", "1.0.0"), Ordering::Equal);
-        assert_eq!(compare_versions("0.0.0", "0.0.0"), Ordering::Equal);
-        assert_eq!(compare_versions("10.20.30", "10.20.30"), Ordering::Equal);
+    fn compare_versions_follows_semver_precedence_examples() {
+        let ordered = [
+            "1.0.0-alpha",
+            "1.0.0-alpha.1",
+            "1.0.0-alpha.beta",
+            "1.0.0-beta",
+            "1.0.0-beta.2",
+            "1.0.0-beta.11",
+            "1.0.0-rc.1",
+            "1.0.0",
+        ];
+
+        for pair in ordered.windows(2) {
+            assert_eq!(compare_versions(pair[0], pair[1]), Ordering::Less);
+        }
     }
 
     #[test]
-    fn test_greater_major() {
-        assert_eq!(compare_versions("2.0.0", "1.0.0"), Ordering::Greater);
-        assert_eq!(compare_versions("10.0.0", "9.0.0"), Ordering::Greater);
+    fn compare_versions_ignores_build_metadata() {
+        assert_eq!(compare_versions("1.2.3+build.1", "1.2.3+build.9"), Ordering::Equal);
+        assert_eq!(
+            compare_versions("1.2.3-beta.1+build.1", "1.2.3-beta.1"),
+            Ordering::Equal
+        );
     }
 
     #[test]
-    fn test_greater_minor() {
-        assert_eq!(compare_versions("1.2.0", "1.1.0"), Ordering::Greater);
-        assert_eq!(compare_versions("1.10.0", "1.9.0"), Ordering::Greater);
-    }
-
-    #[test]
-    fn test_greater_patch() {
-        assert_eq!(compare_versions("1.0.2", "1.0.1"), Ordering::Greater);
-        assert_eq!(compare_versions("1.0.10", "1.0.9"), Ordering::Greater);
-    }
-
-    #[test]
-    fn test_less_than() {
-        assert_eq!(compare_versions("1.0.0", "2.0.0"), Ordering::Less);
-        assert_eq!(compare_versions("1.0.0", "1.1.0"), Ordering::Less);
-        assert_eq!(compare_versions("1.0.0", "1.0.1"), Ordering::Less);
-    }
-
-    #[test]
-    fn test_missing_parts_filled_with_zero() {
-        assert_eq!(compare_versions("1", "1.0.0"), Ordering::Equal);
-        assert_eq!(compare_versions("1.2", "1.2.0"), Ordering::Equal);
-        assert_eq!(compare_versions("1", "1.0.1"), Ordering::Less);
-    }
-
-    #[test]
-    fn test_four_part_versions() {
-        assert_eq!(compare_versions("1.0.0.1", "1.0.0.0"), Ordering::Greater);
-        assert_eq!(compare_versions("1.0.0", "1.0.0.0"), Ordering::Equal);
-        assert_eq!(compare_versions("1.0.0.1", "1.0.0.2"), Ordering::Less);
-    }
-
-    #[test]
-    fn test_complex_comparisons() {
-        assert_eq!(compare_versions("2.0.0", "1.9.9"), Ordering::Greater);
-        assert_eq!(compare_versions("1.0.0", "0.99.99"), Ordering::Greater);
-        assert_eq!(compare_versions("0.0.1", "0.0.0"), Ordering::Greater);
-    }
-
-    #[test]
-    fn test_large_version_numbers() {
-        assert_eq!(compare_versions("100.200.300", "100.200.300"), Ordering::Equal);
-        assert_eq!(compare_versions("100.200.301", "100.200.300"), Ordering::Greater);
-    }
-
-    #[test]
-    fn test_stable_release_is_newer_than_matching_prerelease() {
+    fn compare_versions_treats_release_as_newer_than_matching_prerelease() {
         assert_eq!(
             compare_versions("2859.0.0", "2859.0.0-prerelease.56"),
             Ordering::Greater
@@ -200,23 +95,52 @@ mod tests {
     }
 
     #[test]
-    fn test_prerelease_versions_compare_by_numeric_suffix() {
+    fn validate_version_string_accepts_strict_semver_values() {
+        for version in [
+            "0.0.0",
+            "1.2.3",
+            "10.20.30",
+            "1.0.0-alpha",
+            "1.0.0-alpha.1",
+            "1.0.0-0A.is.legal",
+            "1.0.0+build.1",
+            "1.0.0-alpha+build.1",
+        ] {
+            validate_version_string(version, "version").unwrap();
+        }
+    }
+
+    #[test]
+    fn validate_version_string_rejects_non_compliant_inputs() {
+        for version in [
+            "",
+            "1",
+            "1.2",
+            "1.2.3.4",
+            "01.2.3",
+            "1.02.3",
+            "1.2.03",
+            "1.2.3-01",
+            "1.2.3-alpha..1",
+            "1.2.3+meta+meta",
+            " 1.2.3",
+            "1.2.3 ",
+        ] {
+            assert!(validate_version_string(version, "version").is_err(), "{version}");
+        }
+    }
+
+    #[test]
+    fn canonicalize_version_preserves_valid_semver_shape() {
         assert_eq!(
-            compare_versions("2859.0.0-prerelease.56", "2859.0.0-prerelease.55"),
-            Ordering::Greater
-        );
-        assert_eq!(
-            compare_versions("2859.0.0-prerelease.54", "2859.0.0-prerelease.56"),
-            Ordering::Less
+            canonicalize_version("1.2.3-rc.1+build.5", "version").unwrap(),
+            "1.2.3-rc.1+build.5"
         );
     }
 
     #[test]
-    fn test_build_metadata_does_not_affect_ordering() {
-        assert_eq!(compare_versions("1.2.3+build.1", "1.2.3+build.9"), Ordering::Equal);
-        assert_eq!(
-            compare_versions("1.2.3-beta.1+build.1", "1.2.3-beta.1"),
-            Ordering::Equal
-        );
+    fn is_valid_version_string_reports_strict_semver_status() {
+        assert!(is_valid_version_string("1.2.3"));
+        assert!(!is_valid_version_string("1.2"));
     }
 }

--- a/crates/surge-core/src/supervisor/stub.rs
+++ b/crates/surge-core/src/supervisor/stub.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 
 use crate::error::{Result, SurgeError};
 use crate::platform::fs::list_directories;
-use crate::releases::version::compare_versions;
+use crate::releases::version::{compare_versions, is_valid_version_string};
 
 /// Resolve the active app directory under `install_dir`.
 ///
@@ -24,12 +24,7 @@ pub fn find_latest_app_dir(install_dir: &Path) -> Result<PathBuf> {
 
     for dir_name in &dirs {
         if let Some(version) = dir_name.strip_prefix("app-") {
-            if version.is_empty() {
-                continue;
-            }
-
-            // Validate it looks like a version (starts with a digit)
-            if !version.chars().next().is_some_and(|c| c.is_ascii_digit()) {
+            if !is_valid_version_string(version) {
                 continue;
             }
 

--- a/crates/surge-core/src/update/manager.rs
+++ b/crates/surge-core/src/update/manager.rs
@@ -23,6 +23,7 @@ use crate::platform::shortcuts::install_shortcuts;
 use crate::releases::artifact_cache::prune_cached_artifacts;
 use crate::releases::manifest::{ReleaseEntry, ReleaseIndex, decompress_release_index};
 use crate::releases::restore::{local_checkpoint_artifacts_for_index, required_artifacts_for_index};
+use crate::releases::version::canonicalize_version;
 use crate::storage::{StorageBackend, create_storage_backend};
 use crate::supervisor::state::supervisor_pid_file;
 
@@ -91,6 +92,7 @@ impl UpdateManager {
         channel: &str,
         install_dir: &str,
     ) -> Result<Self> {
+        let current_version = canonicalize_version(current_version, "current version")?;
         let storage_cfg = ctx.storage_config();
         if !storage_cfg.access_key.trim().is_empty() || !storage_cfg.secret_key.trim().is_empty() {
             return Err(SurgeError::Config(
@@ -102,7 +104,7 @@ impl UpdateManager {
         Ok(Self {
             ctx,
             app_id: app_id.to_string(),
-            current_version: current_version.to_string(),
+            current_version,
             channel: channel.to_string(),
             release_retention_limit: DEFAULT_RELEASE_RETENTION_LIMIT,
             install_dir: PathBuf::from(install_dir),
@@ -144,11 +146,7 @@ impl UpdateManager {
 
     /// Update the local version baseline used for update checks.
     pub fn set_current_version(&mut self, version: &str) -> Result<()> {
-        let normalized = version.trim();
-        if normalized.is_empty() {
-            return Err(SurgeError::Config("Current version cannot be empty".to_string()));
-        }
-        self.current_version = normalized.to_string();
+        self.current_version = canonicalize_version(version, "current version")?;
         self.cached_index = None;
         Ok(())
     }
@@ -501,7 +499,7 @@ mod tests {
             full_sha256: String::new(),
             deltas: vec![DeltaArtifact::bsdiff_zstd(
                 "primary",
-                "",
+                "0.0.0",
                 &format!("{version}-delta.tar.zst"),
                 100,
                 "",
@@ -630,7 +628,9 @@ mod tests {
         let err = manager.set_channel("  ").unwrap_err();
         assert!(err.to_string().contains("channel cannot be empty"));
         let err = manager.set_current_version("").unwrap_err();
-        assert!(err.to_string().contains("Current version cannot be empty"));
+        assert!(err.to_string().contains("current version cannot be empty"));
+        let err = manager.set_current_version("1.0").unwrap_err();
+        assert!(err.to_string().contains("Invalid current version semantic version"));
     }
 
     #[test]

--- a/crates/surge-ffi/src/update.rs
+++ b/crates/surge-ffi/src/update.rs
@@ -1,6 +1,7 @@
 use std::ffi::{c_char, c_int, c_void};
 use std::ptr;
 
+use surge_core::releases::version::canonicalize_version;
 use surge_core::update::manager::{ProgressInfo, UpdateManager};
 
 use crate::handles::{ReleaseEntryFfi, SurgeReleasesInfoHandle, SurgeUpdateManagerHandle};
@@ -44,6 +45,14 @@ pub unsafe extern "C" fn surge_update_manager_create(
             set_ctx_error(handle, &e);
             return ptr::null_mut();
         }
+
+        let version_s = match canonicalize_version(&version_s, "current version") {
+            Ok(version) => version,
+            Err(error) => {
+                set_ctx_error(handle, &error);
+                return ptr::null_mut();
+            }
+        };
 
         let mgr = Box::new(SurgeUpdateManagerHandle {
             ctx: handle.ctx.clone(),
@@ -118,13 +127,15 @@ pub unsafe extern "C" fn surge_update_manager_set_current_version(
 
         // SAFETY: `current_version` follows the nullable C string contract.
         let version_s = unsafe { cstr_to_string(current_version) };
-        let version_s = version_s.trim().to_string();
         if version_s.is_empty() {
             let e = surge_core::error::SurgeError::Config("current_version is required".into());
             return set_shared_error(&mgr_ref.ctx, &mgr_ref.last_error, &e);
         }
 
-        mgr_ref.current_version = version_s;
+        mgr_ref.current_version = match canonicalize_version(&version_s, "current version") {
+            Ok(version) => version,
+            Err(error) => return set_shared_error(&mgr_ref.ctx, &mgr_ref.last_error, &error),
+        };
         SURGE_OK
     }))
 }

--- a/crates/surge-installer-ui/src/main.rs
+++ b/crates/surge-installer-ui/src/main.rs
@@ -53,6 +53,7 @@ fn run() -> Result<()> {
     })?;
     let manifest: InstallerManifest = serde_yaml::from_slice(&manifest_bytes)
         .map_err(|e| SurgeError::Config(format!("Failed to parse installer.yml: {e}")))?;
+    manifest.validate()?;
 
     if headless || !has_display() {
         return run_headless(&manifest, extracted.path(), simulator);

--- a/dotnet/Surge.NET.Tests/SurgeTests.cs
+++ b/dotnet/Surge.NET.Tests/SurgeTests.cs
@@ -1,8 +1,14 @@
 using System;
+using Semver;
 using Xunit;
 
 namespace Surge.Tests
 {
+    internal static class TestSemVersions
+    {
+        internal static SemVersion Parse(string value) => SemVersion.Parse(value, SemVersionStyles.Strict);
+    }
+
     public class SurgeAppTests
     {
         private static readonly string[] FallbackCommandLineArgs = { "/opt/fallback" };
@@ -10,7 +16,7 @@ namespace Surge.Tests
         [Fact]
         public void Version_ReturnsExpectedVersion()
         {
-            Assert.Equal("0.1.0", SurgeApp.Version);
+            Assert.Equal("0.1.0", SurgeApp.Version.ToString());
         }
 
         [Fact]
@@ -101,7 +107,7 @@ namespace Surge.Tests
         {
             var info = new SurgeAppInfo();
             Assert.Equal("", info.Id);
-            Assert.Equal("", info.Version);
+            Assert.Equal("0.0.0", info.Version.ToString());
             Assert.Equal("", info.Channel);
             Assert.Equal("", info.InstallDirectory);
             Assert.Equal("", info.SupervisorId);
@@ -118,7 +124,7 @@ namespace Surge.Tests
             var info = new SurgeAppInfo
             {
                 Id = "myapp",
-                Version = "1.2.3",
+                Version = TestSemVersions.Parse("1.2.3"),
                 Channel = "stable",
                 InstallDirectory = "/opt/myapp",
                 SupervisorId = "myapp-supervisor",
@@ -129,7 +135,7 @@ namespace Surge.Tests
             };
 
             Assert.Equal("myapp", info.Id);
-            Assert.Equal("1.2.3", info.Version);
+            Assert.Equal("1.2.3", info.Version.ToString());
             Assert.Equal("stable", info.Channel);
             Assert.Equal("/opt/myapp", info.InstallDirectory);
             Assert.Equal("myapp-supervisor", info.SupervisorId);
@@ -238,7 +244,7 @@ namespace Surge.Tests
         public void DefaultValues_AreEmpty()
         {
             var release = new SurgeRelease();
-            Assert.Equal("", release.Version);
+            Assert.Equal("0.0.0", release.Version.ToString());
             Assert.Equal("", release.Channel);
             Assert.Equal(0L, release.FullSize);
             Assert.Equal(0L, release.DeltaSize);
@@ -251,7 +257,7 @@ namespace Surge.Tests
         {
             var release = new SurgeRelease
             {
-                Version = "2.0.0",
+                Version = TestSemVersions.Parse("2.0.0"),
                 Channel = "beta",
                 FullSize = 1024 * 1024,
                 DeltaSize = 256 * 1024,
@@ -259,7 +265,7 @@ namespace Surge.Tests
                 IsGenesis = true
             };
 
-            Assert.Equal("2.0.0", release.Version);
+            Assert.Equal("2.0.0", release.Version.ToString());
             Assert.Equal("beta", release.Channel);
             Assert.Equal(1024 * 1024, release.FullSize);
             Assert.Equal(256 * 1024, release.DeltaSize);
@@ -338,15 +344,89 @@ namespace Surge.Tests
         {
             var list = new System.Collections.Generic.List<SurgeRelease>
             {
-                new SurgeRelease { Version = "1.0.0", Channel = "stable" },
-                new SurgeRelease { Version = "2.0.0", Channel = "stable" }
+                new SurgeRelease { Version = TestSemVersions.Parse("1.0.0"), Channel = "stable" },
+                new SurgeRelease { Version = TestSemVersions.Parse("2.0.0"), Channel = "stable" }
             };
 
             var releases = new SurgeChannelReleases("stable", list);
             Assert.Equal("stable", releases.Channel);
             Assert.Equal(2, releases.Count);
             Assert.NotNull(releases.Latest);
-            Assert.Equal("2.0.0", releases.Latest!.Version);
+            Assert.Equal("2.0.0", releases.Latest!.Version.ToString());
+        }
+    }
+
+    public class SemVersionIntegrationTests
+    {
+        [Theory]
+        [InlineData("0.0.0")]
+        [InlineData("1.2.3")]
+        [InlineData("1.0.0-alpha")]
+        [InlineData("1.0.0-alpha.1")]
+        [InlineData("1.0.0-0A.is.legal")]
+        [InlineData("1.0.0+build.5")]
+        [InlineData("1.0.0-rc.1+build.9")]
+        public void StrictParse_Accepts_CompliantSemVer(string value)
+        {
+            var version = SemVersion.Parse(value, SemVersionStyles.Strict);
+            Assert.Equal(value, version.ToString());
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("1")]
+        [InlineData("1.2")]
+        [InlineData("1.2.3.4")]
+        [InlineData("01.2.3")]
+        [InlineData("1.02.3")]
+        [InlineData("1.2.03")]
+        [InlineData("1.2.3-01")]
+        [InlineData("1.2.3-alpha..1")]
+        [InlineData("1.2.3 ")]
+        [InlineData(" 1.2.3")]
+        public void StrictParse_Rejects_InvalidSemVer(string value)
+        {
+            Assert.False(SemVersion.TryParse(value, SemVersionStyles.Strict, out _));
+        }
+
+        [Fact]
+        public void ComparePrecedence_Follows_SemVerExamples()
+        {
+            string[] ordered =
+            {
+                "1.0.0-alpha",
+                "1.0.0-alpha.1",
+                "1.0.0-alpha.beta",
+                "1.0.0-beta",
+                "1.0.0-beta.2",
+                "1.0.0-beta.11",
+                "1.0.0-rc.1",
+                "1.0.0"
+            };
+
+            for (int i = 0; i < ordered.Length - 1; i++)
+            {
+                var left = SemVersion.Parse(ordered[i], SemVersionStyles.Strict);
+                var right = SemVersion.Parse(ordered[i + 1], SemVersionStyles.Strict);
+                Assert.True(left.ComparePrecedenceTo(right) < 0, $"{left} should precede {right}");
+            }
+        }
+
+        [Fact]
+        public void ComparePrecedence_Ignores_BuildMetadata()
+        {
+            var left = SemVersion.Parse("1.2.3-beta.1+build.1", SemVersionStyles.Strict);
+            var right = SemVersion.Parse("1.2.3-beta.1+build.9", SemVersionStyles.Strict);
+
+            Assert.Equal(0, left.ComparePrecedenceTo(right));
+            Assert.True(left.CompareSortOrderTo(right) < 0);
+        }
+
+        [Fact]
+        public void ParseArgument_Rejects_InvalidPublicInput()
+        {
+            var ex = Assert.Throws<ArgumentException>(() => SemanticVersions.ParseArgument("1.2", "version"));
+            Assert.Contains("Semantic Versioning 2.0", ex.Message);
         }
     }
 }

--- a/dotnet/Surge.NET/SemanticVersions.cs
+++ b/dotnet/Surge.NET/SemanticVersions.cs
@@ -1,0 +1,43 @@
+using System;
+using Semver;
+
+namespace Surge
+{
+    internal static class SemanticVersions
+    {
+        internal static readonly SemVersion Zero = new SemVersion(0, 0, 0);
+        internal static readonly SemVersion LibraryVersion = ParseArgument("0.1.0", "libraryVersion");
+
+        internal static SemVersion ParseArgument(string value, string paramName)
+        {
+            if (value == null)
+                throw new ArgumentNullException(paramName);
+
+            if (!SemVersion.TryParse(value, SemVersionStyles.Strict, out var version))
+                throw new ArgumentException(
+                    $"Version must be a valid Semantic Versioning 2.0 value: '{value}'.",
+                    paramName);
+
+            return version;
+        }
+
+        internal static SemVersion ParseRuntimeValue(string value, string source)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+                throw new InvalidOperationException($"{source} is missing.");
+
+            if (!SemVersion.TryParse(value, SemVersionStyles.Strict, out var version))
+                throw new InvalidOperationException(
+                    $"{source} is not a valid Semantic Versioning 2.0 value: '{value}'.");
+
+            return version;
+        }
+
+        internal static bool TryParseRuntimeValue(string value, out SemVersion version)
+        {
+            version = Zero;
+            return !string.IsNullOrWhiteSpace(value)
+                && SemVersion.TryParse(value, SemVersionStyles.Strict, out version);
+        }
+    }
+}

--- a/dotnet/Surge.NET/Semver.LICENSE.txt
+++ b/dotnet/Surge.NET/Semver.LICENSE.txt
@@ -1,0 +1,19 @@
+Copyright (c) 2013-2024 Jeff Walker, Max Hauser
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/dotnet/Surge.NET/Semver/Comparers/ISemVersionComparer.cs
+++ b/dotnet/Surge.NET/Semver/Comparers/ISemVersionComparer.cs
@@ -1,0 +1,20 @@
+#nullable disable
+#pragma warning disable
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Semver.Comparers
+{
+    /// <summary>
+    /// An interface that combines equality and order comparison for the <see cref="SemVersion"/>
+    /// class.
+    /// </summary>
+    /// <remarks>
+    /// This interface provides a type for the <see cref="SemVersion.PrecedenceComparer"/> and
+    /// <see cref="SemVersion.SortOrderComparer"/> so that separate properties aren't needed for the
+    /// <see cref="IEqualityComparer{T}"/> and <see cref="IComparer{T}"/> of <see cref="SemVersion"/>.
+    /// </remarks>
+    public interface ISemVersionComparer : IEqualityComparer<SemVersion>, IComparer<SemVersion>, IComparer
+    {
+    }
+}

--- a/dotnet/Surge.NET/Semver/Comparers/PrecedenceComparer.cs
+++ b/dotnet/Surge.NET/Semver/Comparers/PrecedenceComparer.cs
@@ -1,0 +1,83 @@
+#nullable disable
+#pragma warning disable
+using System;
+using System.Collections.Generic;
+using Semver.Utility;
+
+namespace Semver.Comparers
+{
+    internal sealed class PrecedenceComparer : Comparer<SemVersion>, ISemVersionComparer
+    {
+        #region Singleton
+        public static readonly ISemVersionComparer Instance = new PrecedenceComparer();
+
+        private PrecedenceComparer() { }
+        #endregion
+
+        public bool Equals(SemVersion x, SemVersion y)
+        {
+            if (ReferenceEquals(x, y)) return true;
+            if (x is null || y is null) return false;
+
+            return x.Major == y.Major && x.Minor == y.Minor && x.Patch == y.Patch
+                   && Equals(x.PrereleaseIdentifiers, y.PrereleaseIdentifiers);
+        }
+
+        private static bool Equals(
+            IReadOnlyList<PrereleaseIdentifier> xIdentifiers,
+            IReadOnlyList<PrereleaseIdentifier> yIdentifiers)
+        {
+            if (xIdentifiers.Count != yIdentifiers.Count) return false;
+
+            for (int i = 0; i < xIdentifiers.Count; i++)
+                if (xIdentifiers[i] != yIdentifiers[i])
+                    return false;
+
+            return true;
+        }
+
+        public int GetHashCode(SemVersion v)
+        {
+            var hash = CombinedHashCode.Create(v.Major, v.Minor, v.Patch);
+            foreach (var identifier in v.PrereleaseIdentifiers)
+                hash.Add(identifier);
+
+            return hash;
+        }
+
+        public override int Compare(SemVersion x, SemVersion y)
+        {
+            if (ReferenceEquals(x, y)) return 0; // covers both null case
+            if (x is null) return -1;
+            if (y is null) return 1;
+
+            var comparison = x.Major.CompareTo(y.Major);
+            if (comparison != 0) return comparison;
+
+            comparison = x.Minor.CompareTo(y.Minor);
+            if (comparison != 0) return comparison;
+
+            comparison = x.Patch.CompareTo(y.Patch);
+            if (comparison != 0) return comparison;
+
+            // Release are higher precedence than prerelease
+            var xIsRelease = x.IsRelease;
+            var yIsRelease = y.IsRelease;
+            if (xIsRelease && yIsRelease) return 0;
+            if (xIsRelease) return 1;
+            if (yIsRelease) return -1;
+
+            var xPrereleaseIdentifiers = x.PrereleaseIdentifiers;
+            var yPrereleaseIdentifiers = y.PrereleaseIdentifiers;
+
+            var minLength = Math.Min(xPrereleaseIdentifiers.Count, yPrereleaseIdentifiers.Count);
+            for (int i = 0; i < minLength; i++)
+            {
+                comparison = xPrereleaseIdentifiers[i].CompareTo(yPrereleaseIdentifiers[i]);
+                if (comparison != 0) return comparison;
+            }
+
+            return xPrereleaseIdentifiers.Count.CompareTo(yPrereleaseIdentifiers.Count);
+        }
+    }
+}

--- a/dotnet/Surge.NET/Semver/Comparers/SortOrderComparer.cs
+++ b/dotnet/Surge.NET/Semver/Comparers/SortOrderComparer.cs
@@ -1,0 +1,69 @@
+#nullable disable
+#pragma warning disable
+using System;
+using System.Collections.Generic;
+using Semver.Utility;
+
+namespace Semver.Comparers
+{
+    internal sealed class SortOrderComparer : Comparer<SemVersion>, ISemVersionComparer
+    {
+        #region Singleton
+        public static readonly ISemVersionComparer Instance = new SortOrderComparer();
+
+        private SortOrderComparer() { }
+        #endregion
+
+        public bool Equals(SemVersion x, SemVersion y)
+        {
+            if (ReferenceEquals(x, y)) return true;
+            if (x is null || y is null) return false;
+
+            return x.Major == y.Major && x.Minor == y.Minor && x.Patch == y.Patch
+                   // Compare prerelease identifiers by their string value so that "01" != "1"
+                   && string.Equals(x.Prerelease, y.Prerelease, StringComparison.Ordinal)
+                   && string.Equals(x.Metadata, y.Metadata, StringComparison.Ordinal);
+        }
+
+        public int GetHashCode(SemVersion v)
+            // Using v.Prerelease handles leading zero so "01" != "1"
+            => CombinedHashCode.Create(v.Major, v.Minor, v.Patch, v.Prerelease, v.Metadata);
+
+        public override int Compare(SemVersion x, SemVersion y)
+        {
+            if (ReferenceEquals(x, y)) return 0; // covers both null case
+
+            var comparison = PrecedenceComparer.Instance.Compare(x, y);
+            if (comparison != 0) return comparison;
+
+            var xMetadataIdentifiers = x.MetadataIdentifiers;
+            var yMetadataIdentifiers = y.MetadataIdentifiers;
+            var minLength = Math.Min(xMetadataIdentifiers.Count, yMetadataIdentifiers.Count);
+            for (int i = 0; i < minLength; i++)
+            {
+                comparison = xMetadataIdentifiers[i].CompareTo(yMetadataIdentifiers[i]);
+                if (comparison != 0) return comparison;
+            }
+
+            comparison = xMetadataIdentifiers.Count.CompareTo(yMetadataIdentifiers.Count);
+            if (comparison != 0) return comparison;
+
+            // TODO remove the next section in v3.0.0 when prerelease identifiers can't have leading zeros
+            // Now must sort based on leading zeros in prerelease identifiers.
+            // Doing this after metadata so that 1.0.0-1+a < 1.0.0-01+a.b (i.e. leading zeros are the
+            // least significant difference to sort on).
+            var xPrereleaseIdentifiers = x.PrereleaseIdentifiers;
+            var yPrereleaseIdentifiers = y.PrereleaseIdentifiers;
+            minLength = Math.Min(xPrereleaseIdentifiers.Count, yPrereleaseIdentifiers.Count);
+            for (int i = 0; i < minLength; i++)
+                if (xPrereleaseIdentifiers[i].NumericValue != null) // Skip alphanumeric identifiers
+                {
+                    comparison = IdentifierString.Compare(
+                        xPrereleaseIdentifiers[i].Value, yPrereleaseIdentifiers[i].Value);
+                    if (comparison != 0) return comparison;
+                }
+
+            return 0;
+        }
+    }
+}

--- a/dotnet/Surge.NET/Semver/MetadataIdentifier.cs
+++ b/dotnet/Surge.NET/Semver/MetadataIdentifier.cs
@@ -1,0 +1,233 @@
+#nullable disable
+#pragma warning disable
+using System;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using Semver.Utility;
+
+namespace Semver
+{
+    /// <summary>
+    /// An individual metadata identifier for a semantic version.
+    /// </summary>
+    /// <remarks>
+    /// <para>The metadata for a semantic version is composed of dot ('<c>.</c>') separated identifiers.
+    /// A valid identifier is a non-empty string of ASCII alphanumeric and hyphen characters
+    /// (<c>[0-9A-Za-z-]</c>). Metadata identifiers are compared lexically in ASCII sort order.</para>
+    ///
+    /// <para>Because <see cref="MetadataIdentifier"/> is a struct, the default value is a
+    /// <see cref="MetadataIdentifier"/> with a <see langword="null"/> value. However, the
+    /// <see cref="Semver"/> namespace types do not accept and will not return such a
+    /// <see cref="MetadataIdentifier"/>.</para>
+    ///
+    /// <para>Invalid metadata identifiers including arbitrary Unicode characters and empty string can
+    /// currently be produced by the <see cref="SemVersion(int, int, int, string, string)"/>
+    /// constructor. Such identifiers are compared via an ordinal string comparision.</para>
+    /// </remarks>
+    public readonly struct MetadataIdentifier : IEquatable<MetadataIdentifier>, IComparable<MetadataIdentifier>, IComparable
+    {
+        /// <summary>
+        /// The string value of the metadata identifier.
+        /// </summary>
+        /// <value>The string value of this metadata identifier or <see langword="null"/> if this is
+        /// a default <see cref="MetadataIdentifier"/>.</value>
+        public string Value { get; }
+
+        /// <summary>
+        /// Construct a potentially invalid <see cref="MetadataIdentifier"/>.
+        /// </summary>
+        /// <exception cref="ArgumentNullException">The <paramref name="value"/> parameter is <see langword="null"/>.</exception>
+        /// <remarks>This should only be used by the <see cref="SemVersion"/> constructor that
+        /// still accepts illegal values.</remarks>
+        [EditorBrowsable(EditorBrowsableState.Never), Obsolete]
+        internal static MetadataIdentifier CreateLoose(string value)
+        {
+            DebugChecks.IsNotNull(value, nameof(value));
+
+            return new MetadataIdentifier(value, UnsafeOverload.Marker);
+        }
+
+        /// <summary>
+        /// Constructs a <see cref="MetadataIdentifier"/> without checking that any of the invariants
+        /// hold. Used by the parser for performance.
+        /// </summary>
+        /// <remarks>This is a create method rather than a constructor to clearly indicate uses
+        /// of it. The other constructors have not been hidden behind create methods because only
+        /// constructors are visible to the package users. So they see a class consistently
+        /// using constructors without any create methods.</remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static MetadataIdentifier CreateUnsafe(string value)
+        {
+            DebugChecks.IsNotNull(value, nameof(value));
+#if DEBUG
+            if (value.Length == 0) throw new ArgumentException("DEBUG: Metadata identifier cannot be empty.", nameof(value));
+            if (!value.IsAlphanumericOrHyphens())
+                throw new ArgumentException($"DEBUG: A metadata identifier can contain only ASCII alphanumeric characters and hyphens '{value}'.", nameof(value));
+#endif
+            return new MetadataIdentifier(value, UnsafeOverload.Marker);
+        }
+
+        /// <summary>
+        /// Private constructor used by <see cref="CreateUnsafe"/>.
+        /// </summary>
+        /// <param name="value">The value for the identifier. Not validated.</param>
+        /// <param name="_">Unused parameter that differentiates this from the
+        /// constructor that performs validation.</param>
+        private MetadataIdentifier(string value, UnsafeOverload _)
+        {
+            Value = value;
+        }
+
+        /// <summary>
+        /// Constructs a valid <see cref="MetadataIdentifier"/>.
+        /// </summary>
+        /// <exception cref="ArgumentNullException">The <paramref name="value"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentException">The <paramref name="value"/> is empty or contains invalid characters
+        /// (i.e. characters that are not ASCII alphanumerics or hyphens).</exception>
+        public MetadataIdentifier(string value)
+            : this(value, nameof(value))
+        {
+        }
+
+        /// <summary>
+        /// Constructs a valid <see cref="MetadataIdentifier"/>.
+        /// </summary>
+        /// <remarks>
+        /// Internal constructor allows changing the parameter name to enable methods using this
+        /// as part of their metadata identifier validation to match the parameter name to their
+        /// parameter name.
+        /// </remarks>
+        internal MetadataIdentifier(string value, string paramName)
+        {
+            if (value is null)
+                throw new ArgumentNullException(paramName);
+            if (value.Length == 0)
+                throw new ArgumentException("Metadata identifier cannot be empty.", paramName);
+            if (!value.IsAlphanumericOrHyphens())
+                throw new ArgumentException($"A metadata identifier can contain only ASCII alphanumeric characters and hyphens '{value}'.", paramName);
+
+            Value = value;
+        }
+
+        #region Equality
+        /// <summary>
+        /// Determines whether two identifiers are equal.
+        /// </summary>
+        /// <returns><see langword="true"/> if <paramref name="value"/> is equal to the this identifier;
+        /// otherwise <see langword="false"/>.</returns>
+        public bool Equals(MetadataIdentifier value) => Value == value.Value;
+
+        /// <summary>Determines whether the given object is equal to this identifier.</summary>
+        /// <returns><see langword="true"/> if <paramref name="value"/> is equal to the this identifier;
+        /// otherwise <see langword="false"/>.</returns>
+        public override bool Equals(object value)
+            => value is MetadataIdentifier other && Equals(other);
+
+        /// <summary>Gets a hash code for this identifier.</summary>
+        /// <returns>A hash code for this identifier.</returns>
+        public override int GetHashCode() => CombinedHashCode.Create(Value);
+
+        /// <summary>
+        /// Determines whether two identifiers are equal.
+        /// </summary>
+        /// <returns><see langword="true"/> if the value of <paramref name="left"/> is the same as
+        /// the value of <paramref name="right"/>; otherwise <see langword="false"/>.</returns>
+        public static bool operator ==(MetadataIdentifier left, MetadataIdentifier right)
+            => left.Value == right.Value;
+
+        /// <summary>
+        /// Determines whether two identifiers are <em>not</em> equal.
+        /// </summary>
+        /// <returns><see langword="true"/> if the value of <paramref name="left"/> is different
+        /// from the value of <paramref name="right"/>; otherwise <see langword="false"/>.</returns>
+        public static bool operator !=(MetadataIdentifier left, MetadataIdentifier right)
+            => left.Value != right.Value;
+        #endregion
+
+        #region Comparison
+        /// <summary>
+        /// Compares two identifiers and indicates whether this instance precedes, follows, or is
+        /// equal to the other in sort order.
+        /// </summary>
+        /// <returns>
+        /// An integer that indicates whether this instance precedes, follows, or is equal to
+        /// <paramref name="value"/> in sort order.
+        /// <list type="table">
+        ///     <listheader>
+        ///         <term>Value</term>
+        ///         <description>Condition</description>
+        ///     </listheader>
+        ///     <item>
+        ///          <term>-1</term>
+        ///          <description>This instance precedes <paramref name="value"/>.</description>
+        ///     </item>
+        ///     <item>
+        ///          <term>0</term>
+        ///          <description>This instance is equal to <paramref name="value"/>.</description>
+        ///     </item>
+        ///     <item>
+        ///          <term>1</term>
+        ///          <description>This instance follows <paramref name="value"/>.</description>
+        ///     </item>
+        /// </list>
+        /// </returns>
+        /// <remarks>Identifiers are compared lexically in ASCII sort order. Invalid identifiers are
+        /// compared via an ordinal string comparision.</remarks>
+        public int CompareTo(MetadataIdentifier value)
+            => IdentifierString.Compare(Value, value.Value);
+
+        /// <summary>
+        /// Compares this identifier to an <see cref="Object"/> and indicates whether this instance
+        /// precedes, follows, or is equal to the object in sort order.
+        /// </summary>
+        /// <returns>
+        /// An integer that indicates whether this instance precedes, follows, or is equal to
+        /// <paramref name="value"/> in sort order.
+        /// <list type="table">
+        ///     <listheader>
+        ///         <term>Value</term>
+        ///         <description>Condition</description>
+        ///     </listheader>
+        ///     <item>
+        ///          <term>-1</term>
+        ///          <description>This instance precedes <paramref name="value"/>.</description>
+        ///     </item>
+        ///     <item>
+        ///          <term>0</term>
+        ///          <description>This instance is equal to <paramref name="value"/>.</description>
+        ///     </item>
+        ///     <item>
+        ///          <term>1</term>
+        ///          <description>This instance follows <paramref name="value"/> or <paramref name="value"/>
+        ///                         is <see langword="null"/>.</description>
+        ///     </item>
+        /// </list>
+        /// </returns>
+        /// <exception cref="ArgumentException"><paramref name="value"/> is not a <see cref="MetadataIdentifier"/>.</exception>
+        /// <remarks>Identifiers are compared lexically in ASCII sort order. Invalid identifiers are
+        /// compared via an ordinal string comparision.</remarks>
+        public int CompareTo(object value)
+        {
+            if (value is null) return 1;
+            return value is MetadataIdentifier other
+                ? IdentifierString.Compare(Value, other.Value)
+                : throw new ArgumentException($"Object must be of type {nameof(MetadataIdentifier)}.", nameof(value));
+        }
+        #endregion
+
+        /// <summary>
+        /// Converts this identifier into an equivalent string value.
+        /// </summary>
+        /// <returns>The string value of this identifier or <see langword="null"/> if this is
+        /// a default <see cref="MetadataIdentifier"/>.</returns>
+        public static implicit operator string(MetadataIdentifier metadataIdentifier)
+            => metadataIdentifier.Value;
+
+        /// <summary>
+        /// Converts this identifier into an equivalent string value.
+        /// </summary>
+        /// <returns>The string value of this identifier or <see langword="null"/> if this is
+        /// a default <see cref="MetadataIdentifier"/></returns>
+        public override string ToString() => Value;
+    }
+}

--- a/dotnet/Surge.NET/Semver/Parsing/PrereleaseIdentifiers.cs
+++ b/dotnet/Surge.NET/Semver/Parsing/PrereleaseIdentifiers.cs
@@ -1,0 +1,13 @@
+#nullable disable
+#pragma warning disable
+using System.Collections.Generic;
+using Semver.Utility;
+
+namespace Semver.Parsing
+{
+    internal static class PrereleaseIdentifiers
+    {
+        public static readonly IReadOnlyList<PrereleaseIdentifier> Zero
+            = new List<PrereleaseIdentifier>(1) { PrereleaseIdentifier.Zero }.AsReadOnly();
+    }
+}

--- a/dotnet/Surge.NET/Semver/Parsing/SemVersionParser.cs
+++ b/dotnet/Surge.NET/Semver/Parsing/SemVersionParser.cs
@@ -1,0 +1,459 @@
+#nullable disable
+#pragma warning disable
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Runtime.CompilerServices;
+using Semver.Utility;
+
+namespace Semver.Parsing
+{
+    /// <summary>
+    /// Parsing for <see cref="SemVersion"/>
+    /// </summary>
+    /// <remarks>The new parsing code was complex enough that is made sense to break out into its
+    /// own class.</remarks>
+    internal static class SemVersionParser
+    {
+        private const string LeadingWhitespaceMessage = "Version '{0}' has leading whitespace.";
+        private const string TrailingWhitespaceMessage = "Version '{0}' has trailing whitespace.";
+        private const string EmptyVersionMessage = "Empty string is not a valid version.";
+        private const string TooLongVersionMessage = "Exceeded maximum length of {1} for '{0}'.";
+        private const string AllWhitespaceVersionMessage = "Whitespace is not a valid version.";
+        private const string LeadingLowerVMessage = "Leading 'v' in '{0}'.";
+        private const string LeadingUpperVMessage = "Leading 'V' in '{0}'.";
+        private const string LeadingZeroInMajorMinorOrPatchMessage = "{1} version has leading zero in '{0}'.";
+        private const string EmptyMajorMinorOrPatchMessage = "{1} version missing in '{0}'.";
+        private const string MajorMinorOrPatchOverflowMessage = "{1} version '{2}' was too large for Int32 in '{0}'.";
+        private const string FourthVersionNumberMessage = "Fourth version number in '{0}'.";
+        private const string PrereleasePrefixedByDotMessage = "The prerelease identfiers should be prefixed by '-' instead of '.' in '{0}'.";
+        private const string MissingPrereleaseIdentifierMessage = "Missing prerelease identifier in '{0}'.";
+        private const string LeadingZeroInPrereleaseMessage = "Leading zero in prerelease identifier in version '{0}'.";
+        private const string PrereleaseOverflowMessage = "Prerelease identifier '{1}' was too large for Int32 in version '{0}'.";
+        private const string InvalidCharacterInPrereleaseMessage = "Invalid character '{1}' in prerelease identifier in '{0}'.";
+        private const string MissingMetadataIdentifierMessage = "Missing metadata identifier in '{0}'.";
+        private const string InvalidCharacterInMajorMinorOrPatchMessage = "{1} version contains invalid character '{2}' in '{0}'.";
+        private const string InvalidCharacterInMetadataMessage = "Invalid character '{1}' in metadata identifier in '{0}'.";
+        private const string InvalidWildcardInMajorMinorOrPatchMessage = "{1} version is a wildcard and should contain only 1 character in '{0}'.";
+        private const string MinorOrPatchMustBeWildcardVersionMessage = "{1} version should be a wildcard because the preceding version is a wildcard in '{0}'.";
+        private const string InvalidWildcardInPrereleaseMessage = "Prerelease version is a wildcard and should contain only 1 character in '{0}'.";
+        private const string PrereleaseWildcardMustBeLast = "Prerelease identifier follows wildcard prerelease identifier in '{0}'.";
+
+        /// <summary>
+        /// The internal method that all parsing is based on. Because this is called by both
+        /// <see cref="SemVersion.Parse(string, SemVersionStyles, int)"/> and
+        /// <see cref="SemVersion.TryParse(string, SemVersionStyles, out SemVersion, int)"/>
+        /// it does not throw exceptions, but instead returns the exception that should be thrown
+        /// by the parse method. For performance when used from try parse, all exception construction
+        /// and message formatting can be avoided by passing in an exception which will be returned
+        /// when parsing fails.
+        /// </summary>
+        /// <remarks>This does not validate the <paramref name="style"/> or <paramref name="maxLength"/>
+        /// parameter values. That must be done in the calling method.</remarks>
+        public static Exception Parse(
+            string version,
+            SemVersionStyles style,
+            Exception ex,
+            int maxLength,
+            out SemVersion semver)
+        {
+            DebugChecks.IsValid(style, nameof(style));
+            // TODO include in v3.0.0 for issue #72
+            // DebugChecks.IsValidMaxLength(maxLength, nameof(maxLength));
+
+            if (version != null)
+                return Parse(version, style, SemVersionParsingOptions.None, ex, maxLength, out semver, out _);
+            semver = null;
+            return ex ?? new ArgumentNullException(nameof(version));
+        }
+
+        /// <summary>
+        /// An internal method that is used when parsing versions from ranges. Because this is
+        /// called by both
+        /// <see cref="SemVersionRange.Parse(string,SemVersionRangeOptions,int)"/> and
+        /// <see cref="SemVersionRange.TryParse(string,SemVersionRangeOptions,out SemVersionRange,int)"/>
+        /// it does not throw exceptions, but instead returns the exception that should be thrown
+        /// by the parse method. For performance when used from try parse, all exception construction
+        /// and message formatting can be avoided by passing in an exception which will be returned
+        /// when parsing fails.
+        /// </summary>
+        /// <remarks>This does not validate the <paramref name="style"/> or <paramref name="maxLength"/>
+        /// parameter values. That must be done in the calling method.</remarks>
+        public static Exception Parse(
+            StringSegment version,
+            SemVersionStyles style,
+            SemVersionParsingOptions options,
+            Exception ex,
+            int maxLength,
+            out SemVersion semver,
+            out WildcardVersion wildcardVersion)
+        {
+            DebugChecks.IsValid(style, nameof(style));
+            // TODO include in v3.0.0 for issue #72
+            // DebugChecks.IsValidMaxLength(maxLength, nameof(maxLength));
+
+            // Assign once so it doesn't have to be done any time parse fails
+            semver = null;
+            wildcardVersion = WildcardVersion.None;
+
+            // Note: this method relies on the fact that the null coalescing operator `??`
+            // is short circuiting to avoid constructing exceptions and exception messages
+            // when a non-null exception is passed in.
+
+            if (version.Length == 0) return ex ?? new FormatException(EmptyVersionMessage);
+
+            if (version.Length > maxLength)
+                return ex ?? NewFormatException(TooLongVersionMessage, version.ToStringLimitLength(), maxLength);
+
+            // This code does two things to help provide good error messages:
+            // 1. It breaks the version number into segments and then parses those segments
+            // 2. It parses an element first, then checks the flags for whether it should be allowed
+
+            var mainSegment = version;
+
+            var parseEx = ParseLeadingWhitespace(version, ref mainSegment, style, ex);
+            if (parseEx != null) return parseEx;
+
+            // Take of trailing whitespace and remember that there was trailing whitespace
+            var lengthWithTrailingWhitespace = mainSegment.Length;
+            mainSegment = mainSegment.TrimEndWhitespace();
+            var hasTrailingWhitespace = lengthWithTrailingWhitespace > mainSegment.Length;
+
+            // Now break the version number down into segments.
+            mainSegment.SplitBeforeFirst('+', out mainSegment, out var metadataSegment);
+            mainSegment.SplitBeforeFirst('-', out var majorMinorPatchSegment, out var prereleaseSegment);
+
+            parseEx = ParseLeadingV(version, ref majorMinorPatchSegment, style, ex);
+            if (parseEx != null) return parseEx;
+
+            // Are leading zeros allowed
+            var allowLeadingZeros = style.HasStyle(SemVersionStyles.AllowLeadingZeros);
+
+            int major, minor, patch;
+            using (var versionNumbers = majorMinorPatchSegment.Split('.').GetEnumerator())
+            {
+                const bool majorIsOptional = false;
+                const bool majorIsWildcardRequired = false;
+                parseEx = ParseVersionNumber("Major", version, versionNumbers, allowLeadingZeros,
+                    majorIsOptional, majorIsWildcardRequired, options, ex, out major, out var majorIsWildcard);
+                if (parseEx != null) return parseEx;
+                if (majorIsWildcard) wildcardVersion |= WildcardVersion.MajorMinorPatchWildcard;
+
+                var minorIsOptional = style.HasStyle(SemVersionStyles.OptionalMinorPatch) || majorIsWildcard;
+                parseEx = ParseVersionNumber("Minor", version, versionNumbers, allowLeadingZeros,
+                    minorIsOptional, majorIsWildcard, options, ex, out minor, out var minorIsWildcard);
+                if (parseEx != null) return parseEx;
+                if (minorIsWildcard) wildcardVersion |= WildcardVersion.MinorPatchWildcard;
+
+                var patchIsOptional = style.HasStyle(SemVersionStyles.OptionalPatch) || majorIsWildcard || minorIsWildcard;
+                parseEx = ParseVersionNumber("Patch", version, versionNumbers, allowLeadingZeros,
+                    patchIsOptional, minorIsWildcard, options, ex, out patch, out var patchIsWildcard);
+                if (parseEx != null) return parseEx;
+                if (patchIsWildcard) wildcardVersion |= WildcardVersion.PatchWildcard;
+
+                // Handle fourth version number
+                if (versionNumbers.MoveNext())
+                {
+                    var fourthSegment = versionNumbers.Current;
+                    // If it is ".\d" then we'll assume they were trying to have a fourth version number
+                    if (fourthSegment.Length > 0 && fourthSegment[0].IsDigit())
+                        return ex ?? NewFormatException(FourthVersionNumberMessage, version.ToStringLimitLength());
+
+                    // Otherwise, assume they used "." instead of "-" to start the prerelease
+                    return ex ?? NewFormatException(PrereleasePrefixedByDotMessage, version.ToStringLimitLength());
+                }
+            }
+
+            // Parse prerelease version
+            string prerelease;
+            IReadOnlyList<PrereleaseIdentifier> prereleaseIdentifiers;
+            if (prereleaseSegment.Length > 0)
+            {
+                prereleaseSegment = prereleaseSegment.Subsegment(1);
+                parseEx = ParsePrerelease(version, prereleaseSegment, allowLeadingZeros, options, ex,
+                            out prerelease, out prereleaseIdentifiers, out var prereleaseIsWildcard);
+                if (parseEx != null) return parseEx;
+                if (prereleaseIsWildcard) wildcardVersion |= WildcardVersion.PrereleaseWildcard;
+            }
+            else
+            {
+                prerelease = "";
+                prereleaseIdentifiers = ReadOnlyList<PrereleaseIdentifier>.Empty;
+            }
+
+            // Parse metadata
+            string metadata;
+            IReadOnlyList<MetadataIdentifier> metadataIdentifiers;
+            if (metadataSegment.Length > 0)
+            {
+                metadataSegment = metadataSegment.Subsegment(1);
+                parseEx = ParseMetadata(version, metadataSegment, ex, out metadata, out metadataIdentifiers);
+                if (parseEx != null) return parseEx;
+            }
+            else
+            {
+                metadata = "";
+                metadataIdentifiers = ReadOnlyList<MetadataIdentifier>.Empty;
+            }
+
+            // Error if trailing whitespace not allowed
+            if (hasTrailingWhitespace && !style.HasStyle(SemVersionStyles.AllowTrailingWhitespace))
+                return ex ?? NewFormatException(TrailingWhitespaceMessage, version.ToStringLimitLength());
+
+            semver = new SemVersion(major, minor, patch,
+                prerelease, prereleaseIdentifiers, metadata, metadataIdentifiers);
+            return null;
+        }
+
+        private static Exception ParseLeadingWhitespace(
+            StringSegment version,
+            ref StringSegment segment,
+            SemVersionStyles style,
+            Exception ex)
+        {
+            var oldLength = segment.Length;
+
+            // Skip leading whitespace
+            segment = segment.TrimStartWhitespace();
+
+            // Error if all whitespace
+            if (segment.Length == 0)
+                return ex ?? new FormatException(AllWhitespaceVersionMessage);
+
+            // Error if leading whitespace not allowed
+            if (oldLength > segment.Length && !style.HasStyle(SemVersionStyles.AllowLeadingWhitespace))
+                return ex ?? NewFormatException(LeadingWhitespaceMessage, version.ToStringLimitLength());
+
+            return null;
+        }
+
+        private static Exception ParseLeadingV(
+            StringSegment version,
+            ref StringSegment segment,
+            SemVersionStyles style,
+            Exception ex)
+        {
+            // This is safe because the check for all whitespace ensures there is at least one more char
+            var leadChar = segment[0];
+            switch (leadChar)
+            {
+                case 'v' when style.HasStyle(SemVersionStyles.AllowLowerV):
+                    segment = segment.Subsegment(1);
+                    break;
+                case 'v':
+                    return ex ?? NewFormatException(LeadingLowerVMessage, version.ToStringLimitLength());
+                case 'V' when style.HasStyle(SemVersionStyles.AllowUpperV):
+                    segment = segment.Subsegment(1);
+                    break;
+                case 'V':
+                    return ex ?? NewFormatException(LeadingUpperVMessage, version.ToStringLimitLength());
+            }
+
+            return null;
+        }
+
+        private static Exception ParseVersionNumber(
+            string kind, // i.e. Major, Minor, or Patch
+            StringSegment version,
+            IEnumerator<StringSegment> versionNumbers,
+            bool allowLeadingZeros,
+            bool optional,
+            bool wildcardRequired,
+            SemVersionParsingOptions options,
+            Exception ex,
+            out int number,
+            out bool isWildcard)
+        {
+            if (versionNumbers.MoveNext())
+                return ParseVersionNumber(kind, version, versionNumbers.Current, allowLeadingZeros,
+                    wildcardRequired, options, ex, out number, out isWildcard);
+
+            number = 0;
+            isWildcard = options.MissingVersionsAreWildcards;
+            if (!optional)
+                return ex ?? NewFormatException(EmptyMajorMinorOrPatchMessage, version.ToStringLimitLength(), kind);
+
+            return null;
+        }
+
+        private static Exception ParseVersionNumber(
+            string kind, // i.e. Major, Minor, or Patch
+            StringSegment version,
+            StringSegment segment,
+            bool allowLeadingZeros,
+            bool wildcardRequired,
+            SemVersionParsingOptions options,
+            Exception ex,
+            out int number,
+            out bool isWildcard)
+        {
+            // Assign once so it doesn't have to be done any time parse fails
+            number = 0;
+
+            if (segment.Length == 0)
+            {
+                isWildcard = false;
+                return ex ?? NewFormatException(EmptyMajorMinorOrPatchMessage, version.ToStringLimitLength(), kind);
+            }
+
+            if (options.AllowWildcardMajorMinorPatch && segment.Length > 0 && options.IsWildcard(segment[0]))
+            {
+                isWildcard = true;
+                if (segment.Length > 1)
+                    return ex ?? NewFormatException(InvalidWildcardInMajorMinorOrPatchMessage,
+                        version.ToStringLimitLength(), kind);
+
+                return null;
+            }
+
+            isWildcard = false;
+
+            if (wildcardRequired)
+                return ex ?? NewFormatException(MinorOrPatchMustBeWildcardVersionMessage,
+                    version.ToStringLimitLength(), kind);
+
+            var lengthWithLeadingZeros = segment.Length;
+
+            // Skip leading zeros
+            segment = segment.TrimLeadingZeros();
+
+            // Scan for digits
+            var i = 0;
+            while (i < segment.Length && segment[i].IsDigit()) i += 1;
+
+            // If there are unprocessed characters, then it is an invalid char for this segment
+            if (i < segment.Length)
+                return ex ?? NewFormatException(InvalidCharacterInMajorMinorOrPatchMessage,
+                    version.ToStringLimitLength(),
+                    kind, segment[i]);
+
+            if (!allowLeadingZeros && lengthWithLeadingZeros > segment.Length)
+                return ex ?? NewFormatException(LeadingZeroInMajorMinorOrPatchMessage,
+                    version.ToStringLimitLength(), kind);
+
+            var numberString = segment.ToString();
+            if (!int.TryParse(numberString, NumberStyles.None, CultureInfo.InvariantCulture, out number))
+                // Parsing validated this as a string of digits possibly proceeded by zero so the only
+                // possible issue is a numeric overflow for `int`
+                return ex ?? new OverflowException(string.Format(CultureInfo.InvariantCulture,
+                    MajorMinorOrPatchOverflowMessage, version.ToStringLimitLength(), kind, numberString));
+
+            return null;
+        }
+
+        private static Exception ParsePrerelease(
+            StringSegment version,
+            StringSegment segment,
+            bool allowLeadingZero,
+            SemVersionParsingOptions options,
+            Exception ex,
+            out string prerelease,
+            out IReadOnlyList<PrereleaseIdentifier> prereleaseIdentifiers,
+            out bool isWildcard)
+        {
+            prerelease = null;
+            var identifiers = new List<PrereleaseIdentifier>(segment.SplitCount('.'));
+            prereleaseIdentifiers = identifiers.AsReadOnly();
+            isWildcard = false;
+
+            bool hasLeadingZeros = false;
+            foreach (var identifier in segment.Split('.'))
+            {
+                // Identifier after wildcard
+                if (isWildcard)
+                    return ex ?? NewFormatException(PrereleaseWildcardMustBeLast, version.ToStringLimitLength());
+
+                // Empty identifiers not allowed
+                if (identifier.Length == 0)
+                    return ex ?? NewFormatException(MissingPrereleaseIdentifierMessage, version.ToStringLimitLength());
+
+                var isNumeric = true;
+
+                for (int i = 0; i < identifier.Length; i++)
+                {
+                    var c = identifier[i];
+                    if (c.IsAlphaOrHyphen())
+                        isNumeric = false;
+                    else if (options.AllowWildcardPrerelease && options.IsWildcard(c))
+                        isWildcard = true;
+                    else if (!c.IsDigit())
+                        return ex ?? NewFormatException(InvalidCharacterInPrereleaseMessage,
+                            version.ToStringLimitLength(), c);
+                }
+
+                if (isWildcard)
+                {
+                    if (identifier.Length > 1) return ex ?? NewFormatException(InvalidWildcardInPrereleaseMessage, version.ToStringLimitLength());
+                    isWildcard = true;
+                    continue; // continue to make sure there aren't more identifiers
+                }
+
+                if (!isNumeric)
+                    identifiers.Add(PrereleaseIdentifier.CreateUnsafe(identifier.ToString(), null));
+                else
+                {
+                    string identifierString;
+                    if (identifier[0] == '0' && identifier.Length > 1)
+                    {
+                        if (!allowLeadingZero)
+                            return ex ?? NewFormatException(LeadingZeroInPrereleaseMessage,
+                                version.ToStringLimitLength());
+                        hasLeadingZeros = true;
+                        identifierString = identifier.TrimLeadingZeros().ToString();
+                    }
+                    else
+                        identifierString = identifier.ToString();
+
+                    if (!int.TryParse(identifierString, NumberStyles.None, null, out var numericValue))
+                        // Parsing validated this as a string of digits possibly proceeded by zero so the only
+                        // possible issue is a numeric overflow for `int`
+                        return ex ?? new OverflowException(string.Format(CultureInfo.InvariantCulture,
+                            PrereleaseOverflowMessage, version.ToStringLimitLength(), identifier));
+
+                    identifiers.Add(PrereleaseIdentifier.CreateUnsafe(identifierString, numericValue));
+                }
+            }
+
+            // If there are leading zeros or a wildcard, reconstruct the string from the identifiers,
+            // otherwise just take a substring.
+            prerelease = hasLeadingZeros || isWildcard
+                            ? string.Join(".", identifiers) : segment.ToString();
+
+            return null;
+        }
+
+        private static Exception ParseMetadata(
+            StringSegment version,
+            StringSegment segment,
+            Exception ex,
+            out string metadata,
+            out IReadOnlyList<MetadataIdentifier> metadataIdentifiers)
+        {
+            metadata = segment.ToString();
+            var identifiers = new List<MetadataIdentifier>(segment.SplitCount('.'));
+            metadataIdentifiers = identifiers.AsReadOnly();
+            foreach (var identifier in segment.Split('.'))
+            {
+                // Empty identifiers not allowed
+                if (identifier.Length == 0)
+                    return ex ?? NewFormatException(MissingMetadataIdentifierMessage, version.ToStringLimitLength());
+
+                for (int i = 0; i < identifier.Length; i++)
+                {
+                    var c = identifier[i];
+                    if (!c.IsAlphaOrHyphen() && !c.IsDigit())
+                        return ex ?? NewFormatException(InvalidCharacterInMetadataMessage,
+                            version.ToStringLimitLength(), c);
+                }
+
+                identifiers.Add(MetadataIdentifier.CreateUnsafe(identifier.ToString()));
+            }
+
+            return null;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static FormatException NewFormatException(string messageTemplate, params object[] args)
+            => new FormatException(string.Format(CultureInfo.InvariantCulture, messageTemplate, args));
+    }
+}

--- a/dotnet/Surge.NET/Semver/Parsing/SemVersionParsingOptions.cs
+++ b/dotnet/Surge.NET/Semver/Parsing/SemVersionParsingOptions.cs
@@ -1,0 +1,52 @@
+#nullable disable
+#pragma warning disable
+using System;
+
+namespace Semver.Parsing
+{
+    /// <summary>
+    /// Options beyond the <see cref="SemVersionStyles"/> for version parsing used by range parsing.
+    /// </summary>
+    internal class SemVersionParsingOptions
+    {
+        /// <summary>
+        /// No special parsing options. Used when parsing versions outside of ranges.
+        /// </summary>
+        public static SemVersionParsingOptions None
+            = new SemVersionParsingOptions(false, false, false, _ => false);
+
+        public SemVersionParsingOptions(
+            bool allowWildcardMajorMinorPatch,
+            bool allowWildcardPrerelease,
+            bool missingVersionsAreWildcards,
+            Predicate<char> isWildcard)
+        {
+            AllowWildcardMajorMinorPatch = allowWildcardMajorMinorPatch;
+            AllowWildcardPrerelease = allowWildcardPrerelease;
+            MissingVersionsAreWildcards = missingVersionsAreWildcards;
+            IsWildcard = isWildcard;
+        }
+
+        /// <summary>
+        /// Allow wildcards as defined by <see cref="IsWildcard"/> in the major, minor, and patch
+        /// version numbers.
+        /// </summary>
+        public bool AllowWildcardMajorMinorPatch { get; }
+
+        /// <summary>
+        /// Allow a wildcard as defined by <see cref="IsWildcard"/> as the final prerelease identifier.
+        /// </summary>
+        public bool AllowWildcardPrerelease { get; }
+
+        /// <summary>
+        /// Whether missing minor and patch version numbers allowed by the optional minor and patch
+        /// options count as being wildcard version numbers.
+        /// </summary>
+        public bool MissingVersionsAreWildcards { get; }
+
+        /// <summary>
+        /// Determines whether any given character is a wildcard character.
+        /// </summary>
+        public Predicate<char> IsWildcard { get; }
+    }
+}

--- a/dotnet/Surge.NET/Semver/Parsing/WildcardVersion.cs
+++ b/dotnet/Surge.NET/Semver/Parsing/WildcardVersion.cs
@@ -1,0 +1,19 @@
+#nullable disable
+#pragma warning disable
+using System;
+
+namespace Semver.Parsing
+{
+    [Flags]
+    internal enum WildcardVersion : byte
+    {
+        None = 0,
+        MajorWildcard = 1 << 3,
+        MinorWildcard = 1 << 2,
+        PatchWildcard = 1 << 1,
+        PrereleaseWildcard = 1 << 0,
+
+        MinorPatchWildcard = MinorWildcard | PatchWildcard,
+        MajorMinorPatchWildcard = MajorWildcard | MinorPatchWildcard,
+    }
+}

--- a/dotnet/Surge.NET/Semver/Parsing/WildcardVersionExtensions.cs
+++ b/dotnet/Surge.NET/Semver/Parsing/WildcardVersionExtensions.cs
@@ -1,0 +1,25 @@
+#nullable disable
+#pragma warning disable
+using System;
+using System.Runtime.CompilerServices;
+
+namespace Semver.Parsing
+{
+    internal static class WildcardVersionExtensions
+    {
+        /// <summary>
+        /// The <see cref="Enum.HasFlag"/> method is surprisingly slow. This provides
+        /// a fast alternative for the <see cref="WildcardVersion"/> enum.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool HasOption(this WildcardVersion wildcards, WildcardVersion flag)
+            => (wildcards & flag) == flag;
+
+        /// <summary>
+        /// Remove a flag from a <see cref="WildcardVersion"/>.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void RemoveOption(this ref WildcardVersion wildcards, WildcardVersion flag)
+            => wildcards &= ~flag;
+    }
+}

--- a/dotnet/Surge.NET/Semver/PrereleaseIdentifier.cs
+++ b/dotnet/Surge.NET/Semver/PrereleaseIdentifier.cs
@@ -1,0 +1,373 @@
+#nullable disable
+#pragma warning disable
+using System;
+using System.ComponentModel;
+using System.Globalization;
+using System.Runtime.CompilerServices;
+using Semver.Utility;
+
+namespace Semver
+{
+    /// <summary>
+    /// An individual prerelease identifier for a semantic version.
+    /// </summary>
+    /// <remarks>
+    /// <para>The prerelease portion of a semantic version is composed of dot ('<c>.</c>') separated identifiers.
+    /// A prerelease identifier is either an alphanumeric or numeric identifier. A valid numeric
+    /// identifier is composed of ASCII digits (<c>[0-9]</c>) without leading zeros. A valid
+    /// alphanumeric identifier is a non-empty string of ASCII alphanumeric and hyphen characters
+    /// (<c>[0-9A-Za-z-]</c>) with at least one non-digit character. Prerelease identifiers are
+    /// compared first by whether they are numeric or alphanumeric. Numeric identifiers have lower
+    /// precedence than alphanumeric identifiers. Numeric identifiers are compared to each other
+    /// numerically. Alphanumeric identifiers are compared to each other lexically in ASCII sort
+    /// order.</para>
+    ///
+    /// <para>Because <see cref="PrereleaseIdentifier"/> is a struct, the default value is a
+    /// <see cref="PrereleaseIdentifier"/> with a <see langword="null"/> value. However, the
+    /// <see cref="Semver"/> namespace types do not accept and will not return such a
+    /// <see cref="PrereleaseIdentifier"/>.</para>
+    ///
+    /// <para>Invalid prerelease identifiers including arbitrary Unicode characters, empty string,
+    /// and numeric identifiers with leading zero can currently be produced by the
+    /// <see cref="SemVersion(int, int, int, string, string)"/> constructor and the obsolete
+    /// <see cref="SemVersion.Parse(string,bool)"/> and
+    /// <see cref="SemVersion.TryParse(string,out SemVersion,bool)"/> methods. Such alphanumeric
+    /// identifiers are compared via an ordinal string comparision. Numeric identifiers with
+    /// leading zeros are considered equal (e.g. '<c>15</c>' is equal to '<c>015</c>').
+    /// </para>
+    /// </remarks>
+    public readonly struct PrereleaseIdentifier : IEquatable<PrereleaseIdentifier>, IComparable<PrereleaseIdentifier>, IComparable
+    {
+        internal static readonly PrereleaseIdentifier Zero = CreateUnsafe("0", 0);
+        internal static readonly PrereleaseIdentifier Hyphen = CreateUnsafe("-", null);
+
+        /// <summary>
+        /// The string value of the prerelease identifier even if it is a numeric identifier.
+        /// </summary>
+        /// <value>The string value of this prerelease identifier even if it is a numeric identifier
+        /// or <see langword="null"/> if this is a default <see cref="PrereleaseIdentifier"/>.</value>
+        /// <remarks>Invalid numeric prerelease identifiers with leading zeros will have a string
+        /// value including the leading zeros. This can be used to distinguish invalid numeric
+        /// identifiers with different numbers of leading zeros.</remarks>
+        public string Value { get; }
+
+        /// <summary>
+        /// The numeric value of the prerelease identifier if it is a numeric identifier, otherwise
+        /// <see langword="null"/>.
+        /// </summary>
+        /// <value>The numeric value of the prerelease identifier if it is a numeric identifier,
+        /// otherwise <see langword="null"/>.</value>
+        /// <remarks>The numeric value of a prerelease identifier will never be negative.</remarks>
+        public int? NumericValue { get; }
+
+        /// <summary>
+        /// Construct a potentially invalid <see cref="PrereleaseIdentifier"/>.
+        /// </summary>
+        /// <exception cref="ArgumentNullException">The <paramref name="value"/> parameter is <see langword="null"/>.</exception>
+        /// <remarks>This should be used only by the <see cref="SemVersion"/> constructor that
+        /// still accepts illegal values.</remarks>
+        [EditorBrowsable(EditorBrowsableState.Never), Obsolete]
+        internal static PrereleaseIdentifier CreateLoose(string value)
+        {
+            DebugChecks.IsNotNull(value, nameof(value));
+
+            // Avoid parsing some non-ASCII digits as a number by checking that they are all digits
+            if (value.IsDigits() && int.TryParse(value, NumberStyles.None, CultureInfo.InvariantCulture, out var numericValue))
+                return new PrereleaseIdentifier(value, numericValue);
+
+            return new PrereleaseIdentifier(value, null);
+        }
+
+        /// <summary>
+        /// Construct a <see cref="PrereleaseIdentifier"/> without checking that any of the invariants
+        /// hold. Used by the parser for performance.
+        /// </summary>
+        /// <remarks>This is a create method rather than a constructor to clearly indicate uses
+        /// of it. The other constructors have not been hidden behind create methods because only
+        /// constructors are visible to the package users. So they see a class consistently
+        /// using constructors without any create methods.</remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static PrereleaseIdentifier CreateUnsafe(string value, int? numericValue)
+        {
+            DebugChecks.IsNotNull(value, nameof(value));
+#if DEBUG
+            PrereleaseIdentifier expected;
+            try
+            {
+                // Use the standard constructor as a way of validating the input
+                expected = new PrereleaseIdentifier(value);
+            }
+            catch (ArgumentException ex)
+            {
+                throw new ArgumentException("DEBUG: " + ex.Message, ex.ParamName, ex);
+            }
+            catch (OverflowException ex)
+            {
+                throw new OverflowException("DEBUG: " + ex.Message, ex);
+            }
+            if (expected.Value != value)
+                throw new ArgumentException("DEBUG: String value has leading zeros.", nameof(value));
+            if (expected.NumericValue != numericValue)
+                throw new ArgumentException($"DEBUG: Numeric value {numericValue} doesn't match string value.", nameof(numericValue));
+#endif
+            return new PrereleaseIdentifier(value, numericValue);
+        }
+
+        /// <summary>
+        /// Private constructor used by <see cref="CreateUnsafe"/>.
+        /// </summary>
+        private PrereleaseIdentifier(string value, int? numericValue)
+        {
+            Value = value;
+            NumericValue = numericValue;
+        }
+
+        /// <summary>
+        /// Constructs a valid <see cref="PrereleaseIdentifier"/>.
+        /// </summary>
+        /// <param name="value">The string value of this prerelease identifier.</param>
+        /// <param name="allowLeadingZeros">Whether to allow leading zeros in the <paramref name="value"/>
+        /// parameter. If <see langword="true"/>, leading zeros will be allowed on numeric identifiers
+        /// but will be removed.</param>
+        /// <exception cref="ArgumentNullException">The <paramref name="value"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentException">The <paramref name="value"/> is empty or contains invalid characters
+        /// (i.e. characters that are not ASCII alphanumerics or hyphens) or has leading zeros for
+        /// a numeric identifier when <paramref name="allowLeadingZeros"/> is <see langword="false"/>.</exception>
+        /// <exception cref="OverflowException">The numeric identifier value is too large for <see cref="Int32"/>.</exception>
+        /// <remarks>Because a valid numeric identifier does not have leading zeros, this constructor
+        /// will never create a <see cref="PrereleaseIdentifier"/> with leading zeros even if
+        /// <paramref name="allowLeadingZeros"/> is <see langword="true"/>. Any leading zeros will
+        /// be removed.</remarks>
+        public PrereleaseIdentifier(string value, bool allowLeadingZeros = false)
+            : this(value, allowLeadingZeros, nameof(value))
+        {
+        }
+
+        /// <summary>
+        /// Constructs a valid <see cref="PrereleaseIdentifier"/>.
+        /// </summary>
+        /// <remarks>
+        /// Internal constructor allows changing the parameter name to enable methods using this
+        /// as part of their prerelease identifier validation to match the parameter name to their
+        /// parameter name.
+        /// </remarks>
+        internal PrereleaseIdentifier(string value, bool allowLeadingZeros, string paramName)
+        {
+            if (value is null)
+                throw new ArgumentNullException(paramName);
+            if (value.Length == 0)
+                throw new ArgumentException("Prerelease identifier cannot be empty.", paramName);
+            if (value.IsDigits())
+            {
+                if (value.Length > 1 && value[0] == '0')
+                {
+                    if (allowLeadingZeros)
+                        value = value.TrimLeadingZeros();
+                    else
+                        throw new ArgumentException($"Leading zeros are not allowed on numeric prerelease identifiers '{value}'.", paramName);
+                }
+
+                try
+                {
+                    NumericValue = int.Parse(value, NumberStyles.None, CultureInfo.InvariantCulture);
+                }
+                catch (OverflowException)
+                {
+                    // Remake the overflow exception to give better message
+                    throw new OverflowException($"Prerelease identifier '{value}' was too large for {nameof(Int32)}.");
+                }
+            }
+            else
+            {
+                if (!value.IsAlphanumericOrHyphens())
+                    throw new ArgumentException($"A prerelease identifier can contain only ASCII alphanumeric characters and hyphens '{value}'.", paramName);
+                NumericValue = null;
+            }
+
+            Value = value;
+        }
+
+        /// <summary>
+        /// Construct a valid numeric <see cref="PrereleaseIdentifier"/> from an integer value.
+        /// </summary>
+        /// <exception cref="ArgumentOutOfRangeException">The <paramref name="value"/> is negative.</exception>
+        /// <param name="value">The non-negative value of this identifier.</param>
+        public PrereleaseIdentifier(int value)
+        {
+            if (value < 0)
+                throw new ArgumentOutOfRangeException(nameof(value), $"Numeric prerelease identifiers can't be negative: {value}.");
+            Value = value.ToString(CultureInfo.InvariantCulture);
+            NumericValue = value;
+        }
+
+        #region Equality
+        /// <summary>
+        /// Determines whether two identifiers are equal.
+        /// </summary>
+        /// <returns><see langword="true"/> if <paramref name="value"/> is equal to the this identifier;
+        /// otherwise <see langword="false"/>.</returns>
+        /// <remarks>Numeric identifiers with leading zeros are considered equal (e.g. '<c>15</c>'
+        /// is equal to '<c>015</c>').</remarks>
+        public bool Equals(PrereleaseIdentifier value)
+        {
+            if (NumericValue is int numericValue) return numericValue == value.NumericValue;
+            return Value == value.Value;
+        }
+
+        /// <summary>Determines whether the given object is equal to this identifier.</summary>
+        /// <returns><see langword="true"/> if <paramref name="value"/> is equal to the this identifier;
+        /// otherwise <see langword="false"/>.</returns>
+        /// <remarks>Numeric identifiers with leading zeros are considered equal (e.g. '<c>15</c>'
+        /// is equal to '<c>015</c>').</remarks>
+        public override bool Equals(object value)
+            => value is PrereleaseIdentifier other && Equals(other);
+
+        /// <summary>Gets a hash code for this identifier.</summary>
+        /// <returns>A hash code for this identifier.</returns>
+        /// <remarks>Numeric identifiers with leading zeros are have the same hash code (e.g.
+        /// '<c>15</c>' has the same hash code as '<c>015</c>').</remarks>
+        public override int GetHashCode()
+        {
+            if (NumericValue is int numericValue) return CombinedHashCode.Create(numericValue);
+            return CombinedHashCode.Create(Value);
+        }
+
+        /// <summary>
+        /// Determines whether two identifiers are equal.
+        /// </summary>
+        /// <returns><see langword="true"/> if the value of <paramref name="left"/> is the same as
+        /// the value of <paramref name="right"/>; otherwise <see langword="false"/>.</returns>
+        /// <remarks>Numeric identifiers with leading zeros are considered equal (e.g. '<c>15</c>'
+        /// is equal to '<c>015</c>').</remarks>
+        public static bool operator ==(PrereleaseIdentifier left, PrereleaseIdentifier right)
+            => left.Equals(right);
+
+        /// <summary>
+        /// Determines whether two identifiers are <em>not</em> equal.
+        /// </summary>
+        /// <returns><see langword="true"/> if the value of <paramref name="left"/> is different
+        /// from the value of <paramref name="right"/>; otherwise <see langword="false"/>.</returns>
+        /// <remarks>Numeric identifiers with leading zeros are considered equal (e.g. '<c>15</c>'
+        /// is equal to '<c>015</c>').</remarks>
+        public static bool operator !=(PrereleaseIdentifier left, PrereleaseIdentifier right)
+            => !left.Equals(right);
+        #endregion
+
+        #region Comparison
+        /// <summary>
+        /// Compares two identifiers and indicates whether this instance precedes, follows, or is
+        /// equal to the other in precedence order.
+        /// </summary>
+        /// <returns>
+        /// An integer that indicates whether this instance precedes, follows, or is equal to
+        /// <paramref name="value"/> in precedence order.
+        /// <list type="table">
+        ///     <listheader>
+        ///         <term>Value</term>
+        ///         <description>Condition</description>
+        ///     </listheader>
+        ///     <item>
+        ///          <term>-1</term>
+        ///          <description>This instance precedes <paramref name="value"/>.</description>
+        ///     </item>
+        ///     <item>
+        ///          <term>0</term>
+        ///          <description>This instance is equal to <paramref name="value"/>.</description>
+        ///     </item>
+        ///     <item>
+        ///          <term>1</term>
+        ///          <description>This instance follows <paramref name="value"/>.</description>
+        ///     </item>
+        /// </list>
+        /// </returns>
+        /// <remarks>Numeric identifiers have lower precedence than alphanumeric identifiers.
+        /// Numeric identifiers are compared numerically. Numeric identifiers with leading zeros are
+        /// considered equal (e.g. '<c>15</c>' is equal to '<c>015</c>'). Alphanumeric identifiers are
+        /// compared lexically in ASCII sort order. Invalid alphanumeric identifiers are
+        /// compared via an ordinal string comparision.</remarks>
+        public int CompareTo(PrereleaseIdentifier value)
+        {
+            // Handle the fact that numeric identifiers are always less than alphanumeric
+            // and numeric identifiers are compared equal even with leading zeros.
+            if (NumericValue is int numericValue)
+            {
+                if (value.NumericValue is int otherNumericValue)
+                    return numericValue.CompareTo(otherNumericValue);
+
+                return -1;
+            }
+
+            if (value.NumericValue != null)
+                return 1;
+
+            return IdentifierString.Compare(Value, value.Value);
+        }
+
+        /// <summary>
+        /// Compares this identifier to an <see cref="Object"/> and indicates whether this instance
+        /// precedes, follows, or is equal to the object in precedence order.
+        /// </summary>
+        /// <returns>
+        /// An integer that indicates whether this instance precedes, follows, or is equal to
+        /// <paramref name="value"/> in precedence order.
+        /// <list type="table">
+        ///     <listheader>
+        ///         <term>Value</term>
+        ///         <description>Condition</description>
+        ///     </listheader>
+        ///     <item>
+        ///          <term>-1</term>
+        ///          <description>This instance precedes <paramref name="value"/>.</description>
+        ///     </item>
+        ///     <item>
+        ///          <term>0</term>
+        ///          <description>This instance is equal to <paramref name="value"/>.</description>
+        ///     </item>
+        ///     <item>
+        ///          <term>1</term>
+        ///          <description>This instance follows <paramref name="value"/> or <paramref name="value"/>
+        ///                         is <see langword="null"/>.</description>
+        ///     </item>
+        /// </list>
+        /// </returns>
+        /// <exception cref="ArgumentException"><paramref name="value"/> is not a <see cref="PrereleaseIdentifier"/>.</exception>
+        /// <remarks>Numeric identifiers have lower precedence than alphanumeric identifiers.
+        /// Numeric identifiers are compared numerically. Numeric identifiers with leading zeros are
+        /// considered equal (e.g. '<c>15</c>' is equal to '<c>015</c>'). Alphanumeric identifiers are
+        /// compared lexically in ASCII sort order. Invalid alphanumeric identifiers are
+        /// compared via an ordinal string comparision.</remarks>
+        public int CompareTo(object value)
+        {
+            if (value is null) return 1;
+            return value is PrereleaseIdentifier other
+                ? CompareTo(other)
+                : throw new ArgumentException($"Object must be of type {nameof(PrereleaseIdentifier)}.", nameof(value));
+        }
+        #endregion
+
+        /// <summary>
+        /// Converts this identifier into an equivalent string value.
+        /// </summary>
+        /// <returns>The string value of this identifier or <see langword="null"/> if this is
+        /// a default <see cref="PrereleaseIdentifier"/></returns>
+        public static implicit operator string(PrereleaseIdentifier prereleaseIdentifier)
+            => prereleaseIdentifier.Value;
+
+        /// <summary>
+        /// Converts this identifier into an equivalent string value.
+        /// </summary>
+        /// <returns>The string value of this identifier or <see langword="null"/> if this is
+        /// a default <see cref="PrereleaseIdentifier"/></returns>
+        public override string ToString() => Value;
+
+        internal PrereleaseIdentifier NextIdentifier()
+        {
+            if (NumericValue is int numericValue)
+                return numericValue == int.MaxValue
+                    ? Hyphen
+                    : new PrereleaseIdentifier(numericValue + 1);
+
+            return new PrereleaseIdentifier(Value + "-");
+        }
+    }
+}

--- a/dotnet/Surge.NET/Semver/SemVersion.cs
+++ b/dotnet/Surge.NET/Semver/SemVersion.cs
@@ -1,0 +1,1703 @@
+#nullable disable
+#pragma warning disable
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+#if SERIALIZABLE
+using System.Runtime.Serialization;
+using System.Security.Permissions;
+#endif
+using System.Text.RegularExpressions;
+using Semver.Comparers;
+using Semver.Parsing;
+using Semver.Utility;
+
+namespace Semver
+{
+    /// <summary>
+    /// A semantic version number. Conforms with v2.0.0 of semantic versioning
+    /// (<a href="https://semver.org">semver.org</a>).
+    /// </summary>
+#if SERIALIZABLE
+    [Serializable]
+    public sealed class SemVersion : IComparable<SemVersion>, IComparable, IEquatable<SemVersion>, ISerializable
+#else
+    public sealed class SemVersion : IComparable<SemVersion>, IComparable, IEquatable<SemVersion>
+#endif
+    {
+        internal static readonly SemVersion Min = new SemVersion(0, 0, 0, new[] { new PrereleaseIdentifier(0) });
+        internal static readonly SemVersion MinRelease = new SemVersion(0, 0, 0);
+        internal static readonly SemVersion Max = new SemVersion(int.MaxValue, int.MaxValue, int.MaxValue);
+
+        internal const string InvalidSemVersionStylesMessage = "An invalid SemVersionStyles value was used.";
+        private const string InvalidMajorVersionMessage = "Major version must be greater than or equal to zero.";
+        private const string InvalidMinorVersionMessage = "Minor version must be greater than or equal to zero.";
+        private const string InvalidPatchVersionMessage = "Patch version must be greater than or equal to zero.";
+        private const string PrereleaseIdentifierIsDefaultMessage = "Prerelease identifier cannot be default/null.";
+        private const string MetadataIdentifierIsDefaultMessage = "Metadata identifier cannot be default/null.";
+        // TODO include in v3.0.0 for issue #72
+        //internal const string InvalidMaxLengthMessage = "Must not be negative.";
+        internal const int MaxVersionLength = 1024;
+
+        private static readonly Regex ParseRegex =
+            new Regex(@"^(?<major>\d+)" +
+                @"(?>\.(?<minor>\d+))?" +
+                @"(?>\.(?<patch>\d+))?" +
+                @"(?>\-(?<pre>[0-9A-Za-z\-\.]+))?" +
+                @"(?>\+(?<metadata>[0-9A-Za-z\-\.]+))?$",
+#if COMPILED_REGEX
+                RegexOptions.CultureInvariant | RegexOptions.Compiled | RegexOptions.ExplicitCapture,
+#else
+                RegexOptions.CultureInvariant | RegexOptions.ExplicitCapture,
+#endif
+                TimeSpan.FromSeconds(0.5));
+
+#if SERIALIZABLE
+        /// <summary>
+        /// Deserialize a <see cref="SemVersion"/>.
+        /// </summary>
+        /// <exception cref="ArgumentNullException">The <paramref name="info"/> parameter is null.</exception>
+        private SemVersion(SerializationInfo info, StreamingContext context)
+        {
+            if (info == null) throw new ArgumentNullException(nameof(info));
+#pragma warning disable CS0618 // Type or member is obsolete
+            var semVersion = Parse(info.GetString("SemVersion"), true);
+#pragma warning restore CS0618 // Type or member is obsolete
+            Major = semVersion.Major;
+            Minor = semVersion.Minor;
+            Patch = semVersion.Patch;
+            Prerelease = semVersion.Prerelease;
+            PrereleaseIdentifiers = semVersion.PrereleaseIdentifiers;
+            Metadata = semVersion.Metadata;
+            MetadataIdentifiers = semVersion.MetadataIdentifiers;
+        }
+
+        /// <summary>
+        /// Populates a <see cref="SerializationInfo"/> with the data needed to serialize the target object.
+        /// </summary>
+        /// <param name="info">The <see cref="SerializationInfo"/> to populate with data.</param>
+        /// <param name="context">The destination (see <see cref="SerializationInfo"/>) for this serialization.</param>
+        [SecurityPermission(SecurityAction.Demand, SerializationFormatter = true)]
+        public void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            if (info == null) throw new ArgumentNullException(nameof(info));
+            info.AddValue("SemVersion", ToString());
+        }
+#endif
+
+        /// <summary>
+        /// Constructs a new instance of the <see cref="SemVersion" /> class.
+        /// </summary>
+        /// <param name="major">The major version number.</param>
+        // Constructor needed to resolve ambiguity between other overloads with default parameters.
+        public SemVersion(int major)
+        {
+            Major = major;
+            Minor = 0;
+            Patch = 0;
+            Prerelease = "";
+            PrereleaseIdentifiers = ReadOnlyList<PrereleaseIdentifier>.Empty;
+            Metadata = "";
+            MetadataIdentifiers = ReadOnlyList<MetadataIdentifier>.Empty;
+        }
+
+        /// <summary>
+        /// Constructs a new instance of the <see cref="SemVersion" /> class.
+        /// </summary>
+        /// <param name="major">The major version number.</param>
+        /// <param name="minor">The minor version number.</param>
+        // Constructor needed to resolve ambiguity between other overloads with default parameters.
+        public SemVersion(int major, int minor)
+        {
+            Major = major;
+            Minor = minor;
+            Patch = 0;
+            Prerelease = "";
+            PrereleaseIdentifiers = ReadOnlyList<PrereleaseIdentifier>.Empty;
+            Metadata = "";
+            MetadataIdentifiers = ReadOnlyList<MetadataIdentifier>.Empty;
+        }
+
+        /// <summary>
+        /// Constructs a new instance of the <see cref="SemVersion" /> class.
+        /// </summary>
+        /// <param name="major">The major version number.</param>
+        /// <param name="minor">The minor version number.</param>
+        /// <param name="patch">The patch version number.</param>
+        // Constructor needed to resolve ambiguity between other overloads with default parameters.
+        public SemVersion(int major, int minor, int patch)
+        {
+            Major = major;
+            Minor = minor;
+            Patch = patch;
+            Prerelease = "";
+            PrereleaseIdentifiers = ReadOnlyList<PrereleaseIdentifier>.Empty;
+            Metadata = "";
+            MetadataIdentifiers = ReadOnlyList<MetadataIdentifier>.Empty;
+        }
+
+        /// <summary>
+        /// Constructs a new instance of the <see cref="SemVersion" /> class.
+        /// </summary>
+        /// <param name="major">The major version number.</param>
+        /// <param name="minor">The minor version number.</param>
+        /// <param name="patch">The patch version number.</param>
+        /// <param name="prerelease">The prerelease portion (e.g. "alpha.5").</param>
+        /// <param name="build">The build metadata (e.g. "nightly.232").</param>
+        [EditorBrowsable(EditorBrowsableState.Never), Obsolete("This constructor is obsolete. Use another constructor or SemVersion.ParsedFrom() instead.")]
+        public SemVersion(int major, int minor = 0, int patch = 0, string prerelease = "", string build = "")
+        {
+            Major = major;
+            Minor = minor;
+            Patch = patch;
+
+            prerelease = prerelease ?? "";
+            Prerelease = prerelease;
+            PrereleaseIdentifiers = prerelease.SplitAndMapToReadOnlyList('.', PrereleaseIdentifier.CreateLoose);
+
+            build = build ?? "";
+            Metadata = build;
+            MetadataIdentifiers = build.SplitAndMapToReadOnlyList('.', MetadataIdentifier.CreateLoose);
+        }
+
+        /// <summary>
+        /// Constructs a new instance of the <see cref="SemVersion" /> class.
+        /// </summary>
+        /// <param name="major">The major version number.</param>
+        /// <param name="minor">The minor version number.</param>
+        /// <param name="patch">The patch version number.</param>
+        /// <param name="prerelease">The prerelease identifiers.</param>
+        /// <param name="metadata">The build metadata identifiers.</param>
+        /// <exception cref="ArgumentOutOfRangeException">A <paramref name="major"/>,
+        /// <paramref name="minor"/>, or <paramref name="patch"/> version number is negative.</exception>
+        /// <exception cref="ArgumentException">A prerelease or metadata identifier has the default value.</exception>
+        public SemVersion(int major, int minor = 0, int patch = 0,
+            IEnumerable<PrereleaseIdentifier> prerelease = null,
+            IEnumerable<MetadataIdentifier> metadata = null)
+        {
+            if (major < 0) throw new ArgumentOutOfRangeException(nameof(major), InvalidMajorVersionMessage);
+            if (minor < 0) throw new ArgumentOutOfRangeException(nameof(minor), InvalidMinorVersionMessage);
+            if (patch < 0) throw new ArgumentOutOfRangeException(nameof(patch), InvalidPatchVersionMessage);
+            IReadOnlyList<PrereleaseIdentifier> prereleaseIdentifiers;
+            if (prerelease is null)
+                prereleaseIdentifiers = null;
+            else
+            {
+                prereleaseIdentifiers = prerelease.ToReadOnlyList();
+                if (prereleaseIdentifiers.Any(i => i == default))
+                    throw new ArgumentException(PrereleaseIdentifierIsDefaultMessage, nameof(prerelease));
+            }
+
+            IReadOnlyList<MetadataIdentifier> metadataIdentifiers;
+            if (metadata is null)
+                metadataIdentifiers = null;
+            else
+            {
+                metadataIdentifiers = metadata.ToReadOnlyList();
+                if (metadataIdentifiers.Any(i => i == default))
+                    throw new ArgumentException(MetadataIdentifierIsDefaultMessage, nameof(metadata));
+            }
+
+            Major = major;
+            Minor = minor;
+            Patch = patch;
+
+            if (prereleaseIdentifiers is null || prereleaseIdentifiers.Count == 0)
+            {
+                Prerelease = "";
+                PrereleaseIdentifiers = ReadOnlyList<PrereleaseIdentifier>.Empty;
+            }
+            else
+            {
+                Prerelease = string.Join(".", prereleaseIdentifiers);
+                PrereleaseIdentifiers = prereleaseIdentifiers;
+            }
+
+            if (metadataIdentifiers is null || metadataIdentifiers.Count == 0)
+            {
+                Metadata = "";
+                MetadataIdentifiers = ReadOnlyList<MetadataIdentifier>.Empty;
+            }
+            else
+            {
+                Metadata = string.Join(".", metadataIdentifiers);
+                MetadataIdentifiers = metadataIdentifiers;
+            }
+        }
+
+        /// <summary>
+        /// Constructs a new instance of the <see cref="SemVersion" /> class.
+        /// </summary>
+        /// <param name="major">The major version number.</param>
+        /// <param name="minor">The minor version number.</param>
+        /// <param name="patch">The patch version number.</param>
+        /// <param name="prerelease">The prerelease identifiers.</param>
+        /// <param name="metadata">The build metadata identifiers.</param>
+        /// <exception cref="ArgumentOutOfRangeException">A <paramref name="major"/>,
+        /// <paramref name="minor"/>, or <paramref name="patch"/> version number is negative.</exception>
+        /// <exception cref="ArgumentNullException">One of the prerelease or metadata identifiers is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentException">A prerelease identifier is empty or contains invalid
+        /// characters (i.e. characters that are not ASCII alphanumerics or hyphens) or has leading
+        /// zeros for a numeric identifier. Or, a metadata identifier is empty or contains invalid
+        /// characters (i.e. characters that are not ASCII alphanumerics or hyphens).</exception>
+        /// <exception cref="OverflowException">A numeric prerelease identifier value is too large
+        /// for <see cref="Int32"/>.</exception>
+        public SemVersion(int major, int minor = 0, int patch = 0,
+            IEnumerable<string> prerelease = null,
+            IEnumerable<string> metadata = null)
+        {
+            if (major < 0) throw new ArgumentOutOfRangeException(nameof(major), InvalidMajorVersionMessage);
+            if (minor < 0) throw new ArgumentOutOfRangeException(nameof(minor), InvalidMinorVersionMessage);
+            if (patch < 0) throw new ArgumentOutOfRangeException(nameof(patch), InvalidPatchVersionMessage);
+            var prereleaseIdentifiers = prerelease?
+                                        .Select(i => new PrereleaseIdentifier(i, allowLeadingZeros: false, nameof(prerelease)))
+                                        .ToReadOnlyList();
+
+            var metadataIdentifiers = metadata?
+                                      .Select(i => new MetadataIdentifier(i, nameof(metadata)))
+                                      .ToReadOnlyList();
+
+            Major = major;
+            Minor = minor;
+            Patch = patch;
+
+            if (prereleaseIdentifiers is null || prereleaseIdentifiers.Count == 0)
+            {
+                Prerelease = "";
+                PrereleaseIdentifiers = ReadOnlyList<PrereleaseIdentifier>.Empty;
+            }
+            else
+            {
+                Prerelease = string.Join(".", prereleaseIdentifiers);
+                PrereleaseIdentifiers = prereleaseIdentifiers;
+            }
+
+            if (metadataIdentifiers is null || metadataIdentifiers.Count == 0)
+            {
+                Metadata = "";
+                MetadataIdentifiers = ReadOnlyList<MetadataIdentifier>.Empty;
+            }
+            else
+            {
+                Metadata = string.Join(".", metadataIdentifiers);
+                MetadataIdentifiers = metadataIdentifiers;
+            }
+        }
+
+        /// <summary>
+        /// Create a new instance of the <see cref="SemVersion" /> class. Parses prerelease
+        /// and metadata identifiers from dot separated strings. If parsing is not needed, use a
+        /// constructor instead.
+        /// </summary>
+        /// <param name="major">The major version number.</param>
+        /// <param name="minor">The minor version number.</param>
+        /// <param name="patch">The patch version number.</param>
+        /// <param name="prerelease">The prerelease portion (e.g. "alpha.5").</param>
+        /// <param name="metadata">The build metadata (e.g. "nightly.232").</param>
+        /// <param name="allowLeadingZeros">Allow leading zeros in numeric prerelease identifiers. Leading
+        /// zeros will be removed.</param>
+        /// <exception cref="ArgumentOutOfRangeException">A <paramref name="major"/>,
+        /// <paramref name="minor"/>, or <paramref name="patch"/> version number is negative.</exception>
+        /// <exception cref="ArgumentException">A prerelease identifier is empty or contains invalid
+        /// characters (i.e. characters that are not ASCII alphanumerics or hyphens) or has leading
+        /// zeros for a numeric identifier when <paramref name="allowLeadingZeros"/> is
+        /// <see langword="false"/>. Or, a metadata identifier is empty or contains invalid
+        /// characters (i.e. characters that are not ASCII alphanumerics or hyphens).</exception>
+        /// <exception cref="OverflowException">A numeric prerelease identifier value is too large
+        /// for <see cref="int"/>.</exception>
+        public static SemVersion ParsedFrom(int major, int minor = 0, int patch = 0,
+            string prerelease = "", string metadata = "", bool allowLeadingZeros = false)
+        {
+            if (major < 0) throw new ArgumentOutOfRangeException(nameof(major), InvalidMajorVersionMessage);
+            if (minor < 0) throw new ArgumentOutOfRangeException(nameof(minor), InvalidMinorVersionMessage);
+            if (patch < 0) throw new ArgumentOutOfRangeException(nameof(patch), InvalidPatchVersionMessage);
+
+            if (prerelease is null) throw new ArgumentNullException(nameof(prerelease));
+            var prereleaseIdentifiers = prerelease.Length == 0
+                ? ReadOnlyList<PrereleaseIdentifier>.Empty
+                : prerelease.SplitAndMapToReadOnlyList('.',
+                    i => new PrereleaseIdentifier(i, allowLeadingZeros, nameof(prerelease)));
+            if (allowLeadingZeros)
+                // Leading zeros may have been removed, need to reconstruct the prerelease string
+                prerelease = string.Join(".", prereleaseIdentifiers);
+
+            if (metadata is null) throw new ArgumentNullException(nameof(metadata));
+            var metadataIdentifiers = metadata.Length == 0
+                ? ReadOnlyList<MetadataIdentifier>.Empty
+                : metadata.SplitAndMapToReadOnlyList('.', i => new MetadataIdentifier(i, nameof(metadata)));
+
+            return new SemVersion(major, minor, patch,
+                prerelease, prereleaseIdentifiers, metadata, metadataIdentifiers);
+        }
+
+        /// <summary>
+        /// Constructs a new instance of the <see cref="SemVersion"/> class from
+        /// a <see cref="Version"/>.
+        /// </summary>
+        /// <param name="version"><see cref="Version"/> used to initialize
+        /// the major, minor, and patch version numbers and the build metadata.</param>
+        /// <exception cref="ArgumentNullException">The <paramref name="version"/> is null.</exception>
+        /// <remarks>Constructs a <see cref="SemVersion"/> with the same major and
+        /// minor version numbers. The patch version number will be the fourth component
+        /// of the <paramref name="version"/>. The build meta data will contain the third component
+        /// of the <paramref name="version"/> if it is greater than zero.</remarks>
+        [EditorBrowsable(EditorBrowsableState.Never), Obsolete("This constructor is obsolete. Use SemVersion.FromVersion() instead.")]
+        public SemVersion(Version version)
+        {
+            if (version == null)
+                throw new ArgumentNullException(nameof(version));
+
+            Major = version.Major;
+            Minor = version.Minor;
+
+            if (version.Revision >= 0)
+                Patch = version.Revision;
+
+            Prerelease = "";
+            PrereleaseIdentifiers = ReadOnlyList<PrereleaseIdentifier>.Empty;
+
+            if (version.Build > 0)
+            {
+                Metadata = version.Build.ToString(CultureInfo.InvariantCulture);
+                MetadataIdentifiers = new List<MetadataIdentifier>(1) { MetadataIdentifier.CreateUnsafe(Metadata) }.AsReadOnly();
+            }
+            else
+            {
+                Metadata = "";
+                MetadataIdentifiers = ReadOnlyList<MetadataIdentifier>.Empty;
+            }
+        }
+
+        /// <summary>
+        /// Construct a <see cref="SemVersion"/> from its proper parts.
+        /// </summary>
+        /// <remarks>Parameter validation is not performed. The <paramref name="major"/>,
+        /// <paramref name="minor"/>, and <paramref name="patch"/> version numbers must not be
+        /// negative. The <paramref name="prereleaseIdentifiers"/> and
+        /// <paramref name="metadataIdentifiers"/> must not be <see langword="null"/> or
+        /// contain invalid values and must be immutable. The <paramref name="prerelease"/>
+        /// and <paramref name="metadata"/> must not be null and must be equal to the
+        /// corresponding identifiers.</remarks>
+        internal SemVersion(int major, int minor, int patch,
+            string prerelease, IReadOnlyList<PrereleaseIdentifier> prereleaseIdentifiers,
+            string metadata, IReadOnlyList<MetadataIdentifier> metadataIdentifiers)
+        {
+            DebugChecks.IsValidVersionNumber(major, "Major", nameof(major));
+            DebugChecks.IsValidVersionNumber(minor, "Minor", nameof(minor));
+            DebugChecks.IsValidVersionNumber(patch, "Patch", nameof(patch));
+            DebugChecks.IsNotNull(prerelease, nameof(prerelease));
+            DebugChecks.IsNotNull(prerelease, nameof(prereleaseIdentifiers));
+            DebugChecks.ContainsNoDefaultValues(prereleaseIdentifiers, "Prerelease", nameof(prereleaseIdentifiers));
+            DebugChecks.AreEqualWhenJoinedWithDots(prerelease, nameof(prerelease),
+                prereleaseIdentifiers, nameof(prereleaseIdentifiers));
+            DebugChecks.IsNotNull(metadata, nameof(metadata));
+            DebugChecks.IsNotNull(metadataIdentifiers, nameof(metadataIdentifiers));
+            DebugChecks.ContainsNoDefaultValues(metadataIdentifiers, "Metadata", nameof(metadataIdentifiers));
+            DebugChecks.AreEqualWhenJoinedWithDots(metadata, nameof(metadata),
+                metadataIdentifiers, nameof(metadataIdentifiers));
+
+            Major = major;
+            Minor = minor;
+            Patch = patch;
+            Prerelease = prerelease;
+            PrereleaseIdentifiers = prereleaseIdentifiers;
+            Metadata = metadata;
+            MetadataIdentifiers = metadataIdentifiers;
+        }
+
+        #region System.Version
+        /// <summary>
+        /// Converts a <see cref="Version"/> into the equivalent semantic version.
+        /// </summary>
+        /// <param name="version">The version to be converted to a semantic version.</param>
+        /// <returns>The equivalent semantic version.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="version"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentException"><paramref name="version"/> has a revision number greater than zero.</exception>
+        /// <remarks>
+        /// <see cref="Version"/> numbers have the form <em>major</em>.<em>minor</em>[.<em>build</em>[.<em>revision</em>]]
+        /// where square brackets ('[' and ']')  indicate optional components. The first three parts
+        /// are converted to the major, minor, and patch version numbers of a semantic version. If the
+        /// build component is not defined (-1), the patch number is assumed to be zero.
+        /// <see cref="Version"/> numbers with a revision greater than zero cannot be converted to
+        /// semantic versions. An <see cref="ArgumentException"/> is thrown when this method is called
+        /// with such a <see cref="Version"/>.
+        /// </remarks>
+        public static SemVersion FromVersion(Version version)
+        {
+            if (version is null) throw new ArgumentNullException(nameof(version));
+            if (version.Revision > 0) throw new ArgumentException("Version with Revision number can't be converted to SemVer.", nameof(version));
+            var patch = version.Build > 0 ? version.Build : 0;
+            return new SemVersion(version.Major, version.Minor, patch);
+        }
+
+        /// <summary>
+        /// Converts this semantic version to a <see cref="Version"/>.
+        /// </summary>
+        /// <returns>The equivalent <see cref="Version"/>.</returns>
+        /// <exception cref="InvalidOperationException">The semantic version is a prerelease version
+        /// or has build metadata or has a negative major, minor, or patch version number.</exception>
+        /// <remarks>
+        /// A semantic version of the form <em>major</em>.<em>minor</em>.<em>patch</em>
+        /// is converted to a <see cref="Version"/> of the form
+        /// <em>major</em>.<em>minor</em>.<em>build</em> where the build number is the
+        /// patch version of the semantic version. Prerelease versions and build metadata
+        /// are not representable in a <see cref="Version"/>. This method throws
+        /// an <see cref="InvalidOperationException"/> if the semantic version is a
+        /// prerelease version or has build metadata.
+        /// </remarks>
+        public Version ToVersion()
+        {
+            if (Major < 0 || Minor < 0 || Patch < 0) throw new InvalidOperationException("Negative version numbers can't be converted to System.Version.");
+            if (IsPrerelease) throw new InvalidOperationException("Prerelease version can't be converted to System.Version.");
+            if (Metadata.Length != 0) throw new InvalidOperationException("Version with build metadata can't be converted to System.Version.");
+
+            return new Version(Major, Minor, Patch);
+        }
+        #endregion
+
+        /// <summary>
+        /// Converts the string representation of a semantic version to its <see cref="SemVersion"/> equivalent.
+        /// </summary>
+        /// <param name="version">The version string.</param>
+        /// <param name="style">A bitwise combination of enumeration values that indicates the style
+        /// elements that can be present in <paramref name="version"/>. The preferred value to use
+        /// is <see cref="SemVersionStyles.Strict"/>.</param>
+        /// <param name="maxLength">The maximum length of <paramref name="version"/> that should be
+        /// parsed. This prevents attacks using very long version strings.</param>
+        /// <exception cref="ArgumentException"><paramref name="style"/> is not a valid
+        /// <see cref="SemVersionStyles"/> value.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="version"/> is <see langword="null"/>.</exception>
+        /// <exception cref="FormatException">The <paramref name="version"/> is invalid or not in a
+        /// format compliant with <paramref name="style"/>.</exception>
+        /// <exception cref="OverflowException">A numeric part of <paramref name="version"/> is too
+        /// large for an <see cref="Int32"/>.</exception>
+        public static SemVersion Parse(string version, SemVersionStyles style, int maxLength = MaxVersionLength)
+        {
+            if (!style.IsValid()) throw new ArgumentException(InvalidSemVersionStylesMessage, nameof(style));
+            // TODO include in v3.0.0 for issue #72
+            //if (maxLength < 0) throw new ArgumentOutOfRangeException(InvalidMaxLengthMessage, nameof(maxLength));
+            var ex = SemVersionParser.Parse(version, style, null, maxLength, out var semver);
+
+            return ex is null ? semver : throw ex;
+        }
+
+        /// <summary>
+        /// Converts the string representation of a semantic version to its <see cref="SemVersion"/> equivalent.
+        /// </summary>
+        /// <param name="version">The version string.</param>
+        /// <param name="strict">If set to <see langword="true"/>, minor and patch version are required;
+        /// otherwise they are optional.</param>
+        /// <exception cref="ArgumentNullException">The <paramref name="version"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentException">The <paramref name="version"/> has an invalid format.</exception>
+        /// <exception cref="InvalidOperationException">The <paramref name="version"/> is missing minor
+        /// or patch version numbers when <paramref name="strict"/> is <see langword="true"/>.</exception>
+        /// <exception cref="OverflowException">The major, minor, or patch version number is larger
+        /// than <see cref="int.MaxValue"/>.</exception>
+        [EditorBrowsable(EditorBrowsableState.Never), Obsolete("Method is obsolete. Use Parse() overload with SemVersionStyles instead.")]
+        public static SemVersion Parse(string version, bool strict = false)
+        {
+            var match = ParseRegex.Match(version);
+            if (!match.Success)
+                throw new ArgumentException($"Invalid version '{version}'.", nameof(version));
+
+            var major = int.Parse(match.Groups["major"].Value, CultureInfo.InvariantCulture);
+
+            var minorMatch = match.Groups["minor"];
+            int minor = 0;
+            if (minorMatch.Success)
+                minor = int.Parse(minorMatch.Value, CultureInfo.InvariantCulture);
+            else if (strict)
+                throw new InvalidOperationException("Invalid version (no minor version given in strict mode)");
+
+            var patchMatch = match.Groups["patch"];
+            int patch = 0;
+            if (patchMatch.Success)
+                patch = int.Parse(patchMatch.Value, CultureInfo.InvariantCulture);
+            else if (strict)
+                throw new InvalidOperationException("Invalid version (no patch version given in strict mode)");
+
+            var prerelease = match.Groups["pre"].Value;
+            var metadata = match.Groups["metadata"].Value;
+
+            return new SemVersion(major, minor, patch, prerelease, metadata);
+        }
+
+        /// <summary>
+        /// Converts the string representation of a semantic version to its <see cref="SemVersion"/>
+        /// equivalent. The return value indicates whether the conversion succeeded.
+        /// </summary>
+        /// <param name="version">The version string.</param>
+        /// <param name="style">A bitwise combination of enumeration values that indicates the style
+        /// elements that can be present in <paramref name="version"/>. The preferred value to use
+        /// is <see cref="SemVersionStyles.Strict"/>.</param>
+        /// <param name="semver">When this method returns, contains a <see cref="SemVersion"/> instance equivalent
+        /// to the version string passed in, if the version string was valid, or <see langword="null"/> if the
+        /// version string was invalid.</param>
+        /// <param name="maxLength">The maximum length of <paramref name="version"/> that should be
+        /// parsed. This prevents attacks using very long version strings.</param>
+        /// <returns><see langword="false"/> when an invalid version string is passed, otherwise <see langword="true"/>.</returns>
+        /// <exception cref="ArgumentException"><paramref name="style"/> is not a valid
+        /// <see cref="SemVersionStyles"/> value.</exception>
+        public static bool TryParse(string version, SemVersionStyles style,
+            out SemVersion semver, int maxLength = MaxVersionLength)
+        {
+            if (!style.IsValid()) throw new ArgumentException(InvalidSemVersionStylesMessage, nameof(style));
+            // TODO include in v3.0.0 for issue #72
+            //if (maxLength < 0) throw new ArgumentOutOfRangeException(InvalidMaxLengthMessage, nameof(maxLength));
+            var exception = SemVersionParser.Parse(version, style, VersionParsing.FailedException, maxLength, out semver);
+
+#if DEBUG
+            // This check ensures that SemVersionParser.Parse doesn't construct an exception, but always returns ParseFailedException
+            if (exception != null && exception != VersionParsing.FailedException)
+                throw new InvalidOperationException($"DEBUG: {nameof(SemVersionParser)}.{nameof(SemVersionParser.Parse)} returned exception other than {nameof(VersionParsing.FailedException)}", exception);
+#endif
+
+            return exception is null;
+        }
+
+        /// <summary>
+        /// Converts the string representation of a semantic version to its <see cref="SemVersion"/>
+        /// equivalent. The return value indicates whether the conversion succeeded.
+        /// </summary>
+        /// <param name="version">The version string.</param>
+        /// <param name="semver">When this method returns, contains a <see cref="SemVersion"/> instance equivalent
+        /// to the version string passed in, if the version string was valid, or <see langword="null"/> if the
+        /// version string was invalid.</param>
+        /// <param name="strict">If set to <see langword="true"/>, minor and patch version numbers are required;
+        /// otherwise they are optional.</param>
+        /// <returns><see langword="false"/> when an invalid version string is passed, otherwise <see langword="true"/>.</returns>
+        [EditorBrowsable(EditorBrowsableState.Never), Obsolete("Method is obsolete. Use TryParse() overload with SemVersionStyles instead.")]
+        public static bool TryParse(string version, out SemVersion semver, bool strict = false)
+        {
+            semver = null;
+            if (version is null) return false;
+
+            var match = ParseRegex.Match(version);
+            if (!match.Success) return false;
+
+            if (!int.TryParse(match.Groups["major"].Value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var major))
+                return false;
+
+            var minorMatch = match.Groups["minor"];
+            int minor = 0;
+            if (minorMatch.Success)
+            {
+                if (!int.TryParse(minorMatch.Value, NumberStyles.Integer, CultureInfo.InvariantCulture, out minor))
+                    return false;
+            }
+            else if (strict) return false;
+
+            var patchMatch = match.Groups["patch"];
+            int patch = 0;
+            if (patchMatch.Success)
+            {
+                if (!int.TryParse(patchMatch.Value, NumberStyles.Integer, CultureInfo.InvariantCulture, out patch))
+                    return false;
+            }
+            else if (strict) return false;
+
+            var prerelease = match.Groups["pre"].Value;
+            var metadata = match.Groups["metadata"].Value;
+
+            semver = new SemVersion(major, minor, patch, prerelease, metadata);
+            return true;
+        }
+
+        /// <summary>
+        /// Compares two versions and indicates whether the first precedes, follows, or is
+        /// equal to the other in the sort order. Note that sort order is more specific than precedence order.
+        /// </summary>
+        /// <returns>
+        /// An integer that indicates whether <paramref name="versionA"/> precedes, follows, or
+        /// is equal to <paramref name="versionB"/> in the sort order.
+        /// <list type="table">
+        ///     <listheader>
+        ///         <term>Value</term>
+        ///         <description>Condition</description>
+        ///     </listheader>
+        ///     <item>
+        ///         <term>Less than zero</term>
+        ///         <description><paramref name="versionA"/> precedes <paramref name="versionB"/> in the sort order.</description>
+        ///     </item>
+        ///     <item>
+        ///         <term>Zero</term>
+        ///         <description><paramref name="versionA"/> is equal to <paramref name="versionB"/>.</description>
+        ///     </item>
+        ///     <item>
+        ///         <term>Greater than zero</term>
+        ///         <description>
+        ///             <paramref name="versionA"/> follows <paramref name="versionB"/> in the sort order
+        ///             or <paramref name="versionB"/> is <see langword="null" />.
+        ///         </description>
+        ///     </item>
+        /// </list>
+        /// </returns>
+        /// <include file='SemVersionDocParts.xml' path='docParts/part[@id="SortOrder"]/*'/>
+        [EditorBrowsable(EditorBrowsableState.Never), Obsolete("Method is obsolete. Use CompareSortOrder() or ComparePrecedence() instead.")]
+        public static int Compare(SemVersion versionA, SemVersion versionB)
+        {
+            if (ReferenceEquals(versionA, versionB)) return 0;
+            if (versionA is null) return -1;
+            if (versionB is null) return 1;
+            return versionA.CompareTo(versionB);
+        }
+
+        /// <summary>
+        /// Make a copy of the current instance with changed properties.
+        /// </summary>
+        /// <param name="major">The value to replace the major version number or
+        /// <see langword="null"/> to leave it unchanged.</param>
+        /// <param name="minor">The value to replace the minor version number or
+        /// <see langword="null"/> to leave it unchanged.</param>
+        /// <param name="patch">The value to replace the patch version number or
+        /// <see langword="null"/> to leave it unchanged.</param>
+        /// <param name="prerelease">The value to replace the prerelease portion
+        /// or <see langword="null"/> to leave it unchanged.</param>
+        /// <param name="build">The value to replace the build metadata or <see langword="null"/>
+        /// to leave it unchanged.</param>
+        /// <returns>The new version with changed properties.</returns>
+        /// <remarks>
+        /// The change method is intended to be called using named argument syntax, passing only
+        /// those fields to be changed.
+        /// </remarks>
+        /// <example>
+        /// To change only the patch version:
+        /// <code>var changedVersion = version.Change(patch: 4);</code>
+        /// </example>
+        [EditorBrowsable(EditorBrowsableState.Never), Obsolete("Method is obsolete. Use With() or With...() method instead.")]
+        public SemVersion Change(int? major = null, int? minor = null, int? patch = null,
+            string prerelease = null, string build = null)
+        {
+            return new SemVersion(
+                major ?? Major,
+                minor ?? Minor,
+                patch ?? Patch,
+                prerelease ?? Prerelease,
+                build ?? Metadata);
+        }
+
+        /// <summary>
+        /// Creates a copy of the current instance with multiple changed properties. If changing only
+        /// one property use one of the more specific <c>WithX()</c> methods.
+        /// </summary>
+        /// <param name="major">The value to replace the major version number or <see langword="null"/> to leave it unchanged.</param>
+        /// <param name="minor">The value to replace the minor version number or <see langword="null"/> to leave it unchanged.</param>
+        /// <param name="patch">The value to replace the patch version number or <see langword="null"/> to leave it unchanged.</param>
+        /// <param name="prerelease">The value to replace the prerelease identifiers or <see langword="null"/> to leave it unchanged.</param>
+        /// <param name="metadata">The value to replace the build metadata identifiers or <see langword="null"/> to leave it unchanged.</param>
+        /// <returns>The new version with changed properties.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">A <paramref name="major"/>,
+        /// <paramref name="minor"/>, or <paramref name="patch"/> version number is negative.</exception>
+        /// <exception cref="ArgumentException">A prerelease or metadata identifier has the default value.</exception>
+        /// <exception cref="OverflowException">A numeric prerelease identifier value is too large
+        /// for <see cref="int"/>.</exception>
+        /// <remarks>
+        /// The <see cref="With"/> method is intended to be called using named argument syntax, passing only
+        /// those fields to be changed.
+        /// </remarks>
+        /// <example>
+        /// To change the minor and patch versions:
+        /// <code>var modifiedVersion = version.With(minor: 2, patch: 4);</code>
+        /// </example>
+        public SemVersion With(
+            int? major = null,
+            int? minor = null,
+            int? patch = null,
+            IEnumerable<PrereleaseIdentifier> prerelease = null,
+            IEnumerable<MetadataIdentifier> metadata = null)
+        {
+            // Note: It is tempting to null coalesce first, but then this method would report invalid
+            // arguments on invalid SemVersion instances.
+            if (major is int majorInt && majorInt < 0)
+                throw new ArgumentOutOfRangeException(nameof(major), InvalidMajorVersionMessage);
+            if (minor is int minorInt && minorInt < 0)
+                throw new ArgumentOutOfRangeException(nameof(minor), InvalidMinorVersionMessage);
+            if (patch is int patchInt && patchInt < 0)
+                throw new ArgumentOutOfRangeException(nameof(patch), InvalidPatchVersionMessage);
+
+            IReadOnlyList<PrereleaseIdentifier> prereleaseIdentifiers = null;
+            string prereleaseString = null;
+            if (prerelease != null)
+            {
+                prereleaseIdentifiers = prerelease.ToReadOnlyList();
+                if (prereleaseIdentifiers.Count == 0)
+                {
+                    prereleaseIdentifiers = ReadOnlyList<PrereleaseIdentifier>.Empty;
+                    prereleaseString = "";
+                }
+                else if (prereleaseIdentifiers.Any(i => i == default))
+                    throw new ArgumentException(PrereleaseIdentifierIsDefaultMessage, nameof(prerelease));
+                else
+                    prereleaseString = string.Join(".", prereleaseIdentifiers);
+            }
+
+            IReadOnlyList<MetadataIdentifier> metadataIdentifiers = null;
+            string metadataString = null;
+            if (metadata != null)
+            {
+                metadataIdentifiers = metadata.ToReadOnlyList();
+                if (metadataIdentifiers.Count == 0)
+                {
+                    metadataIdentifiers = ReadOnlyList<MetadataIdentifier>.Empty;
+                    metadataString = "";
+                }
+                else if (metadataIdentifiers.Any(i => i == default))
+                    throw new ArgumentException(MetadataIdentifierIsDefaultMessage, nameof(metadata));
+                else
+                    metadataString = string.Join(".", metadataIdentifiers);
+            }
+
+            return new SemVersion(
+                major ?? Major,
+                minor ?? Minor,
+                patch ?? Patch,
+                prereleaseString ?? Prerelease,
+                prereleaseIdentifiers ?? PrereleaseIdentifiers,
+                metadataString ?? Metadata,
+                metadataIdentifiers ?? MetadataIdentifiers);
+        }
+
+        /// <summary>
+        /// Creates a copy of the current instance with multiple changed properties. Parses prerelease
+        /// and metadata identifiers from dot separated strings. Use <see cref="With"/> instead if
+        /// parsing is not needed. If changing only one property use one of the more specific
+        /// <c>WithX()</c> methods.
+        /// </summary>
+        /// <param name="major">The value to replace the major version number or <see langword="null"/> to leave it unchanged.</param>
+        /// <param name="minor">The value to replace the minor version number or <see langword="null"/> to leave it unchanged.</param>
+        /// <param name="patch">The value to replace the patch version number or <see langword="null"/> to leave it unchanged.</param>
+        /// <param name="prerelease">The value to replace the prerelease identifiers or <see langword="null"/> to leave it unchanged.</param>
+        /// <param name="metadata">The value to replace the build metadata identifiers or <see langword="null"/> to leave it unchanged.</param>
+        /// <param name="allowLeadingZeros">Allow leading zeros in numeric prerelease identifiers. Leading
+        /// zeros will be removed.</param>
+        /// <returns>The new version with changed properties.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">A <paramref name="major"/>,
+        /// <paramref name="minor"/>, or <paramref name="patch"/> version number is negative.</exception>
+        /// <exception cref="ArgumentException">A prerelease identifier is empty or contains invalid
+        /// characters (i.e. characters that are not ASCII alphanumerics or hyphens) or has leading
+        /// zeros for a numeric identifier when <paramref name="allowLeadingZeros"/> is
+        /// <see langword="false"/>. Or, a metadata identifier is empty or contains invalid
+        /// characters (i.e. characters that are not ASCII alphanumerics or hyphens).</exception>
+        /// <exception cref="OverflowException">A numeric prerelease identifier value is too large
+        /// for <see cref="int"/>.</exception>
+        /// <remarks>
+        /// The <see cref="WithParsedFrom"/> method is intended to be called using named argument
+        /// syntax, passing only those fields to be changed.
+        /// </remarks>
+        /// <example>
+        /// To change the patch version and prerelease identifiers version:
+        /// <code>var modifiedVersion = version.WithParsedFrom(patch: 4, prerelease: "alpha.5");</code>
+        /// </example>
+        public SemVersion WithParsedFrom(
+            int? major = null,
+            int? minor = null,
+            int? patch = null,
+            string prerelease = null,
+            string metadata = null,
+            bool allowLeadingZeros = false)
+        {
+            // Note: It is tempting to null coalesce first, but then this method would report invalid
+            // arguments on invalid SemVersion instances.
+            if (major is int majorInt && majorInt < 0)
+                throw new ArgumentOutOfRangeException(nameof(major), InvalidMajorVersionMessage);
+            if (minor is int minorInt && minorInt < 0)
+                throw new ArgumentOutOfRangeException(nameof(minor), InvalidMinorVersionMessage);
+            if (patch is int patchInt && patchInt < 0)
+                throw new ArgumentOutOfRangeException(nameof(patch), InvalidPatchVersionMessage);
+
+            var prereleaseIdentifiers = prerelease?.SplitAndMapToReadOnlyList('.',
+                i => new PrereleaseIdentifier(i, allowLeadingZeros, nameof(prerelease)));
+            var metadataIdentifiers = metadata?.SplitAndMapToReadOnlyList('.',
+                i => new MetadataIdentifier(i, nameof(metadata)));
+
+            if (allowLeadingZeros && prerelease != null)
+                // Leading zeros may have been removed, need to reconstruct the prerelease string
+                prerelease = string.Join(".", prereleaseIdentifiers);
+
+            return new SemVersion(
+                major ?? Major,
+                minor ?? Minor,
+                patch ?? Patch,
+                prerelease ?? Prerelease,
+                prereleaseIdentifiers ?? PrereleaseIdentifiers,
+                metadata ?? Metadata,
+                metadataIdentifiers ?? MetadataIdentifiers);
+        }
+
+        #region With... Methods
+        /// <summary>
+        /// Creates a copy of the current instance with a different major version number.
+        /// </summary>
+        /// <param name="major">The value to replace the major version number.</param>
+        /// <returns>The new version with the different major version number.</returns>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="major"/> is negative.</exception>
+        public SemVersion WithMajor(int major)
+        {
+            if (major < 0) throw new ArgumentOutOfRangeException(nameof(major), InvalidMajorVersionMessage);
+            if (Major == major) return this;
+            return new SemVersion(major, Minor, Patch,
+                Prerelease, PrereleaseIdentifiers, Metadata, MetadataIdentifiers);
+        }
+
+        /// <summary>
+        /// Creates a copy of the current instance with a different minor version number.
+        /// </summary>
+        /// <param name="minor">The value to replace the minor version number.</param>
+        /// <returns>The new version with the different minor version number.</returns>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="minor"/> is negative.</exception>
+        public SemVersion WithMinor(int minor)
+        {
+            if (minor < 0) throw new ArgumentOutOfRangeException(nameof(minor), InvalidMinorVersionMessage);
+            if (Minor == minor) return this;
+            return new SemVersion(Major, minor, Patch,
+                Prerelease, PrereleaseIdentifiers, Metadata, MetadataIdentifiers);
+        }
+
+        /// <summary>
+        /// Creates a copy of the current instance with a different patch version number.
+        /// </summary>
+        /// <param name="patch">The value to replace the patch version number.</param>
+        /// <returns>The new version with the different patch version number.</returns>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="patch"/> is negative.</exception>
+        public SemVersion WithPatch(int patch)
+        {
+            if (patch < 0) throw new ArgumentOutOfRangeException(nameof(patch), InvalidPatchVersionMessage);
+            if (Patch == patch) return this;
+            return new SemVersion(Major, Minor, patch,
+                Prerelease, PrereleaseIdentifiers, Metadata, MetadataIdentifiers);
+        }
+
+        /// <summary>
+        /// Creates a copy of the current instance with a different prerelease portion.
+        /// </summary>
+        /// <param name="prerelease">The value to replace the prerelease portion.</param>
+        /// <param name="allowLeadingZeros">Whether to allow leading zeros in the prerelease identifiers.
+        /// If <see langword="true"/>, leading zeros will be allowed on numeric identifiers
+        /// but will be removed.</param>
+        /// <returns>The new version with the different prerelease identifiers.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="prerelease"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentException">A prerelease identifier is empty or contains invalid
+        /// characters (i.e. characters that are not ASCII alphanumerics or hyphens) or has leading
+        /// zeros for a numeric identifier when <paramref name="allowLeadingZeros"/> is <see langword="false"/>.</exception>
+        /// <exception cref="OverflowException">A numeric prerelease identifier value is too large
+        /// for <see cref="Int32"/>.</exception>
+        /// <remarks>Because a valid numeric identifier does not have leading zeros, this constructor
+        /// will never create a <see cref="PrereleaseIdentifier"/> with leading zeros even if
+        /// <paramref name="allowLeadingZeros"/> is <see langword="true"/>. Any leading zeros will
+        /// be removed.</remarks>
+        public SemVersion WithPrereleaseParsedFrom(string prerelease, bool allowLeadingZeros = false)
+        {
+            if (prerelease is null) throw new ArgumentNullException(nameof(prerelease));
+            if (prerelease.Length == 0) return WithoutPrerelease();
+            var identifiers = prerelease.SplitAndMapToReadOnlyList('.',
+                i => new PrereleaseIdentifier(i, allowLeadingZeros, nameof(prerelease)));
+            if (allowLeadingZeros)
+                // Leading zeros may have been removed, need to reconstruct the prerelease string
+                prerelease = string.Join(".", identifiers);
+            return new SemVersion(Major, Minor, Patch,
+                prerelease, identifiers, Metadata, MetadataIdentifiers);
+        }
+
+        /// <summary>
+        /// Creates a copy of the current instance with different prerelease identifiers.
+        /// </summary>
+        /// <param name="prereleaseIdentifier">The first identifier to replace the existing
+        /// prerelease identifiers.</param>
+        /// <param name="prereleaseIdentifiers">The rest of the identifiers to replace the
+        /// existing prerelease identifiers.</param>
+        /// <returns>The new version with the different prerelease identifiers.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="prereleaseIdentifier"/> or
+        /// <paramref name="prereleaseIdentifiers"/> is <see langword="null"/> or one of the
+        /// prerelease identifiers is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentException">A prerelease identifier is empty or contains invalid
+        /// characters (i.e. characters that are not ASCII alphanumerics or hyphens) or has leading
+        /// zeros for a numeric identifier.</exception>
+        /// <exception cref="OverflowException">A numeric prerelease identifier value is too large
+        /// for <see cref="Int32"/>.</exception>
+        public SemVersion WithPrerelease(string prereleaseIdentifier, params string[] prereleaseIdentifiers)
+        {
+            if (prereleaseIdentifier is null) throw new ArgumentNullException(nameof(prereleaseIdentifier));
+            if (prereleaseIdentifiers is null) throw new ArgumentNullException(nameof(prereleaseIdentifiers));
+            var identifiers = prereleaseIdentifiers
+                              .Prepend(prereleaseIdentifier)
+                              .Select(i => new PrereleaseIdentifier(i, allowLeadingZeros: false, nameof(prereleaseIdentifiers)))
+                              .ToReadOnlyList();
+            return new SemVersion(Major, Minor, Patch,
+                string.Join(".", identifiers), identifiers, Metadata, MetadataIdentifiers);
+        }
+
+        /// <summary>
+        /// Creates a copy of the current instance with different prerelease identifiers.
+        /// </summary>
+        /// <param name="prereleaseIdentifiers">The identifiers to replace the prerelease identifiers.</param>
+        /// <returns>The new version with the different prerelease identifiers.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="prereleaseIdentifiers"/> is
+        /// <see langword="null"/> or one of the prerelease identifiers is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentException">A prerelease identifier is empty or contains invalid
+        /// characters (i.e. characters that are not ASCII alphanumerics or hyphens) or has leading
+        /// zeros for a numeric identifier.</exception>
+        /// <exception cref="OverflowException">A numeric prerelease identifier value is too large
+        /// for <see cref="Int32"/>.</exception>
+        public SemVersion WithPrerelease(IEnumerable<string> prereleaseIdentifiers)
+        {
+            if (prereleaseIdentifiers is null) throw new ArgumentNullException(nameof(prereleaseIdentifiers));
+            var identifiers = prereleaseIdentifiers
+                              .Select(i => new PrereleaseIdentifier(i, allowLeadingZeros: false, nameof(prereleaseIdentifiers)))
+                              .ToReadOnlyList();
+            if (identifiers.Count == 0) return WithoutPrerelease();
+            return new SemVersion(Major, Minor, Patch,
+                string.Join(".", identifiers), identifiers, Metadata, MetadataIdentifiers);
+        }
+
+        /// <summary>
+        /// Creates a copy of the current instance with different prerelease identifiers.
+        /// </summary>
+        /// <param name="prereleaseIdentifier">The first identifier to replace the existing
+        /// prerelease identifiers.</param>
+        /// <param name="prereleaseIdentifiers">The rest of the identifiers to replace the
+        /// existing prerelease identifiers.</param>
+        /// <returns>The new version with the different prerelease identifiers.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="prereleaseIdentifiers"/> is
+        /// <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentException">A prerelease identifier has the default value.</exception>
+        public SemVersion WithPrerelease(
+                    PrereleaseIdentifier prereleaseIdentifier,
+                    params PrereleaseIdentifier[] prereleaseIdentifiers)
+        {
+            if (prereleaseIdentifiers is null) throw new ArgumentNullException(nameof(prereleaseIdentifiers));
+            var identifiers = prereleaseIdentifiers.Prepend(prereleaseIdentifier).ToReadOnlyList();
+            if (identifiers.Any(i => i == default)) throw new ArgumentException(PrereleaseIdentifierIsDefaultMessage, nameof(prereleaseIdentifiers));
+            return new SemVersion(Major, Minor, Patch,
+                string.Join(".", identifiers), identifiers, Metadata, MetadataIdentifiers);
+        }
+
+        /// <summary>
+        /// Creates a copy of the current instance with different prerelease identifiers.
+        /// </summary>
+        /// <param name="prereleaseIdentifiers">The identifiers to replace the prerelease identifiers.</param>
+        /// <returns>The new version with the different prerelease identifiers.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="prereleaseIdentifiers"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentException">A prerelease identifier has the default value.</exception>
+        public SemVersion WithPrerelease(IEnumerable<PrereleaseIdentifier> prereleaseIdentifiers)
+        {
+            if (prereleaseIdentifiers is null) throw new ArgumentNullException(nameof(prereleaseIdentifiers));
+            var identifiers = prereleaseIdentifiers.ToReadOnlyList();
+            if (identifiers.Count == 0) return WithoutPrerelease();
+            if (identifiers.Any(i => i == default)) throw new ArgumentException(PrereleaseIdentifierIsDefaultMessage, nameof(prereleaseIdentifiers));
+            return new SemVersion(Major, Minor, Patch,
+                string.Join(".", identifiers), identifiers, Metadata, MetadataIdentifiers);
+        }
+
+        /// <summary>
+        /// Creates a copy of the current instance without prerelease identifiers.
+        /// </summary>
+        /// <returns>The new version without prerelease identifiers.</returns>
+        public SemVersion WithoutPrerelease()
+        {
+            if (!IsPrerelease) return this;
+            return new SemVersion(Major, Minor, Patch,
+                "", ReadOnlyList<PrereleaseIdentifier>.Empty, Metadata, MetadataIdentifiers);
+        }
+
+        /// <summary>
+        /// Creates a copy of the current instance with different build metadata.
+        /// </summary>
+        /// <param name="metadata">The value to replace the build metadata.</param>
+        /// <returns>The new version with the different build metadata.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="metadata"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentException">A metadata identifier is empty or contains invalid
+        /// characters (i.e. characters that are not ASCII alphanumerics or hyphens).</exception>
+        public SemVersion WithMetadataParsedFrom(string metadata)
+        {
+            if (metadata is null) throw new ArgumentNullException(nameof(metadata));
+            if (metadata.Length == 0) return WithoutMetadata();
+            var identifiers = metadata.SplitAndMapToReadOnlyList('.',
+                i => new MetadataIdentifier(i, nameof(metadata)));
+            return new SemVersion(Major, Minor, Patch,
+                Prerelease, PrereleaseIdentifiers, metadata, identifiers);
+        }
+
+        /// <summary>
+        /// Creates a copy of the current instance with different build metadata identifiers.
+        /// </summary>
+        /// <param name="metadataIdentifier">The first identifier to replace the existing
+        /// build metadata identifiers.</param>
+        /// <param name="metadataIdentifiers">The rest of the build metadata identifiers to replace the
+        /// existing build metadata identifiers.</param>
+        /// <returns>The new version with the different build metadata identifiers.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="metadataIdentifier"/> or
+        /// <paramref name="metadataIdentifiers"/> is <see langword="null"/> or one of the metadata
+        /// identifiers is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentException">A metadata identifier is empty or contains invalid
+        /// characters (i.e. characters that are not ASCII alphanumerics or hyphens).</exception>
+        public SemVersion WithMetadata(string metadataIdentifier, params string[] metadataIdentifiers)
+        {
+            if (metadataIdentifier is null) throw new ArgumentNullException(nameof(metadataIdentifiers));
+            if (metadataIdentifiers is null) throw new ArgumentNullException(nameof(metadataIdentifiers));
+            var identifiers = metadataIdentifiers
+                              .Prepend(metadataIdentifier)
+                              .Select(i => new MetadataIdentifier(i, nameof(metadataIdentifiers)))
+                              .ToReadOnlyList();
+            return new SemVersion(Major, Minor, Patch,
+                Prerelease, PrereleaseIdentifiers, string.Join(".", identifiers), identifiers);
+        }
+
+        /// <summary>
+        /// Creates a copy of the current instance with different build metadata identifiers.
+        /// </summary>
+        /// <param name="metadataIdentifiers">The identifiers to replace the build metadata identifiers.</param>
+        /// <returns>The new version with the different build metadata identifiers.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="metadataIdentifiers"/> is
+        /// <see langword="null"/> or one of the metadata identifiers is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentException">A metadata identifier is empty or contains invalid
+        /// characters (i.e. characters that are not ASCII alphanumerics or hyphens).</exception>
+        public SemVersion WithMetadata(IEnumerable<string> metadataIdentifiers)
+        {
+            if (metadataIdentifiers is null) throw new ArgumentNullException(nameof(metadataIdentifiers));
+            var identifiers = metadataIdentifiers
+                              .Select(i => new MetadataIdentifier(i, nameof(metadataIdentifiers)))
+                              .ToReadOnlyList();
+            if (identifiers.Count == 0) return WithoutMetadata();
+            return new SemVersion(Major, Minor, Patch,
+                Prerelease, PrereleaseIdentifiers, string.Join(".", identifiers), identifiers);
+        }
+
+        /// <summary>
+        /// Creates a copy of the current instance with different build metadata identifiers.
+        /// </summary>
+        /// <param name="metadataIdentifier">The first identifier to replace the existing
+        /// build metadata identifiers.</param>
+        /// <param name="metadataIdentifiers">The rest of the identifiers to replace the
+        /// existing build metadata identifiers.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="metadataIdentifiers"/> is
+        /// <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentException">A metadata identifier has the default value.</exception>
+        public SemVersion WithMetadata(
+            MetadataIdentifier metadataIdentifier,
+            params MetadataIdentifier[] metadataIdentifiers)
+        {
+            if (metadataIdentifiers is null) throw new ArgumentNullException(nameof(metadataIdentifiers));
+            var identifiers = metadataIdentifiers.Prepend(metadataIdentifier).ToReadOnlyList();
+            if (identifiers.Any(i => i == default))
+                throw new ArgumentException(MetadataIdentifierIsDefaultMessage, nameof(metadataIdentifiers));
+            return new SemVersion(Major, Minor, Patch,
+                Prerelease, PrereleaseIdentifiers, string.Join(".", identifiers), identifiers);
+        }
+
+        /// <summary>
+        /// Creates a copy of the current instance with different build metadata identifiers.
+        /// </summary>
+        /// <param name="metadataIdentifiers">The identifiers to replace the build metadata identifiers.</param>
+        /// <returns>The new version with the different build metadata identifiers.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="metadataIdentifiers"/> is
+        /// <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentException">A metadata identifier has the default value.</exception>
+        public SemVersion WithMetadata(IEnumerable<MetadataIdentifier> metadataIdentifiers)
+        {
+            if (metadataIdentifiers is null) throw new ArgumentNullException(nameof(metadataIdentifiers));
+            var identifiers = metadataIdentifiers.ToReadOnlyList();
+            if (identifiers.Count == 0) return WithoutMetadata();
+            if (identifiers.Any(i => i == default))
+                throw new ArgumentException(MetadataIdentifierIsDefaultMessage, nameof(metadataIdentifiers));
+            return new SemVersion(Major, Minor, Patch,
+                Prerelease, PrereleaseIdentifiers, string.Join(".", identifiers), identifiers);
+        }
+
+        /// <summary>
+        /// Creates a copy of the current instance without build metadata.
+        /// </summary>
+        /// <returns>The new version without build metadata.</returns>
+        public SemVersion WithoutMetadata()
+        {
+            if (MetadataIdentifiers.Count == 0) return this;
+            return new SemVersion(Major, Minor, Patch,
+                Prerelease, PrereleaseIdentifiers, "", ReadOnlyList<MetadataIdentifier>.Empty);
+        }
+
+        /// <summary>
+        /// Creates a copy of the current instance without prerelease identifiers or build metadata.
+        /// </summary>
+        /// <returns>The new version without prerelease identifiers or build metadata.</returns>
+        public SemVersion WithoutPrereleaseOrMetadata()
+        {
+            if (!IsPrerelease && MetadataIdentifiers.Count == 0) return this;
+            return new SemVersion(Major, Minor, Patch,
+                "", ReadOnlyList<PrereleaseIdentifier>.Empty, "", ReadOnlyList<MetadataIdentifier>.Empty);
+        }
+        #endregion
+
+        /// <summary>The major version number.</summary>
+        /// <value>The major version number.</value>
+        /// <remarks>An increase in the major version number indicates a backwards
+        /// incompatible change.</remarks>
+        public int Major { get; }
+
+        /// <summary>The minor version number.</summary>
+        /// <value>The minor version number.</value>
+        /// <remarks>An increase in the minor version number indicates backwards
+        /// compatible changes.</remarks>
+        public int Minor { get; }
+
+        /// <summary>The patch version number.</summary>
+        /// <value>The patch version number.</value>
+        /// <remarks>An increase in the patch version number indicates backwards
+        /// compatible bug fixes.</remarks>
+        public int Patch { get; }
+
+        /// <summary>
+        /// The prerelease identifiers for this version.
+        /// </summary>
+        /// <value>
+        /// The prerelease identifiers for this version or empty string if this is a release version.
+        /// </value>
+        /// <include file='SemVersionDocParts.xml' path='docParts/part[@id="PrereleaseIdentifiers"]/*'/>
+        // TODO v3.0.0 this should be null when there is no prerelease identifiers
+        public string Prerelease { get; }
+
+        /// <summary>
+        /// The prerelease identifiers for this version.
+        /// </summary>
+        /// <value>
+        /// The prerelease identifiers for this version or empty if this is a release version.
+        /// </value>
+        /// <include file='SemVersionDocParts.xml' path='docParts/part[@id="PrereleaseIdentifiers"]/*'/>
+        public IReadOnlyList<PrereleaseIdentifier> PrereleaseIdentifiers { get; }
+
+        /// <summary>
+        /// Whether this is a prerelease version where the prerelease version is zero (i.e. "-0").
+        /// </summary>
+        internal bool PrereleaseIsZero
+            => PrereleaseIdentifiers.Count == 1
+               && PrereleaseIdentifiers[0] == PrereleaseIdentifier.Zero;
+
+        /// <summary>Whether this is a prerelease version.</summary>
+        /// <value>Whether this is a prerelease version. A semantic version with
+        /// prerelease identifiers is a prerelease version.</value>
+        /// <remarks>When this is <see langword="true"/>, the <see cref="Prerelease"/>
+        /// and <see cref="PrereleaseIdentifiers"/> properties are non-empty. When
+        /// this is <see langword="false"/>, the <see cref="Prerelease"/> property
+        /// will be an empty string and the <see cref="PrereleaseIdentifiers"/> will
+        /// be an empty collection.</remarks>
+        public bool IsPrerelease => Prerelease.Length != 0;
+
+        /// <summary>Whether this is a release version.</summary>
+        /// <value>Whether this is a release version. A semantic version without
+        /// prerelease identifiers is a release version.</value>
+        /// <remarks>When this is <see langword="true"/>, the <see cref="Prerelease"/>
+        /// property will be an empty string and the <see cref="PrereleaseIdentifiers"/>
+        /// will be an empty collection. When this is <see langword="false"/>,
+        /// the <see cref="Prerelease"/> and <see cref="PrereleaseIdentifiers"/>
+        /// properties are non-empty.</remarks>
+        public bool IsRelease => Prerelease.Length == 0;
+
+        /// <summary>The build metadata for this version.</summary>
+        /// <value>
+        /// The build metadata for this version or empty string if there is no build metadata.
+        /// </value>
+        /// <include file='SemVersionDocParts.xml' path='docParts/part[@id="MetadataIdentifiers"]/*'/>
+        [EditorBrowsable(EditorBrowsableState.Never), Obsolete("This property is obsolete. Use Metadata instead.")]
+        public string Build => Metadata;
+
+        /// <summary>The build metadata for this version.</summary>
+        /// <value>The build metadata for this version or empty string if there
+        /// is no metadata.</value>
+        /// <include file='SemVersionDocParts.xml' path='docParts/part[@id="MetadataIdentifiers"]/*'/>
+        // TODO v3.0.0 this should be null when there is no metadata
+        public string Metadata { get; }
+
+        /// <summary>The build metadata identifiers for this version.</summary>
+        /// <value>The build metadata identifiers for this version or empty if there
+        /// is no metadata.</value>
+        /// <include file='SemVersionDocParts.xml' path='docParts/part[@id="MetadataIdentifiers"]/*'/>
+        public IReadOnlyList<MetadataIdentifier> MetadataIdentifiers { get; }
+
+        /// <summary>
+        /// Converts this version to an equivalent string value.
+        /// </summary>
+        /// <returns>
+        /// The <see cref="string" /> equivalent of this version.
+        /// </returns>
+        public override string ToString()
+        {
+            // Assume all separators ("..-+"), at most 2 extra chars
+            var estimatedLength = 4 + Major.DecimalDigits()
+                                    + Minor.DecimalDigits()
+                                    + Patch.DecimalDigits()
+                                    + Prerelease.Length + Metadata.Length;
+            var version = new StringBuilder(estimatedLength);
+            version.Append(Major);
+            version.Append('.');
+            version.Append(Minor);
+            version.Append('.');
+            version.Append(Patch);
+            if (Prerelease.Length > 0)
+            {
+                version.Append('-');
+                version.Append(Prerelease);
+            }
+            if (Metadata.Length > 0)
+            {
+                version.Append('+');
+                version.Append(Metadata);
+            }
+            return version.ToString();
+        }
+
+        #region Equality
+        /// <summary>
+        /// Determines whether two semantic versions are equal.
+        /// </summary>
+        /// <returns><see langword="true"/> if the two versions are equal, otherwise <see langword="false"/>.</returns>
+        /// <remarks>Two versions are equal if every part of the version numbers are equal. Thus two
+        /// versions with the same precedence may not be equal.</remarks>
+        // TODO v3.0.0 rename parameters to `left` and `right` to be consistent with ComparePrecedence etc.
+        public static bool Equals(SemVersion versionA, SemVersion versionB)
+        {
+            if (ReferenceEquals(versionA, versionB)) return true;
+            if (versionA is null || versionB is null) return false;
+            return versionA.Equals(versionB);
+        }
+
+        /// <summary>Determines whether the given object is equal to this version.</summary>
+        /// <returns><see langword="true"/> if <paramref name="obj"/> is equal to the this version;
+        /// otherwise <see langword="false"/>.</returns>
+        /// <remarks>Two versions are equal if every part of the version numbers are equal. Thus two
+        /// versions with the same precedence may not be equal.</remarks>
+        public override bool Equals(object obj)
+            => obj is SemVersion version && Equals(version);
+
+        /// <summary>
+        /// Determines whether two semantic versions are equal.
+        /// </summary>
+        /// <returns><see langword="true"/> if <paramref name="other"/> is equal to the this version;
+        /// otherwise <see langword="false"/>.</returns>
+        /// <remarks>Two versions are equal if every part of the version numbers are equal. Thus two
+        /// versions with the same precedence may not be equal.</remarks>
+        public bool Equals(SemVersion other)
+        {
+            if (other is null)
+                return false;
+
+            if (ReferenceEquals(this, other))
+                return true;
+
+            return Major == other.Major
+                && Minor == other.Minor
+                && Patch == other.Patch
+                && string.Equals(Prerelease, other.Prerelease, StringComparison.Ordinal)
+                && string.Equals(Metadata, other.Metadata, StringComparison.Ordinal);
+        }
+
+        /// <summary>
+        /// Determines whether two semantic versions have the same precedence. Versions that differ
+        /// only by build metadata have the same precedence.
+        /// </summary>
+        /// <param name="other">The semantic version to compare to.</param>
+        /// <returns><see langword="true"/> if the version precedences are equal, otherwise
+        /// <see langword="false"/>.</returns>
+        public bool PrecedenceEquals(SemVersion other)
+            => PrecedenceComparer.Compare(this, other) == 0;
+
+        /// <summary>
+        /// Determines whether two semantic versions have the same precedence. Versions that differ
+        /// only by build metadata have the same precedence.
+        /// </summary>
+        /// <returns><see langword="true"/> if the version precedences are equal, otherwise
+        /// <see langword="false"/>.</returns>
+        public static bool PrecedenceEquals(SemVersion left, SemVersion right)
+            => PrecedenceComparer.Compare(left, right) == 0;
+
+        internal bool MajorMinorPatchEquals(SemVersion other)
+        {
+            if (other is null) return false;
+
+            if (ReferenceEquals(this, other)) return true;
+
+            return Major == other.Major
+                   && Minor == other.Minor
+                   && Patch == other.Patch;
+        }
+
+        /// <summary>
+        /// Determines whether two semantic versions have the same precedence. Versions
+        /// that differ only by build metadata have the same precedence.
+        /// </summary>
+        /// <param name="other">The semantic version to compare to.</param>
+        /// <returns><see langword="true"/> if the version precedences are equal.</returns>
+        [EditorBrowsable(EditorBrowsableState.Never), Obsolete("Method is obsolete. Use PrecedenceEquals() instead.")]
+        public bool PrecedenceMatches(SemVersion other) => CompareByPrecedence(other) == 0;
+
+        /// <summary>
+        /// Gets a hash code for this instance.
+        /// </summary>
+        /// <returns>
+        /// A hash code for this instance, suitable for use in hashing algorithms
+        /// and data structures like a hash table.
+        /// </returns>
+        /// <remarks>Two versions are equal if every part of the version numbers are equal. Thus two
+        /// versions with the same precedence may not have the same hash code.</remarks>
+        public override int GetHashCode()
+            => CombinedHashCode.Create(Major, Minor, Patch, Prerelease, Metadata);
+
+        /// <summary>
+        /// Determines whether two semantic versions are equal.
+        /// </summary>
+        /// <returns><see langword="true"/> if the two versions are equal, otherwise <see langword="false"/>.</returns>
+        /// <remarks>Two versions are equal if every part of the version numbers are equal. Thus two
+        /// versions with the same precedence may not be equal.</remarks>
+        public static bool operator ==(SemVersion left, SemVersion right) => Equals(left, right);
+
+        /// <summary>
+        /// Determines whether two semantic versions are <em>not</em> equal.
+        /// </summary>
+        /// <returns><see langword="true"/> if the two versions are <em>not</em> equal, otherwise <see langword="false"/>.</returns>
+        /// <remarks>Two versions are equal if every part of the version numbers are equal. Thus two
+        /// versions with the same precedence may not be equal.</remarks>
+        public static bool operator !=(SemVersion left, SemVersion right) => !Equals(left, right);
+        #endregion
+
+        #region Comparison
+        /// <summary>
+        /// An <see cref="IEqualityComparer{T}"/> and <see cref="IComparer{T}"/>
+        /// that compares <see cref="SemVersion"/> by precedence. This can be used for sorting,
+        /// binary search, and using <see cref="SemVersion"/> as a dictionary key.
+        /// </summary>
+        /// <value>A precedence comparer that implements <see cref="IEqualityComparer{T}"/> and
+        /// <see cref="IComparer{T}"/> for <see cref="SemVersion"/>.</value>
+        /// <include file='SemVersionDocParts.xml' path='docParts/part[@id="PrecedenceOrder"]/*'/>
+        public static ISemVersionComparer PrecedenceComparer { get; } = Comparers.PrecedenceComparer.Instance;
+
+        /// <summary>
+        /// An <see cref="IEqualityComparer{T}"/> and <see cref="IComparer{T}"/>
+        /// that compares <see cref="SemVersion"/> by sort order. This can be used for sorting,
+        /// binary search, and using <see cref="SemVersion"/> as a dictionary key.
+        /// </summary>
+        /// <value>A sort order comparer that implements <see cref="IEqualityComparer{T}"/> and
+        /// <see cref="IComparer{T}"/> for <see cref="SemVersion"/>.</value>
+        /// <include file='SemVersionDocParts.xml' path='docParts/part[@id="SortOrder"]/*'/>
+        public static ISemVersionComparer SortOrderComparer { get; } = Comparers.SortOrderComparer.Instance;
+
+        /// <summary>
+        /// Compares two versions and indicates whether this instance precedes, follows, or is in the same
+        /// position as the other in the precedence order. Versions that differ only by build metadata
+        /// have the same precedence.
+        /// </summary>
+        /// <returns>
+        /// An integer that indicates whether this instance precedes, follows, or is in the same
+        /// position as <paramref name="other"/> in the precedence order.
+        /// <list type="table">
+        ///     <listheader>
+        ///         <term>Value</term>
+        ///         <description>Condition</description>
+        ///     </listheader>
+        ///     <item>
+        ///         <term>-1</term>
+        ///         <description>This instance precedes <paramref name="other"/> in the precedence order.</description>
+        ///     </item>
+        ///     <item>
+        ///         <term>0</term>
+        ///         <description>This instance has the same precedence as <paramref name="other"/>.</description>
+        ///     </item>
+        ///     <item>
+        ///         <term>1</term>
+        ///         <description>
+        ///             This instance follows <paramref name="other"/> in the precedence order
+        ///             or <paramref name="other"/> is <see langword="null" />.
+        ///         </description>
+        ///     </item>
+        /// </list>
+        /// </returns>
+        /// <include file='SemVersionDocParts.xml' path='docParts/part[@id="PrecedenceOrder"]/*'/>
+        public int ComparePrecedenceTo(SemVersion other) => PrecedenceComparer.Compare(this, other);
+
+        /// <summary>
+        /// Compares two versions and indicates whether this instance precedes, follows, or is equal
+        /// to the other in the sort order. Note that sort order is more specific than precedence order.
+        /// </summary>
+        /// <returns>
+        /// An integer that indicates whether this instance precedes, follows, or is equal to the
+        /// other in the sort order.
+        /// <list type="table">
+        /// 	<listheader>
+        /// 		<term>Value</term>
+        /// 		<description>Condition</description>
+        /// 	</listheader>
+        /// 	<item>
+        /// 		<term>-1</term>
+        /// 		<description>This instance precedes the other in the sort order.</description>
+        /// 	</item>
+        /// 	<item>
+        /// 		<term>0</term>
+        /// 		<description>This instance is equal to the other.</description>
+        /// 	</item>
+        /// 	<item>
+        /// 		<term>1</term>
+        /// 		<description>
+        /// 			This instance follows the other in the sort order
+        /// 			or the other is <see langword="null" />.
+        /// 		</description>
+        /// 	</item>
+        /// </list>
+        /// </returns>
+        /// <include file='SemVersionDocParts.xml' path='docParts/part[@id="SortOrder"]/*'/>
+        public int CompareSortOrderTo(SemVersion other) => SortOrderComparer.Compare(this, other);
+
+        /// <summary>
+        /// Compares two versions and indicates whether the first precedes, follows, or is in the same
+        /// position as the second in the precedence order. Versions that differ only by build metadata
+        /// have the same precedence.
+        /// </summary>
+        /// <returns>
+        /// An integer that indicates whether <paramref name="left"/> precedes, follows, or is in the same
+        /// position as <paramref name="right"/> in the precedence order.
+        /// <list type="table">
+        ///     <listheader>
+        ///         <term>Value</term>
+        ///         <description>Condition</description>
+        ///     </listheader>
+        ///     <item>
+        ///         <term>-1</term>
+        ///         <description>
+        ///             <paramref name="left"/> precedes <paramref name="right"/> in the precedence
+        ///             order or <paramref name="left"/> is <see langword="null" />.</description>
+        ///     </item>
+        ///     <item>
+        ///         <term>0</term>
+        ///         <description><paramref name="left"/> has the same precedence as <paramref name="right"/>.</description>
+        ///     </item>
+        ///     <item>
+        ///         <term>1</term>
+        ///         <description>
+        ///             <paramref name="left"/> follows <paramref name="right"/> in the precedence order
+        ///             or <paramref name="right"/> is <see langword="null" />.
+        ///         </description>
+        ///     </item>
+        /// </list>
+        /// </returns>
+        /// <include file='SemVersionDocParts.xml' path='docParts/part[@id="PrecedenceOrder"]/*'/>
+        public static int ComparePrecedence(SemVersion left, SemVersion right)
+            => PrecedenceComparer.Compare(left, right);
+
+        /// <summary>
+        /// Compares two versions and indicates whether the first precedes, follows, or is equal to
+        /// the second in the sort order. Note that sort order is more specific than precedence order.
+        /// </summary>
+        /// <returns>
+        /// An integer that indicates whether <paramref name="left"/> precedes, follows, or is equal
+        /// to <paramref name="right"/> in the sort order.
+        /// <list type="table">
+        ///     <listheader>
+        ///         <term>Value</term>
+        ///         <description>Condition</description>
+        ///     </listheader>
+        ///     <item>
+        ///         <term>-1</term>
+        ///         <description>
+        ///             <paramref name="left"/> precedes <paramref name="right"/> in the sort
+        ///             order or <paramref name="left"/> is <see langword="null" />.</description>
+        ///     </item>
+        ///     <item>
+        ///         <term>0</term>
+        ///         <description><paramref name="left"/> is equal to <paramref name="right"/>.</description>
+        ///     </item>
+        ///     <item>
+        ///         <term>1</term>
+        ///         <description>
+        ///             <paramref name="left"/> follows <paramref name="right"/> in the sort order
+        ///             or <paramref name="right"/> is <see langword="null" />.
+        ///         </description>
+        ///     </item>
+        /// </list>
+        /// </returns>
+        /// <include file='SemVersionDocParts.xml' path='docParts/part[@id="SortOrder"]/*'/>
+        public static int CompareSortOrder(SemVersion left, SemVersion right)
+            => SortOrderComparer.Compare(left, right);
+
+        /// <summary>
+        /// Compares this version to an <see cref="Object"/> and indicates whether this instance
+        /// precedes, follows, or is equal to the object in the sort order. Note that sort order
+        /// is more specific than precedence order.
+        /// </summary>
+        /// <include file='SemVersionDocParts.xml' path='docParts/part[@id="CompareToReturns"]/*'/>
+        /// <exception cref="InvalidCastException">The <paramref name="obj"/> is not a <see cref="SemVersion"/>.</exception>
+        /// <include file='SemVersionDocParts.xml' path='docParts/part[@id="SortOrder"]/*'/>
+        [EditorBrowsable(EditorBrowsableState.Never), Obsolete("Method is obsolete. Use CompareSortOrderTo() or ComparePrecedenceTo() instead.")]
+        public int CompareTo(object obj) => CompareTo((SemVersion)obj);
+
+        /// <summary>
+        /// Compares two versions and indicates whether this instance precedes, follows, or is
+        /// equal to the other in the sort order. Note that sort order is more specific than precedence order.
+        /// </summary>
+        /// <include file='SemVersionDocParts.xml' path='docParts/part[@id="CompareToReturns"]/*'/>
+        /// <include file='SemVersionDocParts.xml' path='docParts/part[@id="SortOrder"]/*'/>
+        [EditorBrowsable(EditorBrowsableState.Never), Obsolete("Method is obsolete. Use CompareSortOrderTo() or ComparePrecedenceTo() instead.")]
+        public int CompareTo(SemVersion other)
+        {
+            var r = CompareByPrecedence(other);
+            if (r != 0) return r;
+
+            // If other is null, CompareByPrecedence() returns 1
+            return CompareComponents(Metadata, other.Metadata);
+        }
+
+        /// <summary>
+        /// Compares two versions and indicates whether this instance precedes, follows, or is in the same
+        /// position as the other in the precedence order. Versions that differ only by build metadata
+        /// have the same precedence.
+        /// </summary>
+        /// <returns>
+        /// An integer that indicates whether this instance precedes, follows, or is in the same
+        /// position as <paramref name="other"/> in the precedence order.
+        /// <list type="table">
+        ///     <listheader>
+        ///         <term>Value</term>
+        ///         <description>Condition</description>
+        ///     </listheader>
+        ///     <item>
+        ///         <term>Less than zero</term>
+        ///         <description>This instance precedes <paramref name="other"/> in the precedence order.</description>
+        ///     </item>
+        ///     <item>
+        ///         <term>Zero</term>
+        ///         <description>This instance has the same precedence as <paramref name="other"/>.</description>
+        ///     </item>
+        ///     <item>
+        ///         <term>Greater than zero</term>
+        ///         <description>
+        ///             This instance follows <paramref name="other"/> in the precedence order
+        ///             or <paramref name="other"/> is <see langword="null" />.
+        ///         </description>
+        ///     </item>
+        /// </list>
+        /// </returns>
+        /// <remarks>
+        /// <para>Precedence order is determined by comparing the major, minor, patch, and prerelease
+        /// portion in order from left to right. Versions that differ only by build metadata have the
+        /// same precedence. The major, minor, and patch version numbers are compared numerically. A
+        /// prerelease version precedes a release version.</para>
+        ///
+        /// <para>The prerelease portion is compared by comparing each prerelease identifier from
+        /// left to right. Numeric prerelease identifiers precede alphanumeric identifiers. Numeric
+        /// identifiers are compared numerically. Alphanumeric identifiers are compared lexically
+        /// in ASCII sort order. A longer series of prerelease identifiers follows a shorter series
+        /// if all the preceding identifiers are equal.</para>
+        /// </remarks>
+        [EditorBrowsable(EditorBrowsableState.Never), Obsolete("Method is obsolete. Use ComparePrecedenceTo() or CompareSortOrderTo() instead.")]
+        public int CompareByPrecedence(SemVersion other)
+        {
+            if (other is null)
+                return 1;
+
+            var r = Major.CompareTo(other.Major);
+            if (r != 0) return r;
+
+            r = Minor.CompareTo(other.Minor);
+            if (r != 0) return r;
+
+            r = Patch.CompareTo(other.Patch);
+            if (r != 0) return r;
+
+            return CompareComponents(Prerelease, other.Prerelease, true);
+        }
+
+        [EditorBrowsable(EditorBrowsableState.Never), Obsolete]
+        private static int CompareComponents(string a, string b, bool nonEmptyIsLower = false)
+        {
+            var aEmpty = string.IsNullOrEmpty(a);
+            var bEmpty = string.IsNullOrEmpty(b);
+            if (aEmpty && bEmpty)
+                return 0;
+
+            if (aEmpty)
+                return nonEmptyIsLower ? 1 : -1;
+            if (bEmpty)
+                return nonEmptyIsLower ? -1 : 1;
+
+            var aComps = a.Split('.');
+            var bComps = b.Split('.');
+
+            var minLen = Math.Min(aComps.Length, bComps.Length);
+            for (int i = 0; i < minLen; i++)
+            {
+                var ac = aComps[i];
+                var bc = bComps[i];
+                var aIsNum = int.TryParse(ac, out var aNum);
+                var bIsNum = int.TryParse(bc, out var bNum);
+                int r;
+                if (aIsNum && bIsNum)
+                {
+                    r = aNum.CompareTo(bNum);
+                    if (r != 0) return r;
+                }
+                else
+                {
+                    if (aIsNum)
+                        return -1;
+                    if (bIsNum)
+                        return 1;
+                    r = string.CompareOrdinal(ac, bc);
+                    if (r != 0)
+                        return r;
+                }
+            }
+
+            return aComps.Length.CompareTo(bComps.Length);
+        }
+
+        /// <summary>
+        /// Compares two versions by sort order. Note that sort order is more specific than precedence order.
+        /// </summary>
+        /// <returns><see langword="true"/> if <paramref name="left"/> follows <paramref name="right"/>
+        /// in the sort order; otherwise <see langword="false"/>.</returns>
+        /// <include file='SemVersionDocParts.xml' path='docParts/part[@id="SortOrder"]/*'/>
+        [EditorBrowsable(EditorBrowsableState.Never), Obsolete("Operator is obsolete. Use CompareSortOrder() or ComparePrecedence() instead.")]
+        public static bool operator >(SemVersion left, SemVersion right)
+            => Compare(left, right) > 0;
+
+        /// <summary>
+        /// Compares two versions by sort order. Note that sort order is more specific than precedence order.
+        /// </summary>
+        /// <returns><see langword="true"/> if <paramref name="left"/> follows or is equal to
+        /// <paramref name="right"/> in the sort order; otherwise <see langword="false"/>.</returns>
+        /// <include file='SemVersionDocParts.xml' path='docParts/part[@id="SortOrder"]/*'/>
+        [EditorBrowsable(EditorBrowsableState.Never), Obsolete("Operator is obsolete. Use CompareSortOrder() or ComparePrecedence() instead.")]
+        public static bool operator >=(SemVersion left, SemVersion right)
+            => Equals(left, right) || Compare(left, right) > 0;
+
+        /// <summary>
+        /// Compares two versions by sort order. Note that sort order is more specific than precedence order.
+        /// </summary>
+        /// <returns><see langword="true"/> if <paramref name="left"/> precedes <paramref name="right"/>
+        /// in the sort order; otherwise <see langword="false"/>.</returns>
+        /// <include file='SemVersionDocParts.xml' path='docParts/part[@id="SortOrder"]/*'/>
+        [EditorBrowsable(EditorBrowsableState.Never), Obsolete("Operator is obsolete. Use CompareSortOrder() or ComparePrecedence() instead.")]
+        public static bool operator <(SemVersion left, SemVersion right)
+            => Compare(left, right) < 0;
+
+        /// <summary>
+        /// Compares two versions by sort order. Note that sort order is more specific than precedence order.
+        /// </summary>
+        /// <returns><see langword="true"/> if <paramref name="left"/> precedes or is equal to
+        /// <paramref name="right"/> in the sort order; otherwise <see langword="false"/>.</returns>
+        /// <include file='SemVersionDocParts.xml' path='docParts/part[@id="SortOrder"]/*'/>
+        [EditorBrowsable(EditorBrowsableState.Never), Obsolete("Operator is obsolete. Use CompareSortOrder() or ComparePrecedence() instead.")]
+        public static bool operator <=(SemVersion left, SemVersion right)
+            => Equals(left, right) || Compare(left, right) < 0;
+        #endregion
+
+        /// <summary>
+        /// Implicit conversion from <see cref="string"/> to <see cref="SemVersion"/>.
+        /// </summary>
+        /// <param name="version">The semantic version.</param>
+        /// <returns>The <see cref="SemVersion"/> object.</returns>
+        /// <exception cref="ArgumentNullException">The <paramref name="version"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentException">The version number has an invalid format.</exception>
+        /// <exception cref="OverflowException">The major, minor, or patch version number is larger than <see cref="int.MaxValue"/>.</exception>
+        [EditorBrowsable(EditorBrowsableState.Never), Obsolete("Implicit conversion from string is obsolete. Use Parse() or TryParse() method instead.")]
+        public static implicit operator SemVersion(string version)
+            => Parse(version);
+    }
+}

--- a/dotnet/Surge.NET/Semver/SemVersionDocParts.xml
+++ b/dotnet/Surge.NET/Semver/SemVersionDocParts.xml
@@ -1,0 +1,89 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<docParts>
+    <part id="CompareToReturns">
+        <returns>
+            An integer that indicates whether this instance precedes, follows, or is equal to
+            the other in the sort order.
+            <list type="table">
+                <listheader>
+                    <term>Value</term>
+                    <description>Condition</description>
+                </listheader>
+                <item>
+                    <term>Less than zero</term>
+                    <description>This instance precedes the other in the sort order.</description>
+                </item>
+                <item>
+                    <term>Zero</term>
+                    <description>This instance is equal to the other.</description>
+                </item>
+                <item>
+                    <term>Greater than zero</term>
+                    <description>
+                        This instance follows the other in the sort order
+                        or the other is <see langword="null" />.
+                    </description>
+                </item>
+            </list>
+        </returns>
+    </part>
+    <part id="MetadataIdentifiers">
+        <remarks>
+            <para>The build metadata is a series of dot separated identifiers separated from the
+            rest of the version number with a plus sign ('<c>+</c>'). Valid metadata identifiers are
+            non-empty and consist of ASCII alphanumeric characters and hyphens (<c>[0-9A-Za-z-]</c>).</para>
+
+            <para>The metadata does not affect precedence. Two version numbers differing only in
+            build metadata have the same precedence. However, metadata does affect sort order. An
+            otherwise identical version without metadata sorts before one that has metadata.</para>
+        </remarks>
+    </part>
+    <part id="PrereleaseIdentifiers">
+        <remarks>
+            <para>A prerelease version is denoted by appending a hyphen ('<c>-</c>') and a series
+            of dot separated identifiers immediately following the patch version number. Each
+            prerelease identifier may be numeric or alphanumeric. Valid numeric identifiers consist
+            of ASCII digits (<c>[0-9]</c>) without leading zeros. Valid alphanumeric identifiers are
+            non-empty strings of ASCII alphanumeric and hyphen characters (<c>[0-9A-Za-z-]</c>) with
+            at least one non-digit character.</para>
+
+            <para>Prerelease versions have lower precedence than release versions. Prerelease
+            version precedence is determined by comparing each prerelease identifier in order from
+            left to right. Numeric identifiers have lower precedence than alphanumeric identifiers.
+            Numeric identifiers are compared numerically. Alphanumeric identifiers are compared
+            lexically in ASCII sort order.</para>
+        </remarks>
+    </part>
+    <part id="PrecedenceOrder">
+        <remarks>
+            <para>Precedence order is determined by comparing the major, minor, patch, and prerelease
+            portion in order from left to right. Versions that differ only by build metadata have the
+            same precedence. The major, minor, and patch version numbers are compared numerically. A
+            prerelease version precedes a release version.</para>
+
+            <para>The prerelease portion is compared by comparing each prerelease identifier from
+            left to right. Numeric prerelease identifiers precede alphanumeric identifiers. Numeric
+            identifiers are compared numerically. Alphanumeric identifiers are compared lexically
+            in ASCII sort order. A longer series of prerelease identifiers follows a shorter series
+            if all the preceding identifiers are equal.</para>
+        </remarks>
+    </part>
+    <part id="SortOrder">
+        <remarks>
+            <para>Sort order is consistent with precedence order, but provides an order for versions
+            with the same precedence. Sort order is determined by comparing the major, minor,
+            patch, prerelease portion, and build metadata in order from left to right. The major,
+            minor, and patch version numbers are compared numerically. A prerelease version precedes
+            a release version.</para>
+            <para>The prerelease portion is compared by comparing each prerelease identifier from
+            left to right. Numeric prerelease identifiers precede alphanumeric identifiers. Numeric
+            identifiers are compared numerically. Alphanumeric identifiers are compared lexically
+            in ASCII sort order. A longer series of prerelease identifiers follows a shorter series
+            if all the preceding identifiers are equal.</para>
+            <para>Otherwise equal versions without build metadata precede those with metadata. The
+            build metadata is compared by comparing each metadata identifier. Identifiers are
+            compared lexically in ASCII sort order. A longer series of metadata identifiers follows
+            a shorter series if all the preceding identifiers are equal.</para>
+        </remarks>
+    </part>
+</docParts>

--- a/dotnet/Surge.NET/Semver/SemVersionStyles.cs
+++ b/dotnet/Surge.NET/Semver/SemVersionStyles.cs
@@ -1,0 +1,82 @@
+#nullable disable
+#pragma warning disable
+using System;
+
+namespace Semver
+{
+    /// <summary>
+    /// <para>Determines the styles that are allowed in version strings passed to the
+    /// <see cref="SemVersion.Parse(string,SemVersionStyles,int)"/> and
+    /// <see cref="SemVersion.TryParse(string,SemVersionStyles,out SemVersion,int)"/>
+    /// methods. These styles only affect which strings are accepted when parsing. The
+    /// constructed version numbers are valid semantic versions without any of the
+    /// optional features in the original string.</para>
+    ///
+    /// <para>This enumeration supports a bitwise combination of its member values (e.g.
+    /// <c>SemVersionStyles.AllowWhitespace | SemVersionStyles.AllowV</c>).</para>
+    /// </summary>
+    [Flags]
+    public enum SemVersionStyles
+    {
+        /// <summary>
+        /// Accept version strings strictly conforming to the SemVer 2.0 spec.
+        /// </summary>
+        Strict = 0,
+
+        /// <summary>
+        /// <para>Allow leading zeros on major, minor, patch, and prerelease version numbers.</para>
+        ///
+        /// <para>Leading zeros will be removed from the constructed version number.</para>
+        /// </summary>
+        AllowLeadingZeros = 1,
+
+        /// <summary>
+        /// Allow leading whitespace. When combined with leading "v", the whitespace
+        /// must come before the "v".
+        /// </summary>
+        AllowLeadingWhitespace = 1 << 1,
+
+        /// <summary>
+        /// Allow trailing whitespace.
+        /// </summary>
+        AllowTrailingWhitespace = 1 << 2,
+
+        /// <summary>
+        /// Allow leading and/or trailing whitespace. When combined with leading "v",
+        /// the leading whitespace must come before the "v".
+        /// </summary>
+        AllowWhitespace = AllowLeadingWhitespace | AllowTrailingWhitespace,
+
+        /// <summary>
+        /// Allow a leading lowercase "v".
+        /// </summary>
+        AllowLowerV = 1 << 3,
+
+        /// <summary>
+        /// Allow a leading uppercase "V".
+        /// </summary>
+        AllowUpperV = 1 << 4,
+
+        /// <summary>
+        /// Allow a leading "v" or "V".
+        /// </summary>
+        AllowV = AllowLowerV | AllowUpperV,
+
+        /// <summary>
+        /// Patch version number is optional.
+        /// </summary>
+        OptionalPatch = 1 << 5,
+
+        /// <summary>
+        /// Minor and patch version numbers are optional.
+        /// </summary>
+        OptionalMinorPatch = 1 << 6 | OptionalPatch,
+
+        /// <summary>
+        /// <para>Accept any version string format supported.</para>
+        ///
+        /// <para>The formats accepted by this style will change if/when more formats are supported.</para>
+        /// </summary>
+        Any = unchecked((int)0xFFFF_FFFF),
+    }
+}

--- a/dotnet/Surge.NET/Semver/SemVersionStylesExtensions.cs
+++ b/dotnet/Surge.NET/Semver/SemVersionStylesExtensions.cs
@@ -1,0 +1,42 @@
+#nullable disable
+#pragma warning disable
+using System;
+using System.Runtime.CompilerServices;
+using static Semver.SemVersionStyles;
+
+namespace Semver
+{
+    internal static class SemVersionStylesExtensions
+    {
+        internal const SemVersionStyles AllowAll = AllowLeadingZeros
+                                                 | AllowLeadingWhitespace
+                                                 | AllowTrailingWhitespace
+                                                 | AllowWhitespace
+                                                 | AllowLowerV
+                                                 | AllowUpperV
+                                                 | AllowV
+                                                 | OptionalPatch
+                                                 | OptionalMinorPatch;
+        private const SemVersionStyles OptionalMinorWithoutPatch = OptionalMinorPatch & ~OptionalPatch;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool IsValid(this SemVersionStyles styles)
+        {
+            // Either it is the Any style
+            if (styles == Any) return true;
+
+            // Or it is some combination of the flags
+            return (styles & AllowAll) == styles
+                // Except for a flag for optional minor without optional patch
+                && (styles & OptionalMinorPatch) != OptionalMinorWithoutPatch;
+        }
+
+        /// <summary>
+        /// The <see cref="Enum.HasFlag"/> method is surprisingly slow. This provides
+        /// a fast alternative for the <see cref="SemVersionStyles"/> enum.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool HasStyle(this SemVersionStyles styles, SemVersionStyles flag)
+            => (styles & flag) == flag;
+    }
+}

--- a/dotnet/Surge.NET/Semver/Utility/CharExtensions.cs
+++ b/dotnet/Surge.NET/Semver/Utility/CharExtensions.cs
@@ -1,0 +1,22 @@
+#nullable disable
+#pragma warning disable
+using System.Runtime.CompilerServices;
+
+namespace Semver.Utility
+{
+    internal static class CharExtensions
+    {
+        /// <summary>
+        /// Is this character an ASCII digit '0' through '9'
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool IsDigit(this char c) => c >= '0' && c <= '9';
+
+        /// <summary>
+        /// Is this character and ASCII alphabetic character or hyphen [A-Za-z-]
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool IsAlphaOrHyphen(this char c)
+            => (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || c == '-';
+    }
+}

--- a/dotnet/Surge.NET/Semver/Utility/CombinedHashCode.cs
+++ b/dotnet/Surge.NET/Semver/Utility/CombinedHashCode.cs
@@ -1,0 +1,116 @@
+#nullable disable
+#pragma warning disable
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace Semver.Utility
+{
+    /// <summary>
+    /// Combine hash codes in a good way since <c>System.HashCode</c> isn't available.
+    /// </summary>
+    /// <remarks>Algorithm based on HashHelpers previously used in the core CLR.
+    /// https://github.com/dotnet/coreclr/blob/456afea9fbe721e57986a21eb3b4bb1c9c7e4c56/src/System.Private.CoreLib/shared/System/Numerics/Hashing/HashHelpers.cs
+    /// </remarks>
+    [StructLayout(LayoutKind.Auto)]
+    internal struct CombinedHashCode
+    {
+        private static readonly int RandomSeed = new Random().Next(int.MinValue, int.MaxValue);
+
+        #region Create Methods
+        public static CombinedHashCode Create<T1>(T1 value1)
+            => new CombinedHashCode(CombineValue(RandomSeed, value1));
+
+        public static CombinedHashCode Create<T1, T2>(T1 value1, T2 value2)
+        {
+            var hash = RandomSeed;
+            hash = CombineValue(hash, value1);
+            hash = CombineValue(hash, value2);
+            return new CombinedHashCode(hash);
+        }
+
+        public static CombinedHashCode Create<T1, T2, T3>(T1 value1, T2 value2, T3 value3)
+        {
+            var hash = RandomSeed;
+            hash = CombineValue(hash, value1);
+            hash = CombineValue(hash, value2);
+            hash = CombineValue(hash, value3);
+            return new CombinedHashCode(hash);
+        }
+
+        public static CombinedHashCode Create<T1, T2, T3, T4>(T1 value1, T2 value2, T3 value3, T4 value4)
+        {
+            var hash = RandomSeed;
+            hash = CombineValue(hash, value1);
+            hash = CombineValue(hash, value2);
+            hash = CombineValue(hash, value3);
+            hash = CombineValue(hash, value4);
+            return new CombinedHashCode(hash);
+        }
+
+        public static CombinedHashCode Create<T1, T2, T3, T4, T5>(T1 value1, T2 value2, T3 value3, T4 value4, T5 value5)
+        {
+            var hash = RandomSeed;
+            hash = CombineValue(hash, value1);
+            hash = CombineValue(hash, value2);
+            hash = CombineValue(hash, value3);
+            hash = CombineValue(hash, value4);
+            hash = CombineValue(hash, value5);
+            return new CombinedHashCode(hash);
+        }
+
+        public static CombinedHashCode CreateForItems<T>(IEnumerable<T> values)
+        {
+            var hash = RandomSeed;
+            foreach (var value in values)
+                hash = CombineValue(hash, value);
+
+            return new CombinedHashCode(hash);
+        }
+        #endregion
+
+#if DEBUG
+        private static readonly string UninitializedMessage = $"DEBUG: Uninitiated {nameof(CombinedHashCode)}.";
+        private readonly bool initialized;
+#endif
+        private int hash;
+
+        private CombinedHashCode(int hash)
+        {
+#if DEBUG
+            initialized = true;
+#endif
+            this.hash = hash;
+        }
+
+        public void Add<T>(T value)
+        {
+#if DEBUG
+            if (!initialized) throw new InvalidOperationException(UninitializedMessage);
+#endif
+            hash = CombineValue(hash, value);
+        }
+
+        public static implicit operator int(CombinedHashCode hashCode)
+        {
+#if DEBUG
+            if (!hashCode.initialized) throw new InvalidOperationException(UninitializedMessage);
+#endif
+            return hashCode.hash;
+        }
+
+        [EditorBrowsable(EditorBrowsableState.Never), Obsolete("HashCode is a mutable struct and should not be compared with other HashCodes. Use ToHashCode to retrieve the computed hash code.", true)]
+#pragma warning disable CS0809 // Obsolete member overrides non-obsolete member
+        public override int GetHashCode() => throw new NotSupportedException();
+#pragma warning restore CS0809 // Obsolete member overrides non-obsolete member
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static int CombineValue<T>(int hash1, T value)
+        {
+            uint rotateLeft5 = ((uint)hash1 << 5) | ((uint)hash1 >> 27);
+            return ((int)rotateLeft5 + hash1) ^ (value?.GetHashCode() ?? 0);
+        }
+    }
+}

--- a/dotnet/Surge.NET/Semver/Utility/DebugChecks.cs
+++ b/dotnet/Surge.NET/Semver/Utility/DebugChecks.cs
@@ -1,0 +1,104 @@
+#nullable disable
+#pragma warning disable
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using Semver.Parsing;
+
+namespace Semver.Utility
+{
+    /// <summary>
+    /// The <see cref="DebugChecks"/> class allows for the various conditional checks done only in
+    /// debug builds to not count against the code coverage metrics.
+    /// </summary>
+    /// <remarks>When using a preprocessor conditional block, the contained lines are not covered by
+    /// the unit tests (see example below). This is expected because the conditions should not be
+    /// reachable. But it makes it difficult to evaluate at a glance whether full code coverage has
+    /// been reached.
+    /// <code>
+    /// #if DEBUG
+    ///     if(condition) throw new Exception("...");
+    /// #endif
+    /// </code>
+    /// </remarks>
+    [ExcludeFromCodeCoverage]
+    internal static class DebugChecks
+    {
+        [Conditional("DEBUG")]
+        public static void IsValid(SemVersionStyles style, string paramName)
+        {
+            if (!style.IsValid())
+                throw new ArgumentException("DEBUG: " + SemVersion.InvalidSemVersionStylesMessage, paramName);
+        }
+
+        [Conditional("DEBUG")]
+        public static void IsValidMaxLength(int maxLength, string paramName)
+        {
+            if (maxLength < 0)
+                throw new ArgumentOutOfRangeException(paramName, "DEBUG: Must not be negative.");
+        }
+
+        [Conditional("DEBUG")]
+        public static void IsNotWildcardVersionWithPrerelease(WildcardVersion wildcardVersion, SemVersion semver)
+        {
+            if (wildcardVersion != WildcardVersion.None && semver.IsPrerelease)
+                throw new InvalidOperationException("DEBUG: prerelease not allowed with wildcard");
+        }
+
+        [Conditional("DEBUG")]
+        public static void IsNotEmpty(StringSegment segment, string paramName)
+        {
+            if (segment.IsEmpty)
+                throw new ArgumentException("DEBUG: Cannot be empty", paramName);
+        }
+
+        [Conditional("DEBUG")]
+        public static void IsNotNull<T>(T value, string paramName)
+        {
+            if (value == null)
+                throw new ArgumentNullException(paramName, "DEBUG: Value cannot be null.");
+        }
+
+        /// <summary>
+        /// This check ensures that an exception hasn't been constructed, but rather something always
+        /// returns <see cref="VersionParsing.FailedException"/>.
+        /// </summary>
+        [Conditional("DEBUG")]
+        public static void IsNotFailedException(Exception exception, string className, string methodName)
+        {
+            if (exception != null && exception != VersionParsing.FailedException)
+                throw new InvalidOperationException($"DEBUG: {className}.{methodName} returned exception other than {nameof(VersionParsing.FailedException)}", exception);
+        }
+
+        [Conditional("DEBUG")]
+        public static void NoMetadata(SemVersion version, string paramName)
+        {
+            if (version?.MetadataIdentifiers.Any() ?? false)
+                throw new ArgumentException("DEBUG: Cannot have metadata.", paramName);
+        }
+
+        [Conditional("DEBUG")]
+        public static void IsValidVersionNumber(int versionNumber, string kind, string paramName)
+        {
+            if (versionNumber < 0)
+                throw new ArgumentException($"DEBUG: {kind} version must be greater than or equal to zero.", paramName);
+        }
+
+        [Conditional("DEBUG")]
+        public static void ContainsNoDefaultValues<T>(IEnumerable<T> values, string kind, string paramName)
+            where T : struct
+        {
+            if (values.Any(i => EqualityComparer<T>.Default.Equals(i, default)))
+                throw new ArgumentException($"DEBUG: {kind} identifier cannot be default/null.", paramName);
+        }
+
+        [Conditional("DEBUG")]
+        public static void AreEqualWhenJoinedWithDots<T>(string value, string param1Name, IReadOnlyList<T> values, string param2Name)
+        {
+            if (value != string.Join(".", values))
+                throw new ArgumentException($"DEBUG: must be equal to {param2Name} when joined with dots.", param1Name);
+        }
+    }
+}

--- a/dotnet/Surge.NET/Semver/Utility/EnumerableExtensions.cs
+++ b/dotnet/Surge.NET/Semver/Utility/EnumerableExtensions.cs
@@ -1,0 +1,21 @@
+#nullable disable
+#pragma warning disable
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+
+namespace Semver.Utility
+{
+    internal static class EnumerableExtensions
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static IReadOnlyList<T> ToReadOnlyList<T>(this IEnumerable<T> values)
+            => values.ToList().AsReadOnly();
+
+#if !NETSTANDARD1_6_OR_GREATER && !NET471_OR_GREATER && !NETCOREAPP
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static IEnumerable<TSource> Prepend<TSource>(this IEnumerable<TSource> source, TSource element)
+            => new[] { element }.Concat(source);
+#endif
+    }
+}

--- a/dotnet/Surge.NET/Semver/Utility/ExcludeFromCodeCoverageAttribute.cs
+++ b/dotnet/Surge.NET/Semver/Utility/ExcludeFromCodeCoverageAttribute.cs
@@ -1,0 +1,17 @@
+#nullable disable
+#pragma warning disable
+using System;
+
+#if NETSTANDARD1_1
+namespace Semver.Utility
+{
+    /// <summary>
+    /// Specifies that the attributed code should be excluded from code coverage information.
+    /// </summary>
+    [AttributeUsage(
+        AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Constructor
+        | AttributeTargets.Method | AttributeTargets.Property | AttributeTargets.Event,
+        Inherited = false)]
+    internal sealed class ExcludeFromCodeCoverageAttribute : Attribute { }
+}
+#endif

--- a/dotnet/Surge.NET/Semver/Utility/IdentifierString.cs
+++ b/dotnet/Surge.NET/Semver/Utility/IdentifierString.cs
@@ -1,0 +1,23 @@
+#nullable disable
+#pragma warning disable
+using System;
+using System.Runtime.CompilerServices;
+
+namespace Semver.Utility
+{
+    /// <summary>
+    /// Methods for working with the strings that make up identifiers
+    /// </summary>
+    internal static class IdentifierString
+    {
+        /// <summary>
+        /// Compare two strings as they should be compared as identifiers.
+        /// </summary>
+        /// <remarks>This enforces ordinal comparision. It also fixes a technically
+        /// correct but odd thing where the comparision result can be a number
+        /// other than -1, 0, or 1.</remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int Compare(string left, string right)
+            => Math.Sign(string.CompareOrdinal(left, right));
+    }
+}

--- a/dotnet/Surge.NET/Semver/Utility/IntExtensions.cs
+++ b/dotnet/Surge.NET/Semver/Utility/IntExtensions.cs
@@ -1,0 +1,35 @@
+#nullable disable
+#pragma warning disable
+using System.Text;
+
+namespace Semver.Utility
+{
+    internal static class IntExtensions
+    {
+        /// <summary>
+        /// The number of digits in a non-negative number. Returns 1 for all
+        /// negative numbers. That is ok because we are using it to calculate
+        /// string length for a <see cref="StringBuilder"/> for numbers that
+        /// aren't supposed to be negative, but when they are it is just a little
+        /// slower.
+        /// </summary>
+        /// <remarks>
+        /// This approach is based on https://stackoverflow.com/a/51099524/268898
+        /// where the poster offers performance benchmarks showing this is the
+        /// fastest way to get a number of digits.
+        /// </remarks>
+        public static int DecimalDigits(this int n)
+        {
+            if (n < 10) return 1;
+            if (n < 100) return 2;
+            if (n < 1_000) return 3;
+            if (n < 10_000) return 4;
+            if (n < 100_000) return 5;
+            if (n < 1_000_000) return 6;
+            if (n < 10_000_000) return 7;
+            if (n < 100_000_000) return 8;
+            if (n < 1_000_000_000) return 9;
+            return 10;
+        }
+    }
+}

--- a/dotnet/Surge.NET/Semver/Utility/ListExtensions.cs
+++ b/dotnet/Surge.NET/Semver/Utility/ListExtensions.cs
@@ -1,0 +1,17 @@
+#nullable disable
+#pragma warning disable
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Runtime.CompilerServices;
+
+namespace Semver.Utility
+{
+#if NETSTANDARD1_1
+    internal static class ListExtensions
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static ReadOnlyCollection<T> AsReadOnly<T>(this List<T> list)
+            => new ReadOnlyCollection<T>(list);
+    }
+#endif
+}

--- a/dotnet/Surge.NET/Semver/Utility/ReadOnlyList.cs
+++ b/dotnet/Surge.NET/Semver/Utility/ReadOnlyList.cs
@@ -1,0 +1,14 @@
+#nullable disable
+#pragma warning disable
+using System.Collections.Generic;
+
+namespace Semver.Utility
+{
+    /// <summary>
+    /// Internal helper for efficiently creating empty read only lists
+    /// </summary>
+    internal static class ReadOnlyList<T>
+    {
+        public static readonly IReadOnlyList<T> Empty = new List<T>().AsReadOnly();
+    }
+}

--- a/dotnet/Surge.NET/Semver/Utility/StringExtensions.cs
+++ b/dotnet/Surge.NET/Semver/Utility/StringExtensions.cs
@@ -1,0 +1,109 @@
+#nullable disable
+#pragma warning disable
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+
+namespace Semver.Utility
+{
+    internal static class StringExtensions
+    {
+        /// <summary>
+        /// Is this string composed entirely of ASCII digits '0' to '9'?
+        /// </summary>
+        public static bool IsDigits(this string value)
+        {
+            foreach (var c in value)
+                if (!c.IsDigit())
+                    return false;
+
+            return true;
+        }
+
+        /// <summary>
+        /// Is this string composed entirely of ASCII alphanumeric characters and hyphens?
+        /// </summary>
+        public static bool IsAlphanumericOrHyphens(this string value)
+        {
+            foreach (var c in value)
+                if (!c.IsAlphaOrHyphen() && !c.IsDigit())
+                    return false;
+
+            return true;
+        }
+
+        /// <summary>
+        /// Split a string, map the parts, and return a read only list of the values.
+        /// </summary>
+        /// <remarks>Splitting a string, mapping the result and storing into a <see cref="IReadOnlyList{T}"/>
+        /// is a common operation in this package. This method optimizes that. It avoids the
+        /// performance overhead of:
+        /// <list type="bullet">
+        ///   <item><description>Constructing the params array for <see cref="string.Split(char[])"/></description></item>
+        ///   <item><description>Constructing the intermediate <see cref="T:string[]"/> returned by <see cref="string.Split(char[])"/></description></item>
+        ///   <item><description><see cref="System.Linq.Enumerable.Select{TSource,TResult}(IEnumerable{TSource},Func{TSource,TResult})"/></description></item>
+        ///   <item><description>Not allocating list capacity based on the size</description></item>
+        /// </list>
+        /// Benchmarking shows this to be 30%+ faster and that may not reflect the whole benefit
+        /// since it doesn't fully account for reduced allocations.
+        /// </remarks>
+        public static IReadOnlyList<T> SplitAndMapToReadOnlyList<T>(
+            this string value,
+            char splitOn,
+            Func<string, T> func)
+        {
+            if (value.Length == 0) return ReadOnlyList<T>.Empty;
+
+            // Figure out how many items the resulting list will have
+            int count = 1; // Always one more item than there are separators
+            for (int i = 0; i < value.Length; i++)
+                if (value[i] == splitOn)
+                    count++;
+
+            // Allocate enough capacity for the items
+            var items = new List<T>(count);
+            int start = 0;
+            for (int i = 0; i < value.Length; i++)
+                if (value[i] == splitOn)
+                {
+                    items.Add(func(value.Substring(start, i - start)));
+                    start = i + 1;
+                }
+            // Add the final items from the last separator to the end of the string
+            items.Add(func(value.Substring(start, value.Length - start)));
+
+            return items.AsReadOnly();
+        }
+
+        /// <summary>
+        /// Trim leading zeros from a numeric string. If the string consists of all zeros, return
+        /// <c>"0"</c>.
+        /// </summary>
+        /// <remarks>The standard <see cref="string.TrimStart"/> method handles all zeros
+        /// by returning <c>""</c>. This efficiently handles the kind of trimming needed.</remarks>
+        public static string TrimLeadingZeros(this string value)
+        {
+            int start;
+            var searchUpTo = value.Length - 1;
+            for (start = 0; start < searchUpTo; start++)
+                if (value[start] != '0')
+                    break;
+
+            return value.Substring(start);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static StringSegment Slice(this string value, int offset, int length)
+            => new StringSegment(value, offset, length);
+
+        public static string LimitLength(this string value)
+        {
+            if (value.Length > DisplayLimit)
+                return value.Substring(0, DisplayLimit - 3) + "...";
+
+            return value;
+        }
+
+        private const int DisplayLimit = 100;
+    }
+}

--- a/dotnet/Surge.NET/Semver/Utility/StringSegment.cs
+++ b/dotnet/Surge.NET/Semver/Utility/StringSegment.cs
@@ -1,0 +1,225 @@
+#nullable disable
+#pragma warning disable
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace Semver.Utility
+{
+    /// <summary>
+    /// An efficient representation of a section of a string
+    /// </summary>
+    [StructLayout(LayoutKind.Auto)]
+    internal readonly struct StringSegment
+    {
+        public StringSegment(string source, int offset, int length)
+        {
+#if DEBUG
+            if (source is null) throw new ArgumentNullException(nameof(source), "DEBUG: Value cannot be null.");
+            if (offset < 0) throw new ArgumentOutOfRangeException(nameof(offset), offset, "DEBUG: Cannot be negative.");
+            if (offset > source.Length)
+                throw new ArgumentOutOfRangeException(nameof(offset), offset,
+                    $"DEBUG: Must be <= length of {length}. String:\r\n{source}");
+
+            if (length < 0) throw new ArgumentOutOfRangeException(nameof(length), length, "DEBUG: Cannot be negative.");
+            if (offset + length > source.Length)
+                throw new ArgumentOutOfRangeException(nameof(length), length,
+                    $"DEBUG: When added to offset of {offset}, must be <= length of {length}. String:\r\n{source}");
+#endif
+            Source = source;
+            Offset = offset;
+            Length = length;
+        }
+
+        public readonly string Source;
+        public readonly int Offset;
+        public readonly int Length;
+
+        public bool IsEmpty => Length == 0;
+
+        public char this[int i]
+        {
+            get
+            {
+#if DEBUG
+                ValidateIndex(i, nameof(i));
+#endif
+                return Source[Offset + i];
+            }
+        }
+
+        public StringSegment TrimStartSpaces()
+        {
+            var start = Offset;
+            var end = start + Length - 1;
+
+            while (start <= end && Source[start] == ' ') start++;
+
+            return new StringSegment(Source, start, end + 1 - start);
+        }
+
+        public StringSegment TrimStartWhitespace()
+        {
+            var start = Offset;
+            var end = start + Length - 1;
+
+            while (start <= end && char.IsWhiteSpace(Source[start])) start++;
+
+            return new StringSegment(Source, start, end + 1 - start);
+        }
+
+        public StringSegment TrimEndWhitespace()
+        {
+            var end = Offset + Length - 1;
+
+            while (Offset <= end && char.IsWhiteSpace(Source[end])) end--;
+
+            return new StringSegment(Source, Offset, end + 1 - Offset);
+        }
+
+        /// <summary>
+        /// Trim leading zeros from a numeric string segment. If the segment consists of all zeros,
+        /// return <c>"0"</c>.
+        /// </summary>
+        /// <remarks>The standard <see cref="string.TrimStart(char[])"/> method handles all zeros
+        /// by returning <c>""</c>. This efficiently handles the kind of trimming needed.</remarks>
+        public StringSegment TrimLeadingZeros()
+        {
+            int start = Offset;
+            var end = start + Length - 1;
+            for (; start < end; start++)
+                if (Source[start] != '0')
+                    break;
+
+            return new StringSegment(Source, start, end + 1 - start);
+        }
+
+        public StringSegment Subsegment(int start, int length)
+        {
+#if DEBUG
+            ValidateIndex(start, nameof(start));
+            ValidateLength(start, length, nameof(length));
+#endif
+            return new StringSegment(Source, Offset + start, length);
+        }
+
+        public StringSegment Subsegment(int start)
+        {
+#if DEBUG
+            ValidateIndex(start, nameof(start));
+#endif
+            return new StringSegment(Source, Offset + start, Length - start);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public StringSegment EmptySubsegment() => new StringSegment(Source, Offset, 0);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int IndexOf(char value)
+        {
+            var i = Source.IndexOf(value, Offset, Length);
+            return i < 0 ? i : i - Offset;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int IndexOf(char value, int startIndex)
+        {
+#if DEBUG
+            ValidateIndex(startIndex, nameof(startIndex));
+#endif
+            var i = Source.IndexOf(value, Offset + startIndex, Length - startIndex);
+            return i < 0 ? i : i - Offset;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int IndexOf(char value, int startIndex, int count)
+        {
+#if DEBUG
+            ValidateIndex(startIndex, nameof(startIndex));
+            ValidateLength(startIndex, count, nameof(count));
+#endif
+            var i = Source.IndexOf(value, Offset + startIndex, count);
+            return i < 0 ? i : i - Offset;
+        }
+
+        public int SplitCount(char c)
+        {
+            int count = 1; // Always one more item than there are separators
+            var end = Offset + Length;
+            // Use `for` instead of `foreach` to ensure performance
+            for (int i = Offset; i < end; i++)
+                if (Source[i] == c)
+                    count++;
+
+            return count;
+        }
+
+        public IEnumerable<StringSegment> Split(char c)
+        {
+            var start = Offset;
+            var end = start + Length;
+            // Use `for` instead of `foreach` to ensure performance
+            for (int i = start; i < end; i++)
+                if (Source[i] == c)
+                {
+                    yield return Subsegment(start - Offset, i - start);
+                    start = i + 1;
+                }
+
+            // The final segment from the last separator to the end of the string
+            yield return Subsegment(start - Offset);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void SplitBeforeFirst(char c, out StringSegment left, out StringSegment right)
+        {
+            var index = IndexOf(c);
+            var self = this; // make a copy of this in case assigning to left or right modifies it
+            if (index >= 0)
+            {
+                left = self.Subsegment(0, index);
+                right = self.Subsegment(index);
+            }
+            else
+            {
+                left = self;
+                right = self.EmptySubsegment();
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static implicit operator StringSegment(string value)
+            => new StringSegment(value, 0, value.Length);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public override string ToString() => Source.Substring(Offset, Length);
+
+        public string ToStringLimitLength()
+        {
+            if (Length > DisplayLimit) return Subsegment(0, DisplayLimit - 3) + "...";
+
+            return ToString();
+        }
+
+        private const int DisplayLimit = 100;
+
+#if DEBUG
+        [ExcludeFromCodeCoverage]
+        private void ValidateIndex(int i, string paramName)
+        {
+            if (i < 0) throw new ArgumentOutOfRangeException(paramName, i, "DEBUG: Cannot be negative.");
+            if (i > Length) throw new ArgumentOutOfRangeException(paramName, i, $"DEBUG: Cannot be > length {Length}.");
+        }
+
+        [ExcludeFromCodeCoverage]
+        private void ValidateLength(int start, int length, string paramName)
+        {
+            if (length < 0) throw new ArgumentOutOfRangeException(paramName, length, "DEBUG: Cannot be negative.");
+            if (start + length > Length) throw new ArgumentOutOfRangeException(paramName, length,
+                $"DEBUG: When added to offset of {start}, must be <= length of {Length}.");
+        }
+#endif
+    }
+}

--- a/dotnet/Surge.NET/Semver/Utility/Unreachable.cs
+++ b/dotnet/Surge.NET/Semver/Utility/Unreachable.cs
@@ -1,0 +1,18 @@
+#nullable disable
+#pragma warning disable
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Semver.Parsing;
+
+namespace Semver.Utility
+{
+    /// <summary>
+    /// Used to clearly mark when a case should be unreachable and helps properly manage code coverage.
+    /// </summary>
+    [ExcludeFromCodeCoverage]
+    internal static class Unreachable
+    {
+        public static ArgumentException InvalidEnum(WildcardVersion wildcardVersion)
+            => new ArgumentException($"DEBUG: Invalid {nameof(WildcardVersion)} value {wildcardVersion}.");
+    }
+}

--- a/dotnet/Surge.NET/Semver/Utility/UnsafeOverload.cs
+++ b/dotnet/Surge.NET/Semver/Utility/UnsafeOverload.cs
@@ -1,0 +1,13 @@
+#nullable disable
+#pragma warning disable
+namespace Semver.Utility
+{
+    /// <summary>
+    /// Struct used as a marker to differentiate constructor overloads that would
+    /// otherwise be the same as safe overloads.
+    /// </summary>
+    internal readonly struct UnsafeOverload
+    {
+        public static readonly UnsafeOverload Marker = default;
+    }
+}

--- a/dotnet/Surge.NET/Semver/Utility/VersionParsing.cs
+++ b/dotnet/Surge.NET/Semver/Utility/VersionParsing.cs
@@ -1,0 +1,19 @@
+#nullable disable
+#pragma warning disable
+using System;
+using Semver.Parsing;
+
+namespace Semver.Utility
+{
+    internal static class VersionParsing
+    {
+        /// <remarks>
+        /// This exception is used with the
+        /// <see cref="SemVersionParser.Parse(string,SemVersionStyles,Exception,int,out SemVersion)"/>
+        /// method to indicate parse failure without constructing a new exception.
+        /// This exception should never be thrown or exposed outside of this
+        /// package.
+        /// </remarks>
+        public static readonly Exception FailedException = new Exception("Parse Failed");
+    }
+}

--- a/dotnet/Surge.NET/Surge.NET.csproj
+++ b/dotnet/Surge.NET/Surge.NET.csproj
@@ -14,8 +14,14 @@
   </PropertyGroup>
   <ItemGroup>
     <None Include="README.md" Pack="true" PackagePath="\" />
+    <None Include="Semver.LICENSE.txt" Pack="true" PackagePath="\" />
   </ItemGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="Surge.NET.Tests" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Update="Semver/**/*.cs">
+      <Nullable>disable</Nullable>
+    </Compile>
   </ItemGroup>
 </Project>

--- a/dotnet/Surge.NET/SurgeApp.cs
+++ b/dotnet/Surge.NET/SurgeApp.cs
@@ -2,7 +2,9 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Runtime.ExceptionServices;
 using System.Runtime.InteropServices;
+using Semver;
 
 namespace Surge
 {
@@ -53,7 +55,7 @@ namespace Surge
         /// <summary>
         /// The Surge library version.
         /// </summary>
-        public static string Version => "0.1.0";
+        public static SemVersion Version => SemanticVersions.LibraryVersion;
 
         /// <summary>
         /// Process application lifecycle events. Should be called early in the
@@ -66,13 +68,14 @@ namespace Surge
         /// <returns>True if a lifecycle event was handled.</returns>
         public static bool ProcessEvents(
             string[] args,
-            Action<string>? onFirstRun = null,
-            Action<string>? onInstalled = null,
-            Action<string>? onUpdated = null)
+            Action<SemVersion>? onFirstRun = null,
+            Action<SemVersion>? onInstalled = null,
+            Action<SemVersion>? onUpdated = null)
         {
             var lifecycleAction = DetermineLifecycleAction(args);
             var argPtrs = new IntPtr[args.Length];
             var pinnedHandles = new GCHandle[args.Length];
+            Exception? callbackException = null;
 
             try
             {
@@ -95,8 +98,20 @@ namespace Surge
                     {
                         firstRunCb = (versionPtr, _) =>
                         {
-                            var version = MarshalUtf8(versionPtr);
-                            onFirstRun(version);
+                            if (callbackException != null)
+                                return;
+
+                            try
+                            {
+                                var version = SemanticVersions.ParseRuntimeValue(
+                                    MarshalUtf8(versionPtr),
+                                    "Surge first-run version");
+                                onFirstRun(version);
+                            }
+                            catch (Exception ex)
+                            {
+                                callbackException = ex;
+                            }
                         };
                     }
 
@@ -104,8 +119,20 @@ namespace Surge
                     {
                         installedCb = (versionPtr, _) =>
                         {
-                            var version = MarshalUtf8(versionPtr);
-                            onInstalled(version);
+                            if (callbackException != null)
+                                return;
+
+                            try
+                            {
+                                var version = SemanticVersions.ParseRuntimeValue(
+                                    MarshalUtf8(versionPtr),
+                                    "Surge installed version");
+                                onInstalled(version);
+                            }
+                            catch (Exception ex)
+                            {
+                                callbackException = ex;
+                            }
                         };
                     }
 
@@ -113,8 +140,20 @@ namespace Surge
                     {
                         updatedCb = (versionPtr, _) =>
                         {
-                            var version = MarshalUtf8(versionPtr);
-                            onUpdated(version);
+                            if (callbackException != null)
+                                return;
+
+                            try
+                            {
+                                var version = SemanticVersions.ParseRuntimeValue(
+                                    MarshalUtf8(versionPtr),
+                                    "Surge updated version");
+                                onUpdated(version);
+                            }
+                            catch (Exception ex)
+                            {
+                                callbackException = ex;
+                            }
                         };
                     }
 
@@ -125,6 +164,9 @@ namespace Surge
                         installedCb,
                         updatedCb,
                         IntPtr.Zero);
+
+                    if (callbackException != null)
+                        ExceptionDispatchInfo.Capture(callbackException).Throw();
 
                     if (result != 0 || lifecycleAction == LifecycleAction.None)
                     {
@@ -376,10 +418,14 @@ namespace Surge
                     return null;
 
                 var resolvedAppId = appId!.Trim();
+                var resolvedVersion = version ?? "0.0.0";
+                if (!SemanticVersions.TryParseRuntimeValue(resolvedVersion, out var parsedVersion))
+                    return null;
+
                 return new SurgeAppInfo
                 {
                     Id = resolvedAppId,
-                    Version = version ?? "0.0.0",
+                    Version = parsedVersion,
                     Channel = channel ?? "stable",
                     InstallDirectory = ResolveInstallDirectory(resolvedAppId, installDir, assemblyDir),
                     SupervisorId = supervisorId ?? "",

--- a/dotnet/Surge.NET/SurgeAppInfo.cs
+++ b/dotnet/Surge.NET/SurgeAppInfo.cs
@@ -1,3 +1,5 @@
+using Semver;
+
 namespace Surge
 {
     /// <summary>
@@ -11,9 +13,9 @@ namespace Surge
         public string Id { get; init; } = "";
 
         /// <summary>
-        /// Currently installed version string (semver).
+        /// Currently installed semantic version.
         /// </summary>
-        public string Version { get; init; } = "";
+        public SemVersion Version { get; init; } = SemanticVersions.Zero;
 
         /// <summary>
         /// Release channel this installation is tracking.

--- a/dotnet/Surge.NET/SurgeRelease.cs
+++ b/dotnet/Surge.NET/SurgeRelease.cs
@@ -1,3 +1,5 @@
+using Semver;
+
 namespace Surge
 {
     /// <summary>
@@ -6,9 +8,9 @@ namespace Surge
     public sealed class SurgeRelease
     {
         /// <summary>
-        /// Version string (semver) of this release.
+        /// Semantic version of this release.
         /// </summary>
-        public string Version { get; init; } = "";
+        public SemVersion Version { get; init; } = SemanticVersions.Zero;
 
         /// <summary>
         /// Release channel this release belongs to.

--- a/dotnet/Surge.NET/SurgeUpdateManager.cs
+++ b/dotnet/Surge.NET/SurgeUpdateManager.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
+using Semver;
 
 namespace Surge
 {
@@ -15,7 +16,7 @@ namespace Surge
         private IntPtr _nativeMgr;
         private bool _disposed;
         private string _channel = "stable";
-        private string _currentVersion = "0.0.0";
+        private SemVersion _currentVersion = SemanticVersions.Zero;
         private int _releaseRetentionLimit = 1;
 
         /// <summary>
@@ -71,7 +72,7 @@ namespace Surge
             _nativeMgr = NativeMethods.UpdateManagerCreate(
                 _nativeCtx,
                 appInfo.Id,
-                appInfo.Version,
+                appInfo.Version.ToString(),
                 appInfo.Channel,
                 appInfo.InstallDirectory);
 
@@ -83,7 +84,7 @@ namespace Surge
             }
 
             _channel = string.IsNullOrWhiteSpace(appInfo.Channel) ? "stable" : appInfo.Channel;
-            _currentVersion = string.IsNullOrWhiteSpace(appInfo.Version) ? "0.0.0" : appInfo.Version;
+            _currentVersion = appInfo.Version ?? SemanticVersions.Zero;
         }
 
         /// <summary>
@@ -94,7 +95,7 @@ namespace Surge
         /// <summary>
         /// The current installed version baseline used for update checks.
         /// </summary>
-        public string CurrentVersion => _currentVersion;
+        public SemVersion CurrentVersion => _currentVersion;
 
         /// <summary>
         /// Switch update channel at runtime (for example, from production to test).
@@ -141,8 +142,8 @@ namespace Surge
         /// <summary>
         /// Update the current version baseline used for future update checks.
         /// </summary>
-        /// <param name="version">Installed version string.</param>
-        public void SetCurrentVersion(string version)
+        /// <param name="version">Installed semantic version.</param>
+        public void SetCurrentVersion(SemVersion version)
         {
             ThrowIfDisposed();
             SetCurrentVersionInternal(version);
@@ -219,7 +220,9 @@ namespace Surge
 
                             releases.Add(new SurgeRelease
                             {
-                                Version = MarshalUtf8(versionPtr),
+                                Version = SemanticVersions.ParseRuntimeValue(
+                                    MarshalUtf8(versionPtr),
+                                    "Native release version"),
                                 Channel = MarshalUtf8(channelPtr),
                                 FullSize = fullSize,
                                 IsGenesis = isGenesis
@@ -359,12 +362,16 @@ namespace Surge
             return string.IsNullOrWhiteSpace(value) ? null : value;
         }
 
-        private void SetCurrentVersionInternal(string version)
+        private void SetCurrentVersionInternal(SemVersion version)
         {
-            if (string.IsNullOrWhiteSpace(version))
-                throw new ArgumentException("Version cannot be empty.", nameof(version));
+#if NET6_0_OR_GREATER
+            ArgumentNullException.ThrowIfNull(version);
+#else
+            if (version == null)
+                throw new ArgumentNullException(nameof(version));
+#endif
 
-            int result = NativeMethods.UpdateManagerSetCurrentVersion(_nativeMgr, version);
+            int result = NativeMethods.UpdateManagerSetCurrentVersion(_nativeMgr, version.ToString());
             if (result != 0)
             {
                 var errorMsg = GetLastError();

--- a/scripts/set-release-version.sh
+++ b/scripts/set-release-version.sh
@@ -11,7 +11,9 @@ if [[ -z "$version" ]]; then
   exit 1
 fi
 
-if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta)\.[0-9]+)?$ ]]; then
+semver_regex='^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)(\.(0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*))*))?(\+([0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*))?$'
+
+if [[ ! "$version" =~ $semver_regex ]]; then
   echo "Unsupported release version: $version" >&2
   exit 1
 fi


### PR DESCRIPTION
## Summary
- enforce strict Semantic Versioning 2.0 parsing, canonicalization, and precedence handling across Rust release, install, update, and FFI entry points
- vendor an MIT-licensed SemVer implementation into `Surge.NET` and switch managed app/release/version APIs to typed `SemVersion` values
- tighten release-index delta metadata and release scripting so emitted versions stay SemVer 2.0 compliant

Closes #81.

## Behavior impact
- invalid versions such as `1`, `1.2`, `01.2.3`, `1.2.3-01`, and whitespace-padded values are now rejected instead of being accepted loosely
- release-index delta descriptors now require a valid `from_version` and the push path records the actual previous release baseline
- `Surge.NET` lifecycle callbacks and public app/release/version properties now use `SemVersion` rather than `string`

## Source attribution
- vendored managed SemVer source is based on `WalkerCodeRanger/semver` tag `v2.3.0`
- upstream license is MIT and is included under `dotnet/Surge.NET/Semver.LICENSE.txt`

## Validation
- `./scripts/sync-surge-core-vendor.sh --check`
- `./scripts/check-version-sync.sh`
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo test --workspace`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo clippy --workspace --lib --bins --examples -- -D warnings -D clippy::unwrap_used -D clippy::expect_used`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings -W clippy::pedantic`
- `dotnet format dotnet/Surge.slnx --verify-no-changes`
- `dotnet test dotnet/Surge.slnx --configuration Release`

## Migration note
- downstream .NET callers that read or pass version values as strings need to update to `SemVersion` and call `.ToString()` only at string boundaries
