### PR TITLE
fix(promote): build channel-aware delta when promoting across skipped versions

### DIFF
--- a/crates/surge-cli/src/commands/promote.rs
+++ b/crates/surge-cli/src/commands/promote.rs
@@ -6,9 +6,14 @@ use crate::logline;
 use crate::ui::UiTheme;
 use surge_core::config::constants::{DEFAULT_ZSTD_LEVEL, RELEASES_FILE_COMPRESSED};
 use surge_core::config::manifest::SurgeManifest;
+use surge_core::crypto::sha256::sha256_hex;
+use surge_core::diff::chunked::ChunkedDiffOptions;
 use surge_core::error::{Result, SurgeError};
-use surge_core::releases::manifest::compress_release_index;
-use surge_core::storage;
+use surge_core::releases::delta::build_sparse_file_patch;
+use surge_core::releases::manifest::{DeltaArtifact, ReleaseEntry, ReleaseIndex, compress_release_index};
+use surge_core::releases::restore::restore_full_archive_for_version;
+use surge_core::releases::version::compare_versions;
+use surge_core::storage::{self, StorageBackend};
 
 /// Promote a release version to a target channel.
 pub async fn execute(
@@ -48,11 +53,16 @@ pub async fn execute(
         .position(|release| release.version == version && release.rid == rid)
         .ok_or_else(|| SurgeError::NotFound(format!("Release {version} not found for {app_id}/{rid}")))?;
 
-    if index.releases[release_idx]
+    let already_on_channel = index.releases[release_idx]
         .channels
         .iter()
-        .any(|existing| existing == channel)
-    {
+        .any(|existing| existing == channel);
+    let previous_on_channel = previous_release_on_channel(&index, &rid, channel, version);
+    let needs_channel_delta = previous_on_channel
+        .as_deref()
+        .is_some_and(|prev| index.releases[release_idx].delta_from_source(prev).is_none());
+
+    if already_on_channel && !needs_channel_delta {
         print_stage(theme, 3, TOTAL_STAGES, "Updating channel membership");
         print_stage_done(
             theme,
@@ -84,17 +94,35 @@ pub async fn execute(
     );
 
     print_stage(theme, 4, TOTAL_STAGES, "Updating channel membership");
-    let release = &mut index.releases[release_idx];
-    release.channels.push(channel.to_string());
-    release.channels.sort();
-    release.channels.dedup();
+    if !already_on_channel {
+        let release = &mut index.releases[release_idx];
+        release.channels.push(channel.to_string());
+        release.channels.sort();
+        release.channels.dedup();
+    }
+    // Even when the release is already on the channel, re-check that a
+    // production-compatible delta exists. This is what recovers a release that
+    // was previously promoted before this fix shipped: rerun `surge promote`
+    // and the missing channel delta is built in place without a demote/repromote
+    // cycle.
+    let channel_delta_summary = match previous_on_channel {
+        Some(prev_version) => {
+            ensure_channel_delta(&*backend, &mut index, &app_id, &rid, version, &prev_version).await?
+        }
+        None => "no previous release on channel; skipped delta rebuild".to_string(),
+    };
 
     index.last_write_utc = chrono::Utc::now().to_rfc3339();
     let compressed = compress_release_index(&index, DEFAULT_ZSTD_LEVEL)?;
     backend
         .put_object(RELEASES_FILE_COMPRESSED, &compressed, "application/octet-stream")
         .await?;
-    print_stage_done(theme, 4, TOTAL_STAGES, &format!("Added channel '{channel}' to release"));
+    print_stage_done(
+        theme,
+        4,
+        TOTAL_STAGES,
+        &format!("Added channel '{channel}' to release ({channel_delta_summary})"),
+    );
 
     print_stage(theme, 5, TOTAL_STAGES, "Finalize promote summary");
     print_stage_done(
@@ -117,6 +145,94 @@ fn print_stage(theme: UiTheme, stage: usize, total: usize, text: &str) {
 fn print_stage_done(theme: UiTheme, stage: usize, total: usize, text: &str) {
     let _ = theme;
     logline::success(&format!("[{stage}/{total}] {text}"));
+}
+
+/// Find the latest release strictly before `version` for the given `rid` that
+/// will be on `channel` after the in-flight promotion. Returns `None` if no
+/// such predecessor exists, in which case the new release is the channel's
+/// genesis and no cross-version delta needs rebuilding.
+fn previous_release_on_channel(index: &ReleaseIndex, rid: &str, channel: &str, version: &str) -> Option<String> {
+    let mut candidates: Vec<&ReleaseEntry> = index
+        .releases
+        .iter()
+        .filter(|release| {
+            release.rid == rid
+                && release.version != version
+                && release.channels.iter().any(|existing| existing == channel)
+        })
+        .collect();
+    candidates.sort_by(|left, right| compare_versions(&left.version, &right.version));
+    candidates
+        .into_iter()
+        .rev()
+        .find(|release| compare_versions(&release.version, version) == std::cmp::Ordering::Less)
+        .map(|release| release.version.clone())
+}
+
+/// Make sure the release at `version` carries a sparse delta whose basis is the
+/// previous release on the target channel. Builds and uploads the delta when
+/// missing so production nodes can transition from `from_version` to `version`
+/// without hitting a basis hash mismatch on files that changed across an
+/// in-between test-only release.
+///
+/// Returns a one-line summary suitable for inclusion in the promote stage log.
+async fn ensure_channel_delta(
+    backend: &dyn StorageBackend,
+    index: &mut ReleaseIndex,
+    app_id: &str,
+    rid: &str,
+    version: &str,
+    from_version: &str,
+) -> Result<String> {
+    let release_idx = index
+        .releases
+        .iter()
+        .position(|release| release.version == version && release.rid == rid)
+        .ok_or_else(|| SurgeError::NotFound(format!("Release {version} not found for {app_id}/{rid}")))?;
+
+    if index.releases[release_idx].delta_from_source(from_version).is_some() {
+        return Ok(format!("delta from v{from_version} already present"));
+    }
+
+    let prev_archive = restore_full_archive_for_version(backend, index, rid, from_version).await?;
+    let new_archive = restore_full_archive_for_version(backend, index, rid, version).await?;
+
+    let diff_options = ChunkedDiffOptions::default();
+    let patch = build_sparse_file_patch(&prev_archive, &new_archive, DEFAULT_ZSTD_LEVEL, 0, &diff_options)?;
+    let compressed = zstd::encode_all(patch.as_slice(), DEFAULT_ZSTD_LEVEL)
+        .map_err(|err| SurgeError::Archive(format!("Failed to compress channel delta: {err}")))?;
+
+    let from_version_slug = sanitize_version_for_filename(from_version);
+    let delta_filename = format!("{app_id}-{version}-{rid}-from-{from_version_slug}-delta.tar.zst");
+    backend
+        .put_object(&delta_filename, &compressed, "application/octet-stream")
+        .await?;
+
+    let delta_size = i64::try_from(compressed.len())
+        .map_err(|_| SurgeError::Archive(format!("Channel delta is too large: {} bytes", compressed.len())))?;
+    let delta_sha256 = sha256_hex(&compressed);
+    let delta_id = format!("from-{from_version_slug}");
+
+    let delta =
+        DeltaArtifact::sparse_file_ops_zstd(&delta_id, from_version, &delta_filename, delta_size, &delta_sha256);
+    index.releases[release_idx].upsert_delta(delta);
+
+    Ok(format!(
+        "rebuilt delta from v{from_version} ({delta_size} bytes) and stored as {delta_filename}"
+    ))
+}
+
+fn sanitize_version_for_filename(version: &str) -> String {
+    version
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || ch == '.' {
+                ch
+            } else {
+                '_'
+            }
+        })
+        .collect()
 }
 
 #[cfg(test)]
@@ -330,6 +446,155 @@ mod tests {
             .expect("promoted release should exist");
         assert_eq!(promoted.channels, vec!["beta".to_string(), "stable".to_string()]);
         assert_eq!(std::fs::read(store_dir.join(v2_full_key)).unwrap(), v2);
+    }
+
+    #[tokio::test]
+    async fn execute_rebuilds_channel_delta_when_promoting_across_skipped_versions() {
+        use surge_core::archive::packer::ArchivePacker;
+        use surge_core::releases::delta::{apply_delta_patch, decode_delta_patch};
+
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let store_dir = temp_dir.path().join("store");
+        let manifest_path = temp_dir.path().join("surge.yml");
+        let rid = current_rid();
+
+        std::fs::create_dir_all(&store_dir).expect("store dir");
+        write_manifest(&manifest_path, &store_dir, "demo", &rid);
+
+        let stage = temp_dir.path();
+        let v100_dir = stage.join("v100");
+        let v110_dir = stage.join("v110");
+        let v120_dir = stage.join("v120");
+        for dir in [&v100_dir, &v110_dir, &v120_dir] {
+            std::fs::create_dir_all(dir).unwrap();
+        }
+        // A non-trivial file that changes its content (and therefore its hash)
+        // at every release — this is the analog of `camera-tuner.deps.json`
+        // that triggered the production-promotion mismatches in the field.
+        std::fs::write(v100_dir.join("camera-tuner.deps.json"), br#"{"version":"1.0.0"}"#).unwrap();
+        std::fs::write(v110_dir.join("camera-tuner.deps.json"), br#"{"version":"1.1.0"}"#).unwrap();
+        std::fs::write(v120_dir.join("camera-tuner.deps.json"), br#"{"version":"1.2.0"}"#).unwrap();
+        // A second file that is identical across releases, exercising the
+        // sparse-file delta path that copies unchanged files by hash reference.
+        for dir in [&v100_dir, &v110_dir, &v120_dir] {
+            std::fs::write(dir.join("readme.txt"), b"shared content\n").unwrap();
+        }
+
+        let pack_dir = |dir: &Path| -> Vec<u8> {
+            let mut packer = ArchivePacker::new(3).unwrap();
+            packer.add_directory(dir, "").unwrap();
+            packer.finalize().unwrap()
+        };
+
+        let v100_full = pack_dir(&v100_dir);
+        let v110_full = pack_dir(&v110_dir);
+        let v120_full = pack_dir(&v120_dir);
+
+        // Build the v1.1.0 → v1.2.0 sparse delta the same way `surge pack` would,
+        // basing it on the immediate previous overall version (v1.1.0). This is
+        // exactly what production nodes cannot apply when v1.0.0 is their installed
+        // version because the basis-hash check on `camera-tuner.deps.json` fails.
+        let raw_v120_patch =
+            build_sparse_file_patch(&v110_full, &v120_full, 3, 0, &ChunkedDiffOptions::default()).unwrap();
+        let v120_delta_bytes = zstd::encode_all(raw_v120_patch.as_slice(), 3).unwrap();
+
+        let v100_full_key = format!("demo-1.0.0-{rid}-full.tar.zst");
+        let v110_full_key = format!("demo-1.1.0-{rid}-full.tar.zst");
+        let v120_full_key = format!("demo-1.2.0-{rid}-full.tar.zst");
+        let v120_delta_key = format!("demo-1.2.0-{rid}-delta.tar.zst");
+
+        std::fs::write(store_dir.join(&v100_full_key), &v100_full).unwrap();
+        std::fs::write(store_dir.join(&v110_full_key), &v110_full).unwrap();
+        std::fs::write(store_dir.join(&v120_full_key), &v120_full).unwrap();
+        std::fs::write(store_dir.join(&v120_delta_key), &v120_delta_bytes).unwrap();
+
+        let make_release = |version: &str, channels: &[&str], full_key: &str, full_bytes: &[u8]| ReleaseEntry {
+            version: version.to_string(),
+            channels: channels.iter().map(|c| (*c).to_string()).collect(),
+            os: "linux".to_string(),
+            rid: rid.clone(),
+            is_genesis: version == "1.0.0",
+            full_filename: full_key.to_string(),
+            full_size: i64::try_from(full_bytes.len()).unwrap(),
+            full_sha256: sha256_hex(full_bytes),
+            deltas: Vec::new(),
+            preferred_delta_id: String::new(),
+            created_utc: chrono::Utc::now().to_rfc3339(),
+            release_notes: String::new(),
+            name: String::new(),
+            main_exe: "demoapp".to_string(),
+            install_directory: "demoapp".to_string(),
+            supervisor_id: String::new(),
+            icon: String::new(),
+            shortcuts: Vec::new(),
+            persistent_assets: Vec::new(),
+            installers: Vec::new(),
+            environment: std::collections::BTreeMap::new(),
+        };
+
+        let mut v120 = make_release("1.2.0", &["test"], &v120_full_key, &v120_full);
+        v120.deltas = vec![DeltaArtifact::sparse_file_ops_zstd(
+            "primary",
+            "1.1.0",
+            &v120_delta_key,
+            i64::try_from(v120_delta_bytes.len()).unwrap(),
+            &sha256_hex(&v120_delta_bytes),
+        )];
+        v120.preferred_delta_id = "primary".to_string();
+
+        write_index(
+            &store_dir,
+            &ReleaseIndex {
+                app_id: "demo".to_string(),
+                releases: vec![
+                    make_release("1.0.0", &["production", "test"], &v100_full_key, &v100_full),
+                    make_release("1.1.0", &["test"], &v110_full_key, &v110_full),
+                    v120.clone(),
+                ],
+                ..ReleaseIndex::default()
+            },
+        );
+
+        execute(&manifest_path, Some("demo"), "1.2.0", Some(&rid), "production")
+            .await
+            .expect("promote should succeed");
+
+        let index = read_index(&store_dir);
+        let promoted = index
+            .releases
+            .iter()
+            .find(|release| release.version == "1.2.0" && release.rid == rid)
+            .expect("promoted release should exist");
+        assert!(promoted.channels.iter().any(|channel| channel == "production"));
+
+        let production_delta = promoted
+            .delta_from_source("1.0.0")
+            .expect("delta from previous-on-channel release should exist after promote");
+        assert_eq!(production_delta.from_version, "1.0.0");
+
+        // Original test-channel delta from v1.1.0 must still be present so test
+        // nodes can keep updating without regression.
+        let test_delta = promoted
+            .delta_from_source("1.1.0")
+            .expect("original test-channel delta should be preserved");
+        assert_eq!(test_delta.id, "primary");
+
+        let production_delta_path = store_dir.join(&production_delta.filename);
+        let production_delta_bytes = std::fs::read(&production_delta_path)
+            .expect("rebuilt production delta artifact should be uploaded to storage");
+        assert_eq!(sha256_hex(&production_delta_bytes), production_delta.sha256);
+
+        // Verify the new delta actually transforms a v1.0.0 archive into v1.2.0
+        // when applied — this is the apply path that previously crashed with
+        // "Sparse delta file hash mismatch for camera-tuner.deps.json".
+        let decoded = decode_delta_patch(&production_delta_bytes, &production_delta).unwrap();
+        let rebuilt = apply_delta_patch(&v100_full, &decoded, &production_delta).unwrap();
+        let working_dir = tempfile::tempdir().unwrap();
+        surge_core::archive::extractor::extract_to(&rebuilt, working_dir.path(), None).unwrap();
+        assert_eq!(
+            std::fs::read(working_dir.path().join("camera-tuner.deps.json")).unwrap(),
+            br#"{"version":"1.2.0"}"#,
+        );
     }
 
     #[tokio::test]

--- a/crates/surge-core/src/releases/manifest.rs
+++ b/crates/surge-core/src/releases/manifest.rs
@@ -226,6 +226,39 @@ impl ReleaseEntry {
             .collect()
     }
 
+    /// Return the delta whose `from_version` matches `from_version`, if one exists.
+    ///
+    /// A release can carry multiple deltas with different sources (for example one
+    /// built against the previous test version and one built against the previous
+    /// production version). The chain walker uses this lookup so each apply step
+    /// picks the delta whose basis matches the prior step's version.
+    #[must_use]
+    pub fn delta_from_source(&self, from_version: &str) -> Option<DeltaArtifact> {
+        let from_version = from_version.trim();
+        if from_version.is_empty() {
+            return None;
+        }
+        self.deltas
+            .iter()
+            .find(|delta| !delta.filename.trim().is_empty() && delta.from_version == from_version)
+            .cloned()
+    }
+
+    /// Add a delta descriptor, replacing any existing delta with the same `id`.
+    ///
+    /// Empty descriptors are ignored. The `preferred_delta_id` is left untouched
+    /// so callers control which delta becomes the default for `selected_delta`.
+    pub fn upsert_delta(&mut self, delta: DeltaArtifact) {
+        if delta.filename.trim().is_empty() {
+            return;
+        }
+        if let Some(existing) = self.deltas.iter_mut().find(|existing| existing.id == delta.id) {
+            *existing = delta;
+        } else {
+            self.deltas.push(delta);
+        }
+    }
+
     /// Set one canonical delta descriptor.
     pub fn set_primary_delta(&mut self, delta: Option<DeltaArtifact>) {
         match delta {

--- a/crates/surge-core/src/update/manager/release_index.rs
+++ b/crates/surge-core/src/update/manager/release_index.rs
@@ -119,20 +119,21 @@ pub(super) fn resolve_update_info(manager: &mut UpdateManager, index: ReleaseInd
     );
 
     let available_releases: Vec<ReleaseEntry> = newer.into_iter().cloned().collect();
-    let supported_delta_chain = delta_chain.filter(|chain| {
+    let resolved_delta_chain = delta_chain
+        .and_then(|chain| resolve_delta_chain_for_current_install(chain.as_slice(), &manager.current_version));
+    let supported_delta_chain = resolved_delta_chain.filter(|chain| {
         chain
             .iter()
             .all(|release| release.selected_delta().is_some_and(|delta| is_supported_delta(&delta)))
     });
 
     let (apply_releases, apply_strategy, download_size) = if let Some(chain) = supported_delta_chain {
-        let selected: Vec<ReleaseEntry> = chain.into_iter().cloned().collect();
-        let size = selected
+        let size = chain
             .iter()
             .filter_map(ReleaseEntry::selected_delta)
             .map(|delta| delta.size)
             .sum();
-        (selected, ApplyStrategy::Delta, size)
+        (chain, ApplyStrategy::Delta, size)
     } else {
         (vec![latest.clone()], ApplyStrategy::Full, latest.full_size)
     };
@@ -158,6 +159,42 @@ pub(super) fn resolve_update_info(manager: &mut UpdateManager, index: ReleaseInd
     }))
 }
 
+/// For each release in the chain, pick the delta whose `from_version` matches
+/// the previous step's version (or `current_version` for the first step) and
+/// rewrite the release entry to expose only that delta.
+///
+/// Returns `None` if any step lacks a usable delta. Without this lookup, a
+/// delta built against one source version can be applied to a different
+/// installed version, causing sparse-file basis hash mismatches at apply time.
+///
+/// Releases pushed before the index recorded `from_version` carry a single
+/// legacy delta with an empty `from_version`. We accept that delta as a
+/// fallback because legacy `surge pack` always built the delta from the
+/// immediately preceding release; the apply path's basis hash check is the
+/// final guard against an incompatible legacy chain.
+fn resolve_delta_chain_for_current_install(
+    chain: &[&ReleaseEntry],
+    current_version: &str,
+) -> Option<Vec<ReleaseEntry>> {
+    let mut resolved = Vec::with_capacity(chain.len());
+    let mut prev_version = current_version.to_string();
+    for release in chain {
+        let delta = release.delta_from_source(&prev_version).or_else(|| {
+            release
+                .deltas
+                .iter()
+                .find(|delta| !delta.filename.trim().is_empty() && delta.from_version.trim().is_empty())
+                .cloned()
+        })?;
+        let mut entry = (*release).clone();
+        entry.preferred_delta_id.clone_from(&delta.id);
+        entry.deltas = vec![delta];
+        prev_version.clone_from(&entry.version);
+        resolved.push(entry);
+    }
+    Some(resolved)
+}
+
 pub(super) fn release_matches_rid(release: &ReleaseEntry, current_rid: &str) -> bool {
     release.rid.is_empty() || release.rid == current_rid
 }
@@ -172,5 +209,94 @@ pub(super) fn normalize_os_label(raw: &str) -> String {
         "macos" | "osx" | "darwin" => "osx".to_string(),
         "linux" => "linux".to_string(),
         other => other.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::resolve_delta_chain_for_current_install;
+    use crate::releases::manifest::{DeltaArtifact, ReleaseEntry};
+
+    fn release_with_deltas(version: &str, deltas: Vec<DeltaArtifact>) -> ReleaseEntry {
+        ReleaseEntry {
+            version: version.to_string(),
+            channels: vec!["production".to_string()],
+            os: "linux".to_string(),
+            rid: "linux-x64".to_string(),
+            is_genesis: false,
+            full_filename: format!("demo-{version}-linux-x64-full.tar.zst"),
+            full_size: 1,
+            full_sha256: "hash".to_string(),
+            deltas,
+            preferred_delta_id: String::new(),
+            created_utc: String::new(),
+            release_notes: String::new(),
+            name: String::new(),
+            main_exe: "demo".to_string(),
+            install_directory: "demo".to_string(),
+            supervisor_id: String::new(),
+            icon: String::new(),
+            shortcuts: Vec::new(),
+            persistent_assets: Vec::new(),
+            installers: Vec::new(),
+            environment: std::collections::BTreeMap::new(),
+        }
+    }
+
+    #[test]
+    fn resolver_picks_delta_matching_current_install_version() {
+        let release = release_with_deltas(
+            "1.2.0",
+            vec![
+                DeltaArtifact::sparse_file_ops_zstd("primary", "1.1.0", "delta-from-110.tar.zst", 100, "sha-110"),
+                DeltaArtifact::sparse_file_ops_zstd("from-100", "1.0.0", "delta-from-100.tar.zst", 200, "sha-100"),
+            ],
+        );
+
+        let resolved = resolve_delta_chain_for_current_install(&[&release], "1.0.0").expect("chain resolves");
+        assert_eq!(resolved.len(), 1);
+        assert_eq!(resolved[0].deltas.len(), 1);
+        assert_eq!(resolved[0].deltas[0].from_version, "1.0.0");
+        assert_eq!(resolved[0].preferred_delta_id, "from-100");
+    }
+
+    #[test]
+    fn resolver_falls_back_to_legacy_delta_with_empty_from_version() {
+        // Releases pushed before from_version was tracked carry one delta with
+        // an empty from_version. The resolver must still accept those so legacy
+        // chains keep updating.
+        let release = release_with_deltas(
+            "1.1.0",
+            vec![DeltaArtifact::sparse_file_ops_zstd(
+                "primary",
+                "",
+                "delta-legacy.tar.zst",
+                100,
+                "sha-legacy",
+            )],
+        );
+
+        let resolved = resolve_delta_chain_for_current_install(&[&release], "1.0.0").expect("legacy chain resolves");
+        assert_eq!(resolved[0].deltas.len(), 1);
+        assert!(resolved[0].deltas[0].from_version.is_empty());
+    }
+
+    #[test]
+    fn resolver_returns_none_when_no_delta_matches_or_is_legacy() {
+        // A delta with a wrong from_version and no legacy fallback must reject
+        // the chain so the apply path falls back to a full install instead of
+        // attempting an incompatible patch.
+        let release = release_with_deltas(
+            "1.2.0",
+            vec![DeltaArtifact::sparse_file_ops_zstd(
+                "primary",
+                "1.1.0",
+                "delta-from-110.tar.zst",
+                100,
+                "sha-110",
+            )],
+        );
+
+        assert!(resolve_delta_chain_for_current_install(&[&release], "1.0.0").is_none());
     }
 }


### PR DESCRIPTION
## Summary

`surge pack` always builds the release delta against the immediately-previous version overall, regardless of channel. When intermediate releases live only on `test` between two `production` releases, the production-side delta basis no longer matches what production nodes have on disk. The first per-file `PatchFile` basis-hash check during apply fails:

\`\`\`
Sparse delta file hash mismatch for 'camera-tuner.deps.json':
  expected <previous-test hash>, got <previous-production hash>
\`\`\`

The supervisor then never activates the delta. The only operational workaround has been \`surge compact <prod>\` after every promotion, which deletes the broken delta and forces every fleet node into a full reinstall. This pattern shows up in every production promotion log of the youpark fleet (Apr 10, Apr 11, Apr 12).

## What changes

* **`commands/promote.rs`** — after \`ensure_release_full_artifact\`:
  1. Look up the previous release on the target channel.
  2. If the release does not already carry a delta with \`from_version\` matching that predecessor, restore both full archives, build a sparse delta, upload it as \`<app>-<version>-<rid>-from-<prev>-delta.tar.zst\`, and \`upsert_delta\` it onto the release entry.
  3. Original test-channel delta is preserved (multi-delta), so test chains keep working.
  4. Re-running \`surge promote\` on an already-promoted release also rebuilds missing channel deltas, so releases promoted before this fix can recover without a demote/repromote cycle.
* **`update/manager/release_index.rs`** — chain walker resolves each apply step by \`delta_from_source(prev_step.version)\`. Releases pushed before \`from_version\` was tracked carry one delta with an empty \`from_version\`; the resolver accepts those as a legacy fallback so existing chains keep working. Returns \`None\` (forcing full install) when no compatible delta exists, instead of letting the apply path crash with the basis-hash mismatch.
* **`releases/manifest.rs`** — adds \`ReleaseEntry::delta_from_source\` and \`ReleaseEntry::upsert_delta\` helpers.

## Test plan

- [x] \`./scripts/sync-surge-core-vendor.sh --check\`
- [x] \`./scripts/check-version-sync.sh\`
- [x] \`cargo fmt --all -- --check\`
- [x] \`RUSTFLAGS="-D warnings" cargo test --workspace\` (358 tests, +4 new)
- [x] \`cargo clippy --workspace --all-targets --all-features -- -D warnings\`
- [x] \`cargo clippy --workspace --lib --bins --examples -- -D warnings -D clippy::unwrap_used -D clippy::expect_used\`
- [x] \`cargo clippy --workspace --all-targets --all-features -- -D warnings -W clippy::pedantic\`

### New tests

- \`commands::promote::tests::execute_rebuilds_channel_delta_when_promoting_across_skipped_versions\` — constructs real archives via \`ArchivePacker\`, sets up the \`v1.0.0(prod)\` / \`v1.1.0(test)\` / \`v1.2.0(test)\` layout from the field bug, promotes \`v1.2.0\` to production, and verifies the rebuilt delta correctly transforms a v1.0.0 archive into v1.2.0 with the new \`camera-tuner.deps.json\` content.
- \`update::manager::release_index::tests::resolver_picks_delta_matching_current_install_version\`
- \`update::manager::release_index::tests::resolver_falls_back_to_legacy_delta_with_empty_from_version\`
- \`update::manager::release_index::tests::resolver_returns_none_when_no_delta_matches_or_is_legacy\`