### PR TITLE
fix(cli): keep promoted deltas compatible with synthesized bases

### DIFF
--- a/crates/surge-cli/src/commands/promote.rs
+++ b/crates/surge-cli/src/commands/promote.rs
@@ -7,9 +7,8 @@ use crate::ui::UiTheme;
 use surge_core::config::constants::{DEFAULT_ZSTD_LEVEL, RELEASES_FILE_COMPRESSED};
 use surge_core::config::manifest::SurgeManifest;
 use surge_core::crypto::sha256::sha256_hex;
-use surge_core::diff::chunked::ChunkedDiffOptions;
+use surge_core::diff::chunked::{ChunkedDiffOptions, chunked_bsdiff};
 use surge_core::error::{Result, SurgeError};
-use surge_core::releases::delta::build_sparse_file_patch;
 use surge_core::releases::manifest::{DeltaArtifact, ReleaseEntry, ReleaseIndex, compress_release_index};
 use surge_core::releases::restore::restore_full_archive_for_version;
 use surge_core::releases::version::compare_versions;
@@ -169,11 +168,11 @@ fn previous_release_on_channel(index: &ReleaseIndex, rid: &str, channel: &str, v
         .map(|release| release.version.clone())
 }
 
-/// Make sure the release at `version` carries a sparse delta whose basis is the
+/// Make sure the release at `version` carries a delta whose basis is the
 /// previous release on the target channel. Builds and uploads the delta when
 /// missing so production nodes can transition from `from_version` to `version`
-/// without hitting a basis hash mismatch on files that changed across an
-/// in-between test-only release.
+/// even when the target release's primary delta was built against a different
+/// in-between test-only version.
 ///
 /// Returns a one-line summary suitable for inclusion in the promote stage log.
 async fn ensure_channel_delta(
@@ -197,8 +196,7 @@ async fn ensure_channel_delta(
     let prev_archive = restore_full_archive_for_version(backend, index, rid, from_version).await?;
     let new_archive = restore_full_archive_for_version(backend, index, rid, version).await?;
 
-    let diff_options = ChunkedDiffOptions::default();
-    let patch = build_sparse_file_patch(&prev_archive, &new_archive, DEFAULT_ZSTD_LEVEL, 0, &diff_options)?;
+    let patch = chunked_bsdiff(&prev_archive, &new_archive, &ChunkedDiffOptions::default())?;
     let compressed = zstd::encode_all(patch.as_slice(), DEFAULT_ZSTD_LEVEL)
         .map_err(|err| SurgeError::Archive(format!("Failed to compress channel delta: {err}")))?;
 
@@ -213,8 +211,7 @@ async fn ensure_channel_delta(
     let delta_sha256 = sha256_hex(&compressed);
     let delta_id = format!("from-{from_version_slug}");
 
-    let delta =
-        DeltaArtifact::sparse_file_ops_zstd(&delta_id, from_version, &delta_filename, delta_size, &delta_sha256);
+    let delta = DeltaArtifact::chunked_bsdiff_zstd(&delta_id, from_version, &delta_filename, delta_size, &delta_sha256);
     index.releases[release_idx].upsert_delta(delta);
 
     Ok(format!(
@@ -451,7 +448,8 @@ mod tests {
     #[tokio::test]
     async fn execute_rebuilds_channel_delta_when_promoting_across_skipped_versions() {
         use surge_core::archive::packer::ArchivePacker;
-        use surge_core::releases::delta::{apply_delta_patch, decode_delta_patch};
+        use surge_core::releases::delta::{apply_delta_patch, build_sparse_file_patch, decode_delta_patch};
+        const FULL_ARCHIVE_ZSTD_LEVEL: i32 = 7;
 
         let temp_dir = tempfile::tempdir().expect("temp dir");
         let store_dir = temp_dir.path().join("store");
@@ -481,7 +479,7 @@ mod tests {
         }
 
         let pack_dir = |dir: &Path| -> Vec<u8> {
-            let mut packer = ArchivePacker::new(3).unwrap();
+            let mut packer = ArchivePacker::new(FULL_ARCHIVE_ZSTD_LEVEL).unwrap();
             packer.add_directory(dir, "").unwrap();
             packer.finalize().unwrap()
         };
@@ -494,9 +492,15 @@ mod tests {
         // basing it on the immediate previous overall version (v1.1.0). This is
         // exactly what production nodes cannot apply when v1.0.0 is their installed
         // version because the basis-hash check on `camera-tuner.deps.json` fails.
-        let raw_v120_patch =
-            build_sparse_file_patch(&v110_full, &v120_full, 3, 0, &ChunkedDiffOptions::default()).unwrap();
-        let v120_delta_bytes = zstd::encode_all(raw_v120_patch.as_slice(), 3).unwrap();
+        let raw_v120_patch = build_sparse_file_patch(
+            &v110_full,
+            &v120_full,
+            FULL_ARCHIVE_ZSTD_LEVEL,
+            0,
+            &ChunkedDiffOptions::default(),
+        )
+        .unwrap();
+        let v120_delta_bytes = zstd::encode_all(raw_v120_patch.as_slice(), FULL_ARCHIVE_ZSTD_LEVEL).unwrap();
 
         let v100_full_key = format!("demo-1.0.0-{rid}-full.tar.zst");
         let v110_full_key = format!("demo-1.1.0-{rid}-full.tar.zst");
@@ -571,6 +575,10 @@ mod tests {
             .delta_from_source("1.0.0")
             .expect("delta from previous-on-channel release should exist after promote");
         assert_eq!(production_delta.from_version, "1.0.0");
+        assert_eq!(
+            production_delta.patch_format,
+            surge_core::releases::manifest::PATCH_FORMAT_CHUNKED_BSDIFF_V1
+        );
 
         // Original test-channel delta from v1.1.0 must still be present so test
         // nodes can keep updating without regression.
@@ -586,9 +594,12 @@ mod tests {
 
         // Verify the new delta actually transforms a v1.0.0 archive into v1.2.0
         // when applied — this is the apply path that previously crashed with
-        // "Sparse delta file hash mismatch for camera-tuner.deps.json".
+        // "Sparse delta file hash mismatch for camera-tuner.deps.json". It also
+        // must reproduce the exact target archive bytes when the release was
+        // packed with non-default compression settings.
         let decoded = decode_delta_patch(&production_delta_bytes, &production_delta).unwrap();
         let rebuilt = apply_delta_patch(&v100_full, &decoded, &production_delta).unwrap();
+        assert_eq!(rebuilt, v120_full);
         let working_dir = tempfile::tempdir().unwrap();
         surge_core::archive::extractor::extract_to(&rebuilt, working_dir.path(), None).unwrap();
         assert_eq!(

--- a/crates/surge-cli/src/commands/promote.rs
+++ b/crates/surge-cli/src/commands/promote.rs
@@ -6,9 +6,11 @@ use crate::logline;
 use crate::ui::UiTheme;
 use surge_core::config::constants::{DEFAULT_ZSTD_LEVEL, RELEASES_FILE_COMPRESSED};
 use surge_core::config::manifest::SurgeManifest;
+use surge_core::context::ResourceBudget;
 use surge_core::crypto::sha256::sha256_hex;
-use surge_core::diff::chunked::{ChunkedDiffOptions, chunked_bsdiff};
+use surge_core::diff::chunked::ChunkedDiffOptions;
 use surge_core::error::{Result, SurgeError};
+use surge_core::releases::delta::{build_sparse_file_patch, decode_delta_patch, delta_target_archive_encoding};
 use surge_core::releases::manifest::{DeltaArtifact, ReleaseEntry, ReleaseIndex, compress_release_index};
 use surge_core::releases::restore::restore_full_archive_for_version;
 use surge_core::releases::version::compare_versions;
@@ -195,8 +197,16 @@ async fn ensure_channel_delta(
 
     let prev_archive = restore_full_archive_for_version(backend, index, rid, from_version).await?;
     let new_archive = restore_full_archive_for_version(backend, index, rid, version).await?;
+    let (archive_compression_level, archive_zstd_workers) =
+        resolve_target_archive_encoding(backend, &index.releases[release_idx]).await?;
 
-    let patch = chunked_bsdiff(&prev_archive, &new_archive, &ChunkedDiffOptions::default())?;
+    let patch = build_sparse_file_patch(
+        &prev_archive,
+        &new_archive,
+        archive_compression_level,
+        archive_zstd_workers,
+        &ChunkedDiffOptions::default(),
+    )?;
     let compressed = zstd::encode_all(patch.as_slice(), DEFAULT_ZSTD_LEVEL)
         .map_err(|err| SurgeError::Archive(format!("Failed to compress channel delta: {err}")))?;
 
@@ -211,12 +221,31 @@ async fn ensure_channel_delta(
     let delta_sha256 = sha256_hex(&compressed);
     let delta_id = format!("from-{from_version_slug}");
 
-    let delta = DeltaArtifact::chunked_bsdiff_zstd(&delta_id, from_version, &delta_filename, delta_size, &delta_sha256);
+    let delta =
+        DeltaArtifact::sparse_file_ops_zstd(&delta_id, from_version, &delta_filename, delta_size, &delta_sha256);
     index.releases[release_idx].upsert_delta(delta);
 
     Ok(format!(
         "rebuilt delta from v{from_version} ({delta_size} bytes) and stored as {delta_filename}"
     ))
+}
+
+async fn resolve_target_archive_encoding(backend: &dyn StorageBackend, release: &ReleaseEntry) -> Result<(i32, u32)> {
+    if let Some(delta) = release.selected_delta() {
+        match backend.get_object(&delta.filename).await {
+            Ok(delta_bytes) => {
+                let patch = decode_delta_patch(&delta_bytes, &delta)?;
+                if let Some((compression_level, zstd_workers)) = delta_target_archive_encoding(&patch, &delta)? {
+                    return Ok((compression_level, zstd_workers));
+                }
+            }
+            Err(SurgeError::NotFound(_)) => {}
+            Err(err) => return Err(err),
+        }
+    }
+
+    let budget = ResourceBudget::default();
+    Ok((budget.zstd_compression_level, budget.effective_zstd_workers()))
 }
 
 fn sanitize_version_for_filename(version: &str) -> String {
@@ -450,6 +479,8 @@ mod tests {
         use surge_core::archive::packer::ArchivePacker;
         use surge_core::releases::delta::{apply_delta_patch, build_sparse_file_patch, decode_delta_patch};
         const FULL_ARCHIVE_ZSTD_LEVEL: i32 = 7;
+        const SYNTH_ARCHIVE_ZSTD_LEVEL: i32 = 9;
+        const SYNTH_ARCHIVE_ZSTD_WORKERS: u32 = 4;
 
         let temp_dir = tempfile::tempdir().expect("temp dir");
         let store_dir = temp_dir.path().join("store");
@@ -487,6 +518,15 @@ mod tests {
         let v100_full = pack_dir(&v100_dir);
         let v110_full = pack_dir(&v110_dir);
         let v120_full = pack_dir(&v120_dir);
+        let v100_synth = {
+            let synth_extract = tempfile::tempdir().unwrap();
+            surge_core::archive::extractor::extract_to(&v100_full, synth_extract.path(), None).unwrap();
+            let mut synth_packer =
+                ArchivePacker::with_threads(SYNTH_ARCHIVE_ZSTD_LEVEL, SYNTH_ARCHIVE_ZSTD_WORKERS).unwrap();
+            synth_packer.add_directory(synth_extract.path(), "").unwrap();
+            synth_packer.finalize().unwrap()
+        };
+        assert_ne!(v100_synth, v100_full);
 
         // Build the v1.1.0 → v1.2.0 sparse delta the same way `surge pack` would,
         // basing it on the immediate previous overall version (v1.1.0). This is
@@ -577,7 +617,7 @@ mod tests {
         assert_eq!(production_delta.from_version, "1.0.0");
         assert_eq!(
             production_delta.patch_format,
-            surge_core::releases::manifest::PATCH_FORMAT_CHUNKED_BSDIFF_V1
+            surge_core::releases::manifest::PATCH_FORMAT_SPARSE_FILE_OPS_V1
         );
 
         // Original test-channel delta from v1.1.0 must still be present so test
@@ -596,9 +636,11 @@ mod tests {
         // when applied — this is the apply path that previously crashed with
         // "Sparse delta file hash mismatch for camera-tuner.deps.json". It also
         // must reproduce the exact target archive bytes when the release was
-        // packed with non-default compression settings.
+        // packed with non-default compression settings, even if the updater had
+        // to synthesize a tree-equivalent base archive with different zstd
+        // settings from the installed app contents.
         let decoded = decode_delta_patch(&production_delta_bytes, &production_delta).unwrap();
-        let rebuilt = apply_delta_patch(&v100_full, &decoded, &production_delta).unwrap();
+        let rebuilt = apply_delta_patch(&v100_synth, &decoded, &production_delta).unwrap();
         assert_eq!(rebuilt, v120_full);
         let working_dir = tempfile::tempdir().unwrap();
         surge_core::archive::extractor::extract_to(&rebuilt, working_dir.path(), None).unwrap();

--- a/crates/surge-core/src/releases/delta/archive.rs
+++ b/crates/surge-core/src/releases/delta/archive.rs
@@ -71,6 +71,30 @@ pub(super) fn apply_archive_chunked_patch(older: &[u8], patch: &[u8]) -> Result<
     encode_archive_bytes(&newer_tar, compression_level, zstd_workers)
 }
 
+pub(super) fn archive_patch_archive_encoding(data: &[u8], patch_format: &str) -> Result<Option<(i32, u32)>> {
+    if patch_format.eq_ignore_ascii_case(crate::releases::manifest::PATCH_FORMAT_BSDIFF4_ARCHIVE_V3) {
+        let (compression_level, zstd_workers, _) = decode_archive_patch_payload(
+            data,
+            *ARCHIVE_BSDIFF_MAGIC,
+            Some(*LEGACY_ARCHIVE_BSDIFF_MAGIC),
+            Some(b"BSDIFF40"),
+        )?;
+        return Ok(Some((compression_level, zstd_workers)));
+    }
+
+    if patch_format.eq_ignore_ascii_case(crate::releases::manifest::PATCH_FORMAT_CHUNKED_BSDIFF_ARCHIVE_V3) {
+        let (compression_level, zstd_workers, _) = decode_archive_patch_payload(
+            data,
+            *ARCHIVE_CHUNKED_MAGIC,
+            Some(*LEGACY_ARCHIVE_CHUNKED_MAGIC),
+            Some(b"CSDF"),
+        )?;
+        return Ok(Some((compression_level, zstd_workers)));
+    }
+
+    Ok(None)
+}
+
 fn encode_archive_patch_payload(magic: [u8; 4], compression_level: i32, zstd_workers: u32, patch: &[u8]) -> Vec<u8> {
     let mut payload = Vec::with_capacity(ARCHIVE_PATCH_HEADER_LEN + patch.len());
     payload.extend_from_slice(&magic);

--- a/crates/surge-core/src/releases/delta/mod.rs
+++ b/crates/surge-core/src/releases/delta/mod.rs
@@ -75,3 +75,28 @@ pub fn apply_delta_patch(older: &[u8], patch: &[u8], delta: &DeltaArtifact) -> R
         delta.algorithm, delta.patch_format
     )))
 }
+
+pub fn delta_target_archive_encoding(patch: &[u8], delta: &DeltaArtifact) -> Result<Option<(i32, u32)>> {
+    let patch_format = normalized_or_default(&delta.patch_format, PATCH_FORMAT_BSDIFF4);
+    let algorithm = delta.algorithm.trim();
+
+    if patch_format.eq_ignore_ascii_case(PATCH_FORMAT_SPARSE_FILE_OPS_V1) {
+        if !algorithm.is_empty() && !algorithm.eq_ignore_ascii_case(DIFF_ALGORITHM_FILE_OPS) {
+            return Err(SurgeError::Update(format!(
+                "Unsupported delta algorithm/format '{}/{}'",
+                delta.algorithm, delta.patch_format
+            )));
+        }
+        return sparse_ops::sparse_file_patch_archive_encoding(patch).map(Some);
+    }
+
+    let algorithm = normalized_or_default(&delta.algorithm, DIFF_ALGORITHM_BSDIFF);
+    if !algorithm.eq_ignore_ascii_case(DIFF_ALGORITHM_BSDIFF) {
+        return Err(SurgeError::Update(format!(
+            "Unsupported delta algorithm/format '{}/{}'",
+            delta.algorithm, delta.patch_format
+        )));
+    }
+
+    archive::archive_patch_archive_encoding(patch, patch_format)
+}

--- a/crates/surge-core/src/releases/delta/sparse_ops.rs
+++ b/crates/surge-core/src/releases/delta/sparse_ops.rs
@@ -176,6 +176,11 @@ pub fn build_sparse_file_patch(
     )
 }
 
+pub(super) fn sparse_file_patch_archive_encoding(patch: &[u8]) -> Result<(i32, u32)> {
+    let (manifest, _) = decode_sparse_file_ops_payload(patch)?;
+    Ok((manifest.compression_level, manifest.zstd_workers))
+}
+
 pub(super) fn apply_sparse_file_patch(older: &[u8], patch: &[u8]) -> Result<Vec<u8>> {
     let (manifest, payloads) = decode_sparse_file_ops_payload(patch)?;
     let working_dir = tempfile::tempdir()?;

--- a/crates/surge-core/src/releases/delta/tests.rs
+++ b/crates/surge-core/src/releases/delta/tests.rs
@@ -198,3 +198,25 @@ fn test_sparse_file_patch_roundtrip_rebuilds_full_archive_bytes() {
     let rebuilt = apply_delta_patch(&full_v1, &decoded, &delta).unwrap();
     assert_eq!(rebuilt, full_v2);
 }
+
+#[test]
+fn test_delta_target_archive_encoding_reads_sparse_file_patch_settings() {
+    let full_v1 = make_archive("1.0.0", 7, 0);
+    let full_v2 = make_archive("1.1.0", 7, 4);
+    let patch = build_sparse_file_patch(&full_v1, &full_v2, 7, 4, &ChunkedDiffOptions::default()).unwrap();
+    let delta = DeltaArtifact::sparse_file_ops_zstd("primary", "1.0.0", "demo-1.1.0-delta.tar.zst", 1, "sha");
+
+    let encoding = delta_target_archive_encoding(&patch, &delta).unwrap();
+    assert_eq!(encoding, Some((7, 4)));
+}
+
+#[test]
+fn test_delta_target_archive_encoding_reads_archive_chunked_settings() {
+    let full_v1 = make_archive("1.0.0", 11, 0);
+    let full_v2 = make_archive("1.1.0", 11, 4);
+    let patch = build_archive_chunked_patch(&full_v1, &full_v2, 11, 4, &ChunkedDiffOptions::default()).unwrap();
+    let delta = DeltaArtifact::chunked_bsdiff_archive_zstd("primary", "1.0.0", "demo-1.1.0-delta.tar.zst", 1, "sha");
+
+    let encoding = delta_target_archive_encoding(&patch, &delta).unwrap();
+    assert_eq!(encoding, Some((11, 4)));
+}


### PR DESCRIPTION
## Summary
- keep promote-generated channel deltas compatible with synthesized bases rebuilt from the installed app
- derive target archive encoding from the release's existing delta metadata when rebuilding promoted `from-*` deltas
- add regression coverage for promoted delta application from a synthesized base and for archive-encoding introspection

## Testing
- `./scripts/sync-surge-core-vendor.sh --check`
- `./scripts/check-version-sync.sh`
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo test --workspace`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo clippy --workspace --lib --bins --examples -- -D warnings -D clippy::unwrap_used -D clippy::expect_used`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings -W clippy::pedantic`
- `dotnet format dotnet/Surge.slnx --verify-no-changes`
- `dotnet test dotnet/Surge.slnx --configuration Release`

## Notes
- Fixes #87.
- Supersedes #88.
