### PR TITLE
Report apply delta progress

### DIFF
--- a/crates/surge-bench/src/runner/installer.rs
+++ b/crates/surge-bench/src/runner/installer.rs
@@ -99,7 +99,7 @@ fn build_console_installer(
     };
     let installer_path = output_dir.join(format!("Setup-{rid}-{installer_type}.{installer_ext}"));
     let staged_surge_name = surge_binary_name_for_rid(rid);
-    let input_size = fs::metadata(full_package_path).map(|meta| meta.len()).unwrap_or(0);
+    let input_size = fs::metadata(full_package_path).map_or(0, |meta| meta.len());
 
     let (build_result, duration) = time(|| -> Result<()> {
         let staging_dir = tempfile::tempdir()
@@ -149,7 +149,7 @@ fn build_console_installer(
         Ok(())
     });
     build_result?;
-    let output_size = fs::metadata(&installer_path).map(|meta| meta.len()).unwrap_or(0);
+    let output_size = fs::metadata(&installer_path).map_or(0, |meta| meta.len());
 
     Ok((
         installer_path,
@@ -173,7 +173,7 @@ fn run_console_installer(
         fs::remove_dir_all(install_root)?;
     }
     fs::create_dir_all(home_dir)?;
-    let input_size = fs::metadata(installer_path).map(|meta| meta.len()).unwrap_or(0);
+    let input_size = fs::metadata(installer_path).map_or(0, |meta| meta.len());
     let (status, duration) = time(|| {
         Command::new(installer_path)
             .arg("--no-start")

--- a/crates/surge-bench/src/runner/microbench.rs
+++ b/crates/surge-bench/src/runner/microbench.rs
@@ -73,7 +73,7 @@ pub fn run_sha256_memory(archive_data: &[u8]) -> BenchmarkResult {
 }
 
 pub fn run_sha256_file(file_path: &Path) -> BenchmarkResult {
-    let input_size = fs::metadata(file_path).map(|m| m.len()).unwrap_or(0);
+    let input_size = fs::metadata(file_path).map_or(0, |m| m.len());
 
     let (_hash, duration) = time(|| {
         sha256::sha256_hex_file(file_path).expect("Failed to hash file");

--- a/crates/surge-bench/src/runner/update.rs
+++ b/crates/surge-bench/src/runner/update.rs
@@ -67,9 +67,7 @@ pub(super) fn configure_benchmark_context(
     );
 
     let mut budget = ctx.resource_budget();
-    let available_threads = std::thread::available_parallelism()
-        .map(std::num::NonZeroUsize::get)
-        .unwrap_or(1);
+    let available_threads = std::thread::available_parallelism().map_or(1, std::num::NonZeroUsize::get);
     let requested_threads = pack_max_threads.unwrap_or(available_threads).max(1);
     budget.max_threads = i32::try_from(requested_threads).unwrap_or(i32::MAX);
     budget.max_memory_bytes = i64::try_from(pack_memory_mb.saturating_mul(1024 * 1024)).unwrap_or(i64::MAX);
@@ -181,9 +179,7 @@ pub async fn run_update_scenario(
         let version = version_label(version_index);
         let publication =
             publish_release(Arc::clone(&ctx), &manifest_path, app_id, &rid, &version, &artifacts_dir).await?;
-        let release_index_size = fs::metadata(store_dir.join(RELEASES_FILE_COMPRESSED))
-            .map(|meta| meta.len())
-            .unwrap_or(0);
+        let release_index_size = fs::metadata(store_dir.join(RELEASES_FILE_COMPRESSED)).map_or(0, |meta| meta.len());
         release_index_updates.push(publication.release_index_update);
         release_index_sizes.push(release_index_size);
 
@@ -300,7 +296,7 @@ pub async fn run_update_scenario(
     )?;
 
     let releases_index_path = store_dir.join(RELEASES_FILE_COMPRESSED);
-    let releases_index_size = fs::metadata(&releases_index_path).map(|meta| meta.len()).unwrap_or(0);
+    let releases_index_size = fs::metadata(&releases_index_path).map_or(0, |meta| meta.len());
     let check_started = Instant::now();
     let info = update_manager
         .check_for_updates()

--- a/crates/surge-cli/src/commands/install/profile.rs
+++ b/crates/surge-cli/src/commands/install/profile.rs
@@ -34,8 +34,7 @@ fn has_local_nvidia_gpu() -> bool {
     std::process::Command::new("nvidia-smi")
         .arg("-L")
         .output()
-        .map(|output| output.status.success())
-        .unwrap_or(false)
+        .is_ok_and(|output| output.status.success())
 }
 
 pub(super) fn warn_if_local_rid_looks_incompatible(rid: &str, profile: &RuntimeProfile) {

--- a/crates/surge-cli/src/commands/install/remote/mod.rs
+++ b/crates/surge-cli/src/commands/install/remote/mod.rs
@@ -282,9 +282,7 @@ pub(super) async fn install_release_via_tailscale(
             installer_mode,
         )?
     };
-    let installer_size = std::fs::metadata(&installer_path)
-        .map(|metadata| metadata.len())
-        .unwrap_or(0);
+    let installer_size = std::fs::metadata(&installer_path).map_or(0, |metadata| metadata.len());
     logline::info(&format!(
         "Transferring installer to '{file_target}' ({})...",
         crate::formatters::format_bytes(installer_size),

--- a/crates/surge-cli/src/commands/pack/resolution.rs
+++ b/crates/surge-cli/src/commands/pack/resolution.rs
@@ -183,9 +183,7 @@ pub(crate) fn configure_context(manifest_path: &Path, manifest: &SurgeManifest, 
     let ctx = super::super::build_app_scoped_storage_context(manifest, manifest_path, app_id)?;
     let pack_policy = manifest.effective_pack_policy();
     let mut budget = ctx.resource_budget();
-    let available_threads = std::thread::available_parallelism()
-        .map(std::num::NonZeroUsize::get)
-        .unwrap_or(1);
+    let available_threads = std::thread::available_parallelism().map_or(1, std::num::NonZeroUsize::get);
 
     budget.max_threads = i32::try_from(available_threads).unwrap_or(i32::MAX);
     budget.max_memory_bytes = PACK_DEFAULT_MAX_MEMORY_BYTES;

--- a/crates/surge-cli/src/formatters.rs
+++ b/crates/surge-cli/src/formatters.rs
@@ -65,7 +65,7 @@ mod tests {
 
     #[test]
     fn format_duration_uses_minutes_for_60s_and_above() {
-        assert_eq!(format_duration(Duration::from_secs(60)), "1m00s");
+        assert_eq!(format_duration(Duration::from_mins(1)), "1m00s");
         assert_eq!(format_duration(Duration::from_secs(90)), "1m30s");
         assert_eq!(format_duration(Duration::from_secs(725)), "12m05s");
     }

--- a/crates/surge-core/src/archive/packer.rs
+++ b/crates/surge-core/src/archive/packer.rs
@@ -6,6 +6,8 @@ use std::path::{Path, PathBuf};
 
 use crate::error::{Result, SurgeError};
 
+pub type PackProgress<'a> = dyn Fn(u64, u64, u64, u64) + 'a;
+
 pub struct ArchivePacker {
     builder: tar::Builder<zstd::Encoder<'static, Vec<u8>>>,
 }
@@ -36,7 +38,28 @@ impl ArchivePacker {
     }
 
     pub fn add_directory(&mut self, source_dir: &Path, prefix: &str) -> Result<()> {
-        self.add_directory_recursive(source_dir, Path::new(prefix))
+        self.add_directory_with_progress(source_dir, prefix, None)
+    }
+
+    pub fn add_directory_with_progress(
+        &mut self,
+        source_dir: &Path,
+        prefix: &str,
+        progress: Option<&PackProgress<'_>>,
+    ) -> Result<()> {
+        let archive_prefix = Path::new(prefix);
+        let totals = if progress.is_some() {
+            count_directory_entries(source_dir, archive_prefix)?
+        } else {
+            PackTotals::default()
+        };
+        let mut progress_state = PackProgressState {
+            progress,
+            totals,
+            items_done: 0,
+            bytes_done: 0,
+        };
+        self.add_directory_recursive(source_dir, archive_prefix, &mut progress_state)
     }
 
     pub fn add_buffer(&mut self, archive_path: &str, data: &[u8], mode: u32) -> Result<()> {
@@ -72,9 +95,15 @@ impl ArchivePacker {
         Ok(())
     }
 
-    fn add_directory_recursive(&mut self, source_dir: &Path, archive_prefix: &Path) -> Result<()> {
+    fn add_directory_recursive(
+        &mut self,
+        source_dir: &Path,
+        archive_prefix: &Path,
+        progress: &mut PackProgressState<'_>,
+    ) -> Result<()> {
         if !archive_prefix.as_os_str().is_empty() {
             self.add_directory_entry(archive_prefix, source_dir)?;
+            progress.advance(0);
         }
 
         let mut entries = fs::read_dir(source_dir)?.collect::<std::result::Result<Vec<_>, std::io::Error>>()?;
@@ -91,17 +120,19 @@ impl ArchivePacker {
             let metadata = fs::symlink_metadata(&source_path)?;
 
             if metadata.is_dir() {
-                self.add_directory_recursive(&source_path, &archive_path)?;
+                self.add_directory_recursive(&source_path, &archive_path, progress)?;
                 continue;
             }
 
             if metadata.is_file() {
                 self.add_file_entry(&source_path, &archive_path, &metadata)?;
+                progress.advance(metadata.len());
                 continue;
             }
 
             if metadata.file_type().is_symlink() {
                 self.add_symlink_entry(&source_path, &archive_path, &metadata)?;
+                progress.advance(0);
                 continue;
             }
 
@@ -160,6 +191,75 @@ impl ArchivePacker {
             .map_err(|e| SurgeError::Archive(format!("Failed to add symlink: {e}")))?;
         Ok(())
     }
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+struct PackTotals {
+    items: u64,
+    bytes: u64,
+}
+
+struct PackProgressState<'a> {
+    progress: Option<&'a PackProgress<'a>>,
+    totals: PackTotals,
+    items_done: u64,
+    bytes_done: u64,
+}
+
+impl PackProgressState<'_> {
+    fn advance(&mut self, bytes: u64) {
+        self.items_done = self.items_done.saturating_add(1);
+        self.bytes_done = self.bytes_done.saturating_add(bytes);
+        if let Some(cb) = self.progress {
+            cb(self.items_done, self.totals.items, self.bytes_done, self.totals.bytes);
+        }
+    }
+}
+
+fn count_directory_entries(source_dir: &Path, archive_prefix: &Path) -> Result<PackTotals> {
+    let mut totals = PackTotals::default();
+    if !archive_prefix.as_os_str().is_empty() {
+        totals.items = totals.items.saturating_add(1);
+    }
+
+    let mut entries = fs::read_dir(source_dir)?.collect::<std::result::Result<Vec<_>, std::io::Error>>()?;
+    entries.sort_by(|left, right| {
+        archive_child_path(archive_prefix, left.path().file_name().unwrap_or_default()).cmp(&archive_child_path(
+            archive_prefix,
+            right.path().file_name().unwrap_or_default(),
+        ))
+    });
+
+    for entry in entries {
+        let source_path = entry.path();
+        let archive_path = archive_child_path(archive_prefix, &entry.file_name());
+        let metadata = fs::symlink_metadata(&source_path)?;
+
+        if metadata.is_dir() {
+            let child_totals = count_directory_entries(&source_path, &archive_path)?;
+            totals.items = totals.items.saturating_add(child_totals.items);
+            totals.bytes = totals.bytes.saturating_add(child_totals.bytes);
+            continue;
+        }
+
+        if metadata.is_file() {
+            totals.items = totals.items.saturating_add(1);
+            totals.bytes = totals.bytes.saturating_add(metadata.len());
+            continue;
+        }
+
+        if metadata.file_type().is_symlink() {
+            totals.items = totals.items.saturating_add(1);
+            continue;
+        }
+
+        return Err(SurgeError::Archive(format!(
+            "Unsupported filesystem entry while packing: {}",
+            source_path.display()
+        )));
+    }
+
+    Ok(totals)
 }
 
 fn archive_child_path(prefix: &Path, child_name: &std::ffi::OsStr) -> PathBuf {

--- a/crates/surge-core/src/context.rs
+++ b/crates/surge-core/src/context.rs
@@ -64,12 +64,8 @@ impl ResourceBudget {
         if requested <= 1 {
             return 0;
         }
-        let cpus = u32::try_from(
-            std::thread::available_parallelism()
-                .map(std::num::NonZeroUsize::get)
-                .unwrap_or(1),
-        )
-        .unwrap_or(u32::MAX);
+        let cpus = u32::try_from(std::thread::available_parallelism().map_or(1, std::num::NonZeroUsize::get))
+            .unwrap_or(u32::MAX);
         requested.min(cpus)
     }
 }

--- a/crates/surge-core/src/diff/chunked.rs
+++ b/crates/surge-core/src/diff/chunked.rs
@@ -26,6 +26,9 @@ const VERSION: u8 = 1;
 /// Default chunk size: 64 MiB.
 pub const DEFAULT_CHUNK_SIZE: usize = 64 * 1024 * 1024;
 
+/// Progress callback for file-backed patch application: (bytes_done, bytes_total).
+pub type ByteProgress<'a> = dyn Fn(u64, u64) + 'a;
+
 /// Returns whether `data` starts with the chunked patch magic bytes.
 #[must_use]
 pub fn has_magic_prefix(data: &[u8]) -> bool {
@@ -51,7 +54,7 @@ impl Default for ChunkedDiffOptions {
 
 impl ChunkedDiffOptions {
     fn effective_threads(&self) -> usize {
-        let cpu_count = thread::available_parallelism().map(std::num::NonZero::get).unwrap_or(1);
+        let cpu_count = thread::available_parallelism().map_or(1, std::num::NonZero::get);
 
         if self.max_threads != 0 {
             return self.max_threads.min(cpu_count);
@@ -371,6 +374,17 @@ pub fn chunked_bsdiff_files(older_path: &Path, newer_path: &Path, opts: &Chunked
 /// reconstructed file to `output_path` without materializing the entire output
 /// in memory.
 pub fn chunked_bspatch_file(older_path: &Path, patch: &[u8], output_path: &Path) -> Result<()> {
+    chunked_bspatch_file_with_progress(older_path, patch, output_path, None)
+}
+
+/// Apply a chunked binary diff patch directly against a file and report output
+/// bytes as chunks are reconstructed.
+pub fn chunked_bspatch_file_with_progress(
+    older_path: &Path,
+    patch: &[u8],
+    output_path: &Path,
+    progress: Option<&ByteProgress<'_>>,
+) -> Result<()> {
     let (old_size, new_size, chunk_size, chunk_patches) = deserialize_patch(patch)?;
     let actual_old_size = usize::try_from(fs::metadata(older_path)?.len())
         .map_err(|_| SurgeError::Diff("old file exceeds platform limits".into()))?;
@@ -400,6 +414,12 @@ pub fn chunked_bspatch_file(older_path: &Path, patch: &[u8], output_path: &Path)
         };
         output.write_all(&new_chunk)?;
         bytes_written = bytes_written.saturating_add(new_chunk.len());
+        if let Some(cb) = progress {
+            cb(
+                usize_to_u64_saturating(bytes_written),
+                usize_to_u64_saturating(new_size),
+            );
+        }
     }
     output.flush()?;
 
@@ -410,6 +430,10 @@ pub fn chunked_bspatch_file(older_path: &Path, patch: &[u8], output_path: &Path)
     }
 
     Ok(())
+}
+
+fn usize_to_u64_saturating(value: usize) -> u64 {
+    u64::try_from(value).unwrap_or(u64::MAX)
 }
 
 /// Patch format:

--- a/crates/surge-core/src/install/activation.rs
+++ b/crates/surge-core/src/install/activation.rs
@@ -68,9 +68,15 @@ pub fn install_package_locally_at_root_with_progress(
     );
     let extract_progress = |items_done: u64, items_total: u64, bytes_done: u64, bytes_total: u64| {
         let phase_percent = if bytes_total > 0 {
-            ((bytes_done.saturating_mul(100)) / bytes_total).clamp(0, 100) as i32
+            bytes_done
+                .saturating_mul(100)
+                .checked_div(bytes_total)
+                .map_or(0, |percent| percent.clamp(0, 100) as i32)
         } else if items_total > 0 {
-            ((items_done.saturating_mul(100)) / items_total).clamp(0, 100) as i32
+            items_done
+                .saturating_mul(100)
+                .checked_div(items_total)
+                .map_or(0, |percent| percent.clamp(0, 100) as i32)
         } else {
             0
         };

--- a/crates/surge-core/src/pack/builder/delta.rs
+++ b/crates/surge-core/src/pack/builder/delta.rs
@@ -150,9 +150,7 @@ fn chunked_diff_options(budget: &ResourceBudget, older_len: usize, newer_len: us
 
     let requested_threads = usize::try_from(budget.max_threads).ok().unwrap_or(0);
     let planning_threads = if requested_threads == 0 {
-        std::thread::available_parallelism()
-            .map(std::num::NonZeroUsize::get)
-            .unwrap_or(1)
+        std::thread::available_parallelism().map_or(1, std::num::NonZeroUsize::get)
     } else {
         requested_threads
     };

--- a/crates/surge-core/src/platform/detect.rs
+++ b/crates/surge-core/src/platform/detect.rs
@@ -60,9 +60,7 @@ pub fn current_rid() -> String {
 
 #[must_use]
 pub fn cpu_count() -> usize {
-    std::thread::available_parallelism()
-        .map(std::num::NonZero::get)
-        .unwrap_or(1)
+    std::thread::available_parallelism().map_or(1, std::num::NonZero::get)
 }
 
 #[cfg(test)]

--- a/crates/surge-core/src/releases/delta/fs_apply.rs
+++ b/crates/surge-core/src/releases/delta/fs_apply.rs
@@ -1,14 +1,26 @@
 use std::fs;
+use std::io::Write;
 use std::path::{Component, Path, PathBuf};
 
 use crate::crypto::sha256::sha256_hex_file;
-use crate::diff::chunked::chunked_bspatch_file;
+use crate::diff::chunked::chunked_bspatch_file_with_progress;
 use crate::error::{Result, SurgeError};
 
 use super::sparse_ops::SparseFileOp;
 
-pub(super) fn apply_sparse_file_ops(root: &Path, ops: &[SparseFileOp], payloads: &[u8]) -> Result<()> {
+pub(super) type SparseOpProgress<'a> = dyn Fn(u64, u64) + 'a;
+
+pub(super) fn apply_sparse_file_ops_with_progress(
+    root: &Path,
+    ops: &[SparseFileOp],
+    payloads: &[u8],
+    progress: Option<&SparseOpProgress<'_>>,
+) -> Result<()> {
+    let total_units = sparse_file_ops_work_units(ops);
+    let mut completed_units = 0u64;
+
     for op in ops {
+        let op_units = sparse_file_op_work_units(op);
         match op {
             SparseFileOp::Delete { path } => {
                 let target = resolve_relative_path(root, path)?;
@@ -36,7 +48,9 @@ pub(super) fn apply_sparse_file_ops(root: &Path, ops: &[SparseFileOp], payloads:
                 if let Some(parent) = target.parent() {
                     fs::create_dir_all(parent)?;
                 }
-                fs::write(&target, payload)?;
+                write_payload_with_progress(&target, payload, |done, total| {
+                    report_op_progress(progress, completed_units, op_units, done, total, total_units);
+                })?;
                 set_mode(&target, *mode)?;
                 verify_file_sha256(&target, sha256)?;
             }
@@ -55,7 +69,14 @@ pub(super) fn apply_sparse_file_ops(root: &Path, ops: &[SparseFileOp], payloads:
                 if temp_path.exists() {
                     fs::remove_file(&temp_path)?;
                 }
-                chunked_bspatch_file(&target, patch_bytes, &temp_path)?;
+                chunked_bspatch_file_with_progress(
+                    &target,
+                    patch_bytes,
+                    &temp_path,
+                    Some(&|done, total| {
+                        report_op_progress(progress, completed_units, op_units, done, total, total_units);
+                    }),
+                )?;
                 fs::remove_file(&target)?;
                 fs::rename(&temp_path, &target)?;
                 set_mode(&target, *mode)?;
@@ -70,8 +91,73 @@ pub(super) fn apply_sparse_file_ops(root: &Path, ops: &[SparseFileOp], payloads:
                 create_symlink(target, &link_path)?;
             }
         }
+        completed_units = completed_units.saturating_add(op_units);
+        if let Some(cb) = progress {
+            cb(completed_units, total_units);
+        }
     }
     Ok(())
+}
+
+pub(super) fn sparse_file_ops_work_units(ops: &[SparseFileOp]) -> u64 {
+    ops.iter()
+        .fold(0u64, |acc, op| acc.saturating_add(sparse_file_op_work_units(op)))
+        .max(1)
+}
+
+fn sparse_file_op_work_units(op: &SparseFileOp) -> u64 {
+    match op {
+        SparseFileOp::WriteFile { payload_len, .. } | SparseFileOp::PatchFile { payload_len, .. } => {
+            (*payload_len).max(1)
+        }
+        SparseFileOp::Delete { .. }
+        | SparseFileOp::EnsureDir { .. }
+        | SparseFileOp::SetMode { .. }
+        | SparseFileOp::WriteSymlink { .. } => 1,
+    }
+}
+
+fn report_op_progress(
+    progress: Option<&SparseOpProgress<'_>>,
+    completed_units: u64,
+    op_units: u64,
+    op_done: u64,
+    op_total: u64,
+    total_units: u64,
+) {
+    if let Some(cb) = progress {
+        cb(
+            completed_units.saturating_add(scale_units(op_units, op_done, op_total)),
+            total_units,
+        );
+    }
+}
+
+fn write_payload_with_progress<F>(path: &Path, payload: &[u8], progress: F) -> Result<()>
+where
+    F: Fn(u64, u64),
+{
+    let mut file = fs::File::create(path)?;
+    let total = usize_to_u64_saturating(payload.len());
+    let mut written = 0u64;
+    for chunk in payload.chunks(1024 * 1024) {
+        file.write_all(chunk)?;
+        written = written.saturating_add(usize_to_u64_saturating(chunk.len()));
+        progress(written, total);
+    }
+    file.flush()?;
+    Ok(())
+}
+
+fn scale_units(units: u64, done: u64, total: u64) -> u64 {
+    if total == 0 {
+        return 0;
+    }
+    units.saturating_mul(done.min(total)) / total
+}
+
+fn usize_to_u64_saturating(value: usize) -> u64 {
+    u64::try_from(value).unwrap_or(u64::MAX)
 }
 
 fn resolve_relative_path(root: &Path, relative: &str) -> Result<PathBuf> {

--- a/crates/surge-core/src/releases/delta/mod.rs
+++ b/crates/surge-core/src/releases/delta/mod.rs
@@ -23,6 +23,18 @@ pub use self::format::{
 };
 pub use self::sparse_ops::build_sparse_file_patch;
 
+/// Progress information for CPU/disk work while applying one delta artifact.
+#[derive(Debug, Clone, Copy)]
+pub struct DeltaApplyProgress {
+    /// Work units completed within the current delta artifact.
+    pub units_done: u64,
+    /// Total work units expected for the current delta artifact.
+    pub units_total: u64,
+}
+
+/// Callback used while rebuilding an archive from a delta artifact.
+pub type DeltaApplyProgressCallback<'a> = dyn Fn(DeltaApplyProgress) + Send + Sync + 'a;
+
 pub fn decode_delta_patch(data: &[u8], delta: &DeltaArtifact) -> Result<Vec<u8>> {
     let compression = normalized_or_default(&delta.compression, COMPRESSION_ZSTD);
     if compression.eq_ignore_ascii_case(COMPRESSION_ZSTD) {
@@ -35,6 +47,15 @@ pub fn decode_delta_patch(data: &[u8], delta: &DeltaArtifact) -> Result<Vec<u8>>
 }
 
 pub fn apply_delta_patch(older: &[u8], patch: &[u8], delta: &DeltaArtifact) -> Result<Vec<u8>> {
+    apply_delta_patch_with_progress(older, patch, delta, None)
+}
+
+pub fn apply_delta_patch_with_progress(
+    older: &[u8],
+    patch: &[u8],
+    delta: &DeltaArtifact,
+    progress: Option<&DeltaApplyProgressCallback<'_>>,
+) -> Result<Vec<u8>> {
     let patch_format = normalized_or_default(&delta.patch_format, PATCH_FORMAT_BSDIFF4);
     let algorithm = delta.algorithm.trim();
 
@@ -45,7 +66,7 @@ pub fn apply_delta_patch(older: &[u8], patch: &[u8], delta: &DeltaArtifact) -> R
                 delta.algorithm, delta.patch_format
             )));
         }
-        return sparse_ops::apply_sparse_file_patch(older, patch);
+        return sparse_ops::apply_sparse_file_patch_with_progress(older, patch, progress);
     }
 
     let algorithm = normalized_or_default(&delta.algorithm, DIFF_ALGORITHM_BSDIFF);
@@ -57,23 +78,34 @@ pub fn apply_delta_patch(older: &[u8], patch: &[u8], delta: &DeltaArtifact) -> R
         )));
     }
 
-    if patch_format.eq_ignore_ascii_case(PATCH_FORMAT_BSDIFF4) {
-        return bspatch_buffers(older, patch);
+    emit_delta_apply_progress(progress, 0, 1);
+    let result = if patch_format.eq_ignore_ascii_case(PATCH_FORMAT_BSDIFF4) {
+        bspatch_buffers(older, patch)
+    } else if patch_format.eq_ignore_ascii_case(PATCH_FORMAT_CHUNKED_BSDIFF_V1) {
+        chunked_bspatch(older, patch, &ChunkedDiffOptions::default())
+    } else if patch_format.eq_ignore_ascii_case(PATCH_FORMAT_BSDIFF4_ARCHIVE_V3) {
+        archive::apply_archive_bsdiff_patch(older, patch)
+    } else if patch_format.eq_ignore_ascii_case(PATCH_FORMAT_CHUNKED_BSDIFF_ARCHIVE_V3) {
+        archive::apply_archive_chunked_patch(older, patch)
+    } else {
+        Err(SurgeError::Update(format!(
+            "Unsupported delta algorithm/format '{}/{}'",
+            delta.algorithm, delta.patch_format
+        )))
+    };
+    if result.is_ok() {
+        emit_delta_apply_progress(progress, 1, 1);
     }
-    if patch_format.eq_ignore_ascii_case(PATCH_FORMAT_CHUNKED_BSDIFF_V1) {
-        return chunked_bspatch(older, patch, &ChunkedDiffOptions::default());
-    }
-    if patch_format.eq_ignore_ascii_case(PATCH_FORMAT_BSDIFF4_ARCHIVE_V3) {
-        return archive::apply_archive_bsdiff_patch(older, patch);
-    }
-    if patch_format.eq_ignore_ascii_case(PATCH_FORMAT_CHUNKED_BSDIFF_ARCHIVE_V3) {
-        return archive::apply_archive_chunked_patch(older, patch);
-    }
+    result
+}
 
-    Err(SurgeError::Update(format!(
-        "Unsupported delta algorithm/format '{}/{}'",
-        delta.algorithm, delta.patch_format
-    )))
+fn emit_delta_apply_progress(progress: Option<&DeltaApplyProgressCallback<'_>>, units_done: u64, units_total: u64) {
+    if let Some(cb) = progress {
+        cb(DeltaApplyProgress {
+            units_done: units_done.min(units_total),
+            units_total,
+        });
+    }
 }
 
 pub fn delta_target_archive_encoding(patch: &[u8], delta: &DeltaArtifact) -> Result<Option<(i32, u32)>> {

--- a/crates/surge-core/src/releases/delta/sparse_ops.rs
+++ b/crates/surge-core/src/releases/delta/sparse_ops.rs
@@ -8,8 +8,9 @@ use crate::crypto::sha256::sha256_hex_file;
 use crate::diff::chunked::{ChunkedDiffOptions, chunked_bsdiff_files};
 use crate::error::{Result, SurgeError};
 
-use super::fs_apply::apply_sparse_file_ops;
+use super::fs_apply::{apply_sparse_file_ops_with_progress, sparse_file_ops_work_units};
 use super::tree::{TreeEntryKind, collect_tree_entries, files_identical};
+use super::{DeltaApplyProgress, DeltaApplyProgressCallback};
 
 pub(super) const SPARSE_FILE_OPS_MAGIC: &[u8; 4] = b"SFD1";
 
@@ -181,19 +182,83 @@ pub(super) fn sparse_file_patch_archive_encoding(patch: &[u8]) -> Result<(i32, u
     Ok((manifest.compression_level, manifest.zstd_workers))
 }
 
-pub(super) fn apply_sparse_file_patch(older: &[u8], patch: &[u8]) -> Result<Vec<u8>> {
+pub(super) fn apply_sparse_file_patch_with_progress(
+    older: &[u8],
+    patch: &[u8],
+    progress: Option<&DeltaApplyProgressCallback<'_>>,
+) -> Result<Vec<u8>> {
     let (manifest, payloads) = decode_sparse_file_ops_payload(patch)?;
     let working_dir = tempfile::tempdir()?;
-    extract_to(older, working_dir.path(), None)?;
-    apply_sparse_file_ops(working_dir.path(), &manifest.ops, payloads)?;
+
+    let extract_units = usize_to_u64_saturating(older.len()).max(1);
+    let ops_units = sparse_file_ops_work_units(&manifest.ops);
+    let repack_units = extract_units
+        .saturating_add(usize_to_u64_saturating(payloads.len()))
+        .max(1);
+    let total_units = extract_units.saturating_add(ops_units).saturating_add(repack_units);
+
+    emit_progress(progress, 0, total_units);
+
+    let extract_progress = |items_done: u64, items_total: u64, bytes_done: u64, bytes_total: u64| {
+        let units_done = if bytes_total > 0 {
+            scale_units(extract_units, bytes_done, bytes_total)
+        } else {
+            scale_units(extract_units, items_done, items_total)
+        };
+        emit_progress(progress, units_done, total_units);
+    };
+    extract_to(
+        older,
+        working_dir.path(),
+        progress.map(|_| &extract_progress as &crate::archive::extractor::ExtractProgress<'_>),
+    )?;
+    emit_progress(progress, extract_units, total_units);
+
+    let ops_progress = |done: u64, total: u64| {
+        emit_progress(
+            progress,
+            extract_units.saturating_add(scale_units(ops_units, done, total)),
+            total_units,
+        );
+    };
+    apply_sparse_file_ops_with_progress(
+        working_dir.path(),
+        &manifest.ops,
+        payloads,
+        progress.map(|_| &ops_progress as &super::fs_apply::SparseOpProgress<'_>),
+    )?;
+    let repack_start_units = extract_units.saturating_add(ops_units);
+    emit_progress(progress, repack_start_units, total_units);
 
     let mut packer = if manifest.zstd_workers > 1 {
         ArchivePacker::with_threads(manifest.compression_level, manifest.zstd_workers)?
     } else {
         ArchivePacker::new(manifest.compression_level)?
     };
-    packer.add_directory(working_dir.path(), "")?;
-    packer.finalize()
+
+    let add_directory_units = repack_units.saturating_mul(9) / 10;
+    let repack_progress = |items_done: u64, items_total: u64, bytes_done: u64, bytes_total: u64| {
+        let units_done = if bytes_total > 0 {
+            scale_units(add_directory_units, bytes_done, bytes_total)
+        } else {
+            scale_units(add_directory_units, items_done, items_total)
+        };
+        emit_progress(progress, repack_start_units.saturating_add(units_done), total_units);
+    };
+    packer.add_directory_with_progress(
+        working_dir.path(),
+        "",
+        progress.map(|_| &repack_progress as &crate::archive::packer::PackProgress<'_>),
+    )?;
+    emit_progress(
+        progress,
+        repack_start_units.saturating_add(add_directory_units),
+        total_units,
+    );
+
+    let rebuilt = packer.finalize()?;
+    emit_progress(progress, total_units, total_units);
+    Ok(rebuilt)
 }
 
 fn encode_sparse_file_ops_payload(manifest: &SparseFileDeltaManifest, payloads: &[u8]) -> Result<Vec<u8>> {
@@ -241,4 +306,24 @@ fn append_payload(buffer: &mut Vec<u8>, payload: &[u8]) -> Result<(u64, u64)> {
 
 fn path_depth(path: &str) -> usize {
     std::path::Path::new(path).components().count()
+}
+
+fn emit_progress(progress: Option<&DeltaApplyProgressCallback<'_>>, units_done: u64, units_total: u64) {
+    if let Some(cb) = progress {
+        cb(DeltaApplyProgress {
+            units_done: units_done.min(units_total),
+            units_total,
+        });
+    }
+}
+
+fn scale_units(units: u64, done: u64, total: u64) -> u64 {
+    if total == 0 {
+        return 0;
+    }
+    units.saturating_mul(done.min(total)) / total
+}
+
+fn usize_to_u64_saturating(value: usize) -> u64 {
+    u64::try_from(value).unwrap_or(u64::MAX)
 }

--- a/crates/surge-core/src/releases/delta/tests.rs
+++ b/crates/surge-core/src/releases/delta/tests.rs
@@ -199,6 +199,78 @@ fn test_sparse_file_patch_roundtrip_rebuilds_full_archive_bytes() {
     assert_eq!(rebuilt, full_v2);
 }
 
+#[test]
+fn test_sparse_file_patch_reports_incremental_apply_progress() {
+    let dir = tempfile::tempdir().unwrap();
+    let old_dir = dir.path().join("old");
+    let new_dir = dir.path().join("new");
+    std::fs::create_dir_all(old_dir.join("bin")).unwrap();
+    std::fs::create_dir_all(new_dir.join("bin")).unwrap();
+    std::fs::create_dir_all(new_dir.join("models")).unwrap();
+    std::fs::write(old_dir.join("bin").join("runtime.bin"), vec![b'A'; 512 * 1024]).unwrap();
+    std::fs::write(new_dir.join("bin").join("runtime.bin"), {
+        let mut bytes = vec![b'A'; 512 * 1024];
+        bytes[4096] = b'B';
+        bytes
+    })
+    .unwrap();
+    std::fs::write(new_dir.join("models").join("model-v2.bin"), vec![b'Z'; 512 * 1024]).unwrap();
+
+    let mut old_packer = ArchivePacker::new(7).unwrap();
+    old_packer.add_directory(&old_dir, "").unwrap();
+    let full_v1 = old_packer.finalize().unwrap();
+
+    let mut new_packer = ArchivePacker::new(7).unwrap();
+    new_packer.add_directory(&new_dir, "").unwrap();
+    let full_v2 = new_packer.finalize().unwrap();
+
+    let patch = build_sparse_file_patch(
+        &full_v1,
+        &full_v2,
+        7,
+        0,
+        &ChunkedDiffOptions {
+            chunk_size: 128 * 1024,
+            max_threads: 1,
+        },
+    )
+    .unwrap();
+    let delta_bytes = zstd::encode_all(patch.as_slice(), 3).unwrap();
+    let delta = DeltaArtifact::sparse_file_ops_zstd(
+        "primary",
+        "1.0.0",
+        "demo-1.1.0-delta.tar.zst",
+        i64::try_from(delta_bytes.len()).unwrap(),
+        &sha256_hex(&delta_bytes),
+    );
+
+    let observed = std::sync::Mutex::new(Vec::new());
+    let decoded = decode_delta_patch(&delta_bytes, &delta).unwrap();
+    let rebuilt = apply_delta_patch_with_progress(
+        &full_v1,
+        &decoded,
+        &delta,
+        Some(&|progress| {
+            observed
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .push(progress);
+        }),
+    )
+    .unwrap();
+
+    assert_eq!(rebuilt, full_v2);
+    let observed = observed.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+    assert!(
+        observed
+            .iter()
+            .any(|progress| progress.units_done > 0 && progress.units_done < progress.units_total),
+        "expected at least one intermediate sparse delta apply progress event"
+    );
+    let final_progress = observed.last().expect("expected sparse delta apply progress");
+    assert_eq!(final_progress.units_done, final_progress.units_total);
+}
+
 // Multithreaded-zstd variant of the roundtrip test. Mirrors what production
 // pack actually does: full archive and sparse delta are both built with the
 // same (level, workers) as provided by ResourceBudget (by default 4 workers).

--- a/crates/surge-core/src/supervisor/stub.rs
+++ b/crates/surge-core/src/supervisor/stub.rs
@@ -126,10 +126,7 @@ fn find_main_executable(app_dir: &Path) -> Result<PathBuf> {
 #[cfg(unix)]
 fn is_executable(path: &Path) -> bool {
     use std::os::unix::fs::PermissionsExt;
-    path.is_file()
-        && std::fs::metadata(path)
-            .map(|m| m.permissions().mode() & 0o111 != 0)
-            .unwrap_or(false)
+    path.is_file() && std::fs::metadata(path).is_ok_and(|m| m.permissions().mode() & 0o111 != 0)
 }
 
 #[cfg(not(unix))]

--- a/crates/surge-core/src/update/manager.rs
+++ b/crates/surge-core/src/update/manager.rs
@@ -1626,6 +1626,176 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_download_and_apply_reports_incremental_progress_for_single_sparse_delta() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store_root = tmp.path().join("store");
+        let install_root = tmp.path().join("install");
+        let app_id = "test-app";
+        std::fs::create_dir_all(&store_root).unwrap();
+        std::fs::create_dir_all(&install_root).unwrap();
+        let app_store = app_scoped_store_root(&store_root, app_id);
+
+        let rid = current_rid();
+        let os = current_os_label_for_tests();
+
+        let source_v1 = tmp.path().join("source-v1");
+        let source_v2 = tmp.path().join("source-v2");
+        std::fs::create_dir_all(source_v1.join("bin")).unwrap();
+        std::fs::create_dir_all(source_v2.join("bin")).unwrap();
+        std::fs::create_dir_all(source_v2.join("models")).unwrap();
+        std::fs::write(
+            source_v1.join("bin").join("runtime.bin"),
+            pseudo_random_bytes(384 * 1024),
+        )
+        .unwrap();
+        std::fs::write(
+            source_v2.join("bin").join("runtime.bin"),
+            pseudo_random_bytes(384 * 1024),
+        )
+        .unwrap();
+        std::fs::write(
+            source_v2.join("models").join("model.bin"),
+            pseudo_random_bytes(256 * 1024),
+        )
+        .unwrap();
+
+        let mut packer_v1 = ArchivePacker::new(3).unwrap();
+        packer_v1.add_directory(&source_v1, "").unwrap();
+        let full_v1 = packer_v1.finalize().unwrap();
+
+        let mut packer_v2 = ArchivePacker::new(3).unwrap();
+        packer_v2.add_directory(&source_v2, "").unwrap();
+        let full_v2 = packer_v2.finalize().unwrap();
+
+        let patch_v2 = build_sparse_file_patch(
+            &full_v1,
+            &full_v2,
+            3,
+            0,
+            &ChunkedDiffOptions {
+                chunk_size: 128 * 1024,
+                max_threads: 1,
+            },
+        )
+        .unwrap();
+        let delta_v2 = zstd::encode_all(patch_v2.as_slice(), 3).unwrap();
+
+        let full_v1_name = format!("{app_id}-1.0.0-{rid}-full.tar.zst");
+        let full_v2_name = format!("{app_id}-1.1.0-{rid}-full.tar.zst");
+        let delta_v2_name = format!("{app_id}-1.1.0-{rid}-delta.tar.zst");
+        std::fs::write(app_store.join(&full_v1_name), &full_v1).unwrap();
+        std::fs::write(app_store.join(&delta_v2_name), &delta_v2).unwrap();
+
+        let index = ReleaseIndex {
+            app_id: app_id.to_string(),
+            releases: vec![
+                ReleaseEntry {
+                    version: "1.0.0".to_string(),
+                    channels: vec!["stable".to_string()],
+                    os: os.clone(),
+                    rid: rid.clone(),
+                    is_genesis: true,
+                    full_filename: full_v1_name,
+                    full_size: full_v1.len() as i64,
+                    full_sha256: sha256_hex(&full_v1),
+                    full_compression_level: 0,
+                    full_zstd_workers: 0,
+                    deltas: Vec::new(),
+                    preferred_delta_id: String::new(),
+                    created_utc: chrono::Utc::now().to_rfc3339(),
+                    release_notes: String::new(),
+                    name: String::new(),
+                    main_exe: app_id.to_string(),
+                    install_directory: app_id.to_string(),
+                    supervisor_id: String::new(),
+                    icon: String::new(),
+                    shortcuts: Vec::new(),
+                    persistent_assets: Vec::new(),
+                    installers: Vec::new(),
+                    environment: std::collections::BTreeMap::new(),
+                },
+                ReleaseEntry {
+                    version: "1.1.0".to_string(),
+                    channels: vec!["stable".to_string()],
+                    os,
+                    rid: rid.clone(),
+                    is_genesis: false,
+                    full_filename: full_v2_name,
+                    full_size: full_v2.len() as i64,
+                    full_sha256: sha256_hex(&full_v2),
+                    full_compression_level: 0,
+                    full_zstd_workers: 0,
+                    deltas: vec![DeltaArtifact::sparse_file_ops_zstd(
+                        "primary",
+                        "1.0.0",
+                        &delta_v2_name,
+                        delta_v2.len() as i64,
+                        &sha256_hex(&delta_v2),
+                    )],
+                    preferred_delta_id: "primary".to_string(),
+                    created_utc: chrono::Utc::now().to_rfc3339(),
+                    release_notes: String::new(),
+                    name: String::new(),
+                    main_exe: app_id.to_string(),
+                    install_directory: app_id.to_string(),
+                    supervisor_id: String::new(),
+                    icon: String::new(),
+                    shortcuts: Vec::new(),
+                    persistent_assets: Vec::new(),
+                    installers: Vec::new(),
+                    environment: std::collections::BTreeMap::new(),
+                },
+            ],
+            ..ReleaseIndex::default()
+        };
+
+        write_app_scoped_release_index(&store_root, app_id, &index);
+
+        let ctx = Arc::new(Context::new());
+        ctx.set_storage(
+            StorageProvider::Filesystem,
+            store_root.to_str().unwrap(),
+            "",
+            "",
+            "",
+            "",
+        );
+
+        let mut manager = UpdateManager::new(ctx, app_id, "1.0.0", "stable", install_root.to_str().unwrap()).unwrap();
+        let info = manager.check_for_updates().await.unwrap().unwrap();
+        assert_eq!(info.apply_strategy, ApplyStrategy::Delta);
+
+        let observed = Arc::new(Mutex::new(Vec::<ProgressInfo>::new()));
+        let observed_for_progress = Arc::clone(&observed);
+        manager
+            .download_and_apply(
+                &info,
+                Some(move |progress: ProgressInfo| {
+                    observed_for_progress
+                        .lock()
+                        .unwrap_or_else(std::sync::PoisonError::into_inner)
+                        .push(progress);
+                }),
+            )
+            .await
+            .unwrap();
+
+        let observed = observed
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone();
+        assert!(observed.iter().any(|progress| {
+            progress.phase == 5
+                && progress.phase_percent > 0
+                && progress.phase_percent < 100
+                && progress.bytes_done > 0
+                && progress.bytes_done < progress.bytes_total
+                && progress.items_done == 0
+                && progress.items_total == 1
+        }));
+    }
+
+    #[tokio::test]
     async fn test_download_and_apply_delta_restores_missing_base_full() {
         let tmp = tempfile::tempdir().unwrap();
         let store_root = tmp.path().join("store");

--- a/crates/surge-core/src/update/manager/apply.rs
+++ b/crates/surge-core/src/update/manager/apply.rs
@@ -14,7 +14,9 @@ use crate::pack::builder::build_canonical_archive_from_directory;
 use crate::platform::detect::current_rid;
 use crate::platform::fs::write_file_atomic;
 use crate::releases::artifact_cache::cache_path_for_key;
-use crate::releases::delta::{apply_delta_patch, decode_delta_patch, is_supported_delta};
+use crate::releases::delta::{
+    DeltaApplyProgress, apply_delta_patch_with_progress, decode_delta_patch, is_supported_delta,
+};
 use crate::releases::manifest::{ReleaseEntry, decompress_release_index};
 use crate::releases::restore::{
     RestoreOptions, find_release_for_version_rid, restore_full_archive_for_version_with_options,
@@ -137,7 +139,45 @@ where
         let delta_compressed = tokio::fs::read(&delta_path).await?;
         let patch = decode_delta_patch(delta_compressed.as_slice(), &delta)
             .map_err(|e| SurgeError::Archive(format!("Failed to decompress delta {}: {e}", delta.filename)))?;
-        rebuilt_archive = apply_delta_patch(&rebuilt_archive, &patch, &delta)
+        let progress_for_delta = progress.cloned();
+        let completed_bytes_before_delta = apply_delta_bytes_done;
+        let completed_items_before_delta = apply_delta_items_done;
+        let current_delta_bytes = delta.size.max(0);
+        let delta_progress = move |delta_progress: DeltaApplyProgress| {
+            let bytes_done = completed_bytes_before_delta.saturating_add(scale_progress_units_i64(
+                current_delta_bytes,
+                delta_progress.units_done,
+                delta_progress.units_total,
+            ));
+            let phase_percent = if apply_delta_total_bytes > 0 {
+                clamp_progress_percent(bytes_done, apply_delta_total_bytes)
+            } else {
+                scale_apply_delta_items_percent(
+                    completed_items_before_delta,
+                    apply_delta_total_items,
+                    delta_progress.units_done,
+                    delta_progress.units_total,
+                )
+            };
+            emit_progress(
+                progress_for_delta.as_ref(),
+                ProgressInfo {
+                    phase: 5,
+                    phase_percent,
+                    total_percent: phase_total_percent(60, 20, phase_percent),
+                    bytes_done,
+                    bytes_total: apply_delta_total_bytes,
+                    items_done: completed_items_before_delta,
+                    items_total: apply_delta_total_items,
+                    speed_bytes_per_sec: average_speed_bytes_per_sec(
+                        u64::try_from(bytes_done.max(0)).unwrap_or(u64::MAX),
+                        apply_delta_started_at,
+                    ),
+                },
+            );
+        };
+
+        rebuilt_archive = apply_delta_patch_with_progress(&rebuilt_archive, &patch, &delta, Some(&delta_progress))
             .map_err(|e| SurgeError::Update(format!("Failed to apply delta {}: {e}", delta.filename)))?;
 
         if !release.full_sha256.is_empty() {
@@ -198,6 +238,25 @@ where
     } else {
         Ok(extract_dir.to_path_buf())
     }
+}
+
+fn scale_progress_units_i64(total: i64, done: u64, units_total: u64) -> i64 {
+    if total <= 0 || units_total == 0 {
+        return 0;
+    }
+    let total = u64::try_from(total).unwrap_or(u64::MAX);
+    let scaled = total.saturating_mul(done.min(units_total)) / units_total;
+    i64::try_from(scaled).unwrap_or(i64::MAX)
+}
+
+fn scale_apply_delta_items_percent(completed_items: i64, total_items: i64, done: u64, units_total: u64) -> i32 {
+    let total_items = u64::try_from(total_items.max(1)).unwrap_or(u64::MAX);
+    let completed_items = u64::try_from(completed_items.max(0)).unwrap_or(u64::MAX);
+    let units_total = units_total.max(1);
+    let done = done.min(units_total);
+    let scaled_done = completed_items.saturating_mul(units_total).saturating_add(done);
+    let scaled_total = total_items.saturating_mul(units_total);
+    clamp_progress_percent_u64(scaled_done, scaled_total)
 }
 
 async fn restore_base_full_archive(manager: &UpdateManager, artifact_cache_dir: &Path) -> Result<Vec<u8>> {

--- a/crates/surge-core/src/update/manager/artifacts.rs
+++ b/crates/surge-core/src/update/manager/artifacts.rs
@@ -47,7 +47,7 @@ where
 
     let storage = manager.storage.as_ref();
     let download_progress_state = Arc::new(Mutex::new(DownloadProgressState::new()));
-    let mut download_stream = stream::iter(artifacts.into_iter())
+    let mut download_stream = stream::iter(artifacts)
         .map(|artifact| {
             let download_progress_state = Arc::clone(&download_progress_state);
             let progress = progress.clone();

--- a/crates/surge-core/src/update/manager/progress.rs
+++ b/crates/surge-core/src/update/manager/progress.rs
@@ -49,7 +49,9 @@ where
 
 pub(super) fn clamp_progress_percent(done: i64, total: i64) -> i32 {
     if total > 0 {
-        ((done.saturating_mul(100)) / total).clamp(0, 100) as i32
+        done.saturating_mul(100)
+            .checked_div(total)
+            .map_or(0, |percent| percent.clamp(0, 100) as i32)
     } else {
         0
     }
@@ -57,7 +59,9 @@ pub(super) fn clamp_progress_percent(done: i64, total: i64) -> i32 {
 
 pub(super) fn clamp_progress_percent_u64(done: u64, total: u64) -> i32 {
     if total > 0 {
-        ((done.saturating_mul(100)) / total).clamp(0, 100) as i32
+        done.saturating_mul(100)
+            .checked_div(total)
+            .map_or(0, |percent| percent.clamp(0, 100) as i32)
     } else {
         0
     }

--- a/crates/surge-installer-ui/src/install.rs
+++ b/crates/surge-installer-ui/src/install.rs
@@ -227,11 +227,7 @@ fn resolve_package_with_progress(
     send(progress_tx, ctx, ProgressUpdate::Progress(DOWNLOAD_START_PROGRESS));
 
     let download_progress = |done: u64, total: u64| {
-        let phase_percent = if total > 0 {
-            ((done.saturating_mul(100)) / total).clamp(0, 100) as u32
-        } else {
-            0
-        };
+        let phase_percent = percentage_u64(done, total);
         send(
             progress_tx,
             ctx,
@@ -388,6 +384,12 @@ fn percentage(done: i64, total: i64) -> i32 {
     let done = done.max(0);
     let total = total.max(done);
     ((done.saturating_mul(100)) / total).clamp(0, 100) as i32
+}
+
+fn percentage_u64(done: u64, total: u64) -> u32 {
+    done.saturating_mul(100)
+        .checked_div(total)
+        .map_or(0, |percent| percent.clamp(0, 100) as u32)
 }
 
 fn format_bytes(bytes: u64) -> String {


### PR DESCRIPTION
## Summary
- Report intermediate apply-delta progress through the existing update progress callback path.
- Add sparse-file-op progress for archive extraction, file operations, chunk patching, and repacking.
- Refresh current-toolchain clippy style issues needed for the full validation suite.

## Impact
Users now see movement during long sparse delta application instead of waiting on a static progress state until the delta artifact finishes. Existing .NET and C progress API shapes are unchanged.

## Validation
- ./scripts/sync-surge-core-vendor.sh --check
- ./scripts/check-version-sync.sh
- cargo fmt --all -- --check
- RUSTFLAGS="-D warnings" cargo test --workspace
- cargo clippy --all-targets --all-features -- -D warnings
- cargo clippy --workspace --lib --bins --examples -- -D warnings -D clippy::unwrap_used -D clippy::expect_used
- cargo clippy --workspace --all-targets --all-features -- -D warnings -W clippy::pedantic
- dotnet format dotnet/Surge.slnx --verify-no-changes
- dotnet test dotnet/Surge.slnx --configuration Release