### PR TITLE
Add installer cache retention policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -625,6 +625,11 @@ pack:                             # optional; omitted uses built-in defaults
     format: zstd
     level: 3
 
+cache:                            # optional device-side installer cache policy
+  installArtifacts:
+    retention: release_graph       # release_graph | latest_full
+    keepFullCount: 1               # full archives retained when retention is latest_full
+
 apps:
   - id: my-app                    # unique identifier
     name: My App                  # display name
@@ -643,6 +648,7 @@ apps:
 
 Target-level settings override app-level defaults for `icon`, `shortcuts`, `persistentAssets`, `installers`, and `environment`.
 `pack` policy is global and currently controls delta strategy plus compression format/level for `surge pack`.
+`cache.installArtifacts.retention: latest_full` keeps the installed full archive warm on each device and lets future deltas be downloaded again from storage when needed, instead of retaining the full release graph locally.
 
 ### Architecture
 

--- a/crates/surge-bench/src/runner/manifest.rs
+++ b/crates/surge-bench/src/runner/manifest.rs
@@ -6,6 +6,7 @@ use surge_core::config::constants::RELEASES_FILE_COMPRESSED;
 use surge_core::config::installer::{
     InstallerManifest, InstallerRelease, InstallerRuntime, InstallerStorage, InstallerUi,
 };
+use surge_core::config::manifest::CacheManifestConfig;
 use surge_core::error::Result;
 
 use super::BENCH_APP_NAME;
@@ -57,6 +58,7 @@ pub(super) fn installer_manifest(
             installers: vec![installer_type.to_string()],
             environment: BTreeMap::new(),
         },
+        cache: CacheManifestConfig::default(),
     }
 }
 

--- a/crates/surge-cli/src/commands/init.rs
+++ b/crates/surge-cli/src/commands/init.rs
@@ -68,6 +68,7 @@ pub async fn execute(
         lock: None,
         channels: vec![],
         pack: None,
+        cache: None,
         apps: vec![AppConfig {
             id: init.app_id.clone(),
             name: init.name,

--- a/crates/surge-cli/src/commands/install/mod.rs
+++ b/crates/surge-cli/src/commands/install/mod.rs
@@ -455,8 +455,9 @@ mod tests {
     use surge_core::archive::extractor::read_entry;
     use surge_core::archive::packer::ArchivePacker;
     use surge_core::config::constants::DEFAULT_ZSTD_LEVEL;
-    use surge_core::config::manifest::ShortcutLocation;
-    use surge_core::config::manifest::SurgeManifest;
+    use surge_core::config::manifest::{
+        CacheManifestConfig, InstallArtifactCachePolicy, InstallArtifactCacheRetention, ShortcutLocation, SurgeManifest,
+    };
     use surge_core::crypto::sha256::sha256_hex;
     use surge_core::diff::wrapper::bsdiff_buffers;
     use surge_core::installer_bundle::read_embedded_payload;
@@ -519,6 +520,13 @@ mod tests {
             "schema: 1\napps:\n  - id: {app_id}\n    channels:\n{channels_yaml}    targets:\n      - rid: {rid}\n        installers:\n{installers_yaml}"
         );
         serde_yaml::from_str(&yaml).expect("manifest should parse")
+    }
+
+    fn latest_full_cache_policy() -> CacheManifestConfig {
+        CacheManifestConfig::from_install_artifact_cache_policy(InstallArtifactCachePolicy {
+            retention: InstallArtifactCacheRetention::LatestFull,
+            keep_full_count: 1,
+        })
     }
 
     fn create_published_installer(dir: &Path, installer_name: &str, manifest: &InstallerManifest) -> PathBuf {
@@ -589,6 +597,7 @@ mod tests {
             &storage_config("/tmp/releases"),
             &launch_env,
             RemoteInstallerMode::Online,
+            CacheManifestConfig::default(),
         );
 
         assert_eq!(
@@ -1015,6 +1024,44 @@ mod tests {
     }
 
     #[test]
+    fn plan_remote_published_installer_carries_manifest_cache_policy() {
+        let yaml = br"schema: 1
+cache:
+  installArtifacts:
+    retention: latest_full
+    keepFullCount: 1
+apps:
+  - id: demo
+    channels:
+      - production
+    targets:
+      - rid: linux-arm64
+        installers:
+          - online
+";
+        let manifest: SurgeManifest = serde_yaml::from_slice(yaml).expect("manifest should parse");
+        let mut entry = release("1.2.3", "production", "linux-arm64", "demo.tar.zst");
+        entry.installers = vec!["online".to_string()];
+
+        let plan = plan_remote_published_installer(
+            &manifest,
+            "demo",
+            "linux-arm64",
+            "production",
+            &entry,
+            RemoteInstallerMode::Online,
+        )
+        .expect("plan should resolve");
+        let policy = plan
+            .cache
+            .expect("manifest-backed plan should carry cache policy")
+            .effective_install_artifact_cache_policy();
+
+        assert_eq!(policy.retention, InstallArtifactCacheRetention::LatestFull);
+        assert_eq!(policy.keep_full_count, 1);
+    }
+
+    #[test]
     fn plan_remote_published_installer_drops_default_channel_mismatch_blocker() {
         let manifest = remote_manifest("demo", "linux-arm64", &["test", "production"], &["online"]);
         let mut entry = release("1.2.3", "production", "linux-arm64", "demo.tar.zst");
@@ -1089,6 +1136,7 @@ mod tests {
                 installers: vec!["online".to_string()],
                 environment: BTreeMap::new(),
             },
+            cache: CacheManifestConfig::default(),
         };
         create_published_installer(
             &store_dir.join("installers"),
@@ -1168,6 +1216,98 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn try_prepare_published_installer_without_manifest_preserves_embedded_cache_policy() {
+        let tmp = tempfile::tempdir().expect("temp dir should exist");
+        let store_dir = tmp.path().join("store");
+        let download_dir = tmp.path().join("downloads");
+        std::fs::create_dir_all(store_dir.join("installers")).expect("installers dir should exist");
+
+        let mut entry = release("1.2.3", "test", "linux-arm64", "demo.tar.zst");
+        entry.installers = vec!["online".to_string()];
+        entry.main_exe = "demoapp".to_string();
+        entry.install_directory = "demo".to_string();
+        entry.full_filename = "demo.tar.zst".to_string();
+
+        let generic_installer_manifest = InstallerManifest {
+            schema: 1,
+            format: "surge-installer-v1".to_string(),
+            ui: InstallerUi::Console,
+            installer_type: "online".to_string(),
+            app_id: "demo".to_string(),
+            rid: "linux-arm64".to_string(),
+            version: "1.2.3".to_string(),
+            channel: "test".to_string(),
+            generated_utc: "2026-03-13T00:00:00Z".to_string(),
+            headless_default_if_no_display: true,
+            release_index_key: RELEASES_FILE_COMPRESSED.to_string(),
+            storage: InstallerStorage {
+                provider: "filesystem".to_string(),
+                bucket: store_dir.to_string_lossy().to_string(),
+                region: String::new(),
+                endpoint: String::new(),
+                prefix: String::new(),
+            },
+            release: InstallerRelease {
+                full_filename: "demo.tar.zst".to_string(),
+                full_sha256: String::new(),
+                delta_filename: String::new(),
+                delta_algorithm: String::new(),
+                delta_patch_format: String::new(),
+                delta_compression: String::new(),
+            },
+            runtime: InstallerRuntime {
+                name: "Demo".to_string(),
+                main_exe: "demoapp".to_string(),
+                install_directory: "demo".to_string(),
+                supervisor_id: "demo-supervisor".to_string(),
+                icon: String::new(),
+                shortcuts: Vec::new(),
+                persistent_assets: Vec::new(),
+                installers: vec!["online".to_string()],
+                environment: BTreeMap::new(),
+            },
+            cache: latest_full_cache_policy(),
+        };
+        create_published_installer(
+            &store_dir.join("installers"),
+            "Setup-linux-arm64-demo-test-online.bin",
+            &generic_installer_manifest,
+        );
+
+        let backend = FilesystemBackend::new(store_dir.to_str().expect("utf-8 path"), "");
+        let plan = plan_remote_published_installer_without_manifest(
+            "demo",
+            "linux-arm64",
+            "test",
+            &entry,
+            RemoteInstallerMode::Online,
+        );
+
+        let customized_installer = try_prepare_published_installer_for_tailscale(
+            &backend,
+            &download_dir,
+            &plan,
+            "demo",
+            &entry,
+            "test",
+            &storage_config(store_dir.to_str().expect("utf-8 path")),
+            &RemoteLaunchEnvironment::default(),
+            RemoteInstallerMode::Online,
+        )
+        .await
+        .expect("published installer should prepare")
+        .expect("customized installer should exist");
+
+        let payload = read_embedded_payload(&customized_installer).expect("payload should be readable");
+        let installer_manifest: InstallerManifest =
+            serde_yaml::from_slice(&read_entry(&payload, "installer.yml").expect("installer manifest should exist"))
+                .expect("installer manifest should parse");
+        let policy = installer_manifest.effective_install_artifact_cache_policy();
+        assert_eq!(policy.retention, InstallArtifactCacheRetention::LatestFull);
+        assert_eq!(policy.keep_full_count, 1);
+    }
+
     #[test]
     fn missing_remote_installer_error_mentions_keys_and_host_mismatch() {
         let err = missing_remote_installer_error(
@@ -1175,6 +1315,7 @@ mod tests {
             &RemotePublishedInstallerPlan {
                 candidate_keys: vec!["installers/Setup-linux-arm64-demo-test-online.bin".to_string()],
                 blockers: vec!["published installer was not found in storage".to_string()],
+                cache: None,
             },
             RemoteInstallerMode::Online,
         );

--- a/crates/surge-cli/src/commands/install/remote/published_installer.rs
+++ b/crates/surge-cli/src/commands/install/remote/published_installer.rs
@@ -4,6 +4,7 @@ use super::{
     Path, PathBuf, RELEASES_FILE_COMPRESSED, ReleaseEntry, Result, StorageBackend, SurgeError, SurgeManifest,
     cache_path_for_key, core_install, fetch_or_reuse_file, logline, pack,
 };
+use surge_core::config::manifest::CacheManifestConfig;
 
 fn remote_installer_extension_for_rid(rid: &str) -> &'static str {
     if rid.starts_with("win-") || rid.starts_with("windows-") {
@@ -54,6 +55,9 @@ pub(crate) fn plan_remote_published_installer(
     Ok(RemotePublishedInstallerPlan {
         candidate_keys: vec![candidate_key],
         blockers,
+        cache: Some(CacheManifestConfig::from_install_artifact_cache_policy(
+            manifest.effective_install_artifact_cache_policy(),
+        )),
     })
 }
 
@@ -90,6 +94,7 @@ pub(crate) fn plan_remote_published_installer_without_manifest(
     RemotePublishedInstallerPlan {
         candidate_keys: vec![candidate_key],
         blockers,
+        cache: None,
     }
 }
 
@@ -197,6 +202,7 @@ pub(crate) async fn try_prepare_published_installer_for_tailscale(
                 ));
                 return Ok(Some(customize_published_installer_for_tailscale(
                     &installer_path,
+                    plan.cache.as_ref(),
                     app_id,
                     release,
                     channel,
@@ -209,6 +215,7 @@ pub(crate) async fn try_prepare_published_installer_for_tailscale(
                 logline::info(&format!("Fetched published installer '{key}' for remote deployment."));
                 return Ok(Some(customize_published_installer_for_tailscale(
                     &installer_path,
+                    plan.cache.as_ref(),
                     app_id,
                     release,
                     channel,
@@ -225,6 +232,7 @@ pub(crate) async fn try_prepare_published_installer_for_tailscale(
                     ));
                     return Ok(Some(customize_published_installer_for_tailscale(
                         &installer_path,
+                        plan.cache.as_ref(),
                         app_id,
                         release,
                         channel,
@@ -243,6 +251,7 @@ pub(crate) async fn try_prepare_published_installer_for_tailscale(
 
 fn customize_published_installer_for_tailscale(
     published_installer_path: &Path,
+    cache: Option<&CacheManifestConfig>,
     app_id: &str,
     release: &ReleaseEntry,
     channel: &str,
@@ -250,14 +259,6 @@ fn customize_published_installer_for_tailscale(
     launch_env: &RemoteLaunchEnvironment,
     installer_mode: RemoteInstallerMode,
 ) -> Result<PathBuf> {
-    let installer_manifest =
-        build_remote_installer_manifest(app_id, release, channel, storage_config, launch_env, installer_mode);
-    let mut installer_yaml = serde_yaml::to_string(&installer_manifest)
-        .map_err(|e| SurgeError::Config(format!("Failed to serialize installer manifest: {e}")))?;
-    if !installer_yaml.ends_with('\n') {
-        installer_yaml.push('\n');
-    }
-
     let payload_bytes = surge_core::installer_bundle::read_embedded_payload(published_installer_path)?;
     let launcher_bytes = surge_core::installer_bundle::read_launcher_stub(published_installer_path)?;
 
@@ -265,6 +266,24 @@ fn customize_published_installer_for_tailscale(
         tempfile::tempdir().map_err(|e| SurgeError::Platform(format!("Failed to create staging directory: {e}")))?;
     let staging = staging_dir.path();
     surge_core::archive::extractor::extract_to(&payload_bytes, staging, None)?;
+    let cache = match cache {
+        Some(cache) => *cache,
+        None => read_embedded_installer_cache(staging)?,
+    };
+    let installer_manifest = build_remote_installer_manifest(
+        app_id,
+        release,
+        channel,
+        storage_config,
+        launch_env,
+        installer_mode,
+        cache,
+    );
+    let mut installer_yaml = serde_yaml::to_string(&installer_manifest)
+        .map_err(|e| SurgeError::Config(format!("Failed to serialize installer manifest: {e}")))?;
+    if !installer_yaml.ends_with('\n') {
+        installer_yaml.push('\n');
+    }
     std::fs::write(staging.join("installer.yml"), installer_yaml.as_bytes())?;
 
     let payload_archive = tempfile::NamedTempFile::new()
@@ -292,6 +311,22 @@ fn customize_published_installer_for_tailscale(
 
     std::mem::forget(staging_dir);
     Ok(installer_path)
+}
+
+fn read_embedded_installer_cache(staging: &Path) -> Result<CacheManifestConfig> {
+    let installer_manifest_path = staging.join("installer.yml");
+    if !installer_manifest_path.is_file() {
+        return Ok(CacheManifestConfig::default());
+    }
+
+    let bytes = std::fs::read(&installer_manifest_path)?;
+    let manifest: InstallerManifest = serde_yaml::from_slice(&bytes).map_err(|e| {
+        SurgeError::Config(format!(
+            "Failed to parse embedded installer manifest '{}': {e}",
+            installer_manifest_path.display()
+        ))
+    })?;
+    Ok(manifest.cache)
 }
 
 pub(crate) fn build_remote_runtime_environment(
@@ -328,6 +363,7 @@ pub(crate) fn build_remote_installer_manifest(
     storage_config: &surge_core::context::StorageConfig,
     launch_env: &RemoteLaunchEnvironment,
     installer_mode: RemoteInstallerMode,
+    cache: CacheManifestConfig,
 ) -> InstallerManifest {
     let environment = build_remote_runtime_environment(release, launch_env);
 
@@ -373,6 +409,7 @@ pub(crate) fn build_remote_installer_manifest(
             installers: release.installers.clone(),
             environment,
         },
+        cache,
     }
 }
 
@@ -396,8 +433,18 @@ pub(crate) fn build_installer_for_tailscale(
         })
         .filter(|icon| !icon.is_empty());
 
-    let installer_manifest =
-        build_remote_installer_manifest(app_id, release, channel, storage_config, launch_env, installer_mode);
+    let cache = manifest.map_or_else(CacheManifestConfig::default, |manifest| {
+        CacheManifestConfig::from_install_artifact_cache_policy(manifest.effective_install_artifact_cache_policy())
+    });
+    let installer_manifest = build_remote_installer_manifest(
+        app_id,
+        release,
+        channel,
+        storage_config,
+        launch_env,
+        installer_mode,
+        cache,
+    );
     let installer_yaml = serde_yaml::to_string(&installer_manifest)
         .map_err(|e| SurgeError::Config(format!("Failed to serialize installer manifest: {e}")))?;
 

--- a/crates/surge-cli/src/commands/install/remote/types.rs
+++ b/crates/surge-cli/src/commands/install/remote/types.rs
@@ -1,4 +1,5 @@
 use super::{Deserialize, Result, Serialize, SurgeError, infer_os_from_rid, logline};
+use surge_core::config::manifest::CacheManifestConfig;
 
 pub(crate) fn ensure_supported_tailscale_rid(rid: &str) -> Result<()> {
     match infer_os_from_rid(rid) {
@@ -111,4 +112,5 @@ pub(crate) struct RemoteStagedPayloadIdentity {
 pub(crate) struct RemotePublishedInstallerPlan {
     pub(crate) candidate_keys: Vec<String>,
     pub(crate) blockers: Vec<String>,
+    pub(crate) cache: Option<CacheManifestConfig>,
 }

--- a/crates/surge-cli/src/commands/mod.rs
+++ b/crates/surge-cli/src/commands/mod.rs
@@ -208,7 +208,7 @@ mod tests {
     use surge_core::config::installer::{
         InstallerManifest, InstallerRelease, InstallerRuntime, InstallerStorage, InstallerUi,
     };
-    use surge_core::config::manifest::{ShortcutLocation, SurgeManifest};
+    use surge_core::config::manifest::{CacheManifestConfig, ShortcutLocation, SurgeManifest};
     use surge_core::context::{StorageConfig, StorageProvider};
     use surge_core::diff::chunked::{ChunkedDiffOptions, chunked_bsdiff};
     use surge_core::diff::wrapper::bsdiff_buffers;
@@ -580,6 +580,7 @@ apps:
                         installers: Vec::new(),
                         environment: BTreeMap::new(),
                     },
+                    cache: CacheManifestConfig::default(),
                 };
 
                 let config = super::build_storage_config_from_installer_manifest(&manifest, setup_dir).unwrap();

--- a/crates/surge-cli/src/commands/pack/installers.rs
+++ b/crates/surge-cli/src/commands/pack/installers.rs
@@ -5,7 +5,7 @@ use surge_core::config::constants::RELEASES_FILE_COMPRESSED;
 use surge_core::config::installer::{
     InstallerManifest, InstallerRelease, InstallerRuntime, InstallerStorage, InstallerUi,
 };
-use surge_core::config::manifest::{AppConfig, InstallerType, SurgeManifest, TargetConfig};
+use surge_core::config::manifest::{AppConfig, CacheManifestConfig, InstallerType, SurgeManifest, TargetConfig};
 use surge_core::crypto::sha256::sha256_hex_file;
 use surge_core::error::{Result, SurgeError};
 use surge_core::installer_bundle;
@@ -192,6 +192,9 @@ pub(super) fn build_installers_with_launcher(
                 installers: target.installers.clone(),
                 environment: target.environment.clone(),
             },
+            cache: CacheManifestConfig::from_install_artifact_cache_policy(
+                manifest.effective_install_artifact_cache_policy(),
+            ),
         };
         let manifest_yaml = serde_yaml::to_string(&manifest_payload)?;
         std::fs::write(staging.join("installer.yml"), manifest_yaml.as_bytes())?;

--- a/crates/surge-cli/src/commands/setup.rs
+++ b/crates/surge-cli/src/commands/setup.rs
@@ -4,6 +4,7 @@ use std::time::{Duration, Instant};
 
 use crate::logline;
 use surge_core::config::installer::InstallerManifest;
+use surge_core::config::manifest::InstallArtifactCacheRetention;
 use surge_core::error::{Result, SurgeError};
 use surge_core::install::{self as core_install, InstallProfile};
 use surge_core::installer_package::{
@@ -131,6 +132,7 @@ pub async fn execute(dir: &Path, no_start: bool, stage: bool) -> Result<()> {
     if stage {
         let package = resolve_package(dir, &manifest, &install_root).await?;
         ensure_stage_cache_entry(&package, &manifest, &install_root)?;
+        prune_setup_artifact_cache(&install_root, &package, &manifest);
         persist_staged_installer_cache(dir, &manifest, &install_root)?;
         logline::success(&format!(
             "Staged '{}' v{} in artifact cache at '{}'",
@@ -162,20 +164,7 @@ pub async fn execute(dir: &Path, no_start: bool, stage: bool) -> Result<()> {
     );
     core_install::write_runtime_manifest(&active_app_dir, &profile, &runtime_manifest)?;
 
-    if let Some(required_artifacts) = package.required_artifacts.as_ref() {
-        match prune_install_artifact_cache(&install_root, required_artifacts, &manifest.release.full_filename) {
-            Ok(0) => {}
-            Ok(pruned) => {
-                logline::info(&format!(
-                    "Pruned {pruned} stale artifact cache entr{}.",
-                    if pruned == 1 { "y" } else { "ies" }
-                ));
-            }
-            Err(e) => {
-                logline::warn(&format!("Artifact cache pruning failed: {e}"));
-            }
-        }
-    }
+    prune_setup_artifact_cache(&install_root, &package, &manifest);
 
     logline::success(&format!(
         "Installed '{}' to '{}'",
@@ -290,6 +279,31 @@ fn ensure_stage_cache_entry(
     Ok(())
 }
 
+fn prune_setup_artifact_cache(install_root: &Path, package: &ResolvedPackage, manifest: &InstallerManifest) {
+    let empty_retained_artifacts = std::collections::BTreeSet::new();
+    let retained_artifacts = match package.retained_artifacts.as_ref() {
+        Some(retained_artifacts) => retained_artifacts,
+        None if manifest.effective_install_artifact_cache_policy().retention
+            == InstallArtifactCacheRetention::LatestFull =>
+        {
+            &empty_retained_artifacts
+        }
+        None => return,
+    };
+    match prune_install_artifact_cache(install_root, retained_artifacts, &manifest.release.full_filename) {
+        Ok(0) => {}
+        Ok(pruned) => {
+            logline::info(&format!(
+                "Pruned {pruned} stale artifact cache entr{}.",
+                if pruned == 1 { "y" } else { "ies" }
+            ));
+        }
+        Err(e) => {
+            logline::warn(&format!("Artifact cache pruning failed: {e}"));
+        }
+    }
+}
+
 fn persist_staged_installer_cache(dir: &Path, manifest: &InstallerManifest, install_root: &Path) -> Result<()> {
     if !manifest.installer_type.trim().eq_ignore_ascii_case("online") {
         return Ok(());
@@ -402,6 +416,9 @@ mod tests {
     use surge_core::archive::packer::ArchivePacker;
     use surge_core::config::constants::RELEASES_FILE_COMPRESSED;
     use surge_core::config::installer::{InstallerRelease, InstallerRuntime, InstallerStorage, InstallerUi};
+    use surge_core::config::manifest::{
+        CacheManifestConfig, InstallArtifactCachePolicy, InstallArtifactCacheRetention,
+    };
     use surge_core::crypto::sha256::sha256_hex;
     use surge_core::diff::wrapper::bsdiff_buffers;
     use surge_core::platform::detect::current_rid;
@@ -451,7 +468,15 @@ mod tests {
                 installers: Vec::new(),
                 environment: BTreeMap::new(),
             },
+            cache: CacheManifestConfig::default(),
         }
+    }
+
+    fn latest_full_cache_policy() -> CacheManifestConfig {
+        CacheManifestConfig::from_install_artifact_cache_policy(InstallArtifactCachePolicy {
+            retention: InstallArtifactCacheRetention::LatestFull,
+            keep_full_count: 1,
+        })
     }
 
     fn write_archive(path: &Path, payload: &[u8]) {
@@ -664,7 +689,7 @@ mod tests {
             std::fs::read(package.path()).expect("downloaded bytes"),
             std::fs::read(stored_archive).expect("stored bytes")
         );
-        assert!(package.required_artifacts.is_some());
+        assert!(package.retained_artifacts.is_some());
     }
 
     #[tokio::test]
@@ -814,6 +839,117 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn execute_prunes_release_graph_artifacts_when_cache_policy_keeps_latest_full() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let installer_dir = temp_dir.path().join("installer");
+        let install_root = temp_dir.path().join("installed-app");
+        let store_root = temp_dir.path().join("store");
+        let rid = current_rid();
+        let base_full_filename = "demo-app-1.0.0-full.tar.zst";
+        let target_full_filename = "demo-app-1.2.3-full.tar.zst";
+        let delta_filename = "demo-app-1.2.3-delta.tar.zst";
+        let base_archive_path = store_root.join(base_full_filename);
+        let target_archive_path = temp_dir.path().join(target_full_filename);
+        let delta_path = store_root.join(delta_filename);
+
+        std::fs::create_dir_all(&installer_dir).expect("installer dir");
+        std::fs::create_dir_all(&store_root).expect("store dir");
+        write_archive(&base_archive_path, b"base payload");
+        write_archive(&target_archive_path, b"target payload");
+
+        let base_archive = std::fs::read(&base_archive_path).expect("base archive");
+        let target_archive = std::fs::read(&target_archive_path).expect("target archive");
+        let patch = bsdiff_buffers(&base_archive, &target_archive).expect("delta patch");
+        let delta_bytes = zstd::encode_all(patch.as_slice(), 3).expect("delta bytes");
+        std::fs::write(&delta_path, &delta_bytes).expect("write delta");
+
+        let mut manifest = make_manifest(&install_root, &store_root, target_full_filename, "online");
+        manifest.cache = latest_full_cache_policy();
+        let installer_yaml = serde_yaml::to_string(&manifest).expect("installer yaml");
+        std::fs::write(installer_dir.join("installer.yml"), installer_yaml).expect("installer manifest");
+
+        let mut base_release = ReleaseEntry {
+            version: "1.0.0".to_string(),
+            channels: vec![manifest.channel.clone()],
+            os: "linux".to_string(),
+            rid: rid.clone(),
+            is_genesis: false,
+            full_filename: base_full_filename.to_string(),
+            full_size: i64::try_from(base_archive.len()).expect("base size"),
+            full_sha256: sha256_hex(&base_archive),
+            full_compression_level: 0,
+            full_zstd_workers: 0,
+            deltas: Vec::new(),
+            preferred_delta_id: String::new(),
+            created_utc: manifest.generated_utc.clone(),
+            release_notes: String::new(),
+            name: manifest.runtime.name.clone(),
+            main_exe: manifest.runtime.main_exe.clone(),
+            install_directory: manifest.runtime.install_directory.clone(),
+            supervisor_id: manifest.runtime.supervisor_id.clone(),
+            icon: manifest.runtime.icon.clone(),
+            shortcuts: manifest.runtime.shortcuts.clone(),
+            persistent_assets: manifest.runtime.persistent_assets.clone(),
+            installers: manifest.runtime.installers.clone(),
+            environment: manifest.runtime.environment.clone(),
+        };
+        base_release.set_primary_delta(None);
+
+        let mut target_release = ReleaseEntry {
+            version: manifest.version.clone(),
+            channels: vec![manifest.channel.clone()],
+            os: "linux".to_string(),
+            rid,
+            is_genesis: false,
+            full_filename: target_full_filename.to_string(),
+            full_size: i64::try_from(target_archive.len()).expect("target size"),
+            full_sha256: sha256_hex(&target_archive),
+            full_compression_level: 0,
+            full_zstd_workers: 0,
+            deltas: Vec::new(),
+            preferred_delta_id: String::new(),
+            created_utc: manifest.generated_utc.clone(),
+            release_notes: String::new(),
+            name: manifest.runtime.name.clone(),
+            main_exe: manifest.runtime.main_exe.clone(),
+            install_directory: manifest.runtime.install_directory.clone(),
+            supervisor_id: manifest.runtime.supervisor_id.clone(),
+            icon: manifest.runtime.icon.clone(),
+            shortcuts: manifest.runtime.shortcuts.clone(),
+            persistent_assets: manifest.runtime.persistent_assets.clone(),
+            installers: manifest.runtime.installers.clone(),
+            environment: manifest.runtime.environment.clone(),
+        };
+        target_release.set_primary_delta(Some(DeltaArtifact::bsdiff_zstd(
+            "primary",
+            "1.0.0",
+            delta_filename,
+            i64::try_from(delta_bytes.len()).expect("delta size"),
+            &sha256_hex(&delta_bytes),
+        )));
+
+        write_release_index_entries(&store_root, &manifest.app_id, vec![base_release, target_release]);
+
+        execute(&installer_dir, true, false)
+            .await
+            .expect("setup should succeed");
+
+        let artifact_cache = install_root.join(".surge-cache").join("artifacts");
+        assert!(
+            !artifact_cache.join(base_full_filename).exists(),
+            "base full should be pruned by latest_full device cache retention"
+        );
+        assert!(
+            !artifact_cache.join(delta_filename).exists(),
+            "delta should be pruned by latest_full device cache retention"
+        );
+        assert!(
+            artifact_cache.join(target_full_filename).is_file(),
+            "installed target full should remain as a warm cache entry"
+        );
+    }
+
+    #[tokio::test]
     async fn execute_stage_persists_bundled_payload_in_artifact_cache_without_installing() {
         let temp_dir = tempfile::tempdir().expect("temp dir");
         let installer_dir = temp_dir.path().join("installer");
@@ -822,9 +958,12 @@ mod tests {
         let store_root = temp_dir.path().join("store");
         let full_filename = "demo-app-1.2.3-full.tar.zst";
         let bundled_payload = payload_dir.join(full_filename);
+        let stale_path = install_root.join(".surge-cache").join("artifacts").join("stale.bin");
 
         std::fs::create_dir_all(&payload_dir).expect("payload dir");
         std::fs::create_dir_all(&store_root).expect("store dir");
+        std::fs::create_dir_all(stale_path.parent().expect("stale parent")).expect("cache dir");
+        std::fs::write(&stale_path, b"stale").expect("stale cache entry");
 
         let manifest = make_manifest(&install_root, &store_root, full_filename, "offline");
         let installer_yaml = serde_yaml::to_string(&manifest).expect("installer yaml");
@@ -844,6 +983,54 @@ mod tests {
         assert_eq!(
             std::fs::read(&cached_package).expect("cached package should exist"),
             bundled_archive
+        );
+        assert!(
+            stale_path.exists(),
+            "stage mode should not prune stale cache entries when release_graph artifacts are unknown"
+        );
+        assert!(
+            !install_root.join("app").exists(),
+            "stage mode should not activate the install"
+        );
+    }
+
+    #[tokio::test]
+    async fn execute_stage_prunes_bundled_payload_cache_when_policy_keeps_latest_full() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let installer_dir = temp_dir.path().join("installer");
+        let payload_dir = installer_dir.join("payload");
+        let install_root = temp_dir.path().join("installed-app");
+        let store_root = temp_dir.path().join("store");
+        let full_filename = "demo-app-1.2.3-full.tar.zst";
+        let bundled_payload = payload_dir.join(full_filename);
+        let stale_path = install_root.join(".surge-cache").join("artifacts").join("stale.bin");
+
+        std::fs::create_dir_all(&payload_dir).expect("payload dir");
+        std::fs::create_dir_all(&store_root).expect("store dir");
+        std::fs::create_dir_all(stale_path.parent().expect("stale parent")).expect("cache dir");
+        std::fs::write(&stale_path, b"stale").expect("stale cache entry");
+
+        let mut manifest = make_manifest(&install_root, &store_root, full_filename, "offline");
+        manifest.cache = latest_full_cache_policy();
+        let installer_yaml = serde_yaml::to_string(&manifest).expect("installer yaml");
+        std::fs::write(installer_dir.join("installer.yml"), installer_yaml).expect("installer manifest");
+        write_archive(&bundled_payload, b"bundled payload");
+
+        execute(&installer_dir, true, true)
+            .await
+            .expect("setup stage should succeed");
+
+        assert!(
+            install_root
+                .join(".surge-cache")
+                .join("artifacts")
+                .join(full_filename)
+                .is_file(),
+            "bundled payload should be copied into the artifact cache"
+        );
+        assert!(
+            !stale_path.exists(),
+            "latest_full stage mode should prune stale cache entries"
         );
         assert!(
             !install_root.join("app").exists(),

--- a/crates/surge-core/src/config/installer.rs
+++ b/crates/surge-core/src/config/installer.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 
-use crate::config::manifest::ShortcutLocation;
+use crate::config::manifest::{CacheManifestConfig, InstallArtifactCachePolicy, ShortcutLocation};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -28,6 +28,15 @@ pub struct InstallerManifest {
     pub storage: InstallerStorage,
     pub release: InstallerRelease,
     pub runtime: InstallerRuntime,
+    #[serde(default, skip_serializing_if = "CacheManifestConfig::is_default")]
+    pub cache: CacheManifestConfig,
+}
+
+impl InstallerManifest {
+    #[must_use]
+    pub fn effective_install_artifact_cache_policy(&self) -> InstallArtifactCachePolicy {
+        self.cache.effective_install_artifact_cache_policy()
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -75,4 +84,40 @@ pub struct InstallerRuntime {
     pub installers: Vec<String>,
     #[serde(default)]
     pub environment: BTreeMap<String, String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::manifest::InstallArtifactCacheRetention;
+
+    #[test]
+    fn installer_manifest_defaults_cache_policy_for_older_manifests() {
+        let yaml = br#"schema: 1
+format: surge-installer-v1
+ui: console
+installer_type: online
+app_id: demo
+rid: linux-x64
+version: "1.2.3"
+channel: stable
+generated_utc: "2026-04-28T00:00:00Z"
+headless_default_if_no_display: true
+release_index_key: releases.zstd
+storage:
+  provider: filesystem
+  bucket: /tmp/store
+release:
+  full_filename: demo-full.tar.zst
+runtime:
+  name: Demo
+  main_exe: demo
+"#;
+
+        let manifest: InstallerManifest = serde_yaml::from_slice(yaml).expect("installer manifest should parse");
+        let policy = manifest.effective_install_artifact_cache_policy();
+
+        assert_eq!(policy.retention, InstallArtifactCacheRetention::ReleaseGraph);
+        assert_eq!(policy.keep_full_count, 1);
+    }
 }

--- a/crates/surge-core/src/config/manifest/lookup.rs
+++ b/crates/surge-core/src/config/manifest/lookup.rs
@@ -1,4 +1,7 @@
-use super::types::{AppConfig, PackCompressionFormat, PackDeltaStrategy, PackPolicy, SurgeManifest, TargetConfig};
+use super::types::{
+    AppConfig, InstallArtifactCachePolicy, PackCompressionFormat, PackDeltaStrategy, PackPolicy, SurgeManifest,
+    TargetConfig,
+};
 use super::validate::canonicalize_installers;
 
 impl SurgeManifest {
@@ -36,6 +39,13 @@ impl SurgeManifest {
         }
 
         policy
+    }
+
+    #[must_use]
+    pub fn effective_install_artifact_cache_policy(&self) -> InstallArtifactCachePolicy {
+        self.cache.map_or_else(InstallArtifactCachePolicy::default, |cache| {
+            cache.effective_install_artifact_cache_policy()
+        })
     }
 
     pub fn find_app(&self, app_id: &str) -> Option<&AppConfig> {

--- a/crates/surge-core/src/config/manifest/mod.rs
+++ b/crates/surge-core/src/config/manifest/mod.rs
@@ -10,9 +10,11 @@ use serde_yaml::Value;
 use crate::error::{Result, SurgeError};
 
 pub use self::types::{
-    AppConfig, ChannelManifestConfig, InstallerType, LockManifestConfig, PackCompressionFormat,
-    PackCompressionManifestConfig, PackDeltaManifestConfig, PackDeltaStrategy, PackManifestConfig, PackPolicy,
-    PackRetentionManifestConfig, ShortcutLocation, StorageManifestConfig, SurgeManifest, TargetConfig,
+    AppConfig, CacheManifestConfig, ChannelManifestConfig, InstallArtifactCacheManifestConfig,
+    InstallArtifactCachePolicy, InstallArtifactCacheRetention, InstallerType, LockManifestConfig,
+    PackCompressionFormat, PackCompressionManifestConfig, PackDeltaManifestConfig, PackDeltaStrategy,
+    PackManifestConfig, PackPolicy, PackRetentionManifestConfig, ShortcutLocation, StorageManifestConfig,
+    SurgeManifest, TargetConfig,
 };
 
 impl SurgeManifest {
@@ -39,7 +41,7 @@ impl SurgeManifest {
 
 #[cfg(test)]
 mod tests {
-    use super::{PackDeltaStrategy, SurgeManifest};
+    use super::{InstallArtifactCacheRetention, PackDeltaStrategy, SurgeManifest};
     use crate::config::constants::{
         PACK_DEFAULT_CHECKPOINT_EVERY, PACK_DEFAULT_KEEP_LATEST_FULLS, PACK_DEFAULT_MAX_CHAIN_LENGTH,
         PACK_DEFAULT_ZSTD_LEVEL,
@@ -135,6 +137,49 @@ apps:
         assert_eq!(policy.max_chain_length, 4);
         assert_eq!(policy.keep_latest_fulls, 3);
         assert_eq!(policy.checkpoint_every, 9);
+    }
+
+    #[test]
+    fn parse_accepts_install_artifact_cache_policy_override() {
+        let yaml = br"schema: 1
+storage:
+  provider: filesystem
+  bucket: /tmp/store
+cache:
+  installArtifacts:
+    retention: latest_full
+    keepFullCount: 1
+apps:
+  - id: demoapp
+    target:
+      rid: linux-x64
+";
+
+        let manifest = SurgeManifest::parse(yaml).expect("manifest should parse");
+        let policy = manifest.effective_install_artifact_cache_policy();
+
+        assert_eq!(policy.retention, InstallArtifactCacheRetention::LatestFull);
+        assert_eq!(policy.keep_full_count, 1);
+    }
+
+    #[test]
+    fn parse_rejects_zero_install_artifact_cache_keep_full_count() {
+        let yaml = br"schema: 1
+storage:
+  provider: filesystem
+  bucket: /tmp/store
+cache:
+  installArtifacts:
+    retention: latest_full
+    keepFullCount: 0
+apps:
+  - id: demoapp
+    target:
+      rid: linux-x64
+";
+
+        let err = SurgeManifest::parse(yaml).expect_err("manifest should be rejected");
+        assert!(err.to_string().contains("cache.installArtifacts.keepFullCount"));
     }
 
     #[test]

--- a/crates/surge-core/src/config/manifest/types.rs
+++ b/crates/surge-core/src/config/manifest/types.rs
@@ -61,6 +61,94 @@ pub struct PackRetentionManifestConfig {
     pub checkpoint_every: Option<u32>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct CacheManifestConfig {
+    #[serde(
+        default,
+        rename = "installArtifacts",
+        alias = "install_artifacts",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub install_artifacts: Option<InstallArtifactCacheManifestConfig>,
+}
+
+impl CacheManifestConfig {
+    #[must_use]
+    pub fn from_install_artifact_cache_policy(policy: InstallArtifactCachePolicy) -> Self {
+        Self {
+            install_artifacts: Some(InstallArtifactCacheManifestConfig {
+                retention: Some(policy.retention),
+                keep_full_count: Some(policy.keep_full_count),
+            }),
+        }
+    }
+
+    #[must_use]
+    pub fn effective_install_artifact_cache_policy(&self) -> InstallArtifactCachePolicy {
+        let mut policy = InstallArtifactCachePolicy::default();
+        if let Some(install_artifacts) = self.install_artifacts {
+            if let Some(retention) = install_artifacts.retention {
+                policy.retention = retention;
+            }
+            if let Some(keep_full_count) = install_artifacts.keep_full_count {
+                policy.keep_full_count = keep_full_count;
+            }
+        }
+        policy
+    }
+
+    #[must_use]
+    pub fn is_default(&self) -> bool {
+        self.install_artifacts.is_none()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct InstallArtifactCacheManifestConfig {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub retention: Option<InstallArtifactCacheRetention>,
+    #[serde(
+        default,
+        rename = "keepFullCount",
+        alias = "keep_full_count",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub keep_full_count: Option<u32>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum InstallArtifactCacheRetention {
+    #[default]
+    ReleaseGraph,
+    LatestFull,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct InstallArtifactCachePolicy {
+    #[serde(default)]
+    pub retention: InstallArtifactCacheRetention,
+    #[serde(
+        default = "default_install_artifact_cache_keep_full_count",
+        rename = "keepFullCount",
+        alias = "keep_full_count"
+    )]
+    pub keep_full_count: u32,
+}
+
+impl Default for InstallArtifactCachePolicy {
+    fn default() -> Self {
+        Self {
+            retention: InstallArtifactCacheRetention::ReleaseGraph,
+            keep_full_count: default_install_artifact_cache_keep_full_count(),
+        }
+    }
+}
+
+const fn default_install_artifact_cache_keep_full_count() -> u32 {
+    1
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct TargetConfig {
     pub rid: String,
@@ -260,6 +348,8 @@ pub struct SurgeManifest {
     pub channels: Vec<ChannelManifestConfig>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub pack: Option<PackManifestConfig>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cache: Option<CacheManifestConfig>,
     #[serde(default)]
     pub apps: Vec<AppConfig>,
 }

--- a/crates/surge-core/src/config/manifest/validate.rs
+++ b/crates/surge-core/src/config/manifest/validate.rs
@@ -101,6 +101,15 @@ impl SurgeManifest {
             }
         }
 
+        if let Some(cache) = &self.cache
+            && let Some(install_artifacts) = &cache.install_artifacts
+            && install_artifacts.keep_full_count == Some(0)
+        {
+            return Err(SurgeError::Config(
+                "cache.installArtifacts.keepFullCount must be greater than zero".to_string(),
+            ));
+        }
+
         for app in &self.apps {
             if app.id.is_empty() {
                 return Err(SurgeError::Config(

--- a/crates/surge-core/src/installer_package.rs
+++ b/crates/surge-core/src/installer_package.rs
@@ -3,11 +3,12 @@ use std::path::{Path, PathBuf};
 
 use crate::config::constants::RELEASES_FILE_COMPRESSED;
 use crate::config::installer::InstallerManifest;
+use crate::config::manifest::InstallArtifactCacheRetention;
 use crate::error::{Result, SurgeError};
 use crate::releases::artifact_cache::{cache_path_for_key, cached_artifact_matches, prune_cached_artifacts};
 use crate::releases::manifest::{ReleaseEntry, ReleaseIndex, decompress_release_index};
 use crate::releases::restore::{
-    RestoreOptions, RestoreProgressCallback, required_artifacts_for_index,
+    RestoreOptions, RestoreProgressCallback, local_checkpoint_artifacts_for_index, required_artifacts_for_index,
     restore_full_archive_for_version_with_options,
 };
 use crate::storage::{self, StorageBackend, TransferProgress};
@@ -35,7 +36,7 @@ pub enum InstallerPackageAcquisition {
 #[derive(Debug)]
 pub struct ResolvedInstallerPackage {
     path: PathBuf,
-    pub required_artifacts: Option<BTreeSet<String>>,
+    pub retained_artifacts: Option<BTreeSet<String>>,
     pub acquisition: InstallerPackageAcquisition,
 }
 
@@ -71,7 +72,7 @@ pub async fn resolve_installer_package(
         notify_stage(options.stage, InstallerPackageStage::UsingBundledPayload);
         return Ok(ResolvedInstallerPackage {
             path: payload_path,
-            required_artifacts: None,
+            retained_artifacts: None,
             acquisition: InstallerPackageAcquisition::BundledPayload,
         });
     }
@@ -92,13 +93,15 @@ pub async fn resolve_installer_package(
             );
             return Ok(ResolvedInstallerPackage {
                 path: cached_package_path,
-                required_artifacts: None,
+                retained_artifacts: None,
                 acquisition: InstallerPackageAcquisition::ArtifactCacheFallback,
             });
         }
         Err(error) => return Err(error),
     };
-    let required_artifacts = index.as_ref().map(required_artifacts_for_index);
+    let retained_artifacts = index
+        .as_ref()
+        .map(|index| retained_artifacts_for_install_cache(index, manifest));
 
     if let Some(index) = index.as_ref()
         && let Some(release) = find_release_for_installer(index, manifest)
@@ -107,7 +110,7 @@ pub async fn resolve_installer_package(
             notify_stage(options.stage, InstallerPackageStage::UsingCachedPackage);
             return Ok(ResolvedInstallerPackage {
                 path: cached_package_path,
-                required_artifacts,
+                retained_artifacts,
                 acquisition: InstallerPackageAcquisition::ArtifactCache,
             });
         }
@@ -127,7 +130,7 @@ pub async fn resolve_installer_package(
         std::fs::write(&cached_package_path, restored)?;
         return Ok(ResolvedInstallerPackage {
             path: cached_package_path,
-            required_artifacts,
+            retained_artifacts,
             acquisition: InstallerPackageAcquisition::PreparedArtifactCache,
         });
     }
@@ -141,7 +144,7 @@ pub async fn resolve_installer_package(
         );
         return Ok(ResolvedInstallerPackage {
             path: cached_package_path,
-            required_artifacts,
+            retained_artifacts,
             acquisition: InstallerPackageAcquisition::ArtifactCacheFallback,
         });
     }
@@ -153,7 +156,7 @@ pub async fn resolve_installer_package(
 
     Ok(ResolvedInstallerPackage {
         path: cached_package_path,
-        required_artifacts,
+        retained_artifacts,
         acquisition: InstallerPackageAcquisition::Downloaded,
     })
 }
@@ -164,15 +167,26 @@ pub fn install_artifact_cache_dir(install_root: &Path) -> PathBuf {
 
 pub fn prune_install_artifact_cache(
     install_root: &Path,
-    required_artifacts: &BTreeSet<String>,
+    retained_artifacts: &BTreeSet<String>,
     warm_full_filename: &str,
 ) -> Result<usize> {
-    let mut retained_artifacts = required_artifacts.clone();
+    let mut retained_artifacts = retained_artifacts.clone();
     let warm_full_filename = warm_full_filename.trim();
     if !warm_full_filename.is_empty() {
         retained_artifacts.insert(warm_full_filename.to_string());
     }
     prune_cached_artifacts(&install_artifact_cache_dir(install_root), &retained_artifacts)
+}
+
+fn retained_artifacts_for_install_cache(index: &ReleaseIndex, manifest: &InstallerManifest) -> BTreeSet<String> {
+    let policy = manifest.effective_install_artifact_cache_policy();
+    match policy.retention {
+        InstallArtifactCacheRetention::ReleaseGraph => required_artifacts_for_index(index),
+        InstallArtifactCacheRetention::LatestFull => {
+            let keep_full_count = usize::try_from(policy.keep_full_count.max(1)).unwrap_or(usize::MAX);
+            local_checkpoint_artifacts_for_index(index, keep_full_count)
+        }
+    }
 }
 
 fn notify_stage(stage: Option<&InstallerPackageStageCallback<'_>>, value: InstallerPackageStage) {

--- a/crates/surge-installer-ui/src/install.rs
+++ b/crates/surge-installer-ui/src/install.rs
@@ -12,7 +12,7 @@ use std::time::Duration;
 use eframe::egui;
 
 use surge_core::config::installer::InstallerManifest;
-use surge_core::config::manifest::ShortcutLocation;
+use surge_core::config::manifest::{InstallArtifactCacheRetention, ShortcutLocation};
 use surge_core::install::{self as core_install, InstallProfile, InstallProgress, InstallProgressStage};
 use surge_core::installer_package::{
     InstallerPackageStage, ResolveInstallerPackageOptions, ResolvedInstallerPackage, prune_install_artifact_cache,
@@ -170,9 +170,7 @@ fn run_install_inner(
         &manifest.storage.endpoint,
     );
     core_install::write_runtime_manifest(&install_root.join("app"), &profile, &runtime_manifest)?;
-    if let Some(required_artifacts) = package.required_artifacts.as_ref() {
-        let _ = prune_install_artifact_cache(&install_root, required_artifacts, &manifest.release.full_filename);
-    }
+    prune_artifact_cache_for_package(&install_root, &package, manifest);
 
     send(progress_tx, ctx, ProgressUpdate::Progress(1.0));
     send(progress_tx, ctx, ProgressUpdate::Complete(install_root));
@@ -451,12 +449,24 @@ pub fn run_headless(
         &manifest.storage.endpoint,
     );
     core_install::write_runtime_manifest(&install_root.join("app"), &profile, &runtime_manifest)?;
-    if let Some(required_artifacts) = package.required_artifacts.as_ref() {
-        let _ = prune_install_artifact_cache(&install_root, required_artifacts, &manifest.release.full_filename);
-    }
+    prune_artifact_cache_for_package(&install_root, &package, manifest);
     eprintln!("Installed '{}' to '{}'", manifest.app_id, install_root.display());
 
     Ok(install_root)
+}
+
+fn prune_artifact_cache_for_package(install_root: &Path, package: &ResolvedPackage, manifest: &InstallerManifest) {
+    let empty_retained_artifacts = std::collections::BTreeSet::new();
+    let retained_artifacts = match package.retained_artifacts.as_ref() {
+        Some(retained_artifacts) => retained_artifacts,
+        None if manifest.effective_install_artifact_cache_policy().retention
+            == InstallArtifactCacheRetention::LatestFull =>
+        {
+            &empty_retained_artifacts
+        }
+        None => return,
+    };
+    let _ = prune_install_artifact_cache(install_root, retained_artifacts, &manifest.release.full_filename);
 }
 
 #[cfg(test)]
@@ -467,6 +477,7 @@ mod tests {
     use surge_core::archive::packer::ArchivePacker;
     use surge_core::config::constants::RELEASES_FILE_COMPRESSED;
     use surge_core::config::installer::{InstallerRelease, InstallerRuntime, InstallerStorage, InstallerUi};
+    use surge_core::config::manifest::CacheManifestConfig;
     use surge_core::crypto::sha256::sha256_hex;
     use surge_core::diff::wrapper::bsdiff_buffers;
     use surge_core::platform::detect::current_rid;
@@ -511,6 +522,7 @@ mod tests {
                 installers: Vec::new(),
                 environment: BTreeMap::new(),
             },
+            cache: CacheManifestConfig::default(),
         }
     }
 


### PR DESCRIPTION
## Purpose
Add a device-side installer artifact cache policy so constrained installs can keep a warm full archive without retaining the full backend release graph locally.

## What changed
- Added manifest support for `cache.installArtifacts.retention` with `release_graph` as the default and `latest_full` as the bounded option.
- Embedded the effective cache policy into generated, published, and remote installer manifests.
- Pruned artifact caches after both `surge setup --stage` and normal setup activation.
- Kept old installer manifests compatible by defaulting missing cache config to `release_graph`.
- Documented the manifest option in the README.

## Behavior impact
Existing manifests keep the current release-graph behavior. Apps can opt into:

```yaml
cache:
  installArtifacts:
    retention: latest_full
    keepFullCount: 1
```

With `latest_full`, stale delta artifacts in the device cache can be deleted. A future install downloads whatever newer delta it needs from storage and applies it against the retained current full archive; backend release retention is unchanged.

## Validation
- `./scripts/sync-surge-core-vendor.sh --check`
- `./scripts/check-version-sync.sh`
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo test --workspace`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo clippy --workspace --lib --bins --examples -- -D warnings -D clippy::unwrap_used -D clippy::expect_used`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings -W clippy::pedantic`
- `dotnet format dotnet/Surge.slnx --verify-no-changes`
- `dotnet test dotnet/Surge.slnx --configuration Release`
