### PR TITLE
Fix full-only Surge promotion metadata

### DIFF
--- a/crates/surge-cli/src/commands/pack.rs
+++ b/crates/surge-cli/src/commands/pack.rs
@@ -441,6 +441,7 @@ mod tests {
     use surge_core::crypto::sha256::sha256_hex;
     use surge_core::diff::wrapper::bsdiff_buffers;
     use surge_core::installer_bundle::read_embedded_payload;
+    use surge_core::pack::builder::{PackageArtifactMetadata, package_metadata_filename};
     use surge_core::platform::detect::current_rid;
     use surge_core::platform::fs::make_executable;
     use surge_core::releases::manifest::{ReleaseEntry, ReleaseIndex, compress_release_index};
@@ -1109,6 +1110,17 @@ apps:
                 .join(format!("{app_id}-{version}-{rid}-full.tar.zst"))
                 .exists()
         );
+        let full_filename = format!("{app_id}-{version}-{rid}-full.tar.zst");
+        let metadata_path = packages_dir.join(package_metadata_filename(&full_filename));
+        let metadata: PackageArtifactMetadata =
+            serde_yaml::from_slice(&std::fs::read(&metadata_path).expect("package metadata should be readable"))
+                .expect("package metadata should parse");
+        assert_eq!(metadata.app_id, app_id);
+        assert_eq!(metadata.version, version);
+        assert_eq!(metadata.rid, rid);
+        assert_eq!(metadata.archive_filename, full_filename);
+        assert_eq!(metadata.full_compression_level, 3);
+        assert!(metadata.full_zstd_workers >= 0);
         let installer_ext = if rid.starts_with("win-") { "exe" } else { "bin" };
         assert!(
             packages_dir

--- a/crates/surge-cli/src/commands/push.rs
+++ b/crates/surge-cli/src/commands/push.rs
@@ -22,6 +22,7 @@ use surge_core::config::constants::{DEFAULT_ZSTD_LEVEL, RELEASES_FILE_COMPRESSED
 use surge_core::config::manifest::{ShortcutLocation, SurgeManifest};
 use surge_core::crypto::sha256::sha256_hex_file;
 use surge_core::error::{Result, SurgeError};
+use surge_core::pack::builder::{PACKAGE_METADATA_SCHEMA_VERSION, PackageArtifactMetadata, package_metadata_filename};
 use surge_core::releases::delta::patch_format_from_magic_prefix;
 use surge_core::releases::manifest::{
     DeltaArtifact, PATCH_FORMAT_BSDIFF4, PATCH_FORMAT_CHUNKED_BSDIFF_V1, PATCH_FORMAT_SPARSE_FILE_OPS_V1, ReleaseEntry,
@@ -97,6 +98,23 @@ pub async fn execute(
     print_stage(theme, 3, TOTAL_STAGES, "Uploading release artifacts");
     let full_size = std::fs::metadata(&full_archive)?.len() as i64;
     let full_sha256 = sha256_hex_file(&full_archive)?;
+    let full_metadata = load_full_package_metadata(
+        packages_dir,
+        &app_id,
+        version,
+        &rid,
+        &full_filename,
+        full_size,
+        &full_sha256,
+    )?;
+    let (full_compression_level, full_zstd_workers) = full_metadata
+        .as_ref()
+        .map_or((UNRECORDED_COMPRESSION_LEVEL, UNRECORDED_ZSTD_WORKERS), |metadata| {
+            (metadata.full_compression_level, metadata.full_zstd_workers)
+        });
+    if full_metadata.is_some() {
+        logline::subtle("  Loaded full package encoding metadata");
+    }
     let delta_filename = format!("{app_id}-{version}-{rid}-delta.tar.zst");
     let delta_archive = packages_dir.join(&delta_filename);
     let delta_available = delta_archive.is_file();
@@ -166,6 +184,8 @@ pub async fn execute(
         full_filename,
         full_size,
         full_sha256,
+        full_compression_level,
+        full_zstd_workers,
         delta_filename,
         delta_size,
         delta_sha256,
@@ -242,6 +262,8 @@ async fn update_release_index(
     full_filename: String,
     full_size: i64,
     full_sha256: String,
+    full_compression_level: i32,
+    full_zstd_workers: i32,
     delta_filename: String,
     delta_size: i64,
     delta_sha256: String,
@@ -305,12 +327,8 @@ async fn update_release_index(
         full_filename,
         full_size,
         full_sha256,
-        // `surge push` uploads a pre-built archive without knowing how it was
-        // compressed, so we mark the encoding as unrecorded. Promotes of this
-        // release will have to fall back to `selected_delta` to recover the
-        // encoding (and error out if they can't), which is safer than guessing.
-        full_compression_level: UNRECORDED_COMPRESSION_LEVEL,
-        full_zstd_workers: UNRECORDED_ZSTD_WORKERS,
+        full_compression_level,
+        full_zstd_workers,
         deltas: Vec::new(),
         preferred_delta_id: String::new(),
         created_utc: chrono::Utc::now().to_rfc3339(),
@@ -373,6 +391,68 @@ async fn update_release_index(
     let pruned = prune_redundant_artifacts(backend, &index).await?;
 
     Ok(pruned)
+}
+
+fn load_full_package_metadata(
+    packages_dir: &Path,
+    app_id: &str,
+    version: &str,
+    rid: &str,
+    full_filename: &str,
+    full_size: i64,
+    full_sha256: &str,
+) -> Result<Option<PackageArtifactMetadata>> {
+    let metadata_path = packages_dir.join(package_metadata_filename(full_filename));
+    if !metadata_path.is_file() {
+        return Ok(None);
+    }
+
+    let metadata: PackageArtifactMetadata = serde_yaml::from_slice(&std::fs::read(&metadata_path)?)?;
+    validate_full_package_metadata(
+        &metadata_path,
+        &metadata,
+        app_id,
+        version,
+        rid,
+        full_filename,
+        full_size,
+        full_sha256,
+    )?;
+    Ok(Some(metadata))
+}
+
+fn validate_full_package_metadata(
+    metadata_path: &Path,
+    metadata: &PackageArtifactMetadata,
+    app_id: &str,
+    version: &str,
+    rid: &str,
+    full_filename: &str,
+    full_size: i64,
+    full_sha256: &str,
+) -> Result<()> {
+    if metadata.schema != PACKAGE_METADATA_SCHEMA_VERSION {
+        return Err(SurgeError::Storage(format!(
+            "Package metadata {} uses unsupported schema {}",
+            metadata_path.display(),
+            metadata.schema
+        )));
+    }
+
+    if metadata.app_id != app_id
+        || metadata.version != version
+        || metadata.rid != rid
+        || metadata.archive_filename != full_filename
+        || metadata.archive_size != full_size
+        || metadata.archive_sha256 != full_sha256
+    {
+        return Err(SurgeError::Storage(format!(
+            "Package metadata {} does not match full archive {full_filename}",
+            metadata_path.display()
+        )));
+    }
+
+    Ok(())
 }
 
 async fn prune_redundant_artifacts(backend: &dyn StorageBackend, index: &ReleaseIndex) -> Result<usize> {
@@ -507,4 +587,83 @@ async fn upload_artifact_with_feedback(
     ));
 
     Ok(total_bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use surge_core::config::constants::RELEASES_FILE_COMPRESSED;
+    use surge_core::crypto::sha256::sha256_hex;
+    use surge_core::pack::builder::PACKAGE_METADATA_SCHEMA_VERSION;
+    use surge_core::platform::detect::current_rid;
+    use surge_core::releases::manifest::decompress_release_index;
+
+    fn write_manifest(path: &Path, store_dir: &Path, app_id: &str, rid: &str) {
+        let yaml = format!(
+            r"schema: 1
+storage:
+  provider: filesystem
+  bucket: {bucket}
+apps:
+  - id: {app_id}
+    main_exe: demoapp
+    channels: [test, production]
+    target:
+      rid: {rid}
+",
+            bucket = store_dir.display()
+        );
+        std::fs::write(path, yaml).expect("manifest write should succeed");
+    }
+
+    #[tokio::test]
+    async fn execute_records_full_encoding_from_package_metadata() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let store_dir = temp_dir.path().join("store");
+        let packages_dir = temp_dir.path().join("packages");
+        let manifest_path = temp_dir.path().join("surge.yml");
+        let app_id = "demo";
+        let rid = current_rid();
+        let version = "1.2.3";
+
+        std::fs::create_dir_all(&store_dir).expect("store dir should be created");
+        std::fs::create_dir_all(&packages_dir).expect("packages dir should be created");
+        write_manifest(&manifest_path, &store_dir, app_id, &rid);
+
+        let full_filename = format!("{app_id}-{version}-{rid}-full.tar.zst");
+        let full_bytes = b"full package bytes with recorded pack metadata";
+        std::fs::write(packages_dir.join(&full_filename), full_bytes).expect("full package should be written");
+
+        let metadata = PackageArtifactMetadata {
+            schema: PACKAGE_METADATA_SCHEMA_VERSION,
+            app_id: app_id.to_string(),
+            version: version.to_string(),
+            rid: rid.clone(),
+            archive_filename: full_filename.clone(),
+            archive_size: i64::try_from(full_bytes.len()).expect("test bytes fit i64"),
+            archive_sha256: sha256_hex(full_bytes),
+            full_compression_level: 3,
+            full_zstd_workers: 4,
+        };
+        std::fs::write(
+            packages_dir.join(package_metadata_filename(&full_filename)),
+            serde_yaml::to_string(&metadata).expect("metadata should serialize"),
+        )
+        .expect("metadata should be written");
+
+        execute(&manifest_path, Some(app_id), version, Some(&rid), "test", &packages_dir)
+            .await
+            .expect("push should succeed");
+
+        let compressed_index =
+            std::fs::read(store_dir.join(RELEASES_FILE_COMPRESSED)).expect("release index should be written");
+        let index = decompress_release_index(&compressed_index).expect("release index should decompress");
+        let release = index
+            .releases
+            .iter()
+            .find(|release| release.version == version && release.rid == rid)
+            .expect("pushed release should exist");
+        assert_eq!(release.full_compression_level, 3);
+        assert_eq!(release.full_zstd_workers, 4);
+    }
 }

--- a/crates/surge-core/src/pack/builder.rs
+++ b/crates/surge-core/src/pack/builder.rs
@@ -17,9 +17,13 @@ use crate::config::manifest::{PackPolicy, ShortcutLocation, SurgeManifest};
 use crate::context::Context;
 use crate::error::{Result, SurgeError};
 use crate::platform::fs::write_file_atomic;
+use crate::releases::manifest::UNRECORDED_ZSTD_WORKERS;
 use crate::storage::{StorageBackend, create_storage_backend};
 
 pub(crate) use self::staging::build_canonical_archive_from_directory;
+
+pub const PACKAGE_METADATA_SCHEMA_VERSION: u32 = 1;
+pub const PACKAGE_METADATA_SUFFIX: &str = ".metadata.yml";
 
 /// A built package artifact ready for upload.
 #[derive(Debug, Clone)]
@@ -46,6 +50,22 @@ pub struct PackageArtifact {
     /// `zstd_compression_level`.
     pub zstd_workers: u32,
     bytes: Vec<u8>,
+}
+
+/// Metadata that `surge pack` writes next to a full package so a later
+/// `surge push` can preserve the original archive encoding in the release
+/// index.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct PackageArtifactMetadata {
+    pub schema: u32,
+    pub app_id: String,
+    pub version: String,
+    pub rid: String,
+    pub archive_filename: String,
+    pub archive_size: i64,
+    pub archive_sha256: String,
+    pub full_compression_level: i32,
+    pub full_zstd_workers: i32,
 }
 
 #[derive(Debug, Clone)]
@@ -80,6 +100,28 @@ impl PackageArtifact {
     pub fn bytes(&self) -> &[u8] {
         &self.bytes
     }
+}
+
+impl PackageArtifactMetadata {
+    #[must_use]
+    pub fn for_full_artifact(app_id: &str, version: &str, rid: &str, artifact: &PackageArtifact) -> Self {
+        Self {
+            schema: PACKAGE_METADATA_SCHEMA_VERSION,
+            app_id: app_id.to_string(),
+            version: version.to_string(),
+            rid: rid.to_string(),
+            archive_filename: artifact.filename.clone(),
+            archive_size: artifact.size,
+            archive_sha256: artifact.sha256.clone(),
+            full_compression_level: artifact.zstd_compression_level,
+            full_zstd_workers: i32::try_from(artifact.zstd_workers).unwrap_or(UNRECORDED_ZSTD_WORKERS),
+        }
+    }
+}
+
+#[must_use]
+pub fn package_metadata_filename(archive_filename: &str) -> String {
+    format!("{archive_filename}{PACKAGE_METADATA_SUFFIX}")
 }
 
 /// Builds full and delta release packages from application artifacts.
@@ -340,14 +382,24 @@ impl PackBuilder {
     pub fn write_artifacts_to(&self, output_dir: &Path) -> Result<Vec<PathBuf>> {
         std::fs::create_dir_all(output_dir)?;
 
-        self.artifacts
+        let artifact_paths = self
+            .artifacts
             .iter()
             .map(|artifact| {
                 let path = output_dir.join(&artifact.filename);
                 write_file_atomic(&path, artifact.bytes())?;
                 Ok(path)
             })
-            .collect()
+            .collect::<Result<Vec<_>>>()?;
+
+        for artifact in self.artifacts.iter().filter(|artifact| !artifact.is_delta) {
+            let metadata = PackageArtifactMetadata::for_full_artifact(&self.app_id, &self.version, &self.rid, artifact);
+            let metadata_yaml = serde_yaml::to_string(&metadata)?;
+            let metadata_path = output_dir.join(package_metadata_filename(&artifact.filename));
+            write_file_atomic(&metadata_path, metadata_yaml.as_bytes())?;
+        }
+
+        Ok(artifact_paths)
     }
 }
 


### PR DESCRIPTION
## Summary

- write a validated metadata sidecar next to full packages produced by `surge pack`
- have `surge push` read that sidecar and persist the original full archive compression level/workers in `releases.yml`
- keep older package directories compatible by falling back to `UNRECORDED` when no sidecar exists

## Behavior impact

Full-only checkpoint releases produced through `surge pack` and later published through `surge push` now keep enough encoding metadata for `surge promote` to build channel-aware deltas. This prevents the prior failure where a release with no primary delta and `UNRECORDED` full encoding could not be promoted from test to production.

If a metadata sidecar exists but does not match the expected app, version, RID, archive filename, size, or SHA-256, `surge push` now rejects it instead of recording stale encoding settings.

## Validation

- `./scripts/sync-surge-core-vendor.sh --check`
- `./scripts/check-version-sync.sh`
- `cargo fmt --all -- --check`
- `cargo test -p surge-cli execute_records_full_encoding_from_package_metadata`
- `cargo test -p surge-cli execute_pack_uses_default_dot_surge_artifacts_layout`
- `RUSTFLAGS="-D warnings" cargo test --workspace`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo clippy --workspace --lib --bins --examples -- -D warnings -D clippy::unwrap_used -D clippy::expect_used`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings -W clippy::pedantic`
- `dotnet format dotnet/Surge.slnx --verify-no-changes`
- `dotnet test dotnet/Surge.slnx --configuration Release`

## Notes

Agent-authored PR: squash-merge this PR.
