### PR TITLE
Add artifact cache retention modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -625,9 +625,9 @@ pack:                             # optional; omitted uses built-in defaults
     format: zstd
     level: 3
 
-cache:                            # optional device-side installer cache policy
+cache:                            # optional device-side artifact cache policy
   installArtifacts:
-    retention: release_graph       # release_graph | latest_full
+    retention: release_graph       # release_graph | latest_full | just_installed | none
     keepFullCount: 1               # full archives retained when retention is latest_full
 
 apps:
@@ -648,7 +648,12 @@ apps:
 
 Target-level settings override app-level defaults for `icon`, `shortcuts`, `persistentAssets`, `installers`, and `environment`.
 `pack` policy is global and currently controls delta strategy plus compression format/level for `surge pack`.
-`cache.installArtifacts.retention: latest_full` keeps the installed full archive warm on each device and lets future deltas be downloaded again from storage when needed, instead of retaining the full release graph locally.
+`cache.installArtifacts` controls package artifacts kept under `.surge-cache/artifacts/` after setup and successful updates:
+
+- `release_graph` is the default. Use it when offline restore to older versions matters; it keeps the local release graph and uses the most disk.
+- `latest_full` keeps the newest `keepFullCount` full archives per RID and drops deltas. Use it when you want a small reinstall/restore cushion without retaining the full graph.
+- `just_installed` keeps only the installed full archive when that archive is already cached. Use it when full-update reinstall warmth is useful but disk should stay tight. Delta-only updates do not synthesize a new full archive just to warm this cache.
+- `none` keeps no package artifacts after a successful update. Use it when optimizing for minimum disk usage and accepting that restore/reinstall downloads from storage again.
 
 ### Architecture
 

--- a/crates/surge-cli/src/commands/setup.rs
+++ b/crates/surge-cli/src/commands/setup.rs
@@ -4,12 +4,11 @@ use std::time::{Duration, Instant};
 
 use crate::logline;
 use surge_core::config::installer::InstallerManifest;
-use surge_core::config::manifest::InstallArtifactCacheRetention;
 use surge_core::error::{Result, SurgeError};
 use surge_core::install::{self as core_install, InstallProfile};
 use surge_core::installer_package::{
     InstallerPackageAcquisition, ResolveInstallerPackageOptions, ResolvedInstallerPackage, install_artifact_cache_dir,
-    prune_install_artifact_cache, resolve_installer_package,
+    prune_install_artifact_cache, resolve_installer_package, retained_artifacts_for_install_cache_without_index,
 };
 use surge_core::platform::fs::make_executable;
 use surge_core::platform::paths::default_install_root;
@@ -280,17 +279,18 @@ fn ensure_stage_cache_entry(
 }
 
 fn prune_setup_artifact_cache(install_root: &Path, package: &ResolvedPackage, manifest: &InstallerManifest) {
-    let empty_retained_artifacts = std::collections::BTreeSet::new();
+    let owned_retained_artifacts;
     let retained_artifacts = match package.retained_artifacts.as_ref() {
         Some(retained_artifacts) => retained_artifacts,
-        None if manifest.effective_install_artifact_cache_policy().retention
-            == InstallArtifactCacheRetention::LatestFull =>
-        {
-            &empty_retained_artifacts
-        }
-        None => return,
+        None => match retained_artifacts_for_install_cache_without_index(manifest) {
+            Some(retained_artifacts) => {
+                owned_retained_artifacts = retained_artifacts;
+                &owned_retained_artifacts
+            }
+            None => return,
+        },
     };
-    match prune_install_artifact_cache(install_root, retained_artifacts, &manifest.release.full_filename) {
+    match prune_install_artifact_cache(install_root, retained_artifacts) {
         Ok(0) => {}
         Ok(pruned) => {
             logline::info(&format!(

--- a/crates/surge-core/src/config/manifest/mod.rs
+++ b/crates/surge-core/src/config/manifest/mod.rs
@@ -163,6 +163,33 @@ apps:
     }
 
     #[test]
+    fn parse_accepts_bounded_install_artifact_cache_policies() {
+        for (retention, expected) in [
+            ("just_installed", InstallArtifactCacheRetention::JustInstalled),
+            ("none", InstallArtifactCacheRetention::None),
+        ] {
+            let yaml = format!(
+                r"schema: 1
+storage:
+  provider: filesystem
+  bucket: /tmp/store
+cache:
+  installArtifacts:
+    retention: {retention}
+apps:
+  - id: demoapp
+    target:
+      rid: linux-x64
+"
+            );
+
+            let manifest = SurgeManifest::parse(yaml.as_bytes()).expect("manifest should parse");
+            let policy = manifest.effective_install_artifact_cache_policy();
+            assert_eq!(policy.retention, expected);
+        }
+    }
+
+    #[test]
     fn parse_rejects_zero_install_artifact_cache_keep_full_count() {
         let yaml = br"schema: 1
 storage:

--- a/crates/surge-core/src/config/manifest/types.rs
+++ b/crates/surge-core/src/config/manifest/types.rs
@@ -122,6 +122,8 @@ pub enum InstallArtifactCacheRetention {
     #[default]
     ReleaseGraph,
     LatestFull,
+    JustInstalled,
+    None,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/surge-core/src/installer_package.rs
+++ b/crates/surge-core/src/installer_package.rs
@@ -3,13 +3,12 @@ use std::path::{Path, PathBuf};
 
 use crate::config::constants::RELEASES_FILE_COMPRESSED;
 use crate::config::installer::InstallerManifest;
-use crate::config::manifest::InstallArtifactCacheRetention;
 use crate::error::{Result, SurgeError};
 use crate::releases::artifact_cache::{cache_path_for_key, cached_artifact_matches, prune_cached_artifacts};
 use crate::releases::manifest::{ReleaseEntry, ReleaseIndex, decompress_release_index};
 use crate::releases::restore::{
-    RestoreOptions, RestoreProgressCallback, local_checkpoint_artifacts_for_index, required_artifacts_for_index,
-    restore_full_archive_for_version_with_options,
+    RestoreOptions, RestoreProgressCallback, restore_full_archive_for_version_with_options,
+    retained_artifacts_for_cache_policy, retained_artifacts_for_cache_policy_without_index,
 };
 use crate::storage::{self, StorageBackend, TransferProgress};
 use crate::storage_config::build_storage_config_from_installer_manifest;
@@ -165,28 +164,21 @@ pub fn install_artifact_cache_dir(install_root: &Path) -> PathBuf {
     install_root.join(".surge-cache").join("artifacts")
 }
 
-pub fn prune_install_artifact_cache(
-    install_root: &Path,
-    retained_artifacts: &BTreeSet<String>,
-    warm_full_filename: &str,
-) -> Result<usize> {
-    let mut retained_artifacts = retained_artifacts.clone();
-    let warm_full_filename = warm_full_filename.trim();
-    if !warm_full_filename.is_empty() {
-        retained_artifacts.insert(warm_full_filename.to_string());
-    }
-    prune_cached_artifacts(&install_artifact_cache_dir(install_root), &retained_artifacts)
+pub fn prune_install_artifact_cache(install_root: &Path, retained_artifacts: &BTreeSet<String>) -> Result<usize> {
+    prune_cached_artifacts(&install_artifact_cache_dir(install_root), retained_artifacts)
+}
+
+#[must_use]
+pub fn retained_artifacts_for_install_cache_without_index(manifest: &InstallerManifest) -> Option<BTreeSet<String>> {
+    retained_artifacts_for_cache_policy_without_index(
+        manifest.effective_install_artifact_cache_policy(),
+        &manifest.release.full_filename,
+    )
 }
 
 fn retained_artifacts_for_install_cache(index: &ReleaseIndex, manifest: &InstallerManifest) -> BTreeSet<String> {
     let policy = manifest.effective_install_artifact_cache_policy();
-    match policy.retention {
-        InstallArtifactCacheRetention::ReleaseGraph => required_artifacts_for_index(index),
-        InstallArtifactCacheRetention::LatestFull => {
-            let keep_full_count = usize::try_from(policy.keep_full_count.max(1)).unwrap_or(usize::MAX);
-            local_checkpoint_artifacts_for_index(index, keep_full_count)
-        }
-    }
+    retained_artifacts_for_cache_policy(index, policy, &manifest.release.full_filename, 0)
 }
 
 fn notify_stage(stage: Option<&InstallerPackageStageCallback<'_>>, value: InstallerPackageStage) {

--- a/crates/surge-core/src/releases/restore.rs
+++ b/crates/surge-core/src/releases/restore.rs
@@ -11,7 +11,10 @@ pub use self::planning::{
     find_previous_release_for_rid, find_release_for_version_rid, plan_full_archive_restore, sorted_releases_for_rid,
 };
 pub use self::recovery::{restore_full_archive_for_version, restore_full_archive_for_version_with_options};
-pub use self::retention::{local_checkpoint_artifacts_for_index, required_artifacts_for_index};
+pub use self::retention::{
+    local_checkpoint_artifacts_for_index, required_artifacts_for_index, retained_artifacts_for_cache_policy,
+    retained_artifacts_for_cache_policy_without_index,
+};
 
 pub type RestoreProgressCallback<'a> = dyn Fn(RestoreProgress) + Send + Sync + 'a;
 

--- a/crates/surge-core/src/releases/restore/retention.rs
+++ b/crates/surge-core/src/releases/restore/retention.rs
@@ -1,5 +1,6 @@
 use std::collections::{BTreeMap, BTreeSet};
 
+use crate::config::manifest::{InstallArtifactCachePolicy, InstallArtifactCacheRetention};
 use crate::releases::manifest::{ReleaseEntry, ReleaseIndex};
 use crate::releases::version::compare_versions;
 
@@ -37,6 +38,59 @@ pub fn local_checkpoint_artifacts_for_index(index: &ReleaseIndex, per_rid_limit:
     }
 
     retained
+}
+
+#[must_use]
+pub fn retained_artifacts_for_cache_policy(
+    index: &ReleaseIndex,
+    policy: InstallArtifactCachePolicy,
+    warm_full_filename: &str,
+    release_graph_checkpoint_fulls: usize,
+) -> BTreeSet<String> {
+    let mut retained = match policy.retention {
+        InstallArtifactCacheRetention::ReleaseGraph => {
+            let mut retained = required_artifacts_for_index(index);
+            retained.extend(local_checkpoint_artifacts_for_index(
+                index,
+                release_graph_checkpoint_fulls,
+            ));
+            retained
+        }
+        InstallArtifactCacheRetention::LatestFull => {
+            let keep_full_count = usize::try_from(policy.keep_full_count.max(1)).unwrap_or(usize::MAX);
+            local_checkpoint_artifacts_for_index(index, keep_full_count)
+        }
+        InstallArtifactCacheRetention::JustInstalled | InstallArtifactCacheRetention::None => BTreeSet::new(),
+    };
+
+    if !matches!(policy.retention, InstallArtifactCacheRetention::None) {
+        insert_warm_full(&mut retained, warm_full_filename);
+    }
+
+    retained
+}
+
+#[must_use]
+pub fn retained_artifacts_for_cache_policy_without_index(
+    policy: InstallArtifactCachePolicy,
+    warm_full_filename: &str,
+) -> Option<BTreeSet<String>> {
+    match policy.retention {
+        InstallArtifactCacheRetention::ReleaseGraph => None,
+        InstallArtifactCacheRetention::LatestFull | InstallArtifactCacheRetention::JustInstalled => {
+            let mut retained = BTreeSet::new();
+            insert_warm_full(&mut retained, warm_full_filename);
+            Some(retained)
+        }
+        InstallArtifactCacheRetention::None => Some(BTreeSet::new()),
+    }
+}
+
+fn insert_warm_full(retained: &mut BTreeSet<String>, warm_full_filename: &str) {
+    let warm_full_filename = warm_full_filename.trim();
+    if !warm_full_filename.is_empty() {
+        retained.insert(warm_full_filename.to_string());
+    }
 }
 
 fn extend_required_artifacts_for_sorted_releases(releases: &[&ReleaseEntry], required: &mut BTreeSet<String>) {
@@ -80,5 +134,121 @@ fn extend_required_artifacts_for_sorted_releases(releases: &[&ReleaseEntry], req
                 required.insert(key.to_string());
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn release(version: &str, rid: &str, full: &str, delta: Option<&str>) -> ReleaseEntry {
+        let mut release = ReleaseEntry {
+            version: version.to_string(),
+            channels: vec!["stable".to_string()],
+            os: "linux".to_string(),
+            rid: rid.to_string(),
+            is_genesis: false,
+            full_filename: full.to_string(),
+            full_size: 1,
+            full_sha256: String::new(),
+            full_compression_level: 0,
+            full_zstd_workers: 0,
+            deltas: Vec::new(),
+            preferred_delta_id: String::new(),
+            created_utc: String::new(),
+            release_notes: String::new(),
+            name: String::new(),
+            main_exe: "demo".to_string(),
+            install_directory: "demo".to_string(),
+            supervisor_id: String::new(),
+            icon: String::new(),
+            shortcuts: Vec::new(),
+            persistent_assets: Vec::new(),
+            installers: Vec::new(),
+            environment: BTreeMap::new(),
+        };
+        if let Some(delta) = delta {
+            release.set_primary_delta(Some(crate::releases::manifest::DeltaArtifact::bsdiff_zstd(
+                "primary", "", delta, 1, "",
+            )));
+        }
+        release
+    }
+
+    fn index() -> ReleaseIndex {
+        ReleaseIndex {
+            app_id: "demo".to_string(),
+            releases: vec![
+                release("1.0.0", "linux-x64", "v1-full.tar.zst", None),
+                release("1.1.0", "linux-x64", "v2-full.tar.zst", Some("v2-delta.tar.zst")),
+                release("1.2.0", "linux-x64", "v3-full.tar.zst", Some("v3-delta.tar.zst")),
+            ],
+            ..ReleaseIndex::default()
+        }
+    }
+
+    #[test]
+    fn cache_policy_release_graph_keeps_graph_checkpoints_and_warm_full() {
+        let retained = retained_artifacts_for_cache_policy(
+            &index(),
+            InstallArtifactCachePolicy::default(),
+            "warm-full.tar.zst",
+            1,
+        );
+
+        assert!(retained.contains("v1-full.tar.zst"));
+        assert!(retained.contains("v2-delta.tar.zst"));
+        assert!(retained.contains("v3-delta.tar.zst"));
+        assert!(retained.contains("v3-full.tar.zst"));
+        assert!(retained.contains("warm-full.tar.zst"));
+    }
+
+    #[test]
+    fn cache_policy_latest_full_keeps_newest_fulls_and_warm_full() {
+        let retained = retained_artifacts_for_cache_policy(
+            &index(),
+            InstallArtifactCachePolicy {
+                retention: InstallArtifactCacheRetention::LatestFull,
+                keep_full_count: 2,
+            },
+            "warm-full.tar.zst",
+            3,
+        );
+
+        assert!(!retained.contains("v1-full.tar.zst"));
+        assert!(retained.contains("v2-full.tar.zst"));
+        assert!(retained.contains("v3-full.tar.zst"));
+        assert!(retained.contains("warm-full.tar.zst"));
+        assert!(retained.iter().all(|key| !key.contains("delta")));
+    }
+
+    #[test]
+    fn cache_policy_just_installed_keeps_only_warm_full() {
+        let retained = retained_artifacts_for_cache_policy(
+            &index(),
+            InstallArtifactCachePolicy {
+                retention: InstallArtifactCacheRetention::JustInstalled,
+                keep_full_count: 1,
+            },
+            "warm-full.tar.zst",
+            3,
+        );
+
+        assert_eq!(retained, BTreeSet::from(["warm-full.tar.zst".to_string()]));
+    }
+
+    #[test]
+    fn cache_policy_none_keeps_no_artifacts() {
+        let retained = retained_artifacts_for_cache_policy(
+            &index(),
+            InstallArtifactCachePolicy {
+                retention: InstallArtifactCacheRetention::None,
+                keep_full_count: 1,
+            },
+            "warm-full.tar.zst",
+            3,
+        );
+
+        assert!(retained.is_empty());
     }
 }

--- a/crates/surge-core/src/update/manager.rs
+++ b/crates/surge-core/src/update/manager.rs
@@ -12,6 +12,7 @@ use std::sync::Arc;
 use tracing::{debug, info, warn};
 
 use crate::config::constants::RELEASES_FILE_COMPRESSED;
+use crate::config::manifest::{InstallArtifactCachePolicy, InstallArtifactCacheRetention};
 use crate::context::Context;
 use crate::error::{Result, SurgeError};
 use crate::install::{
@@ -22,7 +23,9 @@ use crate::platform::fs::atomic_rename;
 use crate::platform::shortcuts::install_shortcuts;
 use crate::releases::artifact_cache::prune_cached_artifacts;
 use crate::releases::manifest::{ReleaseEntry, ReleaseIndex, decompress_release_index};
-use crate::releases::restore::{local_checkpoint_artifacts_for_index, required_artifacts_for_index};
+use crate::releases::restore::{
+    retained_artifacts_for_cache_policy, retained_artifacts_for_cache_policy_without_index,
+};
 use crate::storage::{StorageBackend, create_storage_backend};
 use crate::supervisor::state::supervisor_pid_file;
 
@@ -57,6 +60,7 @@ pub struct UpdateInfo {
 }
 
 const DEFAULT_RELEASE_RETENTION_LIMIT: usize = 1;
+const RELEASE_GRAPH_CHECKPOINT_FULLS: usize = 3;
 
 /// Manages checking for and applying application updates.
 pub struct UpdateManager {
@@ -65,6 +69,7 @@ pub struct UpdateManager {
     current_version: String,
     channel: String,
     release_retention_limit: usize,
+    artifact_retention_policy: InstallArtifactCachePolicy,
     install_dir: PathBuf,
     storage: Box<dyn StorageBackend>,
     cached_index: Option<ReleaseIndex>,
@@ -105,6 +110,7 @@ impl UpdateManager {
             current_version: current_version.to_string(),
             channel: channel.to_string(),
             release_retention_limit: DEFAULT_RELEASE_RETENTION_LIMIT,
+            artifact_retention_policy: InstallArtifactCachePolicy::default(),
             install_dir: PathBuf::from(install_dir),
             storage,
             cached_index: None,
@@ -142,6 +148,12 @@ impl UpdateManager {
         self.release_retention_limit
     }
 
+    /// Return the local artifact cache retention policy applied after updates.
+    #[must_use]
+    pub fn artifact_retention_policy(&self) -> InstallArtifactCachePolicy {
+        self.artifact_retention_policy
+    }
+
     /// Update the local version baseline used for update checks.
     pub fn set_current_version(&mut self, version: &str) -> Result<()> {
         let normalized = version.trim();
@@ -156,6 +168,17 @@ impl UpdateManager {
     /// Update the number of old app snapshots retained after successful updates.
     pub fn set_release_retention_limit(&mut self, limit: usize) {
         self.release_retention_limit = limit;
+    }
+
+    /// Update the local artifact cache retention policy applied after successful updates.
+    pub fn set_artifact_retention_policy(&mut self, policy: InstallArtifactCachePolicy) -> Result<()> {
+        if policy.retention == InstallArtifactCacheRetention::LatestFull && policy.keep_full_count == 0 {
+            return Err(SurgeError::Config(
+                "artifact retention keep_full_count must be greater than zero for latest_full".to_string(),
+            ));
+        }
+        self.artifact_retention_policy = policy;
+        Ok(())
     }
 
     /// Check for available updates on the configured channel.
@@ -406,13 +429,17 @@ impl UpdateManager {
                 Err(e) => return Err(e),
             }
         };
-        if let Some(index) = prune_index {
-            let mut retained_artifacts = required_artifacts_for_index(&index);
-            retained_artifacts.extend(local_checkpoint_artifacts_for_index(&index, 3));
-            let warm_full_filename = latest.full_filename.trim();
-            if !warm_full_filename.is_empty() {
-                retained_artifacts.insert(warm_full_filename.to_string());
-            }
+        let retained_artifacts = if let Some(index) = prune_index {
+            Some(retained_artifacts_for_cache_policy(
+                &index,
+                self.artifact_retention_policy,
+                &latest.full_filename,
+                RELEASE_GRAPH_CHECKPOINT_FULLS,
+            ))
+        } else {
+            retained_artifacts_for_cache_policy_without_index(self.artifact_retention_policy, &latest.full_filename)
+        };
+        if let Some(retained_artifacts) = retained_artifacts {
             match prune_cached_artifacts(&artifact_cache_dir, &retained_artifacts) {
                 Ok(0) => {}
                 Ok(pruned) => {
@@ -621,18 +648,39 @@ mod tests {
         assert_eq!(manager.channel(), "stable");
         assert_eq!(manager.current_version(), "1.0.0");
         assert_eq!(manager.release_retention_limit(), 1);
+        assert_eq!(
+            manager.artifact_retention_policy(),
+            InstallArtifactCachePolicy::default()
+        );
 
         manager.set_channel("test").unwrap();
         manager.set_current_version("1.1.0").unwrap();
         manager.set_release_retention_limit(0);
+        manager
+            .set_artifact_retention_policy(InstallArtifactCachePolicy {
+                retention: InstallArtifactCacheRetention::None,
+                keep_full_count: 1,
+            })
+            .unwrap();
         assert_eq!(manager.channel(), "test");
         assert_eq!(manager.current_version(), "1.1.0");
         assert_eq!(manager.release_retention_limit(), 0);
+        assert_eq!(
+            manager.artifact_retention_policy().retention,
+            InstallArtifactCacheRetention::None
+        );
 
         let err = manager.set_channel("  ").unwrap_err();
         assert!(err.to_string().contains("channel cannot be empty"));
         let err = manager.set_current_version("").unwrap_err();
         assert!(err.to_string().contains("Current version cannot be empty"));
+        let err = manager
+            .set_artifact_retention_policy(InstallArtifactCachePolicy {
+                retention: InstallArtifactCacheRetention::LatestFull,
+                keep_full_count: 0,
+            })
+            .unwrap_err();
+        assert!(err.to_string().contains("keep_full_count"));
     }
 
     #[test]
@@ -2546,6 +2594,99 @@ mod tests {
         assert!(install_root.join("app").is_dir());
         assert!(!install_root.join("app-1.0.0").exists());
         assert!(!install_root.join("app-0.9.0").exists());
+    }
+
+    #[tokio::test]
+    async fn test_download_and_apply_none_artifact_retention_prunes_local_artifact_cache() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store_root = tmp.path().join("store");
+        let install_root = tmp.path().join("install");
+        let app_id = "test-app";
+        std::fs::create_dir_all(&store_root).unwrap();
+        std::fs::create_dir_all(&install_root).unwrap();
+        let app_store = app_scoped_store_root(&store_root, app_id);
+
+        let current_app_dir = install_root.join("app");
+        std::fs::create_dir_all(&current_app_dir).unwrap();
+        std::fs::write(current_app_dir.join("payload.txt"), "old payload").unwrap();
+
+        let artifact_cache = install_root.join(".surge-cache").join("artifacts");
+        std::fs::create_dir_all(&artifact_cache).unwrap();
+        std::fs::write(artifact_cache.join("stale-full.tar.zst"), b"stale").unwrap();
+        std::fs::write(artifact_cache.join("stale-delta.tar.zst"), b"stale").unwrap();
+
+        let rid = current_rid();
+        let full_filename = format!("{app_id}-1.1.0-{rid}-full.tar.zst");
+        let full_path = app_store.join(&full_filename);
+
+        let mut packer = ArchivePacker::new(3).unwrap();
+        packer.add_buffer("payload.txt", b"new payload", 0o644).unwrap();
+        packer.finalize_to_file(&full_path).unwrap();
+
+        let full_size = std::fs::metadata(&full_path).unwrap().len() as i64;
+        let full_sha256 = sha256_hex_file(&full_path).unwrap();
+
+        let index = ReleaseIndex {
+            app_id: app_id.to_string(),
+            releases: vec![ReleaseEntry {
+                version: "1.1.0".to_string(),
+                channels: vec!["stable".to_string()],
+                os: current_os_label_for_tests(),
+                rid,
+                is_genesis: true,
+                full_filename,
+                full_size,
+                full_sha256,
+                full_compression_level: 0,
+                full_zstd_workers: 0,
+                deltas: Vec::new(),
+                preferred_delta_id: String::new(),
+                created_utc: chrono::Utc::now().to_rfc3339(),
+                release_notes: String::new(),
+                name: String::new(),
+                main_exe: app_id.to_string(),
+                install_directory: app_id.to_string(),
+                supervisor_id: String::new(),
+                icon: String::new(),
+                shortcuts: Vec::new(),
+                persistent_assets: Vec::new(),
+                installers: Vec::new(),
+                environment: std::collections::BTreeMap::new(),
+            }],
+            ..ReleaseIndex::default()
+        };
+
+        write_app_scoped_release_index(&store_root, app_id, &index);
+
+        let ctx = Arc::new(Context::new());
+        ctx.set_storage(
+            StorageProvider::Filesystem,
+            store_root.to_str().unwrap(),
+            "",
+            "",
+            "",
+            "",
+        );
+
+        let mut manager = UpdateManager::new(ctx, app_id, "1.0.0", "stable", install_root.to_str().unwrap()).unwrap();
+        manager
+            .set_artifact_retention_policy(InstallArtifactCachePolicy {
+                retention: InstallArtifactCacheRetention::None,
+                keep_full_count: 1,
+            })
+            .unwrap();
+
+        let info = manager.check_for_updates().await.unwrap().unwrap();
+        manager
+            .download_and_apply(&info, None::<fn(ProgressInfo)>)
+            .await
+            .unwrap();
+
+        let remaining = std::fs::read_dir(&artifact_cache)
+            .unwrap()
+            .collect::<std::io::Result<Vec<_>>>()
+            .unwrap();
+        assert!(remaining.is_empty(), "none retention should prune all cached artifacts");
     }
 
     #[cfg(target_os = "linux")]

--- a/crates/surge-ffi/src/handles.rs
+++ b/crates/surge-ffi/src/handles.rs
@@ -6,6 +6,7 @@
 use std::ffi::{CString, c_char};
 use std::sync::{Arc, Mutex};
 
+use surge_core::config::manifest::InstallArtifactCachePolicy;
 use surge_core::context::Context;
 use surge_core::pack::builder::PackBuilder;
 use surge_core::update::manager::UpdateInfo;
@@ -115,6 +116,7 @@ pub struct SurgeUpdateManagerHandle {
     pub current_version: String,
     pub channel: String,
     pub release_retention_limit: usize,
+    pub artifact_retention_policy: InstallArtifactCachePolicy,
     pub install_dir: String,
 }
 

--- a/crates/surge-ffi/src/lib.rs
+++ b/crates/surge-ffi/src/lib.rs
@@ -48,8 +48,8 @@ use crate::shared::{
 };
 pub use crate::update::{
     surge_update_check, surge_update_download_and_apply, surge_update_manager_create, surge_update_manager_destroy,
-    surge_update_manager_set_channel, surge_update_manager_set_current_version,
-    surge_update_manager_set_release_retention_limit,
+    surge_update_manager_set_artifact_retention_policy, surge_update_manager_set_channel,
+    surge_update_manager_set_current_version, surge_update_manager_set_release_retention_limit,
 };
 use crate::utils::to_lossy_cstring;
 

--- a/crates/surge-ffi/src/update.rs
+++ b/crates/surge-ffi/src/update.rs
@@ -1,6 +1,7 @@
 use std::ffi::{c_char, c_int, c_void};
 use std::ptr;
 
+use surge_core::config::manifest::{InstallArtifactCachePolicy, InstallArtifactCacheRetention};
 use surge_core::update::manager::{ProgressInfo, UpdateManager};
 
 use crate::handles::{ReleaseEntryFfi, SurgeReleasesInfoHandle, SurgeUpdateManagerHandle};
@@ -53,6 +54,7 @@ pub unsafe extern "C" fn surge_update_manager_create(
             current_version: version_s,
             channel: channel_s,
             release_retention_limit: 1,
+            artifact_retention_policy: InstallArtifactCachePolicy::default(),
             install_dir: install_s,
         });
 
@@ -154,6 +156,48 @@ pub unsafe extern "C" fn surge_update_manager_set_release_retention_limit(
     }))
 }
 
+/// Change local artifact cache retention applied after successful updates.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn surge_update_manager_set_artifact_retention_policy(
+    mgr: *mut SurgeUpdateManagerHandle,
+    retention: c_int,
+    keep_full_count: c_int,
+) -> i32 {
+    if mgr.is_null() {
+        return SURGE_ERROR;
+    }
+
+    catch_ffi(std::panic::AssertUnwindSafe(|| {
+        // SAFETY: `mgr` is checked non-null above.
+        let mgr_ref = unsafe { &mut *mgr };
+        clear_shared_error(&mgr_ref.ctx, &mgr_ref.last_error);
+
+        let retention = match retention {
+            0 => InstallArtifactCacheRetention::ReleaseGraph,
+            1 => InstallArtifactCacheRetention::LatestFull,
+            2 => InstallArtifactCacheRetention::JustInstalled,
+            3 => InstallArtifactCacheRetention::None,
+            value => {
+                let e = surge_core::error::SurgeError::Config(format!(
+                    "artifact_retention_policy has unsupported mode {value}"
+                ));
+                return set_shared_error(&mgr_ref.ctx, &mgr_ref.last_error, &e);
+            }
+        };
+
+        if keep_full_count <= 0 {
+            let e = surge_core::error::SurgeError::Config("keep_full_count must be greater than zero".into());
+            return set_shared_error(&mgr_ref.ctx, &mgr_ref.last_error, &e);
+        }
+
+        mgr_ref.artifact_retention_policy = InstallArtifactCachePolicy {
+            retention,
+            keep_full_count: u32::try_from(keep_full_count).unwrap_or(u32::MAX),
+        };
+        SURGE_OK
+    }))
+}
+
 /// Check for available updates.
 ///
 /// Returns `SURGE_OK` if updates are available, `SURGE_NOT_FOUND` if up-to-date.
@@ -190,6 +234,9 @@ pub unsafe extern "C" fn surge_update_check(
             Err(e) => return set_shared_error(&mgr_ref.ctx, &mgr_ref.last_error, &e),
         };
         update_mgr.set_release_retention_limit(mgr_ref.release_retention_limit);
+        if let Err(e) = update_mgr.set_artifact_retention_policy(mgr_ref.artifact_retention_policy) {
+            return set_shared_error(&mgr_ref.ctx, &mgr_ref.last_error, &e);
+        }
 
         let result = mgr_ref.runtime.block_on(update_mgr.check_for_updates());
 
@@ -279,6 +326,9 @@ pub unsafe extern "C" fn surge_update_download_and_apply(
             Err(e) => return set_shared_error(&mgr_ref.ctx, &mgr_ref.last_error, &e),
         };
         update_mgr.set_release_retention_limit(mgr_ref.release_retention_limit);
+        if let Err(e) = update_mgr.set_artifact_retention_policy(mgr_ref.artifact_retention_policy) {
+            return set_shared_error(&mgr_ref.ctx, &mgr_ref.last_error, &e);
+        }
 
         let result = if let Some(cb) = progress_cb {
             let bridge = ProgressBridge {
@@ -312,8 +362,8 @@ mod tests {
 
     use super::{
         SURGE_OK, SurgeReleasesInfoHandle, surge_update_check, surge_update_manager_create,
-        surge_update_manager_destroy, surge_update_manager_set_channel,
-        surge_update_manager_set_release_retention_limit,
+        surge_update_manager_destroy, surge_update_manager_set_artifact_retention_policy,
+        surge_update_manager_set_channel, surge_update_manager_set_release_retention_limit,
     };
 
     #[test]
@@ -386,6 +436,58 @@ mod tests {
             .unwrap_or_default()
             .to_string();
         assert!(msg.contains("release_retention_limit"));
+
+        unsafe {
+            surge_update_manager_destroy(mgr);
+            surge_context_destroy(ctx);
+        }
+    }
+
+    #[test]
+    fn manager_set_artifact_retention_policy_validates_inputs() {
+        let ctx = surge_context_create();
+        assert!(!ctx.is_null());
+
+        let app_id = CString::new("demo").unwrap();
+        let version = CString::new("1.0.0").unwrap();
+        let channel = CString::new("stable").unwrap();
+        let install_dir = CString::new("/tmp/demo").unwrap();
+
+        let mgr = unsafe {
+            surge_update_manager_create(
+                ctx,
+                app_id.as_ptr(),
+                version.as_ptr(),
+                channel.as_ptr(),
+                install_dir.as_ptr(),
+            )
+        };
+        assert!(!mgr.is_null());
+
+        let rc = unsafe { surge_update_manager_set_artifact_retention_policy(mgr, 1, 2) };
+        assert_eq!(rc, SURGE_OK);
+
+        let rc = unsafe { surge_update_manager_set_artifact_retention_policy(mgr, 1, 0) };
+        assert_ne!(rc, SURGE_OK);
+
+        let last = unsafe { surge_context_last_error(ctx) };
+        assert!(!last.is_null());
+        let msg = unsafe { CStr::from_ptr((*last).message) }
+            .to_str()
+            .unwrap_or_default()
+            .to_string();
+        assert!(msg.contains("keep_full_count"));
+
+        let rc = unsafe { surge_update_manager_set_artifact_retention_policy(mgr, 99, 1) };
+        assert_ne!(rc, SURGE_OK);
+
+        let last = unsafe { surge_context_last_error(ctx) };
+        assert!(!last.is_null());
+        let msg = unsafe { CStr::from_ptr((*last).message) }
+            .to_str()
+            .unwrap_or_default()
+            .to_string();
+        assert!(msg.contains("artifact_retention_policy"));
 
         unsafe {
             surge_update_manager_destroy(mgr);

--- a/crates/surge-installer-ui/src/install.rs
+++ b/crates/surge-installer-ui/src/install.rs
@@ -12,11 +12,11 @@ use std::time::Duration;
 use eframe::egui;
 
 use surge_core::config::installer::InstallerManifest;
-use surge_core::config::manifest::{InstallArtifactCacheRetention, ShortcutLocation};
+use surge_core::config::manifest::ShortcutLocation;
 use surge_core::install::{self as core_install, InstallProfile, InstallProgress, InstallProgressStage};
 use surge_core::installer_package::{
     InstallerPackageStage, ResolveInstallerPackageOptions, ResolvedInstallerPackage, prune_install_artifact_cache,
-    resolve_installer_package,
+    resolve_installer_package, retained_artifacts_for_install_cache_without_index,
 };
 use surge_core::platform::paths::default_install_root;
 use surge_core::releases::restore::RestoreProgress;
@@ -456,17 +456,18 @@ pub fn run_headless(
 }
 
 fn prune_artifact_cache_for_package(install_root: &Path, package: &ResolvedPackage, manifest: &InstallerManifest) {
-    let empty_retained_artifacts = std::collections::BTreeSet::new();
+    let owned_retained_artifacts;
     let retained_artifacts = match package.retained_artifacts.as_ref() {
         Some(retained_artifacts) => retained_artifacts,
-        None if manifest.effective_install_artifact_cache_policy().retention
-            == InstallArtifactCacheRetention::LatestFull =>
-        {
-            &empty_retained_artifacts
-        }
-        None => return,
+        None => match retained_artifacts_for_install_cache_without_index(manifest) {
+            Some(retained_artifacts) => {
+                owned_retained_artifacts = retained_artifacts;
+                &owned_retained_artifacts
+            }
+            None => return,
+        },
     };
-    let _ = prune_install_artifact_cache(install_root, retained_artifacts, &manifest.release.full_filename);
+    let _ = prune_install_artifact_cache(install_root, retained_artifacts);
 }
 
 #[cfg(test)]

--- a/dotnet/Surge.NET.Tests/SurgeTests.cs
+++ b/dotnet/Surge.NET.Tests/SurgeTests.cs
@@ -149,6 +149,17 @@ namespace Surge.Tests
             // the constructor should throw InvalidOperationException.
             Assert.Throws<InvalidOperationException>(() => new SurgeUpdateManager());
         }
+
+        [Fact]
+        public void ArtifactRetentionPolicy_ValidatesKeepFullCount()
+        {
+            var policy = SurgeArtifactRetentionPolicy.LatestFull(2);
+            Assert.Equal(SurgeArtifactRetentionMode.LatestFull, policy.Mode);
+            Assert.Equal(2, policy.KeepFullCount);
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => SurgeArtifactRetentionPolicy.LatestFull(0));
+            Assert.Throws<ArgumentOutOfRangeException>(() => new SurgeArtifactRetentionPolicy((SurgeArtifactRetentionMode)99));
+        }
     }
 
     public class SurgeProgressTests

--- a/dotnet/Surge.NET/NativeMethods.cs
+++ b/dotnet/Surge.NET/NativeMethods.cs
@@ -110,6 +110,9 @@ namespace Surge
         [LibraryImport(LibName, EntryPoint = "surge_update_manager_set_release_retention_limit")]
         internal static partial int UpdateManagerSetReleaseRetentionLimit(IntPtr mgr, int releaseRetentionLimit);
 
+        [LibraryImport(LibName, EntryPoint = "surge_update_manager_set_artifact_retention_policy")]
+        internal static partial int UpdateManagerSetArtifactRetentionPolicy(IntPtr mgr, int retention, int keepFullCount);
+
         [LibraryImport(LibName, EntryPoint = "surge_update_check")]
         internal static partial int UpdateCheck(IntPtr mgr, out IntPtr info);
 
@@ -271,6 +274,9 @@ namespace Surge
 
         [DllImport(LibName, EntryPoint = "surge_update_manager_set_release_retention_limit", CallingConvention = CallingConvention.Cdecl)]
         internal static extern int UpdateManagerSetReleaseRetentionLimit(IntPtr mgr, int releaseRetentionLimit);
+
+        [DllImport(LibName, EntryPoint = "surge_update_manager_set_artifact_retention_policy", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern int UpdateManagerSetArtifactRetentionPolicy(IntPtr mgr, int retention, int keepFullCount);
 
         [DllImport(LibName, EntryPoint = "surge_update_check", CallingConvention = CallingConvention.Cdecl)]
         internal static extern int UpdateCheck(IntPtr mgr, out IntPtr info);

--- a/dotnet/Surge.NET/SurgeUpdateManager.cs
+++ b/dotnet/Surge.NET/SurgeUpdateManager.cs
@@ -6,6 +6,48 @@ using System.Threading.Tasks;
 
 namespace Surge
 {
+    public enum SurgeArtifactRetentionMode
+    {
+        ReleaseGraph = 0,
+        LatestFull = 1,
+        JustInstalled = 2,
+        None = 3
+    }
+
+    public readonly struct SurgeArtifactRetentionPolicy
+    {
+        public SurgeArtifactRetentionPolicy(SurgeArtifactRetentionMode mode, int keepFullCount = 1)
+        {
+            if (!IsValidMode(mode))
+                throw new ArgumentOutOfRangeException(nameof(mode), mode, "Unsupported artifact retention mode.");
+            if (keepFullCount <= 0)
+                throw new ArgumentOutOfRangeException(nameof(keepFullCount), keepFullCount, "Keep full count must be greater than zero.");
+
+            Mode = mode;
+            KeepFullCount = keepFullCount;
+        }
+
+        public SurgeArtifactRetentionMode Mode { get; }
+        public int KeepFullCount { get; }
+
+        public static SurgeArtifactRetentionPolicy ReleaseGraph => new SurgeArtifactRetentionPolicy(SurgeArtifactRetentionMode.ReleaseGraph);
+        public static SurgeArtifactRetentionPolicy JustInstalled => new SurgeArtifactRetentionPolicy(SurgeArtifactRetentionMode.JustInstalled);
+        public static SurgeArtifactRetentionPolicy None => new SurgeArtifactRetentionPolicy(SurgeArtifactRetentionMode.None);
+
+        public static SurgeArtifactRetentionPolicy LatestFull(int keepFullCount)
+        {
+            return new SurgeArtifactRetentionPolicy(SurgeArtifactRetentionMode.LatestFull, keepFullCount);
+        }
+
+        internal static bool IsValidMode(SurgeArtifactRetentionMode mode)
+        {
+            return mode == SurgeArtifactRetentionMode.ReleaseGraph
+                || mode == SurgeArtifactRetentionMode.LatestFull
+                || mode == SurgeArtifactRetentionMode.JustInstalled
+                || mode == SurgeArtifactRetentionMode.None;
+        }
+    }
+
     /// <summary>
     /// Manages checking for and applying application updates via the native Surge library.
     /// </summary>
@@ -17,6 +59,7 @@ namespace Surge
         private string _channel = "stable";
         private string _currentVersion = "0.0.0";
         private int _releaseRetentionLimit = 1;
+        private SurgeArtifactRetentionPolicy _artifactRetentionPolicy = SurgeArtifactRetentionPolicy.ReleaseGraph;
 
         /// <summary>
         /// Maximum number of old installed versions to retain on disk after updating.
@@ -30,6 +73,23 @@ namespace Surge
                     throw new ArgumentOutOfRangeException(nameof(ReleaseRetentionLimit), value, "Release retention limit cannot be negative.");
 
                 _releaseRetentionLimit = value;
+            }
+        }
+
+        /// <summary>
+        /// Local package-artifact cache retention applied after successful updates.
+        /// </summary>
+        public SurgeArtifactRetentionPolicy ArtifactRetentionPolicy
+        {
+            get => _artifactRetentionPolicy;
+            set
+            {
+                if (!SurgeArtifactRetentionPolicy.IsValidMode(value.Mode))
+                    throw new ArgumentOutOfRangeException(nameof(ArtifactRetentionPolicy), value.Mode, "Unsupported artifact retention mode.");
+                if (value.KeepFullCount <= 0)
+                    throw new ArgumentOutOfRangeException(nameof(ArtifactRetentionPolicy), value.KeepFullCount, "Keep full count must be greater than zero.");
+
+                _artifactRetentionPolicy = value;
             }
         }
 
@@ -204,7 +264,7 @@ namespace Surge
                     try
                     {
                         cancellationToken.ThrowIfCancellationRequested();
-                        ApplyReleaseRetentionLimit();
+                        ApplyRetentionSettings();
 
                         // Build releases list
                         int count = NativeMethods.ReleasesCount(releasesInfoPtr);
@@ -374,13 +434,23 @@ namespace Surge
             _currentVersion = version;
         }
 
-        private void ApplyReleaseRetentionLimit()
+        private void ApplyRetentionSettings()
         {
             int result = NativeMethods.UpdateManagerSetReleaseRetentionLimit(_nativeMgr, _releaseRetentionLimit);
             if (result != 0)
             {
                 var errorMsg = GetLastError();
                 throw new SurgeException(result, errorMsg ?? "Failed to set release retention limit.");
+            }
+
+            result = NativeMethods.UpdateManagerSetArtifactRetentionPolicy(
+                _nativeMgr,
+                (int)_artifactRetentionPolicy.Mode,
+                _artifactRetentionPolicy.KeepFullCount);
+            if (result != 0)
+            {
+                var errorMsg = GetLastError();
+                throw new SurgeException(result, errorMsg ?? "Failed to set artifact retention policy.");
             }
         }
 

--- a/include/surge/surge_api.h
+++ b/include/surge/surge_api.h
@@ -66,6 +66,18 @@ typedef enum surge_storage_provider {
     SURGE_STORAGE_GITHUB_RELEASES = 4
 } surge_storage_provider;
 
+/** Device-side artifact cache retention applied after successful updates. */
+typedef enum surge_artifact_retention_policy {
+    /** Keep enough artifacts to rebuild the release graph offline. */
+    SURGE_ARTIFACT_RETENTION_RELEASE_GRAPH = 0,
+    /** Keep the newest N full archives per RID and drop deltas. */
+    SURGE_ARTIFACT_RETENTION_LATEST_FULL = 1,
+    /** Keep only the installed full archive when it is already cached. */
+    SURGE_ARTIFACT_RETENTION_JUST_INSTALLED = 2,
+    /** Keep no local package artifacts after a successful update. */
+    SURGE_ARTIFACT_RETENTION_NONE = 3
+} surge_artifact_retention_policy;
+
 /* -------------------------------------------------------------------------- */
 /*  Plain-data structures                                                     */
 /* -------------------------------------------------------------------------- */
@@ -237,6 +249,16 @@ SURGE_API surge_result SURGE_CALL surge_update_manager_set_current_version(surge
  */
 SURGE_API surge_result SURGE_CALL surge_update_manager_set_release_retention_limit(surge_update_manager* mgr,
                                                                                    int32_t release_retention_limit);
+
+/**
+ * Change local package-artifact cache retention after successful updates.
+ * @param mgr             Manager handle.
+ * @param retention       Cache retention policy.
+ * @param keep_full_count Number of full archives per RID for LATEST_FULL; pass 1 for other policies.
+ * @return SURGE_OK on success.
+ */
+SURGE_API surge_result SURGE_CALL surge_update_manager_set_artifact_retention_policy(
+    surge_update_manager* mgr, surge_artifact_retention_policy retention, int32_t keep_full_count);
 
 /**
  * Check for available updates.


### PR DESCRIPTION
## Summary
- add artifact cache retention modes for release graph, latest fulls, just installed, and no local artifacts
- apply the policy through setup, GUI setup, update manager, FFI, and the .NET wrapper
- document mode tradeoffs in the README

Closes #104

## Validation
- ./scripts/sync-surge-core-vendor.sh --check
- ./scripts/check-version-sync.sh
- cargo fmt --all -- --check
- RUSTFLAGS="-D warnings" cargo test --workspace
- cargo clippy --all-targets --all-features -- -D warnings
- cargo clippy --workspace --lib --bins --examples -- -D warnings -D clippy::unwrap_used -D clippy::expect_used
- cargo clippy --workspace --all-targets --all-features -- -D warnings -W clippy::pedantic
- dotnet format dotnet/Surge.slnx --verify-no-changes
- dotnet test dotnet/Surge.slnx --configuration Release
- git diff --check