### PR TITLE
Preserve direct deltas for fleet convergence

### DIFF
--- a/README.md
+++ b/README.md
@@ -620,14 +620,18 @@ lock:
 
 pack:                             # optional; omitted uses built-in defaults
   delta:
-    strategy: archive-chunked-bsdiff
+    strategy: sparse-file-ops
+    max_chain_length: 8
   compression:
     format: zstd
     level: 3
+  retention:
+    keep_latest_fulls: 2
+    checkpoint_every: 10
 
 cache:                            # optional device-side artifact cache policy
   installArtifacts:
-    retention: release_graph       # release_graph | latest_full | just_installed | none
+    retention: latest_full         # release_graph | latest_full | just_installed | none
     keepFullCount: 1               # full archives retained when retention is latest_full
 
 apps:
@@ -647,13 +651,16 @@ apps:
 ```
 
 Target-level settings override app-level defaults for `icon`, `shortcuts`, `persistentAssets`, `installers`, and `environment`.
-`pack` policy is global and currently controls delta strategy plus compression format/level for `surge pack`.
+`pack` policy is global and controls delta strategy, compression, and remote full fallback retention for `surge pack`/`surge push`.
+The generated `surge init` policy optimizes managed fleets for fast latest-following updates: a node on `N-1` should normally apply the direct `N-1 -> N` delta, while checkpoint fulls remain fallback baselines for recovery and stale installs.
 `cache.installArtifacts` controls package artifacts kept under `.surge-cache/artifacts/` after setup and successful updates:
 
-- `release_graph` is the default. Use it when offline restore to older versions matters; it keeps the local release graph and uses the most disk.
-- `latest_full` keeps the newest `keepFullCount` full archives per RID and drops deltas. Use it when you want a small reinstall/restore cushion without retaining the full graph.
+- `latest_full` is the recommended managed-fleet setting. It keeps the newest `keepFullCount` full archives per RID and drops deltas, so normal updates stay delta-based while each device keeps a compact reinstall/restore cushion.
+- `release_graph` keeps the local release graph plus warm full checkpoints. Use it when offline restore to older versions matters; it uses the most disk.
 - `just_installed` keeps only the installed full archive when that archive is already cached. Use it when full-update reinstall warmth is useful but disk should stay tight. Delta-only updates do not synthesize a new full archive just to warm this cache.
 - `none` keeps no package artifacts after a successful update. Use it when optimizing for minimum disk usage and accepting that restore/reinstall downloads from storage again.
+
+Use `surge compact` after rollout convergence, or for deliberate recovery/cleanup, when you want to prune old remote artifacts. Avoid making compaction the immediate default rollout step for a fleet that is still catching up.
 
 ### Architecture
 

--- a/crates/surge-cli/src/commands/init.rs
+++ b/crates/surge-cli/src/commands/init.rs
@@ -7,7 +7,15 @@ use std::io::{self, Write};
 use std::path::Path;
 use uuid::Uuid;
 
-use surge_core::config::manifest::{AppConfig, StorageManifestConfig, SurgeManifest, TargetConfig};
+use surge_core::config::constants::{
+    PACK_DEFAULT_CHECKPOINT_EVERY, PACK_DEFAULT_COMPRESSION_FORMAT, PACK_DEFAULT_DELTA_STRATEGY,
+    PACK_DEFAULT_KEEP_LATEST_FULLS, PACK_DEFAULT_MAX_CHAIN_LENGTH, PACK_DEFAULT_ZSTD_LEVEL,
+};
+use surge_core::config::manifest::{
+    AppConfig, CacheManifestConfig, InstallArtifactCachePolicy, InstallArtifactCacheRetention,
+    PackCompressionManifestConfig, PackDeltaManifestConfig, PackManifestConfig, PackRetentionManifestConfig,
+    StorageManifestConfig, SurgeManifest, TargetConfig,
+};
 use surge_core::error::{Result, SurgeError};
 use surge_core::platform::detect::current_rid;
 
@@ -67,8 +75,8 @@ pub async fn execute(
         },
         lock: None,
         channels: vec![],
-        pack: None,
-        cache: None,
+        pack: Some(default_pack_manifest_config()),
+        cache: Some(default_cache_manifest_config()),
         apps: vec![AppConfig {
             id: init.app_id.clone(),
             name: init.name,
@@ -114,6 +122,30 @@ pub async fn execute(
 
     logline::success(&format!("Created manifest at {}", manifest_path.display()));
     Ok(())
+}
+
+fn default_pack_manifest_config() -> PackManifestConfig {
+    PackManifestConfig {
+        delta: Some(PackDeltaManifestConfig {
+            strategy: Some(PACK_DEFAULT_DELTA_STRATEGY.to_string()),
+            max_chain_length: Some(PACK_DEFAULT_MAX_CHAIN_LENGTH),
+        }),
+        compression: Some(PackCompressionManifestConfig {
+            format: Some(PACK_DEFAULT_COMPRESSION_FORMAT.to_string()),
+            level: Some(PACK_DEFAULT_ZSTD_LEVEL),
+        }),
+        retention: Some(PackRetentionManifestConfig {
+            keep_latest_fulls: Some(PACK_DEFAULT_KEEP_LATEST_FULLS),
+            checkpoint_every: Some(PACK_DEFAULT_CHECKPOINT_EVERY),
+        }),
+    }
+}
+
+fn default_cache_manifest_config() -> CacheManifestConfig {
+    CacheManifestConfig::from_install_artifact_cache_policy(InstallArtifactCachePolicy {
+        retention: InstallArtifactCacheRetention::LatestFull,
+        keep_full_count: 1,
+    })
 }
 
 struct InitInput {

--- a/crates/surge-cli/src/commands/promote.rs
+++ b/crates/surge-cli/src/commands/promote.rs
@@ -797,9 +797,9 @@ mod tests {
             }
         };
 
-        // v1.2.0 is a checkpoint full — no primary delta. This is what
-        // `should_publish_checkpoint_full` in `pack/builder/delta.rs` produces
-        // when `deltas_since_checkpoint >= max_chain_length`.
+        // v1.2.0 models a legacy full-only checkpoint that has no primary
+        // delta. Modern checkpoint releases can carry both a full fallback and
+        // the direct delta, but old indexes must remain promotable.
         write_index(
             &store_dir,
             &ReleaseIndex {

--- a/crates/surge-cli/src/commands/push.rs
+++ b/crates/surge-cli/src/commands/push.rs
@@ -6,6 +6,8 @@
     clippy::too_many_lines
 )]
 
+mod checkpoint;
+
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs::File;
 use std::io::Read;
@@ -19,7 +21,7 @@ use crate::formatters::{format_byte_progress, format_bytes, format_duration};
 use crate::logline;
 use crate::ui::UiTheme;
 use surge_core::config::constants::{DEFAULT_ZSTD_LEVEL, RELEASES_FILE_COMPRESSED, SCHEMA_VERSION};
-use surge_core::config::manifest::{ShortcutLocation, SurgeManifest};
+use surge_core::config::manifest::{PackPolicy, ShortcutLocation, SurgeManifest};
 use surge_core::crypto::sha256::sha256_hex_file;
 use surge_core::error::{Result, SurgeError};
 use surge_core::pack::builder::{PACKAGE_METADATA_SCHEMA_VERSION, PackageArtifactMetadata, package_metadata_filename};
@@ -29,8 +31,7 @@ use surge_core::releases::manifest::{
     ReleaseIndex, UNRECORDED_COMPRESSION_LEVEL, UNRECORDED_ZSTD_WORKERS, compress_release_index,
     decompress_release_index,
 };
-use surge_core::releases::restore::required_artifacts_for_index;
-use surge_core::releases::version::compare_versions;
+use surge_core::releases::restore::{find_previous_release_for_rid, required_artifacts_for_index};
 use surge_core::storage::{self, StorageBackend};
 
 /// Push built packages to cloud storage.
@@ -48,6 +49,7 @@ pub async fn execute(
     let started = Instant::now();
     print_stage(theme, 1, TOTAL_STAGES, "Resolving manifest and target");
     let manifest = SurgeManifest::from_file(manifest_path)?;
+    let pack_policy = manifest.effective_pack_policy();
     let app_id = super::resolve_app_id_with_rid_hint(&manifest, app_id, rid)?;
     let rid = super::resolve_rid(&manifest, &app_id, rid)?;
     let (app, target) = manifest
@@ -126,11 +128,20 @@ pub async fn execute(
 
     let existing_index = fetch_existing_release_index(&*backend).await?;
     let has_existing_full_for_rid = if let Some(index) = existing_index.as_ref() {
-        rid_has_uploaded_full_artifact(&*backend, index, &rid).await?
+        checkpoint::rid_has_uploaded_full_artifact(&*backend, index, &rid).await?
     } else {
         false
     };
-    let full_uploaded = !has_existing_full_for_rid || !delta_available;
+    let full_uploaded = checkpoint::should_upload_full_artifact(
+        &*backend,
+        existing_index.as_ref(),
+        &rid,
+        version,
+        delta_available,
+        has_existing_full_for_rid,
+        pack_policy,
+    )
+    .await?;
     let total_upload_bytes = (if full_uploaded { full_size } else { 0 })
         .saturating_add(delta_size_hint)
         .max(0) as u64;
@@ -199,6 +210,7 @@ pub async fn execute(
         persistent_assets,
         installers,
         environment,
+        pack_policy,
     )
     .await?;
     print_stage_done(
@@ -233,25 +245,6 @@ async fn fetch_existing_release_index(backend: &dyn StorageBackend) -> Result<Op
     }
 }
 
-async fn rid_has_uploaded_full_artifact(backend: &dyn StorageBackend, index: &ReleaseIndex, rid: &str) -> Result<bool> {
-    let mut candidates: Vec<&ReleaseEntry> = index
-        .releases
-        .iter()
-        .filter(|release| (release.rid == rid || release.rid.is_empty()) && !release.full_filename.trim().is_empty())
-        .collect();
-    candidates.sort_by(|a, b| compare_versions(&a.version, &b.version));
-
-    for release in candidates {
-        match backend.head_object(release.full_filename.trim()).await {
-            Ok(_) => return Ok(true),
-            Err(SurgeError::NotFound(_)) => continue,
-            Err(e) => return Err(e),
-        }
-    }
-
-    Ok(false)
-}
-
 #[allow(clippy::too_many_arguments)]
 async fn update_release_index(
     backend: &dyn StorageBackend,
@@ -277,6 +270,7 @@ async fn update_release_index(
     persistent_assets: Vec<String>,
     installers: Vec<String>,
     environment: BTreeMap<String, String>,
+    pack_policy: PackPolicy,
 ) -> Result<usize> {
     let mut index = match backend.get_object(RELEASES_FILE_COMPRESSED).await {
         Ok(data) => decompress_release_index(&data)?,
@@ -313,6 +307,9 @@ async fn update_release_index(
         .releases
         .iter()
         .any(|release| release.rid == rid || release.rid.is_empty());
+    let previous_version = find_previous_release_for_rid(&index, rid, version)
+        .map(|release| release.version.clone())
+        .unwrap_or_default();
 
     index
         .releases
@@ -348,7 +345,7 @@ async fn update_release_index(
     } else if delta_patch_format.eq_ignore_ascii_case(PATCH_FORMAT_SPARSE_FILE_OPS_V1) {
         Some(DeltaArtifact::sparse_file_ops_zstd(
             "primary",
-            "",
+            &previous_version,
             &delta_filename,
             delta_size,
             &delta_sha256,
@@ -356,7 +353,7 @@ async fn update_release_index(
     } else if delta_patch_format.eq_ignore_ascii_case(PATCH_FORMAT_CHUNKED_BSDIFF_V1) {
         Some(DeltaArtifact::chunked_bsdiff_zstd(
             "primary",
-            "",
+            &previous_version,
             &delta_filename,
             delta_size,
             &delta_sha256,
@@ -364,7 +361,7 @@ async fn update_release_index(
     } else if delta_patch_format.eq_ignore_ascii_case(PATCH_FORMAT_BSDIFF4) {
         Some(DeltaArtifact::bsdiff_zstd(
             "primary",
-            "",
+            &previous_version,
             &delta_filename,
             delta_size,
             &delta_sha256,
@@ -372,7 +369,7 @@ async fn update_release_index(
     } else {
         Some(DeltaArtifact::with_patch_format(
             "primary",
-            "",
+            &previous_version,
             &delta_patch_format,
             &delta_filename,
             delta_size,
@@ -388,7 +385,7 @@ async fn update_release_index(
     backend
         .put_object(RELEASES_FILE_COMPRESSED, &compressed, "application/octet-stream")
         .await?;
-    let pruned = prune_redundant_artifacts(backend, &index).await?;
+    let pruned = prune_redundant_artifacts(backend, &index, pack_policy).await?;
 
     Ok(pruned)
 }
@@ -455,8 +452,15 @@ fn validate_full_package_metadata(
     Ok(())
 }
 
-async fn prune_redundant_artifacts(backend: &dyn StorageBackend, index: &ReleaseIndex) -> Result<usize> {
-    let required = required_artifacts_for_index(index);
+async fn prune_redundant_artifacts(
+    backend: &dyn StorageBackend,
+    index: &ReleaseIndex,
+    pack_policy: PackPolicy,
+) -> Result<usize> {
+    let mut required = required_artifacts_for_index(index);
+    required.extend(
+        checkpoint::retained_uploaded_full_artifacts_for_index(backend, index, pack_policy.keep_latest_fulls).await?,
+    );
 
     let mut candidates = BTreeSet::new();
     for release in &index.releases {
@@ -665,5 +669,133 @@ apps:
             .expect("pushed release should exist");
         assert_eq!(release.full_compression_level, 3);
         assert_eq!(release.full_zstd_workers, 4);
+    }
+
+    #[tokio::test]
+    async fn execute_uploads_checkpoint_full_without_dropping_direct_delta() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let store_dir = temp_dir.path().join("store");
+        let packages_dir = temp_dir.path().join("packages");
+        let manifest_path = temp_dir.path().join("surge.yml");
+        let app_id = "demo";
+        let rid = current_rid();
+
+        std::fs::create_dir_all(&store_dir).expect("store dir should be created");
+        std::fs::create_dir_all(&packages_dir).expect("packages dir should be created");
+
+        let manifest_yaml = format!(
+            r"schema: 1
+storage:
+  provider: filesystem
+  bucket: {bucket}
+pack:
+  delta:
+    strategy: sparse-file-ops
+    max_chain_length: 1
+  compression:
+    format: zstd
+    level: 3
+  retention:
+    keep_latest_fulls: 2
+    checkpoint_every: 10
+apps:
+  - id: {app_id}
+    main_exe: demoapp
+    channels: [test, production]
+    target:
+      rid: {rid}
+",
+            bucket = store_dir.display()
+        );
+        std::fs::write(&manifest_path, manifest_yaml).expect("manifest should be written");
+
+        let v1_full_key = format!("{app_id}-1.0.0-{rid}-full.tar.zst");
+        let v2_full_key = format!("{app_id}-1.1.0-{rid}-full.tar.zst");
+        let v2_delta_key = format!("{app_id}-1.1.0-{rid}-delta.tar.zst");
+        std::fs::write(store_dir.join(&v1_full_key), b"v1 full").expect("v1 full should exist remotely");
+
+        let release = |version: &str, full_key: &str, delta: Option<DeltaArtifact>| {
+            let mut release = ReleaseEntry {
+                version: version.to_string(),
+                channels: vec!["test".to_string()],
+                os: detect_os_from_rid(&rid),
+                rid: rid.clone(),
+                is_genesis: version == "1.0.0",
+                full_filename: full_key.to_string(),
+                full_size: 100,
+                full_sha256: format!("{version}-full-sha"),
+                full_compression_level: UNRECORDED_COMPRESSION_LEVEL,
+                full_zstd_workers: UNRECORDED_ZSTD_WORKERS,
+                deltas: Vec::new(),
+                preferred_delta_id: String::new(),
+                created_utc: String::new(),
+                release_notes: String::new(),
+                name: "Demo".to_string(),
+                main_exe: "demoapp".to_string(),
+                install_directory: "demoapp".to_string(),
+                supervisor_id: String::new(),
+                icon: String::new(),
+                shortcuts: Vec::new(),
+                persistent_assets: Vec::new(),
+                installers: Vec::new(),
+                environment: BTreeMap::new(),
+            };
+            release.set_primary_delta(delta);
+            release
+        };
+        let index = ReleaseIndex {
+            schema: SCHEMA_VERSION,
+            app_id: app_id.to_string(),
+            releases: vec![
+                release("1.0.0", &v1_full_key, None),
+                release(
+                    "1.1.0",
+                    &v2_full_key,
+                    Some(DeltaArtifact::bsdiff_zstd(
+                        "primary",
+                        "1.0.0",
+                        &v2_delta_key,
+                        10,
+                        "v2-delta-sha",
+                    )),
+                ),
+            ],
+            ..ReleaseIndex::default()
+        };
+        let compressed_index = compress_release_index(&index, DEFAULT_ZSTD_LEVEL).expect("index should compress");
+        std::fs::write(store_dir.join(RELEASES_FILE_COMPRESSED), compressed_index)
+            .expect("release index should be written");
+
+        let version = "1.2.0";
+        let full_filename = format!("{app_id}-{version}-{rid}-full.tar.zst");
+        let delta_filename = format!("{app_id}-{version}-{rid}-delta.tar.zst");
+        std::fs::write(packages_dir.join(&full_filename), b"v3 full").expect("full package should be written");
+        std::fs::write(packages_dir.join(&delta_filename), b"v3 delta").expect("delta package should be written");
+
+        execute(&manifest_path, Some(app_id), version, Some(&rid), "test", &packages_dir)
+            .await
+            .expect("push should succeed");
+
+        assert!(
+            store_dir.join(&full_filename).is_file(),
+            "checkpoint full fallback should be uploaded"
+        );
+        assert!(
+            store_dir.join(&delta_filename).is_file(),
+            "direct delta should still be uploaded"
+        );
+
+        let compressed_index =
+            std::fs::read(store_dir.join(RELEASES_FILE_COMPRESSED)).expect("release index should be written");
+        let index = decompress_release_index(&compressed_index).expect("release index should decompress");
+        let release = index
+            .releases
+            .iter()
+            .find(|release| release.version == version && release.rid == rid)
+            .expect("pushed release should exist");
+        let delta = release
+            .delta_from_source("1.1.0")
+            .expect("pushed delta should target the previous release");
+        assert_eq!(delta.filename, delta_filename);
     }
 }

--- a/crates/surge-cli/src/commands/push/checkpoint.rs
+++ b/crates/surge-cli/src/commands/push/checkpoint.rs
@@ -1,0 +1,131 @@
+use std::cmp::Ordering as VersionOrdering;
+use std::collections::{BTreeMap, BTreeSet};
+
+use surge_core::config::manifest::PackPolicy;
+use surge_core::error::{Result, SurgeError};
+use surge_core::releases::manifest::{ReleaseEntry, ReleaseIndex};
+use surge_core::releases::restore::sorted_releases_for_rid;
+use surge_core::releases::version::compare_versions;
+use surge_core::storage::StorageBackend;
+
+pub(super) async fn rid_has_uploaded_full_artifact(
+    backend: &dyn StorageBackend,
+    index: &ReleaseIndex,
+    rid: &str,
+) -> Result<bool> {
+    let mut candidates: Vec<&ReleaseEntry> = index
+        .releases
+        .iter()
+        .filter(|release| (release.rid == rid || release.rid.is_empty()) && !release.full_filename.trim().is_empty())
+        .collect();
+    candidates.sort_by(|a, b| compare_versions(&a.version, &b.version));
+
+    for release in candidates {
+        match backend.head_object(release.full_filename.trim()).await {
+            Ok(_) => return Ok(true),
+            Err(SurgeError::NotFound(_)) => continue,
+            Err(e) => return Err(e),
+        }
+    }
+
+    Ok(false)
+}
+
+pub(super) async fn should_upload_full_artifact(
+    backend: &dyn StorageBackend,
+    existing_index: Option<&ReleaseIndex>,
+    rid: &str,
+    version: &str,
+    delta_available: bool,
+    has_existing_full_for_rid: bool,
+    pack_policy: PackPolicy,
+) -> Result<bool> {
+    if !delta_available || !has_existing_full_for_rid {
+        return Ok(true);
+    }
+
+    let Some(index) = existing_index else {
+        return Ok(true);
+    };
+
+    let Some(delta_steps) = delta_steps_since_latest_uploaded_full(backend, index, rid, version).await? else {
+        return Ok(true);
+    };
+
+    Ok(delta_steps >= pack_policy.max_chain_length || delta_steps.saturating_add(1) >= pack_policy.checkpoint_every)
+}
+
+async fn delta_steps_since_latest_uploaded_full(
+    backend: &dyn StorageBackend,
+    index: &ReleaseIndex,
+    rid: &str,
+    version: &str,
+) -> Result<Option<u32>> {
+    let mut delta_steps = 0u32;
+    let releases = sorted_releases_for_rid(index, rid);
+    for release in releases.iter().rev() {
+        if compare_versions(&release.version, version) != VersionOrdering::Less {
+            continue;
+        }
+
+        let full = release.full_filename.trim();
+        if !full.is_empty() {
+            match backend.head_object(full).await {
+                Ok(_) => return Ok(Some(delta_steps)),
+                Err(SurgeError::NotFound(_)) => {}
+                Err(e) => return Err(e),
+            }
+        }
+
+        if release.selected_delta().is_some() {
+            delta_steps = delta_steps.saturating_add(1);
+        } else {
+            return Ok(None);
+        }
+    }
+
+    Ok(None)
+}
+
+pub(super) async fn retained_uploaded_full_artifacts_for_index(
+    backend: &dyn StorageBackend,
+    index: &ReleaseIndex,
+    per_rid_limit: u32,
+) -> Result<BTreeSet<String>> {
+    let limit = usize::try_from(per_rid_limit).unwrap_or(usize::MAX);
+    if limit == 0 {
+        return Ok(BTreeSet::new());
+    }
+
+    let mut by_rid: BTreeMap<&str, Vec<&ReleaseEntry>> = BTreeMap::new();
+    for release in &index.releases {
+        by_rid.entry(release.rid.as_str()).or_default().push(release);
+    }
+
+    let mut retained = BTreeSet::new();
+    for releases in by_rid.values_mut() {
+        releases.sort_by(|a, b| compare_versions(&a.version, &b.version));
+        let mut retained_for_rid = 0usize;
+        for release in releases.iter().rev() {
+            if retained_for_rid >= limit {
+                break;
+            }
+
+            let full = release.full_filename.trim();
+            if full.is_empty() {
+                continue;
+            }
+
+            match backend.head_object(full).await {
+                Ok(_) => {
+                    retained.insert(full.to_string());
+                    retained_for_rid = retained_for_rid.saturating_add(1);
+                }
+                Err(SurgeError::NotFound(_)) => {}
+                Err(e) => return Err(e),
+            }
+        }
+    }
+
+    Ok(retained)
+}

--- a/crates/surge-cli/tests/init_wizard.rs
+++ b/crates/surge-cli/tests/init_wizard.rs
@@ -2,7 +2,11 @@ use std::io::Write;
 use std::path::Path;
 use std::process::{Command, Output, Stdio};
 
-use surge_core::config::manifest::SurgeManifest;
+use surge_core::config::constants::{
+    PACK_DEFAULT_CHECKPOINT_EVERY, PACK_DEFAULT_COMPRESSION_FORMAT, PACK_DEFAULT_DELTA_STRATEGY,
+    PACK_DEFAULT_KEEP_LATEST_FULLS, PACK_DEFAULT_MAX_CHAIN_LENGTH, PACK_DEFAULT_ZSTD_LEVEL,
+};
+use surge_core::config::manifest::{InstallArtifactCacheRetention, SurgeManifest};
 use uuid::Uuid;
 
 fn run_wizard(current_dir: &Path, args: &[&str], stdin_input: &str) -> Output {
@@ -44,6 +48,34 @@ fn output_to_debug(output: &Output) -> String {
     )
 }
 
+fn assert_default_fleet_policy(manifest: &SurgeManifest) {
+    let pack = manifest.pack.as_ref().expect("pack policy should be explicit");
+    let delta = pack.delta.as_ref().expect("delta policy should be explicit");
+    assert_eq!(delta.strategy.as_deref(), Some(PACK_DEFAULT_DELTA_STRATEGY));
+    assert_eq!(delta.max_chain_length, Some(PACK_DEFAULT_MAX_CHAIN_LENGTH));
+
+    let compression = pack
+        .compression
+        .as_ref()
+        .expect("compression policy should be explicit");
+    assert_eq!(compression.format.as_deref(), Some(PACK_DEFAULT_COMPRESSION_FORMAT));
+    assert_eq!(compression.level, Some(PACK_DEFAULT_ZSTD_LEVEL));
+
+    let retention = pack.retention.as_ref().expect("retention policy should be explicit");
+    assert_eq!(retention.keep_latest_fulls, Some(PACK_DEFAULT_KEEP_LATEST_FULLS));
+    assert_eq!(retention.checkpoint_every, Some(PACK_DEFAULT_CHECKPOINT_EVERY));
+
+    let cache = manifest.cache.expect("cache policy should be explicit");
+    let install_artifacts = cache
+        .install_artifacts
+        .expect("install artifact cache policy should be explicit");
+    assert_eq!(
+        install_artifacts.retention,
+        Some(InstallArtifactCacheRetention::LatestFull)
+    );
+    assert_eq!(install_artifacts.keep_full_count, Some(1));
+}
+
 #[test]
 fn test_init_wizard_defaults_to_dot_surge_manifest() {
     let tmp = tempfile::tempdir().unwrap();
@@ -72,6 +104,7 @@ fn test_init_wizard_defaults_to_dot_surge_manifest() {
     assert_eq!(manifest.apps[0].install_directory, "my-app");
     assert!(Uuid::parse_str(&manifest.apps[0].supervisor_id).is_ok());
     assert_eq!(manifest.apps[0].targets.len(), 1);
+    assert_default_fleet_policy(&manifest);
 }
 
 #[test]
@@ -125,6 +158,7 @@ fn test_init_wizard_respects_custom_manifest_path() {
     assert_eq!(manifest.apps[0].install_directory, "demo-install");
     assert!(Uuid::parse_str(&manifest.apps[0].supervisor_id).is_ok());
     assert_eq!(manifest.apps[0].targets[0].rid, "linux-x64");
+    assert_default_fleet_policy(&manifest);
 
     // `packages` auto-creation only happens for `.surge` parent.
     assert!(!tmp.path().join("custom").join("packages").exists());
@@ -165,4 +199,5 @@ fn test_init_non_wizard_when_options_are_provided() {
     assert_eq!(app.main_exe, "demo-main");
     assert_eq!(app.install_directory, "demo-install");
     assert_eq!(app.targets[0].rid, "linux-x64");
+    assert_default_fleet_policy(&manifest);
 }

--- a/crates/surge-core/src/pack/builder.rs
+++ b/crates/surge-core/src/pack/builder.rs
@@ -1226,6 +1226,108 @@ apps:
     }
 
     #[tokio::test]
+    async fn test_checkpoint_threshold_keeps_direct_delta() {
+        let tmp = tempfile::tempdir().expect("tempdir should be created");
+        let store_root = tmp.path().join("store");
+        let artifacts_root = tmp.path().join("artifacts");
+        std::fs::create_dir_all(&store_root).expect("store dir should exist");
+        std::fs::create_dir_all(&artifacts_root).expect("artifacts dir should exist");
+
+        let app_id = "demo";
+        let rid = current_rid();
+        let manifest_path = tmp.path().join("surge.yml");
+        let manifest_yaml = format!(
+            r"schema: 1
+storage:
+  provider: filesystem
+  bucket: {bucket}
+pack:
+  delta:
+    strategy: sparse-file-ops
+    max_chain_length: 1
+  compression:
+    format: zstd
+    level: 3
+  retention:
+    keep_latest_fulls: 2
+    checkpoint_every: 10
+apps:
+  - id: {app_id}
+    target:
+      rid: {rid}
+",
+            bucket = store_root.display()
+        );
+        std::fs::write(&manifest_path, manifest_yaml).expect("manifest should be written");
+
+        let ctx = Arc::new(Context::new());
+        ctx.set_storage(
+            StorageProvider::Filesystem,
+            store_root.to_str().expect("store root utf8"),
+            "",
+            "",
+            "",
+            "",
+        );
+
+        std::fs::write(
+            artifacts_root.join("stable.bin"),
+            deterministic_payload(2 * 1024 * 1024, 41),
+        )
+        .expect("stable payload should be written");
+
+        std::fs::write(artifacts_root.join("payload.txt"), b"v1 payload").expect("v1 payload should be written");
+        let mut builder_v1 = PackBuilder::new(
+            Arc::clone(&ctx),
+            manifest_path.to_str().expect("manifest path utf8"),
+            app_id,
+            &rid,
+            "1.0.0",
+            artifacts_root.to_str().expect("artifacts path utf8"),
+        )
+        .expect("builder v1");
+        builder_v1.build(None).await.expect("v1 build should succeed");
+        builder_v1.push("stable", None).await.expect("v1 push should succeed");
+
+        std::fs::write(artifacts_root.join("payload.txt"), b"v2 payload").expect("v2 payload should be written");
+        let mut builder_v2 = PackBuilder::new(
+            Arc::clone(&ctx),
+            manifest_path.to_str().expect("manifest path utf8"),
+            app_id,
+            &rid,
+            "1.1.0",
+            artifacts_root.to_str().expect("artifacts path utf8"),
+        )
+        .expect("builder v2");
+        builder_v2.build(None).await.expect("v2 build should succeed");
+        builder_v2.push("stable", None).await.expect("v2 push should succeed");
+
+        std::fs::write(artifacts_root.join("payload.txt"), b"v3 payload").expect("v3 payload should be written");
+        let mut builder_v3 = PackBuilder::new(
+            Arc::clone(&ctx),
+            manifest_path.to_str().expect("manifest path utf8"),
+            app_id,
+            &rid,
+            "1.2.0",
+            artifacts_root.to_str().expect("artifacts path utf8"),
+        )
+        .expect("builder v3");
+        builder_v3.build(None).await.expect("v3 build should succeed");
+
+        assert!(
+            builder_v3.artifacts().iter().any(|artifact| !artifact.is_delta),
+            "checkpoint build should still include the full fallback"
+        );
+        let delta = builder_v3
+            .artifacts()
+            .iter()
+            .find(|artifact| artifact.is_delta)
+            .expect("checkpoint build should keep the direct delta");
+        assert_eq!(delta.from_version, "1.1.0");
+        assert_eq!(delta.patch_format, PATCH_FORMAT_SPARSE_FILE_OPS_V1);
+    }
+
+    #[tokio::test]
     async fn test_demoapp_fixture_multi_release_delta_stays_small_and_restorable() {
         let tmp = tempfile::tempdir().unwrap();
         let store_root = tmp.path().join("store");

--- a/crates/surge-core/src/pack/builder/delta.rs
+++ b/crates/surge-core/src/pack/builder/delta.rs
@@ -40,7 +40,7 @@ impl PackBuilder {
             .find(|a| !a.is_delta)
             .map(PackageArtifact::bytes)
             .ok_or_else(|| SurgeError::Pack("Full package not yet built".to_string()))?;
-        if should_publish_checkpoint_full(
+        if should_retain_checkpoint_full(
             &index,
             &self.rid,
             self.pack_policy.max_chain_length,
@@ -50,9 +50,8 @@ impl PackBuilder {
                 app_id = %self.app_id,
                 version = %self.version,
                 rid = %self.rid,
-                "Skipping delta package and publishing a checkpoint full"
+                "Building direct delta while retaining checkpoint full fallback"
             );
-            return Ok(None);
         }
         let n_workers = budget.effective_zstd_workers();
         let diff_options = chunked_diff_options(&budget, prev_data.len(), new_data.len());
@@ -119,7 +118,7 @@ impl PackBuilder {
     }
 }
 
-fn should_publish_checkpoint_full(
+fn should_retain_checkpoint_full(
     index: &ReleaseIndex,
     rid: &str,
     max_chain_length: u32,

--- a/crates/surge-core/src/update/manager.rs
+++ b/crates/surge-core/src/update/manager.rs
@@ -1054,6 +1054,71 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_latest_following_node_uses_delta_after_many_checkpoint_releases() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store_root = tmp.path().join("store");
+        let app_id = "test-app";
+        std::fs::create_dir_all(&store_root).unwrap();
+
+        let rid = current_rid();
+        let os = current_os_label_for_tests();
+        let mut releases = Vec::new();
+        for minor in 1..=100 {
+            let version = format!("1.{minor}.0");
+            let mut release = make_entry(&version, "stable", &os, &rid);
+            release.full_filename = format!("{app_id}-{version}-{rid}-full.tar.zst");
+            release.full_size = 10_000;
+            release.full_sha256 = format!("full-sha-{minor}");
+            release.is_genesis = minor == 1;
+
+            if minor == 1 {
+                release.set_primary_delta(None);
+            } else {
+                let previous_version = format!("1.{}.0", minor - 1);
+                release.set_primary_delta(Some(DeltaArtifact::sparse_file_ops_zstd(
+                    "primary",
+                    &previous_version,
+                    &format!("{app_id}-{version}-{rid}-delta.tar.zst"),
+                    100,
+                    &format!("delta-sha-{minor}"),
+                )));
+            }
+
+            releases.push(release);
+        }
+
+        let index = ReleaseIndex {
+            app_id: app_id.to_string(),
+            releases,
+            ..ReleaseIndex::default()
+        };
+        write_app_scoped_release_index(&store_root, app_id, &index);
+
+        let ctx = Arc::new(Context::new());
+        ctx.set_storage(
+            StorageProvider::Filesystem,
+            store_root.to_str().unwrap(),
+            "",
+            "",
+            "",
+            "",
+        );
+
+        let mut manager = UpdateManager::new(ctx, app_id, "1.99.0", "stable", tmp.path().to_str().unwrap()).unwrap();
+        let info = manager.check_for_updates().await.unwrap().unwrap();
+        assert!(info.delta_available);
+        assert_eq!(info.apply_strategy, ApplyStrategy::Delta);
+        assert_eq!(info.latest_version, "1.100.0");
+        assert_eq!(info.apply_releases.len(), 1);
+        let delta = info.apply_releases[0]
+            .selected_delta()
+            .expect("latest release should keep direct delta");
+        assert_eq!(delta.from_version, "1.99.0");
+        assert_eq!(delta.size, 100);
+        assert_eq!(info.download_size, 100);
+    }
+
+    #[tokio::test]
     async fn test_check_for_updates_falls_back_to_full_for_unsupported_descriptor() {
         let tmp = tempfile::tempdir().unwrap();
         let store_root = tmp.path().join("store");

--- a/docs/performance/pack-policy.md
+++ b/docs/performance/pack-policy.md
@@ -15,6 +15,11 @@ pack:
   retention:
     keep_latest_fulls: 2
     checkpoint_every: 10
+
+cache:
+  installArtifacts:
+    retention: latest_full
+    keepFullCount: 1
 ```
 
 Current operational node policy:
@@ -60,6 +65,7 @@ Reason:
 - publisher cost otherwise grows with history reconstruction work
 - client update cost otherwise grows with chain length
 - broad churn can still produce poor file patches, so full fallback remains necessary
+- latest-following nodes should still receive a direct delta even when the release is also a checkpoint full
 
 ## What `surge tune pack` May Change
 
@@ -108,5 +114,9 @@ It should not become a hidden stage inside normal `surge pack`.
 
 Normal `surge pack` now applies two automatic safety rules:
 
-- if the sparse delta is larger than the full package, publish a full checkpoint instead
-- if the retained delta chain reaches the configured checkpoint thresholds, publish a full checkpoint instead
+- if the sparse delta is larger than the full package, skip the delta and publish/use the full package
+- if the retained delta chain reaches the configured checkpoint thresholds, retain or upload a full checkpoint fallback while still keeping the direct delta when it is valid and smaller than the full package
+
+## Compaction Timing
+
+Use `surge compact` after rollout convergence or for explicit recovery/cleanup. It should not be an automatic immediate step after every production push, because healthy latest-following nodes still need the newest direct delta while they are catching up.


### PR DESCRIPTION
## Summary
- keep useful direct deltas on checkpoint releases instead of making checkpoint fulls replace the fast latest-following path
- make `surge push` upload checkpoint full fallbacks deliberately, record delta source versions, and retain the latest uploaded full fallbacks during pruning
- update `surge init`, README, and pack policy docs with the fleet convergence defaults and cache-mode guidance

Closes #106

## Validation
- `./scripts/sync-surge-core-vendor.sh --check`
- `./scripts/check-version-sync.sh`
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo test --workspace`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo clippy --workspace --lib --bins --examples -- -D warnings -D clippy::unwrap_used -D clippy::expect_used`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings -W clippy::pedantic`
- `dotnet format dotnet/Surge.slnx --verify-no-changes`
- `dotnet test dotnet/Surge.slnx --configuration Release`