### PR TITLE
Converge remote installs through update planning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1013,6 +1013,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3172,6 +3182,7 @@ dependencies = [
  "base64",
  "cc",
  "chrono",
+ "fs2",
  "futures-util",
  "hex",
  "nix",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ futures-util = "0.3"
 dialoguer = "0.12"
 indicatif = "0.18"
 tempfile = "3"
+fs2 = "0.4"
 uuid = { version = "1", features = ["v4"] }
 which = "8"
 eframe = { version = "0.34.2", default-features = false, features = ["glow", "default_fonts", "x11", "wayland"] }

--- a/crates/surge-cli/src/cli.rs
+++ b/crates/surge-cli/src/cli.rs
@@ -256,6 +256,10 @@ pub(crate) enum Commands {
         /// Only cache the package locally without installing (used by --stage)
         #[arg(long)]
         stage: bool,
+
+        /// Force the installer path instead of converging an existing install
+        #[arg(long, hide = true)]
+        reinstall: bool,
     },
 
     /// Print SHA-256 hash of a file

--- a/crates/surge-cli/src/commands/install/mod.rs
+++ b/crates/surge-cli/src/commands/install/mod.rs
@@ -367,12 +367,35 @@ pub async fn execute(
         match &install_target {
             InstallTarget::Local => {
                 logline::warn("Plan only mode: no download performed. Remove --plan-only to fetch the package.");
+                return Ok(());
             }
-            InstallTarget::Tailscale { file_target, .. } => logline::warn(&format!(
-                "Plan only mode: no transfer performed. Remove --plan-only to download and copy package to {file_target}."
-            )),
+            InstallTarget::Tailscale {
+                ssh_target,
+                file_target,
+            } => {
+                install_release_via_tailscale(
+                    manifest.as_ref(),
+                    &*backend,
+                    &index,
+                    download_dir,
+                    ssh_target,
+                    file_target,
+                    &app_id,
+                    &selected_rid,
+                    &rid_candidates,
+                    release,
+                    &channel,
+                    &storage_config,
+                    full_filename,
+                    behavior,
+                )
+                .await?;
+                logline::warn(&format!(
+                    "Plan only mode: no transfer performed. Remove --plan-only to apply the selected plan to {file_target}."
+                ));
+                return Ok(());
+            }
         }
-        return Ok(());
     }
 
     match &install_target {
@@ -430,13 +453,13 @@ mod tests {
     };
     use super::releases::{ArchiveAcquisition, download_release_archive, select_release};
     use super::remote::{
-        RemoteHostInstallerAvailability, RemoteInstallState, RemoteInstallerMode, RemoteLaunchEnvironment,
-        RemotePublishedInstallerPlan, RemoteTailscaleCachedState, RemoteTailscaleOperation,
+        RemoteConvergenceAction, RemoteHostInstallerAvailability, RemoteInstallState, RemoteInstallerMode,
+        RemoteLaunchEnvironment, RemotePublishedInstallerPlan, RemoteTailscaleCachedState, RemoteTailscaleOperation,
         RemoteTailscaleTransferInputs, RemoteTailscaleTransferStrategy, build_remote_app_copy_activation_script,
         build_remote_installer_manifest, build_remote_paths_exist_probe, build_remote_stage_cleanup_command,
         build_remote_staged_installer_setup_command, build_remote_stop_supervisor_command,
         missing_remote_installer_error, parse_remote_install_state, parse_remote_launch_environment,
-        parse_remote_staged_payload_identity, plan_remote_published_installer,
+        parse_remote_staged_payload_identity, plan_remote_convergence, plan_remote_published_installer,
         plan_remote_published_installer_without_manifest, published_installer_public_url, remote_install_matches,
         remote_launch_environment_probe, remote_staged_payload_identity, select_latest_remote_legacy_app_dir,
         select_remote_installer_mode, select_remote_tailscale_transfer_strategy, should_skip_remote_install,
@@ -498,6 +521,17 @@ mod tests {
             provider: Some(surge_core::context::StorageProvider::Filesystem),
             bucket: bucket.to_string(),
             ..surge_core::context::StorageConfig::default()
+        }
+    }
+
+    fn remote_state(version: &str, channel: &str, storage: &surge_core::context::StorageConfig) -> RemoteInstallState {
+        RemoteInstallState {
+            version: version.to_string(),
+            channel: Some(channel.to_string()),
+            storage_provider: Some(core_install::storage_provider_manifest_name(storage.provider).to_string()),
+            storage_bucket: Some(storage.bucket.clone()),
+            storage_region: Some(storage.region.clone()),
+            storage_endpoint: Some(storage.endpoint.clone()),
         }
     }
 
@@ -2070,10 +2104,14 @@ apps:
 
     #[test]
     fn parse_remote_install_state_extracts_version_and_channel() {
-        let state = parse_remote_install_state("version=1.2.3\nchannel=production\n")
-            .expect("remote install state should parse");
+        let state = parse_remote_install_state(
+            "version=1.2.3\nchannel=production\nprovider=filesystem\nbucket=/srv/releases\nregion=\nendpoint=\n",
+        )
+        .expect("remote install state should parse");
         assert_eq!(state.version, "1.2.3");
         assert_eq!(state.channel.as_deref(), Some("production"));
+        assert_eq!(state.storage_provider.as_deref(), Some("filesystem"));
+        assert_eq!(state.storage_bucket.as_deref(), Some("/srv/releases"));
     }
 
     #[test]
@@ -2086,10 +2124,18 @@ apps:
         let production = RemoteInstallState {
             version: "1.2.3".to_string(),
             channel: Some("production".to_string()),
+            storage_provider: None,
+            storage_bucket: None,
+            storage_region: None,
+            storage_endpoint: None,
         };
         let test = RemoteInstallState {
             version: "1.2.3".to_string(),
             channel: Some("test".to_string()),
+            storage_provider: None,
+            storage_bucket: None,
+            storage_region: None,
+            storage_endpoint: None,
         };
 
         assert!(remote_install_matches(Some(&production), "1.2.3", "production"));
@@ -2103,11 +2149,196 @@ apps:
         let remote_state = RemoteInstallState {
             version: "1.2.3".to_string(),
             channel: Some("test".to_string()),
+            storage_provider: None,
+            storage_bucket: None,
+            storage_region: None,
+            storage_endpoint: None,
         };
 
         let install_matches = remote_install_matches(Some(&remote_state), "1.2.3", "test");
 
         assert!(should_skip_remote_install(install_matches, false));
         assert!(!should_skip_remote_install(install_matches, true));
+    }
+
+    #[test]
+    fn remote_convergence_plan_uses_delta_for_stale_existing_install() {
+        let storage = storage_config("/srv/releases");
+        let mut target = release("1.2.0", "test", "linux-x64", "demo-1.2.0-linux-x64-full.tar.zst");
+        target.full_size = 1_000;
+        target.set_primary_delta(Some(DeltaArtifact::sparse_file_ops_zstd(
+            "primary",
+            "1.0.0",
+            "demo-1.2.0-linux-x64-delta.tar.zst",
+            123,
+            "delta-sha",
+        )));
+        let index = ReleaseIndex {
+            app_id: "demo".to_string(),
+            releases: vec![target.clone()],
+            ..ReleaseIndex::default()
+        };
+        let state = remote_state("1.0.0", "test", &storage);
+
+        let plan = plan_remote_convergence(
+            Some(&state),
+            &index,
+            "demo",
+            "linux-x64",
+            &target,
+            "test",
+            &storage,
+            RemoteInstallerMode::Online,
+            false,
+        )
+        .expect("plan should resolve");
+
+        assert_eq!(plan.action, RemoteConvergenceAction::Update);
+        assert!(plan.reason.is_none());
+        let update = plan.update_info.expect("update info should exist");
+        assert_eq!(update.apply_strategy, surge_core::update::manager::ApplyStrategy::Delta);
+        assert_eq!(update.download_size, 123);
+    }
+
+    #[test]
+    fn remote_convergence_plan_skips_current_install_unless_forced() {
+        let storage = storage_config("/srv/releases");
+        let target = release("1.2.0", "test", "linux-x64", "demo-1.2.0-linux-x64-full.tar.zst");
+        let index = ReleaseIndex {
+            app_id: "demo".to_string(),
+            releases: vec![target.clone()],
+            ..ReleaseIndex::default()
+        };
+        let state = remote_state("1.2.0", "test", &storage);
+
+        let plan = plan_remote_convergence(
+            Some(&state),
+            &index,
+            "demo",
+            "linux-x64",
+            &target,
+            "test",
+            &storage,
+            RemoteInstallerMode::Online,
+            false,
+        )
+        .expect("plan should resolve");
+        assert_eq!(plan.action, RemoteConvergenceAction::Skip);
+
+        let forced = plan_remote_convergence(
+            Some(&state),
+            &index,
+            "demo",
+            "linux-x64",
+            &target,
+            "test",
+            &storage,
+            RemoteInstallerMode::Online,
+            true,
+        )
+        .expect("forced plan should resolve");
+        assert_eq!(forced.action, RemoteConvergenceAction::Reinstall);
+    }
+
+    #[test]
+    fn remote_convergence_plan_uses_clean_install_when_no_install_exists() {
+        let storage = storage_config("/srv/releases");
+        let target = release("1.2.0", "test", "linux-x64", "demo-1.2.0-linux-x64-full.tar.zst");
+        let index = ReleaseIndex {
+            app_id: "demo".to_string(),
+            releases: vec![target.clone()],
+            ..ReleaseIndex::default()
+        };
+
+        let plan = plan_remote_convergence(
+            None,
+            &index,
+            "demo",
+            "linux-x64",
+            &target,
+            "test",
+            &storage,
+            RemoteInstallerMode::Online,
+            false,
+        )
+        .expect("plan should resolve");
+
+        assert_eq!(plan.action, RemoteConvergenceAction::CleanInstall);
+    }
+
+    #[test]
+    fn remote_convergence_plan_repairs_current_install_metadata() {
+        let storage = storage_config("/srv/releases");
+        let target = release("1.2.0", "test", "linux-x64", "demo-1.2.0-linux-x64-full.tar.zst");
+        let index = ReleaseIndex {
+            app_id: "demo".to_string(),
+            releases: vec![target.clone()],
+            ..ReleaseIndex::default()
+        };
+        let mut state = remote_state("1.2.0", "test", &storage);
+        state.storage_bucket = Some("/old/releases".to_string());
+
+        let plan = plan_remote_convergence(
+            Some(&state),
+            &index,
+            "demo",
+            "linux-x64",
+            &target,
+            "test",
+            &storage,
+            RemoteInstallerMode::Online,
+            false,
+        )
+        .expect("plan should resolve");
+
+        assert_eq!(plan.action, RemoteConvergenceAction::RepairMetadata);
+    }
+
+    #[test]
+    fn remote_convergence_plan_falls_back_to_full_when_delta_is_unsupported() {
+        let storage = storage_config("/srv/releases");
+        let mut target = release("1.2.0", "test", "linux-x64", "demo-1.2.0-linux-x64-full.tar.zst");
+        target.full_size = 2_000;
+        target.deltas = vec![DeltaArtifact {
+            id: "primary".to_string(),
+            from_version: "1.0.0".to_string(),
+            algorithm: "unsupported".to_string(),
+            patch_format: "unknown".to_string(),
+            compression: "zstd".to_string(),
+            filename: "demo-1.2.0-linux-x64-delta.tar.zst".to_string(),
+            size: 100,
+            sha256: "delta-sha".to_string(),
+        }];
+        target.preferred_delta_id = "primary".to_string();
+        let index = ReleaseIndex {
+            app_id: "demo".to_string(),
+            releases: vec![target.clone()],
+            ..ReleaseIndex::default()
+        };
+        let state = remote_state("1.0.0", "test", &storage);
+
+        let plan = plan_remote_convergence(
+            Some(&state),
+            &index,
+            "demo",
+            "linux-x64",
+            &target,
+            "test",
+            &storage,
+            RemoteInstallerMode::Online,
+            false,
+        )
+        .expect("plan should resolve");
+
+        assert_eq!(plan.action, RemoteConvergenceAction::Update);
+        let update = plan.update_info.expect("update info should exist");
+        assert_eq!(update.apply_strategy, surge_core::update::manager::ApplyStrategy::Full);
+        assert_eq!(update.download_size, 2_000);
+        assert!(
+            update
+                .fallback_reason
+                .as_deref()
+                .is_some_and(|reason| reason.contains("unsupported descriptor"))
+        );
     }
 }

--- a/crates/surge-cli/src/commands/install/remote/mod.rs
+++ b/crates/surge-cli/src/commands/install/remote/mod.rs
@@ -18,6 +18,7 @@ use super::{
 };
 use crate::commands::pack;
 use serde::Deserialize;
+use surge_core::update::manager::ApplyStrategy;
 
 pub(crate) use self::execution::{
     resolve_tailscale_targets, run_tailscale_streaming, stream_file_to_tailscale_node_with_command,
@@ -32,11 +33,12 @@ pub(crate) use self::staging::{
 pub(crate) use self::state::{
     check_remote_install_state, detect_remote_launch_environment, remote_install_matches,
     remote_staged_installer_matches_release, remote_staged_payload_matches_release, select_remote_installer_mode,
-    select_remote_tailscale_transfer_strategy, should_skip_remote_install, verify_remote_stage_readiness,
+    select_remote_tailscale_transfer_strategy, verify_remote_stage_readiness,
 };
 pub(crate) use self::types::{
-    RemoteHostInstallerAvailability, RemoteInstallerMode, RemoteTailscaleCachedState, RemoteTailscaleOperation,
-    RemoteTailscaleTransferInputs, RemoteTailscaleTransferStrategy, ensure_supported_tailscale_rid,
+    RemoteConvergenceAction, RemoteConvergencePlan, RemoteHostInstallerAvailability, RemoteInstallerMode,
+    RemoteTailscaleCachedState, RemoteTailscaleOperation, RemoteTailscaleTransferInputs,
+    RemoteTailscaleTransferStrategy, ensure_supported_tailscale_rid,
 };
 
 #[cfg(test)]
@@ -51,7 +53,8 @@ pub(crate) use self::staging::{
 #[cfg(test)]
 pub(crate) use self::state::{
     parse_remote_install_state, parse_remote_launch_environment, parse_remote_staged_payload_identity,
-    remote_launch_environment_probe, remote_staged_payload_identity,
+    plan_remote_convergence, remote_launch_environment_probe, remote_staged_payload_identity,
+    should_skip_remote_install,
 };
 #[cfg(test)]
 pub(crate) use self::types::{RemoteInstallState, RemoteLaunchEnvironment, RemotePublishedInstallerPlan};
@@ -80,8 +83,20 @@ pub(super) async fn install_release_via_tailscale(
         release.install_directory.trim()
     };
     let remote_state = check_remote_install_state(ssh_target, install_dir).await;
-    let install_matches = remote_install_matches(remote_state.as_ref(), &release.version, channel);
-    if should_skip_remote_install(install_matches, behavior.force) {
+    let convergence_plan = state::plan_remote_convergence(
+        remote_state.as_ref(),
+        index,
+        app_id,
+        selected_rid,
+        release,
+        channel,
+        storage_config,
+        installer_mode,
+        behavior.force,
+    )?;
+    log_remote_convergence_plan(file_target, app_id, channel, release, &convergence_plan);
+
+    if convergence_plan.action == RemoteConvergenceAction::Skip {
         logline::success(&format!(
             "'{app_id}' v{} ({channel}) is already installed on '{file_target}', skipping.",
             release.version
@@ -89,7 +104,8 @@ pub(super) async fn install_release_via_tailscale(
         return Ok(());
     }
 
-    if install_matches {
+    let install_matches = remote_install_matches(remote_state.as_ref(), &release.version, channel);
+    if install_matches && behavior.force {
         logline::info(&format!(
             "'{app_id}' v{} ({channel}) is already installed on '{file_target}'; reinstalling due to --force.",
             release.version
@@ -103,6 +119,16 @@ pub(super) async fn install_release_via_tailscale(
             remote_state.channel.as_deref().unwrap_or("unknown")
         ));
     }
+
+    if behavior.plan_only {
+        return Ok(());
+    }
+
+    let prefer_update_setup = matches!(
+        convergence_plan.action,
+        RemoteConvergenceAction::Update | RemoteConvergenceAction::RepairMetadata
+    ) && installer_mode == RemoteInstallerMode::Online
+        && !behavior.mode.is_stage();
 
     let launch_env = detect_remote_launch_environment(ssh_target).await;
     if let Some(display) = launch_env.display.as_deref() {
@@ -118,38 +144,45 @@ pub(super) async fn install_release_via_tailscale(
     }
 
     let host_can_build_installer = host_can_build_installer_locally(selected_rid);
-    let has_matching_pre_staged_app_copy_payload =
-        if host_can_build_installer && installer_mode == RemoteInstallerMode::Offline && !behavior.mode.is_stage() {
-            remote_staged_payload_matches_release(ssh_target, app_id, release, channel, storage_config).await?
-        } else {
-            false
-        };
+    let has_matching_pre_staged_app_copy_payload = if !prefer_update_setup
+        && host_can_build_installer
+        && installer_mode == RemoteInstallerMode::Offline
+        && !behavior.mode.is_stage()
+    {
+        remote_staged_payload_matches_release(ssh_target, app_id, release, channel, storage_config).await?
+    } else {
+        false
+    };
     let has_matching_pre_staged_installer_cache =
-        if installer_mode == RemoteInstallerMode::Online && !behavior.mode.is_stage() {
+        if !prefer_update_setup && installer_mode == RemoteInstallerMode::Online && !behavior.mode.is_stage() {
             remote_staged_installer_matches_release(ssh_target, app_id, release, channel, storage_config).await?
         } else {
             false
         };
-    let transfer_strategy = select_remote_tailscale_transfer_strategy(RemoteTailscaleTransferInputs {
-        host_installer_availability: if host_can_build_installer {
-            RemoteHostInstallerAvailability::Available
-        } else {
-            RemoteHostInstallerAvailability::Unavailable
-        },
-        installer_mode,
-        operation: if behavior.mode.is_stage() {
-            RemoteTailscaleOperation::Stage
-        } else {
-            RemoteTailscaleOperation::Install
-        },
-        cached_state: if has_matching_pre_staged_installer_cache {
-            RemoteTailscaleCachedState::InstallerCache
-        } else if has_matching_pre_staged_app_copy_payload {
-            RemoteTailscaleCachedState::AppCopyPayload
-        } else {
-            RemoteTailscaleCachedState::None
-        },
-    });
+    let transfer_strategy = if prefer_update_setup {
+        RemoteTailscaleTransferStrategy::Installer { prefer_published: true }
+    } else {
+        select_remote_tailscale_transfer_strategy(RemoteTailscaleTransferInputs {
+            host_installer_availability: if host_can_build_installer {
+                RemoteHostInstallerAvailability::Available
+            } else {
+                RemoteHostInstallerAvailability::Unavailable
+            },
+            installer_mode,
+            operation: if behavior.mode.is_stage() {
+                RemoteTailscaleOperation::Stage
+            } else {
+                RemoteTailscaleOperation::Install
+            },
+            cached_state: if has_matching_pre_staged_installer_cache {
+                RemoteTailscaleCachedState::InstallerCache
+            } else if has_matching_pre_staged_app_copy_payload {
+                RemoteTailscaleCachedState::AppCopyPayload
+            } else {
+                RemoteTailscaleCachedState::None
+            },
+        })
+    };
     if matches!(transfer_strategy, RemoteTailscaleTransferStrategy::AppCopy) {
         deploy_remote_app_copy_for_tailscale(
             backend,
@@ -171,6 +204,8 @@ pub(super) async fn install_release_via_tailscale(
         .await?;
         if !behavior.mode.is_stage() {
             warn_if_remote_stage_cleanup_fails(ssh_target, app_id, release).await;
+            verify_remote_runtime_after_install(ssh_target, file_target, install_dir, release, channel, storage_config)
+                .await?;
         }
         if behavior.mode.is_stage() {
             logline::success(&format!(
@@ -185,6 +220,8 @@ pub(super) async fn install_release_via_tailscale(
 
     if matches!(transfer_strategy, RemoteTailscaleTransferStrategy::StagedInstallerCache) {
         run_remote_staged_installer_setup(ssh_target, file_target, app_id, release, behavior.no_start).await?;
+        verify_remote_runtime_after_install(ssh_target, file_target, install_dir, release, channel, storage_config)
+            .await?;
         logline::success(&format!("Installed '{app_id}' on tailscale node '{file_target}'."));
         return Ok(());
     }
@@ -296,7 +333,13 @@ pub(super) async fn install_release_via_tailscale(
 
     let no_start_flag = if behavior.no_start { " --no-start" } else { "" };
     let stage_flag = if behavior.mode.is_stage() { " --stage" } else { "" };
-    let run_cmd = format!("/tmp/.surge-installer{no_start_flag}{stage_flag} && rm -f /tmp/.surge-installer");
+    let reinstall_flag = if matches!(convergence_plan.action, RemoteConvergenceAction::Reinstall) || behavior.force {
+        " --reinstall"
+    } else {
+        ""
+    };
+    let run_cmd =
+        format!("/tmp/.surge-installer{no_start_flag}{stage_flag}{reinstall_flag} && rm -f /tmp/.surge-installer");
     let ssh_command = format!("sh -lc {}", shell_single_quote(&run_cmd));
     if behavior.mode.is_stage() {
         logline::info(&format!("Running installer in stage mode on '{file_target}'..."));
@@ -306,6 +349,8 @@ pub(super) async fn install_release_via_tailscale(
     run_tailscale_streaming(&["ssh", ssh_target, ssh_command.as_str()], "remote").await?;
     if !behavior.mode.is_stage() {
         warn_if_remote_stage_cleanup_fails(ssh_target, app_id, release).await;
+        verify_remote_runtime_after_install(ssh_target, file_target, install_dir, release, channel, storage_config)
+            .await?;
     }
     if behavior.mode.is_stage() {
         logline::success(&format!(
@@ -317,4 +362,130 @@ pub(super) async fn install_release_via_tailscale(
     }
 
     Ok(())
+}
+
+fn log_remote_convergence_plan(
+    file_target: &str,
+    app_id: &str,
+    channel: &str,
+    release: &ReleaseEntry,
+    plan: &RemoteConvergencePlan,
+) {
+    let installed = plan.installed_version.as_deref().unwrap_or("<none>");
+    logline::info(&format!(
+        "Remote install plan for '{app_id}' on '{file_target}': {} ({} -> {}, channel '{channel}').",
+        remote_action_label(plan.action),
+        installed,
+        plan.target_version
+    ));
+
+    match plan.action {
+        RemoteConvergenceAction::Update => {
+            if let Some(update) = &plan.update_info {
+                let artifacts = selected_update_artifact_labels(update);
+                logline::info(&format!(
+                    "Selected update artifacts: {} ({} total), apply strategy: {}.",
+                    artifacts.join(", "),
+                    crate::formatters::format_bytes(u64::try_from(update.download_size.max(0)).unwrap_or(0)),
+                    update_strategy_label(update.apply_strategy)
+                ));
+                if let Some(reason) = &update.fallback_reason {
+                    logline::warn(&format!("Delta update unavailable; full package selected: {reason}"));
+                }
+            } else if let Some(reason) = &plan.reason {
+                logline::warn(&format!(
+                    "Update plan unavailable; full install transfer will be used: {reason}"
+                ));
+            }
+        }
+        RemoteConvergenceAction::CleanInstall | RemoteConvergenceAction::Reinstall => {
+            logline::info(&format!(
+                "Selected install artifact: {} ({}), transfer/apply strategy: full installer.",
+                release.full_filename,
+                crate::formatters::format_bytes(u64::try_from(release.full_size.max(0)).unwrap_or(0))
+            ));
+            if let Some(reason) = &plan.reason {
+                logline::info(&format!("Plan reason: {reason}"));
+            }
+        }
+        RemoteConvergenceAction::RepairMetadata => {
+            logline::info("Selected action only repairs runtime metadata; no package artifact should be downloaded.");
+        }
+        RemoteConvergenceAction::Skip => {}
+    }
+}
+
+fn selected_update_artifact_labels(update: &surge_core::update::manager::UpdateInfo) -> Vec<String> {
+    if matches!(update.apply_strategy, ApplyStrategy::Delta) {
+        update
+            .apply_releases
+            .iter()
+            .filter_map(ReleaseEntry::selected_delta)
+            .map(|delta| {
+                format!(
+                    "{} ({})",
+                    delta.filename,
+                    crate::formatters::format_bytes(u64::try_from(delta.size.max(0)).unwrap_or(0))
+                )
+            })
+            .collect()
+    } else {
+        update
+            .apply_releases
+            .last()
+            .map(|release| {
+                vec![format!(
+                    "{} ({})",
+                    release.full_filename,
+                    crate::formatters::format_bytes(u64::try_from(release.full_size.max(0)).unwrap_or(0))
+                )]
+            })
+            .unwrap_or_default()
+    }
+}
+
+fn remote_action_label(action: RemoteConvergenceAction) -> &'static str {
+    match action {
+        RemoteConvergenceAction::CleanInstall => "clean install",
+        RemoteConvergenceAction::Update => "update existing install",
+        RemoteConvergenceAction::RepairMetadata => "repair runtime metadata",
+        RemoteConvergenceAction::Reinstall => "reinstall",
+        RemoteConvergenceAction::Skip => "skip",
+    }
+}
+
+fn update_strategy_label(strategy: ApplyStrategy) -> &'static str {
+    match strategy {
+        ApplyStrategy::Full => "full package",
+        ApplyStrategy::Delta => "delta",
+    }
+}
+
+async fn verify_remote_runtime_after_install(
+    ssh_target: &str,
+    file_target: &str,
+    install_dir: &str,
+    release: &ReleaseEntry,
+    channel: &str,
+    storage_config: &surge_core::context::StorageConfig,
+) -> Result<()> {
+    let state = check_remote_install_state(ssh_target, install_dir)
+        .await
+        .ok_or_else(|| {
+            SurgeError::Update(format!(
+                "Remote runtime verification failed on '{file_target}': no runtime metadata found"
+            ))
+        })?;
+    if state.version.trim() == release.version.trim() && state.metadata_matches(channel, storage_config) {
+        logline::success(&format!(
+            "Verified remote runtime on '{file_target}': v{} ({channel}).",
+            release.version
+        ));
+        return Ok(());
+    }
+
+    Err(SurgeError::Update(format!(
+        "Remote runtime verification failed on '{file_target}': found v{} channel {:?}, expected v{} channel '{}'.",
+        state.version, state.channel, release.version, channel
+    )))
 }

--- a/crates/surge-cli/src/commands/install/remote/state.rs
+++ b/crates/surge-cli/src/commands/install/remote/state.rs
@@ -3,13 +3,15 @@ use super::staging::{
     remote_install_root, remote_staged_app_copy_files_exist, remote_staged_installer_cache_files_exist,
 };
 use super::types::{
-    RemoteHostInstallerAvailability, RemoteInstallState, RemoteInstallerMode, RemoteLaunchEnvironment,
-    RemoteStagedPayloadIdentity, RemoteTailscaleCachedState, RemoteTailscaleOperation, RemoteTailscaleTransferInputs,
-    RemoteTailscaleTransferStrategy, VerifiedRemoteStage,
+    RemoteConvergenceAction, RemoteConvergencePlan, RemoteHostInstallerAvailability, RemoteInstallState,
+    RemoteInstallerMode, RemoteLaunchEnvironment, RemoteStagedPayloadIdentity, RemoteTailscaleCachedState,
+    RemoteTailscaleOperation, RemoteTailscaleTransferInputs, RemoteTailscaleTransferStrategy, VerifiedRemoteStage,
 };
 use super::{
-    Path, ReleaseEntry, Result, SurgeError, core_install, host_can_build_installer_locally, logline, shell_single_quote,
+    Path, ReleaseEntry, ReleaseIndex, Result, SurgeError, compare_versions, core_install,
+    host_can_build_installer_locally, logline, shell_single_quote,
 };
+use surge_core::update::manager::plan_update_from_index;
 
 pub(crate) fn select_remote_installer_mode(storage_config: &surge_core::context::StorageConfig) -> RemoteInstallerMode {
     match storage_config
@@ -55,7 +57,11 @@ if [ ! -f "$manifest" ]; then
 fi
 version="$(sed -n 's/^version:[[:space:]]*//p' "$manifest" | head -n1)"
 channel="$(sed -n 's/^channel:[[:space:]]*//p' "$manifest" | head -n1)"
-printf 'version=%s\nchannel=%s\n' "$version" "$channel""#,
+provider="$(sed -n 's/^provider:[[:space:]]*//p' "$manifest" | head -n1)"
+bucket="$(sed -n 's/^bucket:[[:space:]]*//p' "$manifest" | head -n1)"
+region="$(sed -n 's/^region:[[:space:]]*//p' "$manifest" | head -n1)"
+endpoint="$(sed -n 's/^endpoint:[[:space:]]*//p' "$manifest" | head -n1)"
+printf 'version=%s\nchannel=%s\nprovider=%s\nbucket=%s\nregion=%s\nendpoint=%s\n' "$version" "$channel" "$provider" "$bucket" "$region" "$endpoint""#,
         install_dir.replace('\'', ""),
     );
     let command = format!("sh -c {}", shell_single_quote(&probe));
@@ -68,6 +74,10 @@ printf 'version=%s\nchannel=%s\n' "$version" "$channel""#,
 pub(crate) fn parse_remote_install_state(output: &str) -> Option<RemoteInstallState> {
     let mut version = None;
     let mut channel = None;
+    let mut storage_provider = None;
+    let mut storage_bucket = None;
+    let mut storage_region = None;
+    let mut storage_endpoint = None;
 
     for line in output.lines() {
         if let Some(value) = line.strip_prefix("version=") {
@@ -83,10 +93,121 @@ pub(crate) fn parse_remote_install_state(output: &str) -> Option<RemoteInstallSt
             if !value.is_empty() {
                 channel = Some(value.to_string());
             }
+            continue;
+        }
+
+        if let Some(value) = line.strip_prefix("provider=") {
+            let value = value.trim();
+            if !value.is_empty() {
+                storage_provider = Some(value.to_string());
+            }
+            continue;
+        }
+
+        if let Some(value) = line.strip_prefix("bucket=") {
+            let value = value.trim();
+            if !value.is_empty() {
+                storage_bucket = Some(value.to_string());
+            }
+            continue;
+        }
+
+        if let Some(value) = line.strip_prefix("region=") {
+            let value = value.trim();
+            if !value.is_empty() {
+                storage_region = Some(value.to_string());
+            }
+            continue;
+        }
+
+        if let Some(value) = line.strip_prefix("endpoint=") {
+            let value = value.trim();
+            if !value.is_empty() {
+                storage_endpoint = Some(value.to_string());
+            }
         }
     }
 
-    version.map(|version| RemoteInstallState { version, channel })
+    version.map(|version| RemoteInstallState {
+        version,
+        channel,
+        storage_provider,
+        storage_bucket,
+        storage_region,
+        storage_endpoint,
+    })
+}
+
+pub(crate) fn plan_remote_convergence(
+    remote_state: Option<&RemoteInstallState>,
+    index: &ReleaseIndex,
+    app_id: &str,
+    selected_rid: &str,
+    release: &ReleaseEntry,
+    channel: &str,
+    storage_config: &surge_core::context::StorageConfig,
+    installer_mode: RemoteInstallerMode,
+    force: bool,
+) -> Result<RemoteConvergencePlan> {
+    let Some(remote_state) = remote_state else {
+        return Ok(RemoteConvergencePlan::clean_install(release));
+    };
+
+    let installed_version = Some(remote_state.version.clone());
+    let metadata_matches = remote_state.metadata_matches(channel, storage_config);
+    match compare_versions(&remote_state.version, &release.version) {
+        std::cmp::Ordering::Equal if metadata_matches && !force => Ok(RemoteConvergencePlan {
+            action: RemoteConvergenceAction::Skip,
+            installed_version,
+            target_version: release.version.clone(),
+            update_info: None,
+            reason: Some("installed version, channel, and storage metadata already match".to_string()),
+        }),
+        std::cmp::Ordering::Equal if !force => Ok(RemoteConvergencePlan {
+            action: RemoteConvergenceAction::RepairMetadata,
+            installed_version,
+            target_version: release.version.clone(),
+            update_info: None,
+            reason: Some("installed version matches but runtime channel or storage metadata is stale".to_string()),
+        }),
+        std::cmp::Ordering::Greater if !force => Err(SurgeError::Update(format!(
+            "Remote install is already on newer version {} than selected target {}. Use --force to reinstall the selected version.",
+            remote_state.version, release.version
+        ))),
+        std::cmp::Ordering::Less if installer_mode == RemoteInstallerMode::Online && !force => {
+            let update_info = plan_update_from_index(
+                index,
+                app_id,
+                &remote_state.version,
+                channel,
+                Some(&release.version),
+                selected_rid,
+            )?;
+            let reason = update_info.as_ref().and_then(|info| info.fallback_reason.clone());
+            Ok(RemoteConvergencePlan {
+                action: RemoteConvergenceAction::Update,
+                installed_version,
+                target_version: release.version.clone(),
+                reason: if update_info.is_some() {
+                    reason
+                } else {
+                    Some("release graph did not produce an exact update plan".to_string())
+                },
+                update_info,
+            })
+        }
+        _ => Ok(RemoteConvergencePlan {
+            action: RemoteConvergenceAction::Reinstall,
+            installed_version,
+            target_version: release.version.clone(),
+            update_info: None,
+            reason: if force {
+                Some("--force requested reinstall".to_string())
+            } else {
+                Some("remote update requires online storage; using full install transfer".to_string())
+            },
+        }),
+    }
 }
 
 pub(crate) fn remote_staged_payload_identity(
@@ -290,6 +411,7 @@ pub(crate) fn remote_install_matches(
     })
 }
 
+#[cfg(test)]
 pub(crate) fn should_skip_remote_install(install_matches: bool, force: bool) -> bool {
     install_matches && !force
 }

--- a/crates/surge-cli/src/commands/install/remote/types.rs
+++ b/crates/surge-cli/src/commands/install/remote/types.rs
@@ -1,5 +1,8 @@
-use super::{Deserialize, Result, Serialize, SurgeError, infer_os_from_rid, logline};
+use super::{Deserialize, ReleaseEntry, Result, Serialize, SurgeError, infer_os_from_rid, logline};
 use surge_core::config::manifest::CacheManifestConfig;
+use surge_core::context::StorageConfig;
+use surge_core::install::storage_provider_manifest_name;
+use surge_core::update::manager::UpdateInfo;
 
 pub(crate) fn ensure_supported_tailscale_rid(rid: &str) -> Result<()> {
     match infer_os_from_rid(rid) {
@@ -90,6 +93,58 @@ pub(crate) struct RemoteTailscaleTransferInputs {
 pub(crate) struct RemoteInstallState {
     pub(crate) version: String,
     pub(crate) channel: Option<String>,
+    pub(crate) storage_provider: Option<String>,
+    pub(crate) storage_bucket: Option<String>,
+    pub(crate) storage_region: Option<String>,
+    pub(crate) storage_endpoint: Option<String>,
+}
+
+impl RemoteInstallState {
+    pub(crate) fn metadata_matches(&self, expected_channel: &str, storage_config: &StorageConfig) -> bool {
+        self.channel
+            .as_deref()
+            .is_some_and(|value| value.trim() == expected_channel)
+            && self
+                .storage_provider
+                .as_deref()
+                .is_some_and(|value| value.trim() == storage_provider_manifest_name(storage_config.provider))
+            && self
+                .storage_bucket
+                .as_deref()
+                .is_some_and(|value| value.trim() == storage_config.bucket.trim())
+            && self.storage_region.as_deref().unwrap_or("").trim() == storage_config.region.trim()
+            && self.storage_endpoint.as_deref().unwrap_or("").trim() == storage_config.endpoint.trim()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RemoteConvergenceAction {
+    CleanInstall,
+    Update,
+    RepairMetadata,
+    Reinstall,
+    Skip,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct RemoteConvergencePlan {
+    pub(crate) action: RemoteConvergenceAction,
+    pub(crate) installed_version: Option<String>,
+    pub(crate) target_version: String,
+    pub(crate) update_info: Option<UpdateInfo>,
+    pub(crate) reason: Option<String>,
+}
+
+impl RemoteConvergencePlan {
+    pub(crate) fn clean_install(release: &ReleaseEntry) -> Self {
+        Self {
+            action: RemoteConvergenceAction::CleanInstall,
+            installed_version: None,
+            target_version: release.version.clone(),
+            update_info: None,
+            reason: Some("no existing install was detected".to_string()),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/crates/surge-cli/src/commands/setup.rs
+++ b/crates/surge-cli/src/commands/setup.rs
@@ -14,6 +14,9 @@ use surge_core::platform::fs::make_executable;
 use surge_core::platform::paths::default_install_root;
 use surge_core::releases::artifact_cache::cache_path_for_key;
 use surge_core::releases::restore::RestoreProgress;
+use surge_core::update::manager::ProgressInfo;
+
+mod convergence;
 
 const PACKAGE_PROGRESS_LOG_INTERVAL: Duration = Duration::from_secs(10);
 const PACKAGE_PROGRESS_PERCENT_STEP: u64 = 10;
@@ -95,6 +98,39 @@ impl ProgressReporter {
 
         Some(format!("{} step {items_done}/{items_total} ({}%)", self.label, percent))
     }
+
+    fn observe_update(&mut self, progress: &ProgressInfo) -> Option<String> {
+        let bytes_total = u64::try_from(progress.bytes_total.max(0)).unwrap_or(0);
+        let bytes_done = u64::try_from(progress.bytes_done.max(0)).unwrap_or(0);
+        if bytes_total > 0 {
+            return self.observe_bytes(bytes_done, bytes_total);
+        }
+
+        let items_total = u64::try_from(progress.items_total.max(0)).unwrap_or(0);
+        let items_done = u64::try_from(progress.items_done.max(0)).unwrap_or(0);
+        if items_total == 0 {
+            return None;
+        }
+
+        let percent = percent(items_done, items_total);
+        let now = Instant::now();
+        let crossed_percent = percent >= self.next_percent;
+        let timed_out =
+            now.duration_since(self.last_logged_at) >= PACKAGE_PROGRESS_LOG_INTERVAL && items_done > self.last_value;
+        let finished = items_done >= items_total && items_done > self.last_value;
+
+        if !crossed_percent && !timed_out && !finished {
+            return None;
+        }
+
+        self.last_logged_at = now;
+        self.last_value = items_done;
+        while self.next_percent <= percent && self.next_percent <= 100 {
+            self.next_percent = self.next_percent.saturating_add(PACKAGE_PROGRESS_PERCENT_STEP);
+        }
+
+        Some(format!("{} step {items_done}/{items_total} ({}%)", self.label, percent))
+    }
 }
 
 fn percent(done: u64, total: u64) -> u64 {
@@ -109,7 +145,7 @@ fn percent(done: u64, total: u64) -> u64 {
 ///
 /// This is called either directly via `surge setup [dir]` or auto-detected when
 /// warp extracts the bundle and runs `surge` with no arguments.
-pub async fn execute(dir: &Path, no_start: bool, stage: bool) -> Result<()> {
+pub async fn execute(dir: &Path, no_start: bool, stage: bool, reinstall: bool) -> Result<()> {
     let manifest_path = dir.join("installer.yml");
     if !manifest_path.is_file() {
         return Err(SurgeError::Config(format!(
@@ -139,6 +175,10 @@ pub async fn execute(dir: &Path, no_start: bool, stage: bool) -> Result<()> {
             manifest.version,
             install_root.display()
         ));
+        return Ok(());
+    }
+
+    if !reinstall && convergence::converge_existing_install(&manifest, &install_root, no_start).await? {
         return Ok(());
     }
 
@@ -479,6 +519,14 @@ mod tests {
         })
     }
 
+    fn os_label_for_rid(rid: &str) -> String {
+        match rid.split('-').next().unwrap_or_default() {
+            "macos" | "darwin" | "osx" => "osx".to_string(),
+            "win" | "windows" => "windows".to_string(),
+            value => value.to_string(),
+        }
+    }
+
     fn write_archive(path: &Path, payload: &[u8]) {
         let mut packer = ArchivePacker::new(3).expect("archive packer");
         packer
@@ -493,7 +541,7 @@ mod tests {
         let release = ReleaseEntry {
             version: manifest.version.clone(),
             channels: vec![manifest.channel.clone()],
-            os: "linux".to_string(),
+            os: os_label_for_rid(&manifest.rid),
             rid: manifest.rid.clone(),
             is_genesis: false,
             full_filename: manifest.release.full_filename.clone(),
@@ -574,7 +622,7 @@ mod tests {
         std::fs::write(installer_dir.join("installer.yml"), installer_yaml).expect("installer manifest");
         write_archive(&payload_dir.join(full_filename), b"bundled payload");
 
-        execute(&installer_dir, true, false)
+        execute(&installer_dir, true, false, false)
             .await
             .expect("setup should succeed");
 
@@ -634,7 +682,7 @@ mod tests {
             .finalize_to_file(&payload_dir.join(full_filename))
             .expect("archive file");
 
-        execute(&installer_dir, true, false)
+        execute(&installer_dir, true, false, false)
             .await
             .expect("setup should succeed");
 
@@ -713,7 +761,7 @@ mod tests {
         let installer_yaml = serde_yaml::to_string(&manifest).expect("installer yaml");
         std::fs::write(installer_dir.join("installer.yml"), installer_yaml).expect("installer manifest");
 
-        execute(&installer_dir, true, false)
+        execute(&installer_dir, true, false, false)
             .await
             .expect("setup should succeed");
 
@@ -725,6 +773,134 @@ mod tests {
                 .join(full_filename)
                 .is_file(),
             "resolved package should remain in cache"
+        );
+    }
+
+    #[tokio::test]
+    async fn execute_converges_existing_online_install_with_delta_chain_and_repairs_metadata() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let installer_dir = temp_dir.path().join("installer");
+        let install_root = temp_dir.path().join("installed-app");
+        let store_root = temp_dir.path().join("store");
+        let rid = current_rid();
+        let full_v1_name = format!("demo-app-1.0.0-{rid}-full.tar.zst");
+        let full_v2_name = format!("demo-app-1.1.0-{rid}-full.tar.zst");
+        let full_v3_name = format!("demo-app-1.2.0-{rid}-full.tar.zst");
+        let delta_v2_name = format!("demo-app-1.1.0-{rid}-delta.tar.zst");
+        let delta_v3_name = format!("demo-app-1.2.0-{rid}-delta.tar.zst");
+
+        std::fs::create_dir_all(&installer_dir).expect("installer dir");
+        std::fs::create_dir_all(&store_root).expect("store dir");
+        let app_store = store_root.join("demo-app");
+        std::fs::create_dir_all(&app_store).expect("app-scoped store dir");
+
+        let full_v1_path = temp_dir.path().join(&full_v1_name);
+        let full_v2_path = temp_dir.path().join(&full_v2_name);
+        let full_v3_path = temp_dir.path().join(&full_v3_name);
+        write_archive(&full_v1_path, b"payload v1");
+        write_archive(&full_v2_path, b"payload v2");
+        write_archive(&full_v3_path, b"payload v3");
+        let full_v1 = std::fs::read(&full_v1_path).expect("v1 full");
+        let full_v2 = std::fs::read(&full_v2_path).expect("v2 full");
+        let full_v3 = std::fs::read(&full_v3_path).expect("v3 full");
+
+        let delta_v2 = zstd::encode_all(bsdiff_buffers(&full_v1, &full_v2).expect("v2 delta").as_slice(), 3)
+            .expect("v2 delta zstd");
+        let delta_v3 = zstd::encode_all(bsdiff_buffers(&full_v2, &full_v3).expect("v3 delta").as_slice(), 3)
+            .expect("v3 delta zstd");
+
+        std::fs::write(app_store.join(&full_v1_name), &full_v1).expect("store v1 full");
+        std::fs::write(app_store.join(&delta_v2_name), &delta_v2).expect("store v2 delta");
+        std::fs::write(app_store.join(&delta_v3_name), &delta_v3).expect("store v3 delta");
+
+        let mut manifest = make_manifest(&install_root, &store_root, &full_v3_name, "online");
+        manifest.version = "1.2.0".to_string();
+        manifest.cache = latest_full_cache_policy();
+        let installer_yaml = serde_yaml::to_string(&manifest).expect("installer yaml");
+        std::fs::write(installer_dir.join("installer.yml"), installer_yaml).expect("installer manifest");
+
+        let profile = InstallProfile::from_installer_manifest(&manifest, &manifest.runtime.shortcuts);
+        core_install::install_package_locally_at_root(&profile, &full_v1_path, &install_root)
+            .expect("v1 install should succeed");
+        let active_app_dir = install_root.join("app");
+        let stale_runtime =
+            core_install::RuntimeManifestMetadata::new("1.0.0", "stable", "filesystem", "/old/store", "", "");
+        core_install::write_runtime_manifest(&active_app_dir, &profile, &stale_runtime)
+            .expect("stale runtime manifest");
+
+        let mut v1 = ReleaseEntry {
+            version: "1.0.0".to_string(),
+            channels: vec!["stable".to_string()],
+            os: os_label_for_rid(&rid),
+            rid: rid.clone(),
+            is_genesis: true,
+            full_filename: full_v1_name.clone(),
+            full_size: i64::try_from(full_v1.len()).expect("full_v1 length should fit i64"),
+            full_sha256: sha256_hex(&full_v1),
+            full_compression_level: 0,
+            full_zstd_workers: 0,
+            deltas: Vec::new(),
+            preferred_delta_id: String::new(),
+            created_utc: chrono::Utc::now().to_rfc3339(),
+            release_notes: String::new(),
+            name: manifest.runtime.name.clone(),
+            main_exe: manifest.runtime.main_exe.clone(),
+            install_directory: manifest.runtime.install_directory.clone(),
+            supervisor_id: manifest.runtime.supervisor_id.clone(),
+            icon: manifest.runtime.icon.clone(),
+            shortcuts: manifest.runtime.shortcuts.clone(),
+            persistent_assets: Vec::new(),
+            installers: manifest.runtime.installers.clone(),
+            environment: manifest.runtime.environment.clone(),
+        };
+        v1.set_primary_delta(None);
+        let mut v2 = v1.clone();
+        v2.version = "1.1.0".to_string();
+        v2.is_genesis = false;
+        v2.full_filename = full_v2_name;
+        v2.full_size = i64::try_from(full_v2.len()).expect("full_v2 length should fit i64");
+        v2.full_sha256 = sha256_hex(&full_v2);
+        v2.set_primary_delta(Some(DeltaArtifact::bsdiff_zstd(
+            "primary",
+            "1.0.0",
+            &delta_v2_name,
+            i64::try_from(delta_v2.len()).expect("delta_v2 length should fit i64"),
+            &sha256_hex(&delta_v2),
+        )));
+        let mut v3 = v1.clone();
+        v3.version = "1.2.0".to_string();
+        v3.is_genesis = false;
+        v3.full_filename = full_v3_name.clone();
+        v3.full_size = i64::try_from(full_v3.len()).expect("full_v3 length should fit i64");
+        v3.full_sha256 = sha256_hex(&full_v3);
+        v3.set_primary_delta(Some(DeltaArtifact::bsdiff_zstd(
+            "primary",
+            "1.1.0",
+            &delta_v3_name,
+            i64::try_from(delta_v3.len()).expect("delta_v3 length should fit i64"),
+            &sha256_hex(&delta_v3),
+        )));
+        write_release_index_entries(&app_store, &manifest.app_id, vec![v1, v2, v3]);
+
+        execute(&installer_dir, true, false, false)
+            .await
+            .expect("setup should converge existing install through update manager");
+
+        assert_eq!(
+            std::fs::read_to_string(active_app_dir.join("payload.txt")).expect("payload should exist"),
+            "payload v3"
+        );
+        let runtime_yaml = std::fs::read_to_string(active_app_dir.join(core_install::RUNTIME_MANIFEST_RELATIVE_PATH))
+            .expect("runtime manifest");
+        assert!(runtime_yaml.contains("version: 1.2.0"));
+        assert!(runtime_yaml.contains(&format!("bucket: {}", store_root.display())));
+        assert!(
+            !install_root
+                .join(".surge-cache")
+                .join("artifacts")
+                .join(&full_v3_name)
+                .exists(),
+            "target full package should not be fetched when the delta chain is usable"
         );
     }
 
@@ -819,7 +995,7 @@ mod tests {
 
         write_release_index_entries(&store_root, &manifest.app_id, vec![base_release, target_release]);
 
-        execute(&installer_dir, true, false)
+        execute(&installer_dir, true, false, false)
             .await
             .expect("setup should succeed");
 
@@ -930,7 +1106,7 @@ mod tests {
 
         write_release_index_entries(&store_root, &manifest.app_id, vec![base_release, target_release]);
 
-        execute(&installer_dir, true, false)
+        execute(&installer_dir, true, false, false)
             .await
             .expect("setup should succeed");
 
@@ -971,7 +1147,7 @@ mod tests {
         write_archive(&bundled_payload, b"bundled payload");
         let bundled_archive = std::fs::read(&bundled_payload).expect("bundled payload should exist");
 
-        execute(&installer_dir, true, true)
+        execute(&installer_dir, true, true, false)
             .await
             .expect("setup stage should succeed");
 
@@ -1016,7 +1192,7 @@ mod tests {
         std::fs::write(installer_dir.join("installer.yml"), installer_yaml).expect("installer manifest");
         write_archive(&bundled_payload, b"bundled payload");
 
-        execute(&installer_dir, true, true)
+        execute(&installer_dir, true, true, false)
             .await
             .expect("setup stage should succeed");
 
@@ -1060,7 +1236,7 @@ mod tests {
         std::fs::write(&surge_binary, b"#!/bin/sh\nexit 0\n").expect("surge stub");
         make_executable(&surge_binary).expect("surge stub should be executable");
 
-        execute(&installer_dir, true, true)
+        execute(&installer_dir, true, true, false)
             .await
             .expect("setup stage should succeed");
 

--- a/crates/surge-cli/src/commands/setup/convergence.rs
+++ b/crates/surge-cli/src/commands/setup/convergence.rs
@@ -1,0 +1,198 @@
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+
+use super::ProgressReporter;
+use crate::logline;
+use surge_core::config::installer::InstallerManifest;
+use surge_core::context::{Context, StorageProvider};
+use surge_core::error::{Result, SurgeError};
+use surge_core::install::{self as core_install, InstallProfile};
+use surge_core::releases::version::compare_versions;
+use surge_core::storage_config::build_storage_config_from_installer_manifest;
+use surge_core::update::manager::{ApplyStrategy, ProgressInfo, UpdateManager};
+
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct InstalledRuntimeManifest {
+    #[serde(default)]
+    id: String,
+    #[serde(default)]
+    version: String,
+    #[serde(default)]
+    channel: String,
+    #[serde(default)]
+    provider: String,
+    #[serde(default)]
+    bucket: String,
+    #[serde(default)]
+    region: String,
+    #[serde(default)]
+    endpoint: String,
+}
+
+pub(super) async fn converge_existing_install(
+    manifest: &InstallerManifest,
+    install_root: &Path,
+    no_start: bool,
+) -> Result<bool> {
+    let active_app_dir = install_root.join("app");
+    let Some(existing) = read_installed_runtime_manifest(&active_app_dir)? else {
+        return Ok(false);
+    };
+
+    if existing.id.trim() != manifest.app_id.trim() || existing.version.trim().is_empty() {
+        return Ok(false);
+    }
+
+    match compare_versions(existing.version.trim(), manifest.version.trim()) {
+        std::cmp::Ordering::Equal => {
+            if runtime_metadata_matches(&existing, manifest) {
+                logline::success(&format!(
+                    "'{}' v{} ({}) is already installed, skipping.",
+                    manifest.app_id, manifest.version, manifest.channel
+                ));
+            } else {
+                repair_runtime_metadata(manifest, install_root)?;
+                logline::success(&format!(
+                    "Repaired runtime metadata for '{}' v{} ({}).",
+                    manifest.app_id, manifest.version, manifest.channel
+                ));
+            }
+            if !no_start {
+                logline::info("Existing install was already current; no restart was performed.");
+            }
+            Ok(true)
+        }
+        std::cmp::Ordering::Greater => Err(SurgeError::Update(format!(
+            "Installed version {} is newer than installer target {}. Use a reinstall path to downgrade.",
+            existing.version, manifest.version
+        ))),
+        std::cmp::Ordering::Less => update_existing_install(manifest, install_root, &existing.version).await,
+    }
+}
+
+async fn update_existing_install(
+    manifest: &InstallerManifest,
+    install_root: &Path,
+    current_version: &str,
+) -> Result<bool> {
+    let ctx = Arc::new(context_from_installer_manifest(manifest)?);
+    let mut manager = UpdateManager::new(
+        Arc::clone(&ctx),
+        &manifest.app_id,
+        current_version,
+        &manifest.channel,
+        install_root.to_str().ok_or_else(|| {
+            SurgeError::Config(format!("Install root is not valid UTF-8: {}", install_root.display()))
+        })?,
+    )?;
+    manager.set_artifact_retention_policy(manifest.effective_install_artifact_cache_policy())?;
+
+    let Some(update) = manager.check_for_updates().await? else {
+        repair_runtime_metadata(manifest, install_root)?;
+        logline::success(&format!(
+            "Repaired runtime metadata for '{}' v{} ({}).",
+            manifest.app_id, manifest.version, manifest.channel
+        ));
+        return Ok(true);
+    };
+
+    if update.latest_version != manifest.version {
+        logline::warn(&format!(
+            "Release channel '{}' latest is v{}, but this installer targets v{}; falling back to exact full-package setup.",
+            manifest.channel, update.latest_version, manifest.version
+        ));
+        return Ok(false);
+    }
+
+    logline::info(&format!(
+        "Updating existing '{}' install from v{} to v{} via {} ({}).",
+        manifest.app_id,
+        current_version,
+        manifest.version,
+        update_strategy_label(update.apply_strategy),
+        crate::formatters::format_bytes(u64::try_from(update.download_size.max(0)).unwrap_or(0))
+    ));
+    if let Some(reason) = &update.fallback_reason {
+        logline::warn(&format!("Delta update unavailable; using full package: {reason}"));
+    }
+
+    let update_progress = Mutex::new(ProgressReporter::new("Applying update..."));
+    manager
+        .download_and_apply(
+            &update,
+            Some(|progress: ProgressInfo| {
+                let mut reporter = update_progress
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner);
+                if let Some(message) = reporter.observe_update(&progress) {
+                    logline::subtle(&message);
+                }
+            }),
+        )
+        .await?;
+
+    repair_runtime_metadata(manifest, install_root)?;
+    logline::success(&format!(
+        "Updated '{}' to v{} ({}).",
+        manifest.app_id, manifest.version, manifest.channel
+    ));
+    Ok(true)
+}
+
+fn update_strategy_label(strategy: ApplyStrategy) -> &'static str {
+    match strategy {
+        ApplyStrategy::Full => "full package",
+        ApplyStrategy::Delta => "delta update",
+    }
+}
+
+fn read_installed_runtime_manifest(active_app_dir: &Path) -> Result<Option<InstalledRuntimeManifest>> {
+    let path = active_app_dir.join(core_install::RUNTIME_MANIFEST_RELATIVE_PATH);
+    if !path.is_file() {
+        return Ok(None);
+    }
+    let bytes = std::fs::read(&path)?;
+    let manifest = serde_yaml::from_slice(&bytes)
+        .map_err(|e| SurgeError::Config(format!("Failed to parse runtime manifest '{}': {e}", path.display())))?;
+    Ok(Some(manifest))
+}
+
+fn runtime_metadata_matches(existing: &InstalledRuntimeManifest, manifest: &InstallerManifest) -> bool {
+    existing.channel.trim() == manifest.channel.trim()
+        && existing.provider.trim() == manifest.storage.provider.trim()
+        && existing.bucket.trim() == manifest.storage.bucket.trim()
+        && existing.region.trim() == manifest.storage.region.trim()
+        && existing.endpoint.trim() == manifest.storage.endpoint.trim()
+}
+
+fn repair_runtime_metadata(manifest: &InstallerManifest, install_root: &Path) -> Result<()> {
+    let active_app_dir = install_root.join("app");
+    let profile = InstallProfile::from_installer_manifest(manifest, &manifest.runtime.shortcuts);
+    let runtime_manifest = core_install::RuntimeManifestMetadata::new(
+        &manifest.version,
+        &manifest.channel,
+        &manifest.storage.provider,
+        &manifest.storage.bucket,
+        &manifest.storage.region,
+        &manifest.storage.endpoint,
+    );
+    core_install::write_runtime_manifest(&active_app_dir, &profile, &runtime_manifest)?;
+    Ok(())
+}
+
+fn context_from_installer_manifest(manifest: &InstallerManifest) -> Result<Context> {
+    let storage = build_storage_config_from_installer_manifest(manifest)?;
+    let provider = storage.provider.unwrap_or(StorageProvider::Filesystem);
+    let ctx = Context::new();
+    ctx.set_storage(
+        provider,
+        &storage.bucket,
+        &storage.region,
+        &storage.access_key,
+        &storage.secret_key,
+        &storage.endpoint,
+    );
+    ctx.set_storage_prefix(&storage.prefix);
+    Ok(ctx)
+}

--- a/crates/surge-cli/src/main.rs
+++ b/crates/surge-cli/src/main.rs
@@ -40,7 +40,7 @@ fn main() -> ExitCode {
                         return ExitCode::FAILURE;
                     }
                 };
-                return match rt.block_on(commands::setup::execute(&installer_dir, false, false)) {
+                return match rt.block_on(commands::setup::execute(&installer_dir, false, false, false)) {
                     Ok(()) => ExitCode::SUCCESS,
                     Err(e) => {
                         logline::error_chain(&e);
@@ -255,7 +255,12 @@ async fn run(cli: Cli) -> surge_core::error::Result<()> {
             }
         }
 
-        Commands::Setup { dir, no_start, stage } => commands::setup::execute(&dir, no_start, stage).await,
+        Commands::Setup {
+            dir,
+            no_start,
+            stage,
+            reinstall,
+        } => commands::setup::execute(&dir, no_start, stage, reinstall).await,
 
         Commands::Sha256 { file } => {
             let hash = surge_core::crypto::sha256::sha256_hex_file(&file)?;

--- a/crates/surge-core/Cargo.toml
+++ b/crates/surge-core/Cargo.toml
@@ -36,6 +36,7 @@ quick-xml = { workspace = true }
 async-trait = { workspace = true }
 futures-util = { workspace = true }
 tempfile = { workspace = true }
+fs2 = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
 nix = { version = "0.31", features = ["signal", "process", "fs"] }

--- a/crates/surge-core/src/releases/artifact_cache.rs
+++ b/crates/surge-core/src/releases/artifact_cache.rs
@@ -1,9 +1,12 @@
 use std::collections::BTreeSet;
+use std::fs::{File, OpenOptions};
 use std::path::{Component, Path, PathBuf};
 
 use crate::crypto::sha256::sha256_hex_file;
 use crate::error::{Result, SurgeError};
+use crate::platform::fs::atomic_rename;
 use crate::storage::{StorageBackend, TransferProgress};
+use fs2::FileExt;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CacheFetchOutcome {
@@ -58,6 +61,7 @@ pub async fn fetch_or_reuse_file(
     progress: Option<&TransferProgress<'_>>,
 ) -> Result<CacheFetchOutcome> {
     let expected = expected_sha256.trim();
+    let _lock = CacheFileLock::acquire(destination).await?;
     let had_local = destination.is_file();
     if !expected.is_empty() && had_local && sha256_matches_file(destination, expected)? {
         return Ok(CacheFetchOutcome::ReusedLocal);
@@ -66,18 +70,97 @@ pub async fn fetch_or_reuse_file(
     if let Some(parent) = destination.parent() {
         std::fs::create_dir_all(parent)?;
     }
-    storage.download_to_file(key, destination, progress).await?;
+    let tmp_path = temporary_download_path(destination)?;
+    let download_result = storage.download_to_file(key, &tmp_path, progress).await;
+    if let Err(error) = download_result {
+        remove_file_if_exists(&tmp_path);
+        return Err(error);
+    }
 
-    if !expected.is_empty() && !sha256_matches_file(destination, expected)? {
+    if !expected.is_empty() && !sha256_matches_file(&tmp_path, expected)? {
+        remove_file_if_exists(&tmp_path);
         return Err(SurgeError::Storage(format!(
             "SHA-256 mismatch for '{key}' after download"
         )));
     }
 
+    atomic_rename(&tmp_path, destination)?;
+
     if had_local && !expected.is_empty() {
         Ok(CacheFetchOutcome::DownloadedAfterInvalidLocal)
     } else {
         Ok(CacheFetchOutcome::DownloadedFresh)
+    }
+}
+
+struct CacheFileLock {
+    #[allow(dead_code)]
+    file: File,
+}
+
+impl CacheFileLock {
+    async fn acquire(destination: &Path) -> Result<Self> {
+        let parent = destination.parent().ok_or_else(|| {
+            SurgeError::Storage(format!(
+                "Cannot lock cache path without parent directory: {}",
+                destination.display()
+            ))
+        })?;
+        std::fs::create_dir_all(parent)?;
+        let lock_path = cache_lock_path(destination);
+        let file = OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .read(true)
+            .write(true)
+            .open(&lock_path)
+            .map_err(|e| SurgeError::Storage(format!("Failed to open cache lock '{}': {e}", lock_path.display())))?;
+        let file = tokio::task::spawn_blocking(move || {
+            lock_cache_file(&file, &lock_path)?;
+            Ok::<File, SurgeError>(file)
+        })
+        .await
+        .map_err(|e| SurgeError::Storage(format!("Failed to join cache lock task: {e}")))??;
+        Ok(Self { file })
+    }
+}
+
+fn lock_cache_file(file: &File, lock_path: &Path) -> Result<()> {
+    file.lock_exclusive()
+        .map_err(|e| SurgeError::Storage(format!("Failed to lock cache file '{}': {e}", lock_path.display())))
+}
+
+fn cache_lock_path(destination: &Path) -> PathBuf {
+    let file_name = destination
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("artifact");
+    destination.with_file_name(format!(".{file_name}.lock"))
+}
+
+fn temporary_download_path(destination: &Path) -> Result<PathBuf> {
+    let parent = destination.parent().ok_or_else(|| {
+        SurgeError::Storage(format!(
+            "Cannot create temporary cache path without parent directory: {}",
+            destination.display()
+        ))
+    })?;
+    let file_name = destination
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("artifact");
+    let temp = tempfile::Builder::new()
+        .prefix(&format!(".{file_name}."))
+        .suffix(".tmp")
+        .tempfile_in(parent)?;
+    let path = temp.path().to_path_buf();
+    drop(temp);
+    Ok(path)
+}
+
+fn remove_file_if_exists(path: &Path) {
+    if path.exists() {
+        let _ = std::fs::remove_file(path);
     }
 }
 
@@ -156,7 +239,68 @@ fn prune_empty_directories(dir: &Path, root: &Path) -> Result<bool> {
 mod tests {
     use super::*;
     use crate::crypto::sha256::sha256_hex;
-    use crate::storage::filesystem::FilesystemBackend;
+    use crate::storage::{ListResult, ObjectInfo, TransferProgress, filesystem::FilesystemBackend};
+    use std::sync::{
+        Arc,
+        atomic::{AtomicBool, AtomicUsize, Ordering},
+    };
+    use std::time::Duration;
+
+    struct SlowBackend {
+        payload: Vec<u8>,
+        downloads: AtomicUsize,
+    }
+
+    #[async_trait::async_trait]
+    impl StorageBackend for SlowBackend {
+        async fn put_object(&self, _key: &str, _data: &[u8], _content_type: &str) -> Result<()> {
+            unimplemented!("test backend is read-only")
+        }
+
+        async fn get_object(&self, _key: &str) -> Result<Vec<u8>> {
+            unimplemented!("test backend only supports file downloads")
+        }
+
+        async fn head_object(&self, _key: &str) -> Result<ObjectInfo> {
+            Ok(ObjectInfo {
+                size: i64::try_from(self.payload.len()).expect("payload length should fit i64"),
+                ..ObjectInfo::default()
+            })
+        }
+
+        async fn delete_object(&self, _key: &str) -> Result<()> {
+            unimplemented!("test backend is read-only")
+        }
+
+        async fn list_objects(&self, _prefix: &str, _marker: Option<&str>, _max_keys: i32) -> Result<ListResult> {
+            Ok(ListResult::default())
+        }
+
+        async fn download_to_file(
+            &self,
+            _key: &str,
+            dest: &Path,
+            progress: Option<&TransferProgress<'_>>,
+        ) -> Result<()> {
+            self.downloads.fetch_add(1, Ordering::SeqCst);
+            tokio::time::sleep(Duration::from_millis(50)).await;
+            tokio::fs::write(dest, &self.payload).await?;
+            if let Some(progress) = progress {
+                let len = self.payload.len() as u64;
+                progress(len, len);
+            }
+            Ok(())
+        }
+
+        async fn upload_from_file(
+            &self,
+            _key: &str,
+            _src: &Path,
+            _progress: Option<&TransferProgress<'_>>,
+        ) -> Result<()> {
+            unimplemented!("test backend is read-only")
+        }
+    }
 
     #[test]
     fn cache_path_for_key_rejects_parent_traversal() {
@@ -239,6 +383,94 @@ mod tests {
 
         assert_eq!(outcome, CacheFetchOutcome::DownloadedFresh);
         assert_eq!(std::fs::read(&local).expect("read local"), b"remote-payload");
+    }
+
+    #[tokio::test]
+    async fn fetch_or_reuse_file_serializes_concurrent_writes_to_same_cache_path() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let destination = tmp.path().join("artifact.bin");
+        let payload = b"remote-payload".to_vec();
+        let expected_sha = sha256_hex(&payload);
+        let backend = Arc::new(SlowBackend {
+            payload,
+            downloads: AtomicUsize::new(0),
+        });
+
+        let first_backend = Arc::clone(&backend);
+        let first_destination = destination.clone();
+        let first_sha = expected_sha.clone();
+        let first = tokio::spawn(async move {
+            fetch_or_reuse_file(
+                first_backend.as_ref(),
+                "artifact.bin",
+                &first_destination,
+                &first_sha,
+                None,
+            )
+            .await
+        });
+
+        let second_backend = Arc::clone(&backend);
+        let second_destination = destination.clone();
+        let second_sha = expected_sha.clone();
+        let second = tokio::spawn(async move {
+            fetch_or_reuse_file(
+                second_backend.as_ref(),
+                "artifact.bin",
+                &second_destination,
+                &second_sha,
+                None,
+            )
+            .await
+        });
+
+        let outcomes = (first.await.expect("first task"), second.await.expect("second task"));
+        assert!(matches!(
+            outcomes,
+            (
+                Ok(CacheFetchOutcome::DownloadedFresh),
+                Ok(CacheFetchOutcome::ReusedLocal)
+            ) | (
+                Ok(CacheFetchOutcome::ReusedLocal),
+                Ok(CacheFetchOutcome::DownloadedFresh)
+            )
+        ));
+        assert_eq!(backend.downloads.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            std::fs::read(destination).expect("cache file should exist"),
+            b"remote-payload"
+        );
+    }
+
+    #[tokio::test]
+    async fn fetch_or_reuse_file_does_not_expose_partial_download_at_final_path() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let destination = tmp.path().join("artifact.bin");
+        let payload = b"remote-payload".to_vec();
+        let expected_sha = sha256_hex(&payload);
+        let backend = SlowBackend {
+            payload,
+            downloads: AtomicUsize::new(0),
+        };
+        let observed_final_path_during_download = Arc::new(AtomicBool::new(false));
+        let observed = Arc::clone(&observed_final_path_during_download);
+        let watched_destination = destination.clone();
+        let progress = move |_done: u64, _total: u64| {
+            if watched_destination.exists() {
+                observed.store(true, Ordering::SeqCst);
+            }
+        };
+
+        let outcome = fetch_or_reuse_file(&backend, "artifact.bin", &destination, &expected_sha, Some(&progress))
+            .await
+            .expect("fetch should succeed");
+
+        assert_eq!(outcome, CacheFetchOutcome::DownloadedFresh);
+        assert!(!observed_final_path_during_download.load(Ordering::SeqCst));
+        assert_eq!(
+            std::fs::read(destination).expect("cache file should exist"),
+            b"remote-payload"
+        );
     }
 
     #[test]

--- a/crates/surge-core/src/update/manager.rs
+++ b/crates/surge-core/src/update/manager.rs
@@ -33,6 +33,7 @@ use self::apply::materialize_update_payload;
 use self::artifacts::prepare_update_artifacts;
 pub use self::progress::ProgressInfo;
 use self::progress::emit_progress;
+pub use self::release_index::plan_update_from_index;
 use self::release_index::{load_release_index as load_release_index_impl, resolve_update_info};
 
 /// Strategy used when applying an update.
@@ -57,6 +58,8 @@ pub struct UpdateInfo {
     pub apply_releases: Vec<ReleaseEntry>,
     /// Which strategy is used for this update.
     pub apply_strategy: ApplyStrategy,
+    /// Reason a full update was selected when a delta path was unavailable.
+    pub fallback_reason: Option<String>,
 }
 
 const DEFAULT_RELEASE_RETENTION_LIMIT: usize = 1;
@@ -598,6 +601,7 @@ mod tests {
             download_size: 1024,
             apply_releases: vec![],
             apply_strategy: ApplyStrategy::Full,
+            fallback_reason: Some("no delta chain".to_string()),
         };
         assert_eq!(info.latest_version, "2.0.0");
         assert!(!info.delta_available);

--- a/crates/surge-core/src/update/manager/release_index.rs
+++ b/crates/surge-core/src/update/manager/release_index.rs
@@ -81,28 +81,47 @@ fn app_scoped_prefix(base_prefix: &str, app_id: &str) -> Option<String> {
 }
 
 pub(super) fn resolve_update_info(manager: &mut UpdateManager, index: ReleaseIndex) -> Result<Option<UpdateInfo>> {
-    let current_rid = current_rid();
-    let current_os = normalize_os_label(current_rid.split('-').next().unwrap_or_default());
+    let planned = plan_update_from_index(
+        &index,
+        &manager.app_id,
+        &manager.current_version,
+        &manager.channel,
+        None,
+        &current_rid(),
+    )?;
+    manager.cached_index = Some(index);
+    Ok(planned)
+}
 
-    if !index.app_id.is_empty() && index.app_id != manager.app_id {
+pub fn plan_update_from_index(
+    index: &ReleaseIndex,
+    app_id: &str,
+    current_version: &str,
+    channel: &str,
+    target_version: Option<&str>,
+    target_rid: &str,
+) -> Result<Option<UpdateInfo>> {
+    let current_os = normalize_os_label(target_rid.split('-').next().unwrap_or_default());
+
+    if !index.app_id.is_empty() && index.app_id != app_id {
         return Err(SurgeError::Update(format!(
             "Release index app_id '{}' does not match requested app '{}'",
-            index.app_id, manager.app_id
+            index.app_id, app_id
         )));
     }
 
     let mut compatible_index = index.clone();
     compatible_index.releases.retain(|release| {
-        release.channels.iter().any(|channel| channel == &manager.channel)
-            && compare_versions(&release.version, &manager.current_version) == Ordering::Greater
-            && release_matches_rid(release, &current_rid)
+        release.channels.iter().any(|candidate| candidate == channel)
+            && compare_versions(&release.version, current_version) == Ordering::Greater
+            && target_version.is_none_or(|target| compare_versions(&release.version, target) != Ordering::Greater)
+            && release_matches_rid(release, target_rid)
             && release_matches_os(release, &current_os)
     });
 
-    let newer = get_releases_newer_than(&compatible_index, &manager.current_version, &manager.channel);
+    let newer = get_releases_newer_than(&compatible_index, current_version, channel);
     if newer.is_empty() {
         debug!("No updates available");
-        manager.cached_index = Some(index);
         return Ok(None);
     }
 
@@ -111,31 +130,32 @@ pub(super) fn resolve_update_info(manager: &mut UpdateManager, index: ReleaseInd
         .map(|release| (*release).clone())
         .ok_or_else(|| SurgeError::Update("No latest release found".to_string()))?;
     let latest_version = latest.version.clone();
-    let delta_chain = get_delta_chain(
-        &compatible_index,
-        &manager.current_version,
-        &latest_version,
-        &manager.channel,
-    );
+    if let Some(target_version) = target_version.map(str::trim).filter(|value| !value.is_empty())
+        && latest_version != target_version
+    {
+        return Ok(None);
+    }
+
+    let delta_chain = get_delta_chain(&compatible_index, current_version, &latest_version, channel);
 
     let available_releases: Vec<ReleaseEntry> = newer.into_iter().cloned().collect();
-    let resolved_delta_chain = delta_chain
-        .and_then(|chain| resolve_delta_chain_for_current_install(chain.as_slice(), &manager.current_version));
-    let supported_delta_chain = resolved_delta_chain.filter(|chain| {
-        chain
-            .iter()
-            .all(|release| release.selected_delta().is_some_and(|delta| is_supported_delta(&delta)))
-    });
+    let delta_resolution = resolve_supported_delta_chain(delta_chain.as_deref(), current_version, channel, &latest);
 
-    let (apply_releases, apply_strategy, download_size) = if let Some(chain) = supported_delta_chain {
-        let size = chain
-            .iter()
-            .filter_map(ReleaseEntry::selected_delta)
-            .map(|delta| delta.size)
-            .sum();
-        (chain, ApplyStrategy::Delta, size)
-    } else {
-        (vec![latest.clone()], ApplyStrategy::Full, latest.full_size)
+    let (apply_releases, apply_strategy, download_size, fallback_reason) = match delta_resolution {
+        Ok(chain) => {
+            let size = chain
+                .iter()
+                .filter_map(ReleaseEntry::selected_delta)
+                .map(|delta| delta.size)
+                .sum();
+            (chain, ApplyStrategy::Delta, size, None)
+        }
+        Err(reason) => (
+            vec![latest.clone()],
+            ApplyStrategy::Full,
+            latest.full_size,
+            Some(reason),
+        ),
     };
     let delta_available = matches!(apply_strategy, ApplyStrategy::Delta);
 
@@ -147,8 +167,6 @@ pub(super) fn resolve_update_info(manager: &mut UpdateManager, index: ReleaseInd
         "Updates available"
     );
 
-    manager.cached_index = Some(index);
-
     Ok(Some(UpdateInfo {
         available_releases,
         latest_version,
@@ -156,7 +174,42 @@ pub(super) fn resolve_update_info(manager: &mut UpdateManager, index: ReleaseInd
         download_size,
         apply_releases,
         apply_strategy,
+        fallback_reason,
     }))
+}
+
+fn resolve_supported_delta_chain(
+    chain: Option<&[&ReleaseEntry]>,
+    current_version: &str,
+    channel: &str,
+    latest: &ReleaseEntry,
+) -> std::result::Result<Vec<ReleaseEntry>, String> {
+    let chain = chain.ok_or_else(|| {
+        format!(
+            "no contiguous delta chain from v{current_version} to v{} on channel '{channel}'",
+            latest.version
+        )
+    })?;
+    let resolved = resolve_delta_chain_for_current_install(chain, current_version).ok_or_else(|| {
+        format!(
+            "no delta artifact matched the installed version chain from v{current_version} to v{}",
+            latest.version
+        )
+    })?;
+
+    for release in &resolved {
+        let Some(delta) = release.selected_delta() else {
+            return Err(format!("release v{} has no selected delta artifact", release.version));
+        };
+        if !is_supported_delta(&delta) {
+            return Err(format!(
+                "delta '{}' for v{} uses unsupported descriptor (algorithm='{}', format='{}', compression='{}')",
+                delta.filename, release.version, delta.algorithm, delta.patch_format, delta.compression
+            ));
+        }
+    }
+
+    Ok(resolved)
 }
 
 /// For each release in the chain, pick the delta whose `from_version` matches


### PR DESCRIPTION
## Summary

- Probes an existing remote runtime manifest before `surge install tailscale` chooses a transfer strategy.
- Reuses the release-index update planner for existing online installs so matching deltas are preferred and unsupported or missing chains fall back to a full package with an explicit reason.
- Keeps clean installs on the installer path, skips already-current installs unless `--force` is set, and repairs stale runtime channel/storage metadata through setup.
- Makes shared artifact-cache downloads write to temporary files under a per-artifact lock before atomic rename.

## Operator Impact

- `surge install tailscale --node <node> --channel <channel>` now reports the selected action, installed version to target version, selected artifacts, total bytes, transfer/apply strategy, and final remote runtime verification.
- `--plan-only`, `--force`, and `--stage` keep their existing command meanings.
- Clean installs still require the published or locally built installer path.

## Validation

- `./scripts/sync-surge-core-vendor.sh --check`
- `./scripts/check-version-sync.sh`
- `cargo fmt --all -- --check`
- `./scripts/check-maintainability.sh`
- `RUSTFLAGS="-D warnings" cargo test --workspace`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo clippy --workspace --lib --bins --examples -- -D warnings -D clippy::unwrap_used -D clippy::expect_used`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings -W clippy::pedantic`
- `dotnet format dotnet/Surge.slnx --verify-no-changes`
- `dotnet test dotnet/Surge.slnx --configuration Release`

## Release Note

Remote Tailscale installs now converge existing online installs through the shared update planner, preferring compatible deltas and falling back to full packages with clear plan output when needed.