### PR TITLE
fix(core): persist explicit update convergence state (closes #113)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3206,6 +3206,7 @@ dependencies = [
 name = "surge-ffi"
 version = "1.0.0"
 dependencies = [
+ "serde_json",
  "surge-core",
  "tokio",
  "tracing",

--- a/crates/surge-cli/src/cli.rs
+++ b/crates/surge-cli/src/cli.rs
@@ -269,6 +269,17 @@ pub(crate) enum Commands {
         file: PathBuf,
     },
 
+    /// Print the persisted update convergence record for a Surge-managed install
+    Status {
+        /// Root install directory (containing .surge-update-status.json)
+        #[arg(value_name = "INSTALL_DIR")]
+        install_dir: PathBuf,
+
+        /// Emit the record as JSON instead of a human-readable summary
+        #[arg(long)]
+        json: bool,
+    },
+
     /// Install packages using a selected transport method
     Install {
         /// Install method (defaults to backend)

--- a/crates/surge-cli/src/commands/mod.rs
+++ b/crates/surge-cli/src/commands/mod.rs
@@ -10,6 +10,7 @@ pub mod promote;
 pub mod push;
 pub mod restore;
 pub mod setup;
+pub mod status;
 pub mod tune;
 
 pub(crate) use surge_core::storage_config::{append_prefix, parse_storage_provider};

--- a/crates/surge-cli/src/commands/status.rs
+++ b/crates/surge-cli/src/commands/status.rs
@@ -1,0 +1,56 @@
+use std::path::Path;
+
+use surge_core::error::{Result, SurgeError};
+use surge_core::update::status::{read_update_status, update_status_path};
+
+use crate::logline;
+
+pub(crate) fn execute(install_dir: &Path, as_json: bool) -> Result<()> {
+    if !install_dir.is_dir() {
+        return Err(SurgeError::NotFound(format!(
+            "Install directory not found: {}",
+            install_dir.display()
+        )));
+    }
+
+    let record = read_update_status(install_dir)?;
+    match record {
+        Some(record) if as_json => {
+            let json = serde_json::to_string_pretty(&record)
+                .map_err(|e| SurgeError::Config(format!("Failed to encode status as JSON: {e}")))?;
+            logline::emit_raw(&json);
+        }
+        Some(record) => {
+            logline::info(&format!("state: {}", record.state));
+            logline::info(&format!("app_id: {}", record.app_id));
+            logline::info(&format!("channel: {}", record.channel));
+            logline::info(&format!("installed_version: {}", record.installed_version));
+            logline::info(&format!("target_version: {}", record.target_version));
+            logline::info(&format!(
+                "supervisor_restart_confirmed: {}",
+                record.supervisor_restart_confirmed
+            ));
+            if let Some(attempted) = record.attempted_at_utc.as_deref() {
+                logline::info(&format!("attempted_at_utc: {attempted}"));
+            }
+            if let Some(completed) = record.completed_at_utc.as_deref() {
+                logline::info(&format!("completed_at_utc: {completed}"));
+            }
+            if let Some(reason) = record.reason.as_deref() {
+                logline::info(&format!("reason: {reason}"));
+            }
+        }
+        None => {
+            let path = update_status_path(install_dir);
+            if as_json {
+                logline::emit_raw("null");
+            } else {
+                logline::info(&format!("No update status record present at {}", path.display()));
+                logline::info(
+                    "The install has not run through a Surge update flow that writes the convergence record yet.",
+                );
+            }
+        }
+    }
+    Ok(())
+}

--- a/crates/surge-cli/src/main.rs
+++ b/crates/surge-cli/src/main.rs
@@ -268,6 +268,8 @@ async fn run(cli: Cli) -> surge_core::error::Result<()> {
             Ok(())
         }
 
+        Commands::Status { install_dir, json } => commands::status::execute(&install_dir, json),
+
         Commands::Install {
             method,
             target,

--- a/crates/surge-core/src/update/manager.rs
+++ b/crates/surge-core/src/update/manager.rs
@@ -28,9 +28,11 @@ use crate::releases::restore::{
 };
 use crate::storage::{StorageBackend, create_storage_backend};
 use crate::supervisor::state::supervisor_pid_file;
+use crate::update::status::{self, UpdateStatusRecord};
 
 use self::apply::materialize_update_payload;
 use self::artifacts::prepare_update_artifacts;
+use self::lifecycle::SupervisorRestartOutcome;
 pub use self::progress::ProgressInfo;
 use self::progress::emit_progress;
 pub use self::release_index::plan_update_from_index;
@@ -212,12 +214,93 @@ impl UpdateManager {
     /// 4. Extract - extract the final archive into the install tree
     /// 5. Apply delta - rebuild the final archive when using delta updates
     /// 6. Finalize - move files into place, clean up
+    ///
+    /// On every attempt this method also writes an explicit convergence record
+    /// to `{install_dir}/.surge-update-status.json` so dashboards and repair
+    /// tooling can distinguish "update in progress", "applied but pending
+    /// supervisor restart", "fully converged", and "failed" without inferring
+    /// state from version drift alone (see [`status`]).
     pub async fn download_and_apply<F>(&self, info: &UpdateInfo, progress: Option<F>) -> Result<()>
     where
         F: Fn(ProgressInfo) + Send + Sync,
     {
-        self.ctx.check_cancelled()?;
+        let attempted_at_utc = status::now_utc_rfc3339();
+        let pre_attempt_version = self.current_version.clone();
+        let target_version = info.latest_version.clone();
+
+        let in_progress_record = UpdateStatusRecord::in_progress(
+            &self.app_id,
+            &pre_attempt_version,
+            &target_version,
+            &self.channel,
+            attempted_at_utc.clone(),
+        );
+        if let Err(e) = status::write_update_status(&self.install_dir, &in_progress_record) {
+            warn!(error = %e, "Failed to persist in-progress update status (continuing)");
+        }
+
         let progress = progress.map(Arc::new);
+        match self.download_and_apply_inner(info, progress).await {
+            Ok(restart_outcome) => {
+                let completed_at_utc = status::now_utc_rfc3339();
+                let record = match restart_outcome {
+                    SupervisorRestartOutcome::NotApplicable => UpdateStatusRecord::converged(
+                        &self.app_id,
+                        &target_version,
+                        &self.channel,
+                        Some(attempted_at_utc),
+                        completed_at_utc,
+                        false,
+                    ),
+                    SupervisorRestartOutcome::Confirmed => UpdateStatusRecord::converged(
+                        &self.app_id,
+                        &target_version,
+                        &self.channel,
+                        Some(attempted_at_utc),
+                        completed_at_utc,
+                        true,
+                    ),
+                    SupervisorRestartOutcome::Unconfirmed { reason } => UpdateStatusRecord::pending_restart(
+                        &self.app_id,
+                        &target_version,
+                        &target_version,
+                        &self.channel,
+                        attempted_at_utc,
+                        completed_at_utc,
+                        &reason,
+                    ),
+                };
+                if let Err(e) = status::write_update_status(&self.install_dir, &record) {
+                    warn!(error = %e, "Failed to persist post-update convergence status (continuing)");
+                }
+                Ok(())
+            }
+            Err(e) => {
+                let record = UpdateStatusRecord::failed(
+                    &self.app_id,
+                    &pre_attempt_version,
+                    &target_version,
+                    &self.channel,
+                    attempted_at_utc,
+                    &e.to_string(),
+                );
+                if let Err(write_err) = status::write_update_status(&self.install_dir, &record) {
+                    warn!(error = %write_err, "Failed to persist failed-update status (continuing)");
+                }
+                Err(e)
+            }
+        }
+    }
+
+    async fn download_and_apply_inner<F>(
+        &self,
+        info: &UpdateInfo,
+        progress: Option<Arc<F>>,
+    ) -> Result<SupervisorRestartOutcome>
+    where
+        F: Fn(ProgressInfo) + Send + Sync,
+    {
+        self.ctx.check_cancelled()?;
 
         // Phase 1: Check
         info!(version = %info.latest_version, "Starting update");
@@ -460,9 +543,11 @@ impl UpdateManager {
 
         lifecycle::invoke_post_update_hook(&self.install_dir, &active_app_dir, latest);
 
-        if supervisor_was_running {
-            lifecycle::restart_supervisor_after_update(&self.install_dir, &active_app_dir, latest);
-        }
+        let restart_outcome = if supervisor_was_running {
+            lifecycle::restart_supervisor_after_update(&self.install_dir, &active_app_dir, latest)
+        } else {
+            SupervisorRestartOutcome::NotApplicable
+        };
 
         emit_progress(
             progress.as_ref(),
@@ -479,7 +564,7 @@ impl UpdateManager {
             "Update applied successfully"
         );
 
-        Ok(())
+        Ok(restart_outcome)
     }
 }
 
@@ -1299,6 +1384,109 @@ mod tests {
         assert!(installed_file.exists());
         assert_eq!(std::fs::read_to_string(installed_file).unwrap(), "installed payload");
         assert!(runtime_manifest.is_file());
+
+        let status = status::read_update_status(&install_root).unwrap().unwrap();
+        assert_eq!(status.state, status::UpdateConvergenceState::Converged);
+        assert_eq!(status.installed_version, "1.1.0");
+        assert_eq!(status.target_version, "1.1.0");
+        assert_eq!(status.channel, "stable");
+        assert_eq!(status.app_id, app_id);
+        assert!(!status.supervisor_restart_confirmed);
+        assert!(status.completed_at_utc.is_some());
+        assert!(status.reason.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_download_and_apply_writes_failed_status_when_storage_artifact_missing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store_root = tmp.path().join("store");
+        let install_root = tmp.path().join("install");
+        let app_id = "test-app";
+        std::fs::create_dir_all(&store_root).unwrap();
+        std::fs::create_dir_all(&install_root).unwrap();
+        let app_store = app_scoped_store_root(&store_root, app_id);
+
+        let rid = current_rid();
+        let full_filename = format!("{app_id}-1.1.0-{rid}-full.tar.zst");
+        let full_path = app_store.join(&full_filename);
+
+        let mut packer = ArchivePacker::new(3).unwrap();
+        packer.add_buffer("payload.txt", b"installed payload", 0o644).unwrap();
+        packer.finalize_to_file(&full_path).unwrap();
+
+        let full_size = std::fs::metadata(&full_path).unwrap().len() as i64;
+        let full_sha256 = sha256_hex_file(&full_path).unwrap();
+
+        let index = ReleaseIndex {
+            app_id: app_id.to_string(),
+            releases: vec![ReleaseEntry {
+                version: "1.1.0".to_string(),
+                channels: vec!["stable".to_string()],
+                os: current_os_label_for_tests(),
+                rid: rid.clone(),
+                is_genesis: true,
+                full_filename: full_filename.clone(),
+                full_size,
+                full_sha256,
+                full_compression_level: 0,
+                full_zstd_workers: 0,
+                deltas: Vec::new(),
+                preferred_delta_id: String::new(),
+                created_utc: chrono::Utc::now().to_rfc3339(),
+                release_notes: String::new(),
+                name: String::new(),
+                main_exe: app_id.to_string(),
+                install_directory: app_id.to_string(),
+                supervisor_id: String::new(),
+                icon: String::new(),
+                shortcuts: Vec::new(),
+                persistent_assets: Vec::new(),
+                installers: Vec::new(),
+                environment: std::collections::BTreeMap::new(),
+            }],
+            ..ReleaseIndex::default()
+        };
+
+        write_app_scoped_release_index(&store_root, app_id, &index);
+
+        let ctx = Arc::new(Context::new());
+        ctx.set_storage(
+            StorageProvider::Filesystem,
+            store_root.to_str().unwrap(),
+            "",
+            "",
+            "",
+            "",
+        );
+
+        let mut manager = UpdateManager::new(ctx, app_id, "1.0.0", "stable", install_root.to_str().unwrap()).unwrap();
+        let info = manager.check_for_updates().await.unwrap().unwrap();
+
+        // Remove the backing artifact so download_and_apply must fail.
+        std::fs::remove_file(&full_path).unwrap();
+
+        let err = manager
+            .download_and_apply(&info, None::<fn(ProgressInfo)>)
+            .await
+            .expect_err("download_and_apply should fail when the full artifact is missing");
+        let err_msg = err.to_string();
+
+        let status_record = status::read_update_status(&install_root).unwrap().unwrap();
+        assert_eq!(status_record.state, status::UpdateConvergenceState::Failed);
+        assert_eq!(
+            status_record.installed_version, "1.0.0",
+            "failed record preserves pre-attempt version"
+        );
+        assert_eq!(status_record.target_version, "1.1.0");
+        assert!(status_record.completed_at_utc.is_none());
+        let reason = status_record
+            .reason
+            .as_deref()
+            .expect("failed status records must include a reason");
+        assert!(
+            reason.contains(&err_msg) || err_msg.contains(reason),
+            "stored reason '{reason}' should match the propagated error '{err_msg}'"
+        );
     }
 
     #[tokio::test]

--- a/crates/surge-core/src/update/manager/lifecycle.rs
+++ b/crates/surge-core/src/update/manager/lifecycle.rs
@@ -7,6 +7,22 @@ use crate::error::{Result, SurgeError};
 use crate::platform::process::{ProcessHandle, current_pid, spawn_detached, spawn_process, supervisor_binary_name};
 use crate::releases::manifest::ReleaseEntry;
 use crate::supervisor::state::{read_restart_args, supervisor_pid_file, supervisor_stop_file};
+use crate::update::status::confirm_supervisor_restart;
+
+const SUPERVISOR_RESTART_CONFIRM_TIMEOUT: Duration = Duration::from_secs(5);
+
+#[derive(Debug, Clone)]
+pub(super) enum SupervisorRestartOutcome {
+    /// No supervisor was configured for this release (or wasn't running before
+    /// the update) so there is no post-update restart to confirm.
+    NotApplicable,
+    /// Supervisor restart was confirmed by observing the supervisor pid file
+    /// within `SUPERVISOR_RESTART_CONFIRM_TIMEOUT` after the spawn.
+    Confirmed,
+    /// Supervisor restart could not be confirmed within the timeout window.
+    /// The reason describes why (spawn failure, missing binary, no pid file).
+    Unconfirmed { reason: String },
+}
 
 pub(super) async fn request_supervisor_shutdown(install_dir: &Path, supervisor_id: &str) -> Result<()> {
     request_supervisor_shutdown_with_timeout(
@@ -122,10 +138,14 @@ fn wait_for_post_update_hook(handle: &mut ProcessHandle, exe_path: &Path) {
     let _ = handle.wait();
 }
 
-pub(super) fn restart_supervisor_after_update(install_dir: &Path, active_app_dir: &Path, latest: &ReleaseEntry) {
+pub(super) fn restart_supervisor_after_update(
+    install_dir: &Path,
+    active_app_dir: &Path,
+    latest: &ReleaseEntry,
+) -> SupervisorRestartOutcome {
     let supervisor_id = latest.supervisor_id.trim();
     if supervisor_id.is_empty() {
-        return;
+        return SupervisorRestartOutcome::NotApplicable;
     }
 
     let supervisor_path = active_app_dir.join(supervisor_binary_name());
@@ -134,7 +154,9 @@ pub(super) fn restart_supervisor_after_update(install_dir: &Path, active_app_dir
             supervisor = %supervisor_path.display(),
             "Cannot restart supervisor after update because the bundled binary is missing"
         );
-        return;
+        return SupervisorRestartOutcome::Unconfirmed {
+            reason: format!("supervisor binary missing at {}", supervisor_path.display()),
+        };
     }
 
     let exe_path = active_app_dir.join(&latest.main_exe);
@@ -143,7 +165,9 @@ pub(super) fn restart_supervisor_after_update(install_dir: &Path, active_app_dir
             exe = %exe_path.display(),
             "Cannot restart supervisor after update because the application executable is missing"
         );
-        return;
+        return SupervisorRestartOutcome::Unconfirmed {
+            reason: format!("application executable missing at {}", exe_path.display()),
+        };
     }
 
     let restart_args = match read_restart_args(install_dir, supervisor_id) {
@@ -187,6 +211,22 @@ pub(super) fn restart_supervisor_after_update(install_dir: &Path, active_app_dir
                 error = %e,
                 "Failed to restart supervisor after update (continuing)"
             );
+            return SupervisorRestartOutcome::Unconfirmed {
+                reason: format!("spawn failed: {e}"),
+            };
+        }
+    }
+
+    if confirm_supervisor_restart(install_dir, supervisor_id, SUPERVISOR_RESTART_CONFIRM_TIMEOUT) {
+        SupervisorRestartOutcome::Confirmed
+    } else {
+        let timeout_ms = u64::try_from(SUPERVISOR_RESTART_CONFIRM_TIMEOUT.as_millis()).unwrap_or(u64::MAX);
+        warn!(
+            supervisor_id,
+            timeout_ms, "Supervisor pid file did not appear after restart within timeout window"
+        );
+        SupervisorRestartOutcome::Unconfirmed {
+            reason: format!("supervisor pid file did not appear within {timeout_ms}ms after restart"),
         }
     }
 }

--- a/crates/surge-core/src/update/mod.rs
+++ b/crates/surge-core/src/update/mod.rs
@@ -1,1 +1,2 @@
 pub mod manager;
+pub mod status;

--- a/crates/surge-core/src/update/status.rs
+++ b/crates/surge-core/src/update/status.rs
@@ -1,0 +1,398 @@
+//! Explicit update convergence state recorded per install root.
+//!
+//! After a channel promotion, operators need a reliable signal that distinguishes:
+//! - **`Idle`** — the install completed but no update has been attempted since.
+//! - **`InProgress`** — an update is currently being applied.
+//! - **`Converged`** — the latest update applied to disk and the supervisor restart
+//!   (or the install-time auto-start) was confirmed by observing the supervisor pid
+//!   file.
+//! - **`PendingRestart`** — the latest update applied to disk but the supervisor
+//!   restart could not be confirmed within the post-update window. The runtime
+//!   process may still be running an older binary even though `installed_version`
+//!   already reflects the new release.
+//! - **`Failed`** — the most recent attempt failed before the install swap could
+//!   complete. The `installed_version` field reflects the pre-attempt state.
+//!
+//! This record is persisted at `{install_dir}/.surge-update-status.json` so it
+//! survives the active app directory swap that happens on every successful update.
+
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::{Result, SurgeError};
+use crate::platform::fs::write_file_atomic;
+use crate::supervisor::state::supervisor_pid_file;
+
+pub const UPDATE_STATUS_FILE_NAME: &str = ".surge-update-status.json";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum UpdateConvergenceState {
+    Idle,
+    InProgress,
+    Converged,
+    PendingRestart,
+    Failed,
+}
+
+impl UpdateConvergenceState {
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            UpdateConvergenceState::Idle => "idle",
+            UpdateConvergenceState::InProgress => "in_progress",
+            UpdateConvergenceState::Converged => "converged",
+            UpdateConvergenceState::PendingRestart => "pending_restart",
+            UpdateConvergenceState::Failed => "failed",
+        }
+    }
+}
+
+impl std::fmt::Display for UpdateConvergenceState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// A point-in-time snapshot of the install's convergence to a channel release.
+///
+/// `installed_version` always reflects what is on disk in the active app
+/// directory at the time the record was written. `target_version` is the
+/// version the most recent update attempt was trying to reach. For `Converged`
+/// records the two are equal; for `Failed` records `installed_version` is the
+/// pre-attempt version; for `PendingRestart` records `installed_version` is
+/// already the new release even though the runtime process may not yet be.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct UpdateStatusRecord {
+    pub state: UpdateConvergenceState,
+    pub installed_version: String,
+    pub target_version: String,
+    pub channel: String,
+    pub app_id: String,
+    /// True when a supervisor was configured for this release and its pid file
+    /// was observed after the post-update restart, or when no supervisor was
+    /// configured (in which case there is nothing to restart and the field
+    /// carries no signal).
+    pub supervisor_restart_confirmed: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub attempted_at_utc: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub completed_at_utc: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+impl UpdateStatusRecord {
+    #[must_use]
+    pub fn idle(app_id: &str, installed_version: &str, channel: &str) -> Self {
+        Self {
+            state: UpdateConvergenceState::Idle,
+            installed_version: installed_version.to_string(),
+            target_version: installed_version.to_string(),
+            channel: channel.to_string(),
+            app_id: app_id.to_string(),
+            supervisor_restart_confirmed: false,
+            attempted_at_utc: None,
+            completed_at_utc: None,
+            reason: None,
+        }
+    }
+
+    #[must_use]
+    pub fn in_progress(
+        app_id: &str,
+        installed_version: &str,
+        target_version: &str,
+        channel: &str,
+        attempted_at_utc: String,
+    ) -> Self {
+        Self {
+            state: UpdateConvergenceState::InProgress,
+            installed_version: installed_version.to_string(),
+            target_version: target_version.to_string(),
+            channel: channel.to_string(),
+            app_id: app_id.to_string(),
+            supervisor_restart_confirmed: false,
+            attempted_at_utc: Some(attempted_at_utc),
+            completed_at_utc: None,
+            reason: None,
+        }
+    }
+
+    #[must_use]
+    pub fn converged(
+        app_id: &str,
+        version: &str,
+        channel: &str,
+        attempted_at_utc: Option<String>,
+        completed_at_utc: String,
+        supervisor_restart_confirmed: bool,
+    ) -> Self {
+        Self {
+            state: UpdateConvergenceState::Converged,
+            installed_version: version.to_string(),
+            target_version: version.to_string(),
+            channel: channel.to_string(),
+            app_id: app_id.to_string(),
+            supervisor_restart_confirmed,
+            attempted_at_utc,
+            completed_at_utc: Some(completed_at_utc),
+            reason: None,
+        }
+    }
+
+    #[must_use]
+    pub fn pending_restart(
+        app_id: &str,
+        installed_version: &str,
+        target_version: &str,
+        channel: &str,
+        attempted_at_utc: String,
+        completed_at_utc: String,
+        reason: &str,
+    ) -> Self {
+        Self {
+            state: UpdateConvergenceState::PendingRestart,
+            installed_version: installed_version.to_string(),
+            target_version: target_version.to_string(),
+            channel: channel.to_string(),
+            app_id: app_id.to_string(),
+            supervisor_restart_confirmed: false,
+            attempted_at_utc: Some(attempted_at_utc),
+            completed_at_utc: Some(completed_at_utc),
+            reason: Some(reason.to_string()),
+        }
+    }
+
+    #[must_use]
+    pub fn failed(
+        app_id: &str,
+        installed_version: &str,
+        target_version: &str,
+        channel: &str,
+        attempted_at_utc: String,
+        reason: &str,
+    ) -> Self {
+        Self {
+            state: UpdateConvergenceState::Failed,
+            installed_version: installed_version.to_string(),
+            target_version: target_version.to_string(),
+            channel: channel.to_string(),
+            app_id: app_id.to_string(),
+            supervisor_restart_confirmed: false,
+            attempted_at_utc: Some(attempted_at_utc),
+            completed_at_utc: None,
+            reason: Some(reason.to_string()),
+        }
+    }
+}
+
+#[must_use]
+pub fn update_status_path(install_dir: &Path) -> PathBuf {
+    install_dir.join(UPDATE_STATUS_FILE_NAME)
+}
+
+/// Read the persisted update status record from `install_dir`, if any.
+///
+/// Returns `Ok(None)` when no record has been written yet (clean install that
+/// happened before this signal existed, or never converged through an update
+/// flow that writes the file).
+pub fn read_update_status(install_dir: &Path) -> Result<Option<UpdateStatusRecord>> {
+    let path = update_status_path(install_dir);
+    if !path.is_file() {
+        return Ok(None);
+    }
+    let raw = std::fs::read(&path)?;
+    serde_json::from_slice(&raw)
+        .map(Some)
+        .map_err(|e| SurgeError::Config(format!("Failed to decode {}: {e}", path.display())))
+}
+
+pub fn write_update_status(install_dir: &Path, record: &UpdateStatusRecord) -> Result<()> {
+    let path = update_status_path(install_dir);
+    let json = serde_json::to_vec_pretty(record)
+        .map_err(|e| SurgeError::Config(format!("Failed to encode update status: {e}")))?;
+    write_file_atomic(&path, &json)?;
+    Ok(())
+}
+
+#[must_use]
+pub fn now_utc_rfc3339() -> String {
+    chrono::Utc::now().to_rfc3339()
+}
+
+/// Poll for the supervisor pid file to appear after a restart attempt.
+///
+/// Returns `true` if the pid file is present and parses as a non-zero PID
+/// within the timeout window, `false` otherwise. An empty `supervisor_id`
+/// means there is no supervisor to confirm; the caller is responsible for
+/// deciding what that implies for the convergence state.
+#[must_use]
+pub fn confirm_supervisor_restart(install_dir: &Path, supervisor_id: &str, timeout: Duration) -> bool {
+    let supervisor_id = supervisor_id.trim();
+    if supervisor_id.is_empty() {
+        return false;
+    }
+
+    let pid_file = supervisor_pid_file(install_dir, supervisor_id);
+    let deadline = Instant::now() + timeout;
+    let poll_interval = Duration::from_millis(100);
+    loop {
+        if let Ok(contents) = std::fs::read_to_string(&pid_file)
+            && contents.trim().parse::<u32>().is_ok_and(|pid| pid > 0)
+        {
+            return true;
+        }
+        if Instant::now() >= deadline {
+            return false;
+        }
+        std::thread::sleep(poll_interval);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trip_converged_record() {
+        let dir = tempfile::tempdir().unwrap();
+        let record = UpdateStatusRecord::converged(
+            "demo-app",
+            "9999.0.0",
+            "stable",
+            Some("2026-05-11T14:00:00Z".to_string()),
+            "2026-05-11T14:05:00Z".to_string(),
+            true,
+        );
+
+        write_update_status(dir.path(), &record).unwrap();
+        let loaded = read_update_status(dir.path()).unwrap().unwrap();
+
+        assert_eq!(loaded, record);
+        assert_eq!(loaded.state, UpdateConvergenceState::Converged);
+        assert_eq!(loaded.installed_version, "9999.0.0");
+        assert!(loaded.supervisor_restart_confirmed);
+    }
+
+    #[test]
+    fn round_trip_pending_restart_record() {
+        let dir = tempfile::tempdir().unwrap();
+        let record = UpdateStatusRecord::pending_restart(
+            "demo-app",
+            "9999.0.0",
+            "9999.0.0",
+            "stable",
+            "2026-05-11T14:00:00Z".to_string(),
+            "2026-05-11T14:05:00Z".to_string(),
+            "supervisor pid file never appeared after restart",
+        );
+
+        write_update_status(dir.path(), &record).unwrap();
+        let loaded = read_update_status(dir.path()).unwrap().unwrap();
+
+        assert_eq!(loaded.state, UpdateConvergenceState::PendingRestart);
+        assert!(!loaded.supervisor_restart_confirmed);
+        assert!(loaded.reason.as_deref().unwrap().contains("supervisor pid"));
+    }
+
+    #[test]
+    fn round_trip_failed_record_preserves_pre_attempt_version() {
+        let dir = tempfile::tempdir().unwrap();
+        let record = UpdateStatusRecord::failed(
+            "demo-app",
+            "9998.0.0",
+            "9999.0.0",
+            "stable",
+            "2026-05-11T14:00:00Z".to_string(),
+            "storage backend returned 503",
+        );
+
+        write_update_status(dir.path(), &record).unwrap();
+        let loaded = read_update_status(dir.path()).unwrap().unwrap();
+
+        assert_eq!(loaded.state, UpdateConvergenceState::Failed);
+        assert_eq!(loaded.installed_version, "9998.0.0");
+        assert_eq!(loaded.target_version, "9999.0.0");
+        assert!(loaded.completed_at_utc.is_none());
+    }
+
+    #[test]
+    fn read_returns_none_when_file_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(read_update_status(dir.path()).unwrap().is_none());
+    }
+
+    #[test]
+    fn write_overwrites_existing_record() {
+        let dir = tempfile::tempdir().unwrap();
+        let in_progress = UpdateStatusRecord::in_progress(
+            "demo-app",
+            "9998.0.0",
+            "9999.0.0",
+            "stable",
+            "2026-05-11T14:00:00Z".to_string(),
+        );
+        write_update_status(dir.path(), &in_progress).unwrap();
+
+        let converged = UpdateStatusRecord::converged(
+            "demo-app",
+            "9999.0.0",
+            "stable",
+            Some("2026-05-11T14:00:00Z".to_string()),
+            "2026-05-11T14:05:00Z".to_string(),
+            true,
+        );
+        write_update_status(dir.path(), &converged).unwrap();
+
+        let loaded = read_update_status(dir.path()).unwrap().unwrap();
+        assert_eq!(loaded.state, UpdateConvergenceState::Converged);
+        assert_eq!(loaded.installed_version, "9999.0.0");
+    }
+
+    #[test]
+    fn confirm_supervisor_restart_detects_fresh_pid_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let pid_file = supervisor_pid_file(dir.path(), "demo-supervisor");
+        std::fs::write(&pid_file, "12345").unwrap();
+
+        let confirmed = confirm_supervisor_restart(dir.path(), "demo-supervisor", Duration::from_millis(200));
+        assert!(confirmed);
+    }
+
+    #[test]
+    fn confirm_supervisor_restart_times_out_when_pid_file_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let confirmed = confirm_supervisor_restart(dir.path(), "demo-supervisor", Duration::from_millis(200));
+        assert!(!confirmed);
+    }
+
+    #[test]
+    fn confirm_supervisor_restart_returns_false_when_supervisor_id_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(!confirm_supervisor_restart(dir.path(), "", Duration::from_millis(200)));
+        assert!(!confirm_supervisor_restart(
+            dir.path(),
+            "   ",
+            Duration::from_millis(200)
+        ));
+    }
+
+    #[test]
+    fn convergence_state_as_str_round_trips_through_serde() {
+        for state in [
+            UpdateConvergenceState::Idle,
+            UpdateConvergenceState::InProgress,
+            UpdateConvergenceState::Converged,
+            UpdateConvergenceState::PendingRestart,
+            UpdateConvergenceState::Failed,
+        ] {
+            let encoded = serde_json::to_string(&state).unwrap();
+            let decoded: UpdateConvergenceState = serde_json::from_str(&encoded).unwrap();
+            assert_eq!(decoded, state);
+            assert_eq!(state.to_string(), state.as_str());
+        }
+    }
+}

--- a/crates/surge-ffi/Cargo.toml
+++ b/crates/surge-ffi/Cargo.toml
@@ -11,6 +11,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 surge-core = { workspace = true }
+serde_json = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/crates/surge-ffi/src/lib.rs
+++ b/crates/surge-ffi/src/lib.rs
@@ -50,6 +50,7 @@ pub use crate::update::{
     surge_update_check, surge_update_download_and_apply, surge_update_manager_create, surge_update_manager_destroy,
     surge_update_manager_set_artifact_retention_policy, surge_update_manager_set_channel,
     surge_update_manager_set_current_version, surge_update_manager_set_release_retention_limit,
+    surge_update_status_read_json,
 };
 use crate::utils::to_lossy_cstring;
 
@@ -421,4 +422,18 @@ pub unsafe extern "C" fn surge_cancel(ctx: *mut SurgeContextHandle) -> i32 {
         handle.ctx.cancel();
         SURGE_OK
     }))
+}
+
+// =========================================================================
+//  11. Allocator (1 function)
+// =========================================================================
+
+/// Free a NUL-terminated C string that was returned by a Surge FFI call which
+/// documents its output as `free()`-owned (for example
+/// `surge_update_status_read_json`). Safe to call with NULL.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn surge_free_cstring(ptr: *mut c_char) {
+    // SAFETY: caller guarantees `ptr` was returned by a Surge FFI function
+    // documented as `free()`-owned, or is null.
+    unsafe { crate::shared::libc_free(ptr.cast::<c_void>()) };
 }

--- a/crates/surge-ffi/src/shared.rs
+++ b/crates/surge-ffi/src/shared.rs
@@ -170,6 +170,24 @@ pub(crate) fn libc_malloc(size: usize) -> *mut u8 {
     unsafe { malloc(size).cast::<u8>() }
 }
 
+/// Counterpart to [`libc_malloc`]: frees a pointer returned by any Surge FFI
+/// function that documents its output as `free()`-owned.
+///
+/// # Safety
+/// `ptr` must have been returned by a Surge FFI call that allocated via
+/// [`libc_malloc`], or must be null. Passing a pointer that was allocated by a
+/// different allocator (e.g. .NET `Marshal.AllocHGlobal`) is undefined behavior.
+pub(crate) unsafe fn libc_free(ptr: *mut c_void) {
+    unsafe extern "C" {
+        fn free(ptr: *mut c_void);
+    }
+    if ptr.is_null() {
+        return;
+    }
+    // SAFETY: caller guarantees `ptr` came from libc `malloc`.
+    unsafe { free(ptr) };
+}
+
 #[cfg(test)]
 mod tests {
     use std::ffi::CString;

--- a/crates/surge-ffi/src/update.rs
+++ b/crates/surge-ffi/src/update.rs
@@ -354,6 +354,73 @@ pub unsafe extern "C" fn surge_update_download_and_apply(
     }))
 }
 
+/// Read the persisted update convergence record from `install_dir` as JSON.
+///
+/// On `SURGE_OK`, `*json_out` is set to a `malloc()`-allocated, NUL-terminated
+/// UTF-8 JSON string that the caller must free with `free()`. On
+/// `SURGE_NOT_FOUND` no status record has been written for this install yet
+/// (clean install, or no update has been attempted) and `*json_out` is set to
+/// NULL. On `SURGE_ERROR` reading or decoding failed; `*json_out` is NULL.
+///
+/// The JSON schema matches [`surge_core::update::status::UpdateStatusRecord`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn surge_update_status_read_json(install_dir: *const c_char, json_out: *mut *mut c_char) -> i32 {
+    if json_out.is_null() {
+        return SURGE_ERROR;
+    }
+    // SAFETY: `json_out` is checked non-null above; clear it before any work.
+    unsafe {
+        *json_out = ptr::null_mut();
+    }
+
+    if install_dir.is_null() {
+        return SURGE_ERROR;
+    }
+
+    catch_ffi(std::panic::AssertUnwindSafe(|| {
+        // SAFETY: `install_dir` follows the nullable C string contract; the
+        // out pointer was cleared above.
+        let install_dir_s = unsafe { cstr_to_string(install_dir) };
+        if install_dir_s.trim().is_empty() {
+            return SURGE_ERROR;
+        }
+
+        let install_path = std::path::Path::new(&install_dir_s);
+        let record = match surge_core::update::status::read_update_status(install_path) {
+            Ok(Some(record)) => record,
+            Ok(None) => return SURGE_NOT_FOUND,
+            Err(e) => {
+                tracing::error!("surge_update_status_read_json failed: {e}");
+                return SURGE_ERROR;
+            }
+        };
+
+        let json = match serde_json::to_string(&record) {
+            Ok(json) => json,
+            Err(e) => {
+                tracing::error!("surge_update_status_read_json encode failed: {e}");
+                return SURGE_ERROR;
+            }
+        };
+
+        let c_json = match std::ffi::CString::new(json) {
+            Ok(cs) => cs,
+            Err(_) => return SURGE_ERROR,
+        };
+        let bytes = c_json.as_bytes_with_nul();
+        let buf = crate::shared::libc_malloc(bytes.len()).cast::<c_char>();
+        if buf.is_null() {
+            return SURGE_ERROR;
+        }
+        // SAFETY: `buf` points to `bytes.len()` writable bytes from malloc.
+        unsafe {
+            ptr::copy_nonoverlapping(bytes.as_ptr().cast::<c_char>(), buf, bytes.len());
+            *json_out = buf;
+        }
+        SURGE_OK
+    }))
+}
+
 #[cfg(test)]
 mod tests {
     use std::ffi::{CStr, CString};

--- a/dotnet/Surge.NET.Tests/SurgeUpdateStatusTests.cs
+++ b/dotnet/Surge.NET.Tests/SurgeUpdateStatusTests.cs
@@ -1,0 +1,132 @@
+using Xunit;
+
+namespace Surge.Tests
+{
+    public class SurgeUpdateStatusTests
+    {
+        [Fact]
+        public void Parse_ConvergedRecord_RoundTrip()
+        {
+            const string json = """
+                {
+                  "state": "converged",
+                  "installed_version": "9999.0.0",
+                  "target_version": "9999.0.0",
+                  "channel": "stable",
+                  "app_id": "demo-app",
+                  "supervisor_restart_confirmed": true,
+                  "attempted_at_utc": "2026-05-11T14:00:00Z",
+                  "completed_at_utc": "2026-05-11T14:05:00Z"
+                }
+                """;
+
+            var status = SurgeUpdateStatus.Parse(json);
+            Assert.NotNull(status);
+            Assert.Equal(SurgeUpdateConvergenceState.Converged, status!.State);
+            Assert.Equal("9999.0.0", status.InstalledVersion);
+            Assert.Equal("9999.0.0", status.TargetVersion);
+            Assert.Equal("stable", status.Channel);
+            Assert.Equal("demo-app", status.AppId);
+            Assert.True(status.SupervisorRestartConfirmed);
+            Assert.Equal("2026-05-11T14:00:00Z", status.AttemptedAtUtc);
+            Assert.Equal("2026-05-11T14:05:00Z", status.CompletedAtUtc);
+            Assert.Null(status.Reason);
+        }
+
+        [Fact]
+        public void Parse_PendingRestart_PreservesReason()
+        {
+            const string json = """
+                {
+                  "state": "pending_restart",
+                  "installed_version": "9999.0.0",
+                  "target_version": "9999.0.0",
+                  "channel": "stable",
+                  "app_id": "demo-app",
+                  "supervisor_restart_confirmed": false,
+                  "attempted_at_utc": "2026-05-11T14:00:00Z",
+                  "completed_at_utc": "2026-05-11T14:05:00Z",
+                  "reason": "supervisor pid file did not appear within 5000ms after restart"
+                }
+                """;
+
+            var status = SurgeUpdateStatus.Parse(json);
+            Assert.NotNull(status);
+            Assert.Equal(SurgeUpdateConvergenceState.PendingRestart, status!.State);
+            Assert.False(status.SupervisorRestartConfirmed);
+            Assert.Contains("supervisor pid file did not appear", status.Reason);
+        }
+
+        [Fact]
+        public void Parse_FailedRecord_PreservesPreAttemptVersion()
+        {
+            const string json = """
+                {
+                  "state": "failed",
+                  "installed_version": "9998.0.0",
+                  "target_version": "9999.0.0",
+                  "channel": "stable",
+                  "app_id": "demo-app",
+                  "supervisor_restart_confirmed": false,
+                  "attempted_at_utc": "2026-05-11T14:00:00Z",
+                  "reason": "storage backend returned 503"
+                }
+                """;
+
+            var status = SurgeUpdateStatus.Parse(json);
+            Assert.NotNull(status);
+            Assert.Equal(SurgeUpdateConvergenceState.Failed, status!.State);
+            Assert.Equal("9998.0.0", status.InstalledVersion);
+            Assert.Equal("9999.0.0", status.TargetVersion);
+            Assert.Null(status.CompletedAtUtc);
+            Assert.Equal("storage backend returned 503", status.Reason);
+        }
+
+        [Fact]
+        public void Parse_UnknownState_DoesNotThrow()
+        {
+            const string json = """
+                {
+                  "state": "something_brand_new",
+                  "installed_version": "1.0.0",
+                  "target_version": "1.0.0",
+                  "channel": "stable",
+                  "app_id": "demo-app",
+                  "supervisor_restart_confirmed": false
+                }
+                """;
+
+            var status = SurgeUpdateStatus.Parse(json);
+            Assert.NotNull(status);
+            Assert.Equal(SurgeUpdateConvergenceState.Unknown, status!.State);
+        }
+
+        [Fact]
+        public void Parse_DecodesEscapeSequencesInReason()
+        {
+            const string json = """
+                {
+                  "state": "failed",
+                  "installed_version": "1.0.0",
+                  "target_version": "1.0.0",
+                  "channel": "stable",
+                  "app_id": "demo-app",
+                  "supervisor_restart_confirmed": false,
+                  "reason": "broke at \"phase 5\"\nretry pending"
+                }
+                """;
+
+            var status = SurgeUpdateStatus.Parse(json);
+            Assert.NotNull(status);
+            Assert.Equal("broke at \"phase 5\"\nretry pending", status!.Reason);
+        }
+
+        [Fact]
+        public void Parse_RejectsMalformedJson()
+        {
+            Assert.Null(SurgeUpdateStatus.Parse("{not json"));
+            Assert.Null(SurgeUpdateStatus.Parse(""));
+            Assert.Null(SurgeUpdateStatus.Parse("[]"));
+        }
+    }
+}

--- a/dotnet/Surge.NET/NativeMethods.cs
+++ b/dotnet/Surge.NET/NativeMethods.cs
@@ -123,6 +123,12 @@ namespace Surge
             SurgeProgressCallbackDelegate? progressCb,
             IntPtr userData);
 
+        [LibraryImport(LibName, EntryPoint = "surge_update_status_read_json", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int UpdateStatusReadJson(string installDir, out IntPtr jsonOut);
+
+        [LibraryImport(LibName, EntryPoint = "surge_free_cstring")]
+        internal static partial void FreeCString(IntPtr ptr);
+
         // --- Releases info accessors ---
 
         [LibraryImport(LibName, EntryPoint = "surge_releases_count")]
@@ -287,6 +293,12 @@ namespace Surge
             IntPtr info,
             SurgeProgressCallbackDelegate? progressCb,
             IntPtr userData);
+
+        [DllImport(LibName, EntryPoint = "surge_update_status_read_json", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+        internal static extern int UpdateStatusReadJson(string installDir, out IntPtr jsonOut);
+
+        [DllImport(LibName, EntryPoint = "surge_free_cstring", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern void FreeCString(IntPtr ptr);
 
         // --- Releases info accessors ---
 

--- a/dotnet/Surge.NET/SurgeApp.cs
+++ b/dotnet/Surge.NET/SurgeApp.cs
@@ -51,6 +51,26 @@ namespace Surge
         public static string WorkingDirectory => GetWorkingDirectory();
 
         /// <summary>
+        /// Most recently persisted update convergence record for the currently
+        /// installed application, or null when there is no Surge-managed
+        /// installation or no record has been written yet.
+        ///
+        /// Use this to distinguish "installed and converged", "applied but
+        /// pending supervisor restart", and "update failed" without inferring
+        /// the state from version drift alone (see <see cref="SurgeUpdateConvergenceState"/>).
+        /// </summary>
+        public static SurgeUpdateStatus? LastUpdateStatus
+        {
+            get
+            {
+                var current = Current;
+                if (current == null || string.IsNullOrWhiteSpace(current.InstallDirectory))
+                    return null;
+                return SurgeUpdateStatus.Read(current.InstallDirectory);
+            }
+        }
+
+        /// <summary>
         /// The Surge library version.
         /// </summary>
         public static string Version => "0.1.0";

--- a/dotnet/Surge.NET/SurgeUpdateManager.cs
+++ b/dotnet/Surge.NET/SurgeUpdateManager.cs
@@ -157,6 +157,25 @@ namespace Surge
         public string CurrentVersion => _currentVersion;
 
         /// <summary>
+        /// Read the most recently persisted update convergence record for this
+        /// installation. Returns null when no record has been written yet (e.g.
+        /// the install has never run through an update flow).
+        ///
+        /// This is the structured signal that distinguishes "in progress",
+        /// "applied but pending supervisor restart", "fully converged", and
+        /// "failed" so dashboards and repair tooling do not have to infer the
+        /// state from version drift alone.
+        /// </summary>
+        public SurgeUpdateStatus? GetCurrentStatus()
+        {
+            ThrowIfDisposed();
+            var appInfo = SurgeApp.Current;
+            if (appInfo == null || string.IsNullOrWhiteSpace(appInfo.InstallDirectory))
+                return null;
+            return SurgeUpdateStatus.Read(appInfo.InstallDirectory);
+        }
+
+        /// <summary>
         /// Switch update channel at runtime (for example, from production to test).
         /// </summary>
         /// <param name="channel">Target channel name.</param>

--- a/dotnet/Surge.NET/SurgeUpdateStatus.cs
+++ b/dotnet/Surge.NET/SurgeUpdateStatus.cs
@@ -1,0 +1,343 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace Surge
+{
+    /// <summary>
+    /// Convergence state recorded by <see cref="SurgeUpdateManager"/> after every
+    /// update attempt. Use this to distinguish "update in progress", "applied but
+    /// pending supervisor restart", "fully converged", and "failed" without
+    /// having to infer the state from version drift between the installed
+    /// manifest and the running process.
+    /// </summary>
+    public enum SurgeUpdateConvergenceState
+    {
+        /// <summary>State could not be classified (record predates this enum).</summary>
+        Unknown,
+        /// <summary>Install completed but no update has been attempted yet.</summary>
+        Idle,
+        /// <summary>An update is currently being applied.</summary>
+        InProgress,
+        /// <summary>
+        /// Latest update applied to disk and the supervisor restart was confirmed
+        /// by observing the supervisor pid file.
+        /// </summary>
+        Converged,
+        /// <summary>
+        /// Latest update applied to disk but the supervisor restart could not be
+        /// confirmed within the post-update window. The runtime process may still
+        /// be running an older binary even though
+        /// <see cref="SurgeUpdateStatus.InstalledVersion"/> already reflects the
+        /// new release.
+        /// </summary>
+        PendingRestart,
+        /// <summary>
+        /// Most recent attempt failed before the install swap could complete.
+        /// <see cref="SurgeUpdateStatus.InstalledVersion"/> reflects the
+        /// pre-attempt state.
+        /// </summary>
+        Failed,
+    }
+
+    /// <summary>
+    /// A point-in-time snapshot of the install's convergence to a channel
+    /// release. Read via <see cref="SurgeUpdateStatus.Read(string)"/> or
+    /// <see cref="SurgeUpdateManager.GetCurrentStatus"/>.
+    /// </summary>
+    public sealed class SurgeUpdateStatus
+    {
+        /// <summary>Convergence state at the time the record was written.</summary>
+        public SurgeUpdateConvergenceState State { get; init; }
+
+        /// <summary>Application identifier the record was written for.</summary>
+        public string AppId { get; init; } = "";
+
+        /// <summary>
+        /// Version present in the active app directory at the time the record
+        /// was written. For <see cref="SurgeUpdateConvergenceState.Failed"/>
+        /// records this is the pre-attempt version; for
+        /// <see cref="SurgeUpdateConvergenceState.PendingRestart"/> records this
+        /// is the new release even though the runtime process may not be.
+        /// </summary>
+        public string InstalledVersion { get; init; } = "";
+
+        /// <summary>
+        /// Version that the most recent update attempt targeted. Equal to
+        /// <see cref="InstalledVersion"/> for converged records.
+        /// </summary>
+        public string TargetVersion { get; init; } = "";
+
+        /// <summary>Channel the install is tracking.</summary>
+        public string Channel { get; init; } = "";
+
+        /// <summary>
+        /// True when a supervisor was configured for this release and its pid
+        /// file was observed after the post-update restart. When no supervisor
+        /// was configured this is false and carries no signal — read
+        /// <see cref="State"/> for convergence.
+        /// </summary>
+        public bool SupervisorRestartConfirmed { get; init; }
+
+        /// <summary>UTC timestamp (RFC 3339) the attempt began, if known.</summary>
+        public string? AttemptedAtUtc { get; init; }
+
+        /// <summary>UTC timestamp (RFC 3339) the attempt completed, if known.</summary>
+        public string? CompletedAtUtc { get; init; }
+
+        /// <summary>
+        /// Human-readable reason for <see cref="SurgeUpdateConvergenceState.Failed"/>
+        /// and <see cref="SurgeUpdateConvergenceState.PendingRestart"/> records.
+        /// </summary>
+        public string? Reason { get; init; }
+
+        /// <summary>
+        /// Read the persisted update convergence record from <paramref name="installDirectory"/>.
+        /// Returns <c>null</c> when no record has been written yet (e.g. clean
+        /// install that has never run an update).
+        /// </summary>
+        public static SurgeUpdateStatus? Read(string installDirectory)
+        {
+            if (string.IsNullOrWhiteSpace(installDirectory))
+                throw new ArgumentException("Install directory must be provided.", nameof(installDirectory));
+
+            int rc = NativeMethods.UpdateStatusReadJson(installDirectory, out IntPtr jsonPtr);
+            try
+            {
+                if (rc != 0 || jsonPtr == IntPtr.Zero)
+                    return null;
+
+                string? json = MarshalUtf8(jsonPtr);
+                if (string.IsNullOrWhiteSpace(json))
+                    return null;
+                return Parse(json!);
+            }
+            finally
+            {
+                if (jsonPtr != IntPtr.Zero)
+                    NativeMethods.FreeCString(jsonPtr);
+            }
+        }
+
+        /// <summary>
+        /// Parse a JSON record written by surge-core's <c>update::status</c>
+        /// module. Exposed for tests; production code should use
+        /// <see cref="Read(string)"/>.
+        /// </summary>
+        internal static SurgeUpdateStatus? Parse(string json)
+        {
+            var fields = ParseFlatJsonObject(json);
+            if (fields == null)
+                return null;
+
+            return new SurgeUpdateStatus
+            {
+                State = ParseState(GetString(fields, "state")),
+                AppId = GetString(fields, "app_id") ?? "",
+                InstalledVersion = GetString(fields, "installed_version") ?? "",
+                TargetVersion = GetString(fields, "target_version") ?? "",
+                Channel = GetString(fields, "channel") ?? "",
+                SupervisorRestartConfirmed = GetBool(fields, "supervisor_restart_confirmed"),
+                AttemptedAtUtc = NullIfEmpty(GetString(fields, "attempted_at_utc")),
+                CompletedAtUtc = NullIfEmpty(GetString(fields, "completed_at_utc")),
+                Reason = NullIfEmpty(GetString(fields, "reason")),
+            };
+        }
+
+        private static SurgeUpdateConvergenceState ParseState(string? raw)
+        {
+            return (raw ?? "").Trim() switch
+            {
+                "idle" => SurgeUpdateConvergenceState.Idle,
+                "in_progress" => SurgeUpdateConvergenceState.InProgress,
+                "converged" => SurgeUpdateConvergenceState.Converged,
+                "pending_restart" => SurgeUpdateConvergenceState.PendingRestart,
+                "failed" => SurgeUpdateConvergenceState.Failed,
+                _ => SurgeUpdateConvergenceState.Unknown,
+            };
+        }
+
+        private static string? NullIfEmpty(string? value) => string.IsNullOrWhiteSpace(value) ? null : value;
+
+        private static string? GetString(Dictionary<string, JsonValue> fields, string key)
+        {
+            return fields.TryGetValue(key, out var value) && value.Kind == JsonValueKind.String ? value.StringValue : null;
+        }
+
+        private static bool GetBool(Dictionary<string, JsonValue> fields, string key)
+        {
+            return fields.TryGetValue(key, out var value) && value.Kind == JsonValueKind.Bool && value.BoolValue;
+        }
+
+        private static string? MarshalUtf8(IntPtr ptr)
+        {
+#if NETSTANDARD2_0
+            return MarshalHelper.PtrToStringUTF8(ptr);
+#else
+            return Marshal.PtrToStringUTF8(ptr);
+#endif
+        }
+
+        // ----------------------------------------------------------------------
+        // Tiny hand-written JSON parser for one shallow object with string/bool
+        // values. Keeps the .NET wrapper free of System.Text.Json package and
+        // AOT/trim warnings while matching the schema written by surge-core's
+        // update::status module exactly.
+        // ----------------------------------------------------------------------
+
+        private enum JsonValueKind { Null, String, Bool }
+
+        private readonly struct JsonValue
+        {
+            public JsonValueKind Kind { get; }
+            public string? StringValue { get; }
+            public bool BoolValue { get; }
+
+            public static readonly JsonValue Null = new JsonValue(JsonValueKind.Null, null, false);
+            public static JsonValue OfString(string s) => new JsonValue(JsonValueKind.String, s, false);
+            public static JsonValue OfBool(bool b) => new JsonValue(JsonValueKind.Bool, null, b);
+
+            private JsonValue(JsonValueKind kind, string? stringValue, bool boolValue)
+            {
+                Kind = kind;
+                StringValue = stringValue;
+                BoolValue = boolValue;
+            }
+        }
+
+        private static Dictionary<string, JsonValue>? ParseFlatJsonObject(string json)
+        {
+            var dict = new Dictionary<string, JsonValue>(StringComparer.Ordinal);
+            int i = 0;
+            if (!SkipWhitespace(json, ref i) || i >= json.Length || json[i] != '{')
+                return null;
+            i++;
+
+            while (true)
+            {
+                if (!SkipWhitespace(json, ref i))
+                    return null;
+                if (i >= json.Length)
+                    return null;
+                if (json[i] == '}') { i++; break; }
+
+                if (!TryReadString(json, ref i, out string key))
+                    return null;
+                if (!SkipWhitespace(json, ref i) || i >= json.Length || json[i] != ':')
+                    return null;
+                i++;
+                if (!SkipWhitespace(json, ref i) || i >= json.Length)
+                    return null;
+
+                JsonValue value;
+                if (json[i] == '"')
+                {
+                    if (!TryReadString(json, ref i, out string sv))
+                        return null;
+                    value = JsonValue.OfString(sv);
+                }
+                else if (TryReadKeyword(json, ref i, "true"))
+                    value = JsonValue.OfBool(true);
+                else if (TryReadKeyword(json, ref i, "false"))
+                    value = JsonValue.OfBool(false);
+                else if (TryReadKeyword(json, ref i, "null"))
+                    value = JsonValue.Null;
+                else
+                    return null;
+
+                dict[key] = value;
+
+                if (!SkipWhitespace(json, ref i) || i >= json.Length)
+                    return null;
+                if (json[i] == ',') { i++; continue; }
+                if (json[i] == '}') { i++; break; }
+                return null;
+            }
+
+            return dict;
+        }
+
+        private static bool SkipWhitespace(string s, ref int i)
+        {
+            while (i < s.Length)
+            {
+                char c = s[i];
+                if (c == ' ' || c == '\t' || c == '\r' || c == '\n')
+                    i++;
+                else
+                    return true;
+            }
+            return true;
+        }
+
+        private static bool TryReadKeyword(string s, ref int i, string keyword)
+        {
+            if (i + keyword.Length > s.Length)
+                return false;
+            for (int k = 0; k < keyword.Length; k++)
+            {
+                if (s[i + k] != keyword[k])
+                    return false;
+            }
+            i += keyword.Length;
+            return true;
+        }
+
+        private static bool TryReadString(string s, ref int i, out string value)
+        {
+            value = "";
+            if (i >= s.Length || s[i] != '"')
+                return false;
+            i++;
+
+            var sb = new StringBuilder();
+            while (i < s.Length)
+            {
+                char c = s[i++];
+                if (c == '"')
+                {
+                    value = sb.ToString();
+                    return true;
+                }
+                if (c != '\\')
+                {
+                    sb.Append(c);
+                    continue;
+                }
+                if (i >= s.Length)
+                    return false;
+                char esc = s[i++];
+                switch (esc)
+                {
+                    case '"': sb.Append('"'); break;
+                    case '\\': sb.Append('\\'); break;
+                    case '/': sb.Append('/'); break;
+                    case 'b': sb.Append('\b'); break;
+                    case 'f': sb.Append('\f'); break;
+                    case 'n': sb.Append('\n'); break;
+                    case 'r': sb.Append('\r'); break;
+                    case 't': sb.Append('\t'); break;
+                    case 'u':
+                        if (i + 4 > s.Length)
+                            return false;
+#if NETSTANDARD2_0
+                        if (!ushort.TryParse(s.Substring(i, 4), System.Globalization.NumberStyles.HexNumber,
+                            System.Globalization.CultureInfo.InvariantCulture, out ushort code))
+                            return false;
+#else
+                        if (!ushort.TryParse(s.AsSpan(i, 4), System.Globalization.NumberStyles.HexNumber,
+                            System.Globalization.CultureInfo.InvariantCulture, out ushort code))
+                            return false;
+#endif
+                        sb.Append((char)code);
+                        i += 4;
+                        break;
+                    default:
+                        return false;
+                }
+            }
+            return false;
+        }
+    }
+}

--- a/include/surge/surge_api.h
+++ b/include/surge/surge_api.h
@@ -281,6 +281,31 @@ SURGE_API surge_result SURGE_CALL surge_update_download_and_apply(surge_update_m
                                                                   const surge_releases_info* info,
                                                                   surge_progress_callback progress_cb, void* user_data);
 
+/**
+ * Read the persisted update convergence record from @p install_dir as a JSON
+ * string. The record is written by surge_update_download_and_apply() so
+ * dashboards and repair tooling can distinguish "in progress", "applied but
+ * pending supervisor restart", "fully converged", and "failed" without having
+ * to infer the state from version drift alone.
+ *
+ * @param install_dir Root install directory containing
+ *                    `.surge-update-status.json`.
+ * @param json_out    [out] Receives a malloc()-allocated NUL-terminated JSON
+ *                    string on SURGE_OK, or NULL on SURGE_NOT_FOUND /
+ *                    SURGE_ERROR. Caller must free with free().
+ * @return SURGE_OK when a record exists; SURGE_NOT_FOUND when no record has
+ *         been written yet; SURGE_ERROR on read/decode failure.
+ */
+SURGE_API surge_result SURGE_CALL surge_update_status_read_json(const char* install_dir, char** json_out);
+
+/**
+ * Free a NUL-terminated string returned by a Surge FFI call that documents its
+ * output as `free()`-owned (for example surge_update_status_read_json). Safe
+ * to call with NULL. Use this rather than the host's free() to ensure the
+ * matching allocator is used across libraries.
+ */
+SURGE_API void SURGE_CALL surge_free_cstring(char* ptr);
+
 /* -------------------------------------------------------------------------- */
 /*  Release-info accessors                                                    */
 /* -------------------------------------------------------------------------- */


### PR DESCRIPTION
## Summary
- Persist an explicit per-install convergence record (`.surge-update-status.json`) so dashboards and repair tooling no longer have to infer state from version drift alone (fixes #113).
- States: `Idle`, `InProgress`, `Converged`, `PendingRestart`, `Failed`. Each record carries app_id, channel, installed/target versions, attempted/completed timestamps, supervisor restart confirmation, and a free-form reason for the non-converged states.
- Exposed via the C FFI (`surge_update_status_read_json`), the .NET wrapper (`SurgeApp.LastUpdateStatus`, `SurgeUpdateManager.GetCurrentStatus`), and a new local diagnostic command (`surge status <install_dir>`).

## Why it matters
Issue #113 describes the failure shape where after a promotion:
- some online nodes never converge (didn't poll yet / install failed),
- some nodes report installed=new but runtime=old (supervisor restart did not complete).

Previously the only signal was `runtime.yml`'s `version` field, which is written before the supervisor restart and so cannot distinguish those cases. The new record captures each transition explicitly:
- `InProgress` written at the start of `download_and_apply`,
- `Failed` written on any error path (preserves the pre-attempt version),
- `Converged` / `PendingRestart` based on whether the supervisor pid file is observed within a 5s window after the post-update restart.

The file lives at the install root (above the active app directory) so it survives the directory swap on every successful update.

## Behavior impact
- New file `.surge-update-status.json` appears at the install root after the first update attempt.
- `lifecycle::restart_supervisor_after_update` now returns a `SupervisorRestartOutcome` (internal API). Existing FFI/.NET callers are unaffected.
- Two new FFI functions: `surge_update_status_read_json`, `surge_free_cstring` (the latter is a generic allocator-safe free for any FFI output that documents itself as `free()`-owned).

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `RUSTFLAGS="-D warnings" cargo test --workspace` (all green, including 2 new tests covering Converged + Failed flows and 9 new tests covering the status module round-trip and supervisor-pid confirmation polling)
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --workspace --lib --bins --examples -- -D warnings -D clippy::unwrap_used -D clippy::expect_used`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings -W clippy::pedantic`
- [x] `dotnet format dotnet/Surge.slnx --verify-no-changes`
- [x] `dotnet test dotnet/Surge.slnx --configuration Release` (39 passing, includes 6 new tests covering the parser, escape sequences, unknown-state forward compatibility, and malformed input)
- [x] `./scripts/sync-surge-core-vendor.sh --check` and `./scripts/check-version-sync.sh`
- [x] Smoke-tested `surge status` CLI against a hand-written record (Converged/PendingRestart/no-record paths)

## Migration notes
- No schema changes to existing files. The new `.surge-update-status.json` is additive; absent records are interpreted as "no update has been attempted yet" and treated identically to today.
- The .NET API is purely additive: `SurgeUpdateStatus`, `SurgeUpdateConvergenceState`, and the two new accessors. Existing host apps are unaffected unless they opt in to the new signal.