### PR TITLE
fix(cli): verify size+sha256 and atomic-move remote installer (#115)

### DIFF
--- a/crates/surge-cli/src/commands/install/remote/execution.rs
+++ b/crates/surge-cli/src/commands/install/remote/execution.rs
@@ -9,6 +9,47 @@ use super::{
 const REMOTE_COPY_CONFIRMATION_TIMEOUT: Duration = Duration::from_mins(10);
 const TAILSCALE_STREAM_COMMAND_TIMEOUT: Duration = Duration::from_mins(30);
 
+pub(crate) const REMOTE_INSTALLER_FINAL_PATH: &str = "/tmp/.surge-installer";
+pub(crate) const REMOTE_INSTALLER_PARTIAL_PATH: &str = "/tmp/.surge-installer.partial";
+
+/// Build a shell command that receives the installer on stdin, validates it
+/// against the expected size + SHA-256, and atomically moves it into place.
+///
+/// The script writes to a `.partial` file, verifies size and hash, then renames
+/// to the final path. On any failure the partial file is cleaned up and the
+/// stderr contains an actionable reason that callers can surface to the user.
+pub(crate) fn build_remote_installer_install_command(expected_size: u64, expected_sha256: &str) -> String {
+    let partial = REMOTE_INSTALLER_PARTIAL_PATH;
+    let final_path = REMOTE_INSTALLER_FINAL_PATH;
+    let expected_sha256 = expected_sha256.trim();
+    format!(
+        "set -eu; \
+trap 'rm -f {partial}' EXIT; \
+cat > {partial}; \
+expected_size='{expected_size}'; \
+expected_sha256='{expected_sha256}'; \
+actual_size=\"$(wc -c < {partial} | tr -d '[:space:]')\"; \
+if [ \"$actual_size\" != \"$expected_size\" ]; then \
+  echo \"remote installer size mismatch at {partial}: expected $expected_size bytes, got $actual_size bytes\" >&2; \
+  exit 1; \
+fi; \
+if command -v sha256sum >/dev/null 2>&1; then \
+  actual_sha256=\"$(sha256sum {partial} | awk '{{print $1}}')\"; \
+elif command -v shasum >/dev/null 2>&1; then \
+  actual_sha256=\"$(shasum -a 256 {partial} | awk '{{print $1}}')\"; \
+else \
+  echo 'remote host has no sha256sum or shasum command available to verify installer transfer' >&2; \
+  exit 1; \
+fi; \
+if [ \"$actual_sha256\" != \"$expected_sha256\" ]; then \
+  echo \"remote installer sha256 mismatch at {partial}: expected $expected_sha256, got $actual_sha256\" >&2; \
+  exit 1; \
+fi; \
+chmod +x {partial}; \
+mv {partial} {final_path}"
+    )
+}
+
 pub(crate) fn resolve_tailscale_targets(node: &str, node_user: Option<&str>) -> Result<(String, String)> {
     let node = node.trim();
     if node.is_empty() {
@@ -372,4 +413,120 @@ where
     }
 
     Ok(captured)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Write;
+    use std::path::Path;
+    use std::process::{Command as StdCommand, Output, Stdio as StdStdio};
+
+    use super::*;
+
+    fn install_script_for_temp_paths(script: &str, partial_path: &Path, final_path: &Path) -> String {
+        script
+            .replace("/tmp/.surge-installer.partial", &partial_path.to_string_lossy())
+            .replace("/tmp/.surge-installer", &final_path.to_string_lossy())
+    }
+
+    fn run_install_script_with_stdin(script: &str, stdin_payload: &[u8]) -> Output {
+        let mut child = StdCommand::new("sh")
+            .arg("-c")
+            .arg(script)
+            .stdin(StdStdio::piped())
+            .stderr(StdStdio::piped())
+            .spawn()
+            .expect("spawn sh");
+        child
+            .stdin
+            .as_mut()
+            .expect("stdin pipe")
+            .write_all(stdin_payload)
+            .expect("write payload");
+        drop(child.stdin.take());
+        child.wait_with_output().expect("wait sh")
+    }
+
+    #[test]
+    fn build_remote_installer_install_command_includes_expected_values_and_paths() {
+        let cmd = build_remote_installer_install_command(
+            4_702_432,
+            "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789",
+        );
+
+        assert!(cmd.contains("/tmp/.surge-installer.partial"));
+        assert!(cmd.contains("/tmp/.surge-installer"));
+        assert!(cmd.contains("expected_size='4702432'"));
+        assert!(cmd.contains("expected_sha256='abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789'"));
+        assert!(cmd.contains("trap 'rm -f /tmp/.surge-installer.partial' EXIT"));
+        assert!(cmd.contains("mv /tmp/.surge-installer.partial /tmp/.surge-installer"));
+        assert!(cmd.contains("chmod +x /tmp/.surge-installer.partial"));
+        assert!(cmd.contains("size mismatch"));
+        assert!(cmd.contains("sha256 mismatch"));
+        assert!(cmd.contains("sha256sum"));
+        assert!(cmd.contains("shasum -a 256"));
+        assert!(cmd.contains("set -eu"));
+    }
+
+    #[test]
+    fn build_remote_installer_install_command_trims_expected_hash() {
+        let cmd = build_remote_installer_install_command(123, "  deadbeef  ");
+        assert!(cmd.contains("expected_sha256='deadbeef'"));
+    }
+
+    #[test]
+    fn execute_remote_installer_install_command_round_trips_payload() {
+        let temp_dir = tempfile::tempdir().expect("tempdir");
+        let payload = b"surge-installer-test-payload";
+        let expected_sha256 = surge_core::crypto::sha256::sha256_hex(payload);
+        let partial_path = temp_dir.path().join(".surge-installer.partial");
+        let final_path = temp_dir.path().join(".surge-installer");
+        let raw_script = build_remote_installer_install_command(payload.len() as u64, &expected_sha256);
+        let script = install_script_for_temp_paths(&raw_script, &partial_path, &final_path);
+
+        let output = run_install_script_with_stdin(&script, payload);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(output.status.success(), "script failed: {stderr}");
+        assert!(!partial_path.exists(), "partial file should have been moved");
+        assert!(final_path.exists(), "final file should exist");
+        let installed = std::fs::read(&final_path).expect("read final");
+        assert_eq!(installed, payload);
+    }
+
+    #[test]
+    fn execute_remote_installer_install_command_rejects_size_mismatch() {
+        let temp_dir = tempfile::tempdir().expect("tempdir");
+        let payload = b"surge-installer-test-payload";
+        let expected_sha256 = surge_core::crypto::sha256::sha256_hex(payload);
+        let partial_path = temp_dir.path().join(".surge-installer.partial");
+        let final_path = temp_dir.path().join(".surge-installer");
+        let wrong_size = (payload.len() as u64) + 1;
+        let raw_script = build_remote_installer_install_command(wrong_size, &expected_sha256);
+        let script = install_script_for_temp_paths(&raw_script, &partial_path, &final_path);
+
+        let output = run_install_script_with_stdin(&script, payload);
+        assert!(!output.status.success(), "script should fail");
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(stderr.contains("size mismatch"), "stderr was: {stderr}");
+        assert!(!partial_path.exists(), "partial file should be cleaned up on failure");
+        assert!(!final_path.exists(), "final file should not be written on failure");
+    }
+
+    #[test]
+    fn execute_remote_installer_install_command_rejects_sha256_mismatch() {
+        let temp_dir = tempfile::tempdir().expect("tempdir");
+        let payload = b"surge-installer-test-payload";
+        let wrong_hash = "0".repeat(64);
+        let partial_path = temp_dir.path().join(".surge-installer.partial");
+        let final_path = temp_dir.path().join(".surge-installer");
+        let raw_script = build_remote_installer_install_command(payload.len() as u64, &wrong_hash);
+        let script = install_script_for_temp_paths(&raw_script, &partial_path, &final_path);
+
+        let output = run_install_script_with_stdin(&script, payload);
+        assert!(!output.status.success(), "script should fail");
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(stderr.contains("sha256 mismatch"), "stderr was: {stderr}");
+        assert!(!partial_path.exists(), "partial file should be cleaned up on failure");
+        assert!(!final_path.exists(), "final file should not be written on failure");
+    }
 }

--- a/crates/surge-cli/src/commands/install/remote/execution.rs
+++ b/crates/surge-cli/src/commands/install/remote/execution.rs
@@ -417,18 +417,23 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::io::Write;
-    use std::path::Path;
-    use std::process::{Command as StdCommand, Output, Stdio as StdStdio};
-
     use super::*;
 
+    #[cfg(unix)]
+    use std::io::Write;
+    #[cfg(unix)]
+    use std::path::Path;
+    #[cfg(unix)]
+    use std::process::{Command as StdCommand, Output, Stdio as StdStdio};
+
+    #[cfg(unix)]
     fn install_script_for_temp_paths(script: &str, partial_path: &Path, final_path: &Path) -> String {
         script
             .replace("/tmp/.surge-installer.partial", &partial_path.to_string_lossy())
             .replace("/tmp/.surge-installer", &final_path.to_string_lossy())
     }
 
+    #[cfg(unix)]
     fn run_install_script_with_stdin(script: &str, stdin_payload: &[u8]) -> Output {
         let mut child = StdCommand::new("sh")
             .arg("-c")
@@ -474,6 +479,13 @@ mod tests {
         assert!(cmd.contains("expected_sha256='deadbeef'"));
     }
 
+    // The remote install command is a POSIX sh script run on the *remote*
+    // tailscale node (always Linux/macOS in practice). The integration tests
+    // below run the script locally to drive its happy/error paths, which
+    // requires a POSIX `sh` plus `sha256sum`/`shasum` in PATH. Gate on Unix
+    // so CI on the Windows host (which runs the local invoker side, not the
+    // remote side) doesn't try to exec a missing `sh`.
+    #[cfg(unix)]
     #[test]
     fn execute_remote_installer_install_command_round_trips_payload() {
         let temp_dir = tempfile::tempdir().expect("tempdir");
@@ -493,6 +505,7 @@ mod tests {
         assert_eq!(installed, payload);
     }
 
+    #[cfg(unix)]
     #[test]
     fn execute_remote_installer_install_command_rejects_size_mismatch() {
         let temp_dir = tempfile::tempdir().expect("tempdir");
@@ -512,6 +525,7 @@ mod tests {
         assert!(!final_path.exists(), "final file should not be written on failure");
     }
 
+    #[cfg(unix)]
     #[test]
     fn execute_remote_installer_install_command_rejects_sha256_mismatch() {
         let temp_dir = tempfile::tempdir().expect("tempdir");

--- a/crates/surge-cli/src/commands/install/remote/mod.rs
+++ b/crates/surge-cli/src/commands/install/remote/mod.rs
@@ -21,7 +21,8 @@ use serde::Deserialize;
 use surge_core::update::manager::ApplyStrategy;
 
 pub(crate) use self::execution::{
-    resolve_tailscale_targets, run_tailscale_streaming, stream_file_to_tailscale_node_with_command,
+    REMOTE_INSTALLER_FINAL_PATH, build_remote_installer_install_command, resolve_tailscale_targets,
+    run_tailscale_streaming, stream_file_to_tailscale_node_with_command,
 };
 pub(crate) use self::published_installer::{
     build_installer_for_tailscale, missing_remote_installer_error, plan_remote_published_installer,
@@ -341,17 +342,22 @@ pub(super) async fn install_release_via_tailscale(
             installer_mode,
         )?
     };
-    let installer_size = std::fs::metadata(&installer_path).map_or(0, |metadata| metadata.len());
+    let installer_size = std::fs::metadata(&installer_path)
+        .map_err(|e| {
+            SurgeError::Platform(format!(
+                "Failed to read installer metadata at '{}': {e}",
+                installer_path.display()
+            ))
+        })?
+        .len();
+    let installer_sha256 = surge_core::crypto::sha256::sha256_hex_file(&installer_path)?;
     logline::info(&format!(
-        "Transferring installer to '{file_target}' ({})...",
+        "Transferring installer to '{file_target}' ({}, sha256 {})...",
         crate::formatters::format_bytes(installer_size),
+        &installer_sha256[..installer_sha256.len().min(12)],
     ));
-    stream_file_to_tailscale_node_with_command(
-        ssh_target,
-        &installer_path,
-        "cat > /tmp/.surge-installer && chmod +x /tmp/.surge-installer",
-    )
-    .await?;
+    let install_command = build_remote_installer_install_command(installer_size, &installer_sha256);
+    stream_file_to_tailscale_node_with_command(ssh_target, &installer_path, &install_command).await?;
 
     let no_start_flag = if behavior.no_start { " --no-start" } else { "" };
     let stage_flag = if behavior.mode.is_stage() { " --stage" } else { "" };
@@ -360,8 +366,9 @@ pub(super) async fn install_release_via_tailscale(
     } else {
         ""
     };
-    let run_cmd =
-        format!("/tmp/.surge-installer{no_start_flag}{stage_flag}{reinstall_flag} && rm -f /tmp/.surge-installer");
+    let run_cmd = format!(
+        "{REMOTE_INSTALLER_FINAL_PATH}{no_start_flag}{stage_flag}{reinstall_flag} && rm -f {REMOTE_INSTALLER_FINAL_PATH}"
+    );
     let ssh_command = format!("sh -lc {}", shell_single_quote(&run_cmd));
     if behavior.mode.is_stage() {
         logline::info(&format!("Running installer in stage mode on '{file_target}'..."));


### PR DESCRIPTION
## Summary
- Closes #115.
- The tailscale remote install previously streamed the installer with `cat > /tmp/.surge-installer && chmod +x /tmp/.surge-installer`. When the local stream printed 100% but the remote command hadn't fully landed the bytes (or had landed mismatched bytes), the CLI sat at "Waiting for remote copy confirmation..." until the 10-min timeout fired with a generic message.
- The remote script now writes to a `.partial` temp path, validates the size matches the locally-known size, validates SHA-256 matches the locally-computed hash, chmod +x the partial, then atomically moves it to `/tmp/.surge-installer`. On any failure the partial is removed via an EXIT trap and stderr carries an actionable reason (size mismatch / sha256 mismatch / no sha256 tool available).
- The script is built by a new `build_remote_installer_install_command` helper covered by unit tests that drive the actual shell script in `/tmp` against happy-path, size-mismatch, and sha256-mismatch payloads.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --workspace --lib --bins --examples -- -D warnings -D clippy::unwrap_used -D clippy::expect_used`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings -W clippy::pedantic`
- [x] `RUSTFLAGS="-D warnings" cargo test --workspace`
- [x] `dotnet format dotnet/Surge.slnx --verify-no-changes`
- [x] `dotnet test dotnet/Surge.slnx --configuration Release`
- [x] `./scripts/sync-surge-core-vendor.sh --check`
- [x] `./scripts/check-version-sync.sh`