### PR TITLE
fix(core): surface finalize substep progress and persist current phase (#116)

### DIFF
--- a/crates/surge-cli/src/commands/setup.rs
+++ b/crates/surge-cli/src/commands/setup.rs
@@ -27,6 +27,7 @@ struct ProgressReporter {
     last_logged_at: Instant,
     last_value: u64,
     next_percent: u64,
+    last_phase_label: Option<&'static str>,
 }
 
 impl ProgressReporter {
@@ -36,6 +37,7 @@ impl ProgressReporter {
             last_logged_at: Instant::now(),
             last_value: 0,
             next_percent: PACKAGE_PROGRESS_PERCENT_STEP,
+            last_phase_label: None,
         }
     }
 
@@ -100,6 +102,10 @@ impl ProgressReporter {
     }
 
     fn observe_update(&mut self, progress: &ProgressInfo) -> Option<String> {
+        if let Some(phase_message) = self.observe_phase_label(progress.phase_label) {
+            return Some(phase_message);
+        }
+
         let bytes_total = u64::try_from(progress.bytes_total.max(0)).unwrap_or(0);
         let bytes_done = u64::try_from(progress.bytes_done.max(0)).unwrap_or(0);
         if bytes_total > 0 {
@@ -130,6 +136,22 @@ impl ProgressReporter {
         }
 
         Some(format!("{} step {items_done}/{items_total} ({}%)", self.label, percent))
+    }
+
+    /// Convert phase-label transitions into log messages. Returns `Some` the
+    /// first time a new non-empty `phase_label` is observed so the operator
+    /// learns what the updater is doing during silent finalize substeps that
+    /// would otherwise leave the progress bar sitting at 100%.
+    fn observe_phase_label(&mut self, phase_label: &'static str) -> Option<String> {
+        if phase_label.is_empty() {
+            return None;
+        }
+        if self.last_phase_label == Some(phase_label) {
+            return None;
+        }
+        self.last_phase_label = Some(phase_label);
+        self.last_logged_at = Instant::now();
+        Some(format!("{} {phase_label}...", self.label))
     }
 }
 
@@ -686,6 +708,37 @@ mod tests {
         assert_eq!(
             reporter.observe_bytes_at(base + PACKAGE_PROGRESS_LOG_INTERVAL + Duration::from_millis(1), 6, 100),
             Some("Downloading package... 6 B / 100 B (6%)".to_string())
+        );
+    }
+
+    #[test]
+    fn progress_reporter_emits_message_for_each_distinct_phase_label() {
+        let mut reporter = ProgressReporter::new("Applying update...");
+        // No label -> nothing emitted.
+        assert!(reporter.observe_update(&ProgressInfo::default()).is_none());
+
+        let with_label = ProgressInfo {
+            phase: 6,
+            phase_label: "stopping supervisor",
+            total_percent: 91,
+            ..ProgressInfo::default()
+        };
+        assert_eq!(
+            reporter.observe_update(&with_label),
+            Some("Applying update... stopping supervisor...".to_string())
+        );
+        // Same label again is suppressed.
+        assert!(reporter.observe_update(&with_label).is_none());
+
+        let next_label = ProgressInfo {
+            phase: 6,
+            phase_label: "swapping app directory",
+            total_percent: 93,
+            ..ProgressInfo::default()
+        };
+        assert_eq!(
+            reporter.observe_update(&next_label),
+            Some("Applying update... swapping app directory...".to_string())
         );
     }
 

--- a/crates/surge-core/src/update/manager.rs
+++ b/crates/surge-core/src/update/manager.rs
@@ -2,39 +2,31 @@
 
 mod apply;
 mod artifacts;
+mod finalize;
 mod lifecycle;
 mod progress;
+mod progress_substep;
 mod release_index;
 
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use tracing::{debug, info, warn};
+use tracing::{info, warn};
 
-use crate::config::constants::RELEASES_FILE_COMPRESSED;
 use crate::config::manifest::{InstallArtifactCachePolicy, InstallArtifactCacheRetention};
 use crate::context::Context;
 use crate::error::{Result, SurgeError};
-use crate::install::{
-    InstallProfile, RuntimeManifestMetadata, copy_persistent_assets, prune_version_snapshots,
-    storage_provider_manifest_name, write_runtime_manifest,
-};
-use crate::platform::fs::atomic_rename;
-use crate::platform::shortcuts::install_shortcuts;
-use crate::releases::artifact_cache::prune_cached_artifacts;
-use crate::releases::manifest::{ReleaseEntry, ReleaseIndex, decompress_release_index};
-use crate::releases::restore::{
-    retained_artifacts_for_cache_policy, retained_artifacts_for_cache_policy_without_index,
-};
+use crate::releases::manifest::{ReleaseEntry, ReleaseIndex};
 use crate::storage::{StorageBackend, create_storage_backend};
-use crate::supervisor::state::supervisor_pid_file;
 use crate::update::status::{self, UpdateStatusRecord};
 
 use self::apply::materialize_update_payload;
 use self::artifacts::prepare_update_artifacts;
+use self::finalize::finalize_update;
 use self::lifecycle::SupervisorRestartOutcome;
 pub use self::progress::ProgressInfo;
 use self::progress::emit_progress;
+use self::progress_substep::PhaseProgressEmitter;
 pub use self::release_index::plan_update_from_index;
 use self::release_index::{load_release_index as load_release_index_impl, resolve_update_info};
 
@@ -65,117 +57,19 @@ pub struct UpdateInfo {
 }
 
 const DEFAULT_RELEASE_RETENTION_LIMIT: usize = 1;
-const RELEASE_GRAPH_CHECKPOINT_FULLS: usize = 3;
-/// Bound the post-finalize storage read used to pick which artifacts to keep
-/// in the local cache. Pruning is best-effort, so an unreachable storage
-/// backend must not stall the rest of finalize indefinitely.
-const PRUNE_INDEX_FETCH_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
-/// Periodic re-emit interval for finalize substeps whose underlying work
-/// can block silently for many seconds (supervisor shutdown, post-update
-/// hook). Operators watching CLI output use this to distinguish "stuck"
-/// from "still running".
-const HEARTBEAT_INTERVAL: std::time::Duration = std::time::Duration::from_secs(5);
-
-/// Substep labels for the finalize phase. These appear in `ProgressInfo`
-/// events and on the persisted `current_phase` field of in-progress update
-/// status records so operators can tell a stuck "swapping app directory"
-/// apart from a stuck "starting supervisor".
-pub(crate) mod finalize_phase {
-    pub const STOPPING_SUPERVISOR: &str = "stopping supervisor";
-    pub const PREPARING_SWAP: &str = "preparing app swap";
-    pub const SWAPPING_APP_DIRECTORY: &str = "swapping app directory";
-    pub const COPYING_PERSISTENT_ASSETS: &str = "copying persistent assets";
-    pub const WRITING_RUNTIME_MANIFEST: &str = "writing runtime metadata";
-    pub const INSTALLING_SHORTCUTS: &str = "installing shortcuts";
-    pub const PRUNING_OLD_VERSIONS: &str = "pruning old versions and caches";
-    pub const POST_UPDATE_HOOK: &str = "running post-update hook";
-    pub const RESTARTING_SUPERVISOR: &str = "restarting supervisor";
-}
-
-/// Bundle of state used to emit phase progress and persist the current
-/// substep label to the update status record.
-struct PhaseProgressEmitter<'a, F>
-where
-    F: Fn(ProgressInfo) + Send + Sync,
-{
-    progress: Option<&'a Arc<F>>,
-    install_dir: &'a std::path::Path,
-    in_progress_template: &'a UpdateStatusRecord,
-}
-
-impl<F> PhaseProgressEmitter<'_, F>
-where
-    F: Fn(ProgressInfo) + Send + Sync,
-{
-    /// Run a future while periodically re-emitting the substep label so
-    /// observers see "still working" beats during long-running phases that
-    /// don't themselves report progress (supervisor shutdown, post-update
-    /// hook, supervisor restart). The label is emitted once up front, then
-    /// every `interval` until the future resolves.
-    async fn run_with_heartbeat<Fut, T>(
-        &self,
-        phase: i32,
-        label: &'static str,
-        total_percent: i32,
-        interval: std::time::Duration,
-        future: Fut,
-    ) -> T
-    where
-        Fut: std::future::Future<Output = T>,
-    {
-        self.emit_substep(phase, label, total_percent);
-        tokio::pin!(future);
-        let mut ticker = tokio::time::interval(interval);
-        // Skip the immediate tick; we already emitted once via emit_substep above.
-        ticker.tick().await;
-        loop {
-            tokio::select! {
-                result = &mut future => return result,
-                _ = ticker.tick() => {
-                    emit_progress(
-                        self.progress,
-                        ProgressInfo {
-                            phase,
-                            phase_label: label,
-                            total_percent,
-                            ..ProgressInfo::default()
-                        },
-                    );
-                }
-            }
-        }
-    }
-
-    /// Emit a progress event and best-effort persist the current substep
-    /// label to the in-progress status record.
-    fn emit_substep(&self, phase: i32, label: &'static str, total_percent: i32) {
-        emit_progress(
-            self.progress,
-            ProgressInfo {
-                phase,
-                phase_label: label,
-                total_percent,
-                ..ProgressInfo::default()
-            },
-        );
-        let record = self.in_progress_template.clone().with_current_phase(label);
-        if let Err(e) = status::write_update_status(self.install_dir, &record) {
-            warn!(error = %e, phase = label, "Failed to persist in-progress substep status (continuing)");
-        }
-    }
-}
+pub(super) const RELEASE_GRAPH_CHECKPOINT_FULLS: usize = 3;
 
 /// Manages checking for and applying application updates.
 pub struct UpdateManager {
-    ctx: Arc<Context>,
-    app_id: String,
-    current_version: String,
-    channel: String,
-    release_retention_limit: usize,
-    artifact_retention_policy: InstallArtifactCachePolicy,
-    install_dir: PathBuf,
-    storage: Box<dyn StorageBackend>,
-    cached_index: Option<ReleaseIndex>,
+    pub(super) ctx: Arc<Context>,
+    pub(super) app_id: String,
+    pub(super) current_version: String,
+    pub(super) channel: String,
+    pub(super) release_retention_limit: usize,
+    pub(super) artifact_retention_policy: InstallArtifactCachePolicy,
+    pub(super) install_dir: PathBuf,
+    pub(super) storage: Box<dyn StorageBackend>,
+    pub(super) cached_index: Option<ReleaseIndex>,
 }
 
 impl UpdateManager {
@@ -465,238 +359,15 @@ impl UpdateManager {
         .await?;
 
         // Phase 6: Finalize
-        emit_progress(
-            progress.as_ref(),
-            ProgressInfo {
-                phase: 6,
-                total_percent: 90,
-                ..ProgressInfo::default()
-            },
-        );
-        let latest = info
-            .apply_releases
-            .last()
-            .ok_or_else(|| SurgeError::Update("No latest release".to_string()))?;
-        let active_app_dir = self.install_dir.join("app");
-        let next_app_dir = self.install_dir.join(".surge-app-next");
-        let previous_swap_dir = self.install_dir.join(".surge-app-prev");
-        let supervisor_was_running = !latest.supervisor_id.trim().is_empty()
-            && supervisor_pid_file(&self.install_dir, &latest.supervisor_id).is_file();
-
-        if supervisor_was_running {
-            progress_emitter
-                .run_with_heartbeat(
-                    6,
-                    finalize_phase::STOPPING_SUPERVISOR,
-                    91,
-                    HEARTBEAT_INTERVAL,
-                    lifecycle::request_supervisor_shutdown(&self.install_dir, &latest.supervisor_id),
-                )
-                .await?;
-        } else {
-            lifecycle::request_supervisor_shutdown(&self.install_dir, &latest.supervisor_id).await?;
-        }
-
-        progress_emitter.emit_substep(6, finalize_phase::PREPARING_SWAP, 92);
-        if next_app_dir.exists() {
-            tokio::fs::remove_dir_all(&next_app_dir).await?;
-        }
-        if previous_swap_dir.exists() {
-            tokio::fs::remove_dir_all(&previous_swap_dir).await?;
-        }
-
-        // Legacy installs may still be on `app-{version}` layout.
-        let fallback_previous_app_dir = if active_app_dir.is_dir() {
-            None
-        } else {
-            apply::find_previous_app_dir(&self.install_dir, &self.current_version)
-        };
-
-        progress_emitter.emit_substep(6, finalize_phase::SWAPPING_APP_DIRECTORY, 93);
-        atomic_rename(&extracted_final_dir, &next_app_dir)?;
-
-        if active_app_dir.is_dir() {
-            atomic_rename(&active_app_dir, &previous_swap_dir)?;
-        }
-        if let Err(err) = atomic_rename(&next_app_dir, &active_app_dir) {
-            // Best effort rollback to previous active content.
-            if previous_swap_dir.is_dir() && !active_app_dir.exists() {
-                let _ = atomic_rename(&previous_swap_dir, &active_app_dir);
-            }
-            return Err(err);
-        }
-
-        let previous_app_dir_for_assets = if previous_swap_dir.is_dir() {
-            Some(previous_swap_dir.as_path())
-        } else {
-            fallback_previous_app_dir.as_deref()
-        };
-
-        if !latest.persistent_assets.is_empty() && previous_app_dir_for_assets.is_some() {
-            progress_emitter.emit_substep(6, finalize_phase::COPYING_PERSISTENT_ASSETS, 94);
-            if let Some(previous) = previous_app_dir_for_assets {
-                copy_persistent_assets(previous, &active_app_dir, &latest.persistent_assets)?;
-            }
-        } else if !latest.persistent_assets.is_empty() {
-            debug!(
-                version = %latest.version,
-                "No previous app directory found; skipping persistent asset carry-over"
-            );
-        }
-
-        progress_emitter.emit_substep(6, finalize_phase::WRITING_RUNTIME_MANIFEST, 95);
-        let storage_cfg = self.ctx.storage_config();
-        let runtime_manifest_profile = InstallProfile::new(
-            &self.app_id,
-            latest.display_name(&self.app_id),
-            &latest.main_exe,
-            &latest.install_directory,
-            &latest.supervisor_id,
-            &latest.icon,
-            &latest.shortcuts,
-            &latest.persistent_assets,
-            &latest.environment,
-        );
-        let runtime_manifest_metadata = RuntimeManifestMetadata::new(
-            &latest.version,
-            &self.channel,
-            storage_provider_manifest_name(storage_cfg.provider),
-            &storage_cfg.bucket,
-            &storage_cfg.region,
-            &storage_cfg.endpoint,
-        );
-        write_runtime_manifest(&active_app_dir, &runtime_manifest_profile, &runtime_manifest_metadata)?;
-
-        if !latest.shortcuts.is_empty() {
-            progress_emitter.emit_substep(6, finalize_phase::INSTALLING_SHORTCUTS, 96);
-            match install_shortcuts(
-                &self.app_id,
-                latest.display_name(&self.app_id),
-                &active_app_dir,
-                &latest.main_exe,
-                &latest.supervisor_id,
-                &latest.icon,
-                &latest.shortcuts,
-                &latest.environment,
-            ) {
-                Ok(()) => {
-                    debug!(version = %latest.version, "Installed shortcuts");
-                }
-                Err(e) => {
-                    warn!(
-                        version = %latest.version,
-                        error = %e,
-                        "Failed to install shortcuts (continuing)"
-                    );
-                }
-            }
-        }
-
-        progress_emitter.emit_substep(6, finalize_phase::PRUNING_OLD_VERSIONS, 97);
-        if previous_swap_dir.is_dir() {
-            let previous_version_dir = self.install_dir.join(format!("app-{}", self.current_version));
-            if !self.current_version.trim().is_empty()
-                && previous_version_dir != active_app_dir
-                && !previous_version_dir.exists()
-            {
-                if let Err(e) = atomic_rename(&previous_swap_dir, &previous_version_dir) {
-                    warn!(
-                        previous = %previous_swap_dir.display(),
-                        target = %previous_version_dir.display(),
-                        error = %e,
-                        "Failed to preserve previous active directory snapshot"
-                    );
-                    let _ = tokio::fs::remove_dir_all(&previous_swap_dir).await;
-                }
-            } else {
-                let _ = tokio::fs::remove_dir_all(&previous_swap_dir).await;
-            }
-        }
-        match prune_version_snapshots(&self.install_dir, self.release_retention_limit) {
-            Ok(0) => {}
-            Ok(pruned) => {
-                debug!(
-                    pruned,
-                    retained = self.release_retention_limit,
-                    "Pruned stale installed app version snapshots"
-                );
-            }
-            Err(e) => {
-                warn!(error = %e, "Failed to prune installed app version snapshots");
-            }
-        }
-
-        // Clean up staging directory
-        if staging_dir.exists() {
-            let _ = tokio::fs::remove_dir_all(&staging_dir).await;
-        }
-
-        let prune_index = if let Some(cached) = &self.cached_index {
-            Some(cached.clone())
-        } else {
-            match tokio::time::timeout(
-                PRUNE_INDEX_FETCH_TIMEOUT,
-                self.storage.get_object(RELEASES_FILE_COMPRESSED),
-            )
-            .await
-            {
-                Ok(Ok(data)) => Some(decompress_release_index(&data)?),
-                Ok(Err(SurgeError::NotFound(_))) => None,
-                Ok(Err(e)) => return Err(e),
-                Err(_) => {
-                    warn!(
-                        timeout_secs = PRUNE_INDEX_FETCH_TIMEOUT.as_secs(),
-                        "Timed out fetching release index for artifact pruning; skipping prune step"
-                    );
-                    None
-                }
-            }
-        };
-        let retained_artifacts = if let Some(index) = prune_index {
-            Some(retained_artifacts_for_cache_policy(
-                &index,
-                self.artifact_retention_policy,
-                &latest.full_filename,
-                RELEASE_GRAPH_CHECKPOINT_FULLS,
-            ))
-        } else {
-            retained_artifacts_for_cache_policy_without_index(self.artifact_retention_policy, &latest.full_filename)
-        };
-        if let Some(retained_artifacts) = retained_artifacts {
-            match prune_cached_artifacts(&artifact_cache_dir, &retained_artifacts) {
-                Ok(0) => {}
-                Ok(pruned) => {
-                    debug!(
-                        pruned,
-                        retained = retained_artifacts.len(),
-                        "Pruned stale local artifact cache entries"
-                    );
-                }
-                Err(e) => {
-                    warn!(error = %e, "Failed to prune local artifact cache");
-                }
-            }
-        }
-
-        progress_emitter.emit_substep(6, finalize_phase::POST_UPDATE_HOOK, 98);
-        lifecycle::invoke_post_update_hook(&self.install_dir, &active_app_dir, latest);
-
-        let restart_outcome = if supervisor_was_running {
-            progress_emitter.emit_substep(6, finalize_phase::RESTARTING_SUPERVISOR, 99);
-            lifecycle::restart_supervisor_after_update(&self.install_dir, &active_app_dir, latest)
-        } else {
-            SupervisorRestartOutcome::NotApplicable
-        };
-
-        emit_progress(
-            progress.as_ref(),
-            ProgressInfo {
-                phase: 6,
-                phase_percent: 100,
-                total_percent: 100,
-                ..ProgressInfo::default()
-            },
-        );
+        let restart_outcome = finalize_update(
+            self,
+            info,
+            &extracted_final_dir,
+            &staging_dir,
+            &artifact_cache_dir,
+            &progress_emitter,
+        )
+        .await?;
 
         info!(
             version = %info.latest_version,
@@ -715,9 +386,10 @@ mod tests {
     use std::sync::Mutex;
     use std::time::Duration;
 
+    use super::progress_substep::labels as finalize_phase;
     use super::*;
     use crate::archive::packer::ArchivePacker;
-    use crate::config::constants::DEFAULT_ZSTD_LEVEL;
+    use crate::config::constants::{DEFAULT_ZSTD_LEVEL, RELEASES_FILE_COMPRESSED};
     #[cfg(target_os = "linux")]
     use crate::config::manifest::ShortcutLocation;
     use crate::context::StorageProvider;

--- a/crates/surge-core/src/update/manager.rs
+++ b/crates/surge-core/src/update/manager.rs
@@ -66,6 +66,104 @@ pub struct UpdateInfo {
 
 const DEFAULT_RELEASE_RETENTION_LIMIT: usize = 1;
 const RELEASE_GRAPH_CHECKPOINT_FULLS: usize = 3;
+/// Bound the post-finalize storage read used to pick which artifacts to keep
+/// in the local cache. Pruning is best-effort, so an unreachable storage
+/// backend must not stall the rest of finalize indefinitely.
+const PRUNE_INDEX_FETCH_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+/// Periodic re-emit interval for finalize substeps whose underlying work
+/// can block silently for many seconds (supervisor shutdown, post-update
+/// hook). Operators watching CLI output use this to distinguish "stuck"
+/// from "still running".
+const HEARTBEAT_INTERVAL: std::time::Duration = std::time::Duration::from_secs(5);
+
+/// Substep labels for the finalize phase. These appear in `ProgressInfo`
+/// events and on the persisted `current_phase` field of in-progress update
+/// status records so operators can tell a stuck "swapping app directory"
+/// apart from a stuck "starting supervisor".
+pub(crate) mod finalize_phase {
+    pub const STOPPING_SUPERVISOR: &str = "stopping supervisor";
+    pub const PREPARING_SWAP: &str = "preparing app swap";
+    pub const SWAPPING_APP_DIRECTORY: &str = "swapping app directory";
+    pub const COPYING_PERSISTENT_ASSETS: &str = "copying persistent assets";
+    pub const WRITING_RUNTIME_MANIFEST: &str = "writing runtime metadata";
+    pub const INSTALLING_SHORTCUTS: &str = "installing shortcuts";
+    pub const PRUNING_OLD_VERSIONS: &str = "pruning old versions and caches";
+    pub const POST_UPDATE_HOOK: &str = "running post-update hook";
+    pub const RESTARTING_SUPERVISOR: &str = "restarting supervisor";
+}
+
+/// Bundle of state used to emit phase progress and persist the current
+/// substep label to the update status record.
+struct PhaseProgressEmitter<'a, F>
+where
+    F: Fn(ProgressInfo) + Send + Sync,
+{
+    progress: Option<&'a Arc<F>>,
+    install_dir: &'a std::path::Path,
+    in_progress_template: &'a UpdateStatusRecord,
+}
+
+impl<F> PhaseProgressEmitter<'_, F>
+where
+    F: Fn(ProgressInfo) + Send + Sync,
+{
+    /// Run a future while periodically re-emitting the substep label so
+    /// observers see "still working" beats during long-running phases that
+    /// don't themselves report progress (supervisor shutdown, post-update
+    /// hook, supervisor restart). The label is emitted once up front, then
+    /// every `interval` until the future resolves.
+    async fn run_with_heartbeat<Fut, T>(
+        &self,
+        phase: i32,
+        label: &'static str,
+        total_percent: i32,
+        interval: std::time::Duration,
+        future: Fut,
+    ) -> T
+    where
+        Fut: std::future::Future<Output = T>,
+    {
+        self.emit_substep(phase, label, total_percent);
+        tokio::pin!(future);
+        let mut ticker = tokio::time::interval(interval);
+        // Skip the immediate tick; we already emitted once via emit_substep above.
+        ticker.tick().await;
+        loop {
+            tokio::select! {
+                result = &mut future => return result,
+                _ = ticker.tick() => {
+                    emit_progress(
+                        self.progress,
+                        ProgressInfo {
+                            phase,
+                            phase_label: label,
+                            total_percent,
+                            ..ProgressInfo::default()
+                        },
+                    );
+                }
+            }
+        }
+    }
+
+    /// Emit a progress event and best-effort persist the current substep
+    /// label to the in-progress status record.
+    fn emit_substep(&self, phase: i32, label: &'static str, total_percent: i32) {
+        emit_progress(
+            self.progress,
+            ProgressInfo {
+                phase,
+                phase_label: label,
+                total_percent,
+                ..ProgressInfo::default()
+            },
+        );
+        let record = self.in_progress_template.clone().with_current_phase(label);
+        if let Err(e) = status::write_update_status(self.install_dir, &record) {
+            warn!(error = %e, phase = label, "Failed to persist in-progress substep status (continuing)");
+        }
+    }
+}
 
 /// Manages checking for and applying application updates.
 pub struct UpdateManager {
@@ -240,7 +338,10 @@ impl UpdateManager {
         }
 
         let progress = progress.map(Arc::new);
-        match self.download_and_apply_inner(info, progress).await {
+        match self
+            .download_and_apply_inner(info, progress, in_progress_record.clone())
+            .await
+        {
             Ok(restart_outcome) => {
                 let completed_at_utc = status::now_utc_rfc3339();
                 let record = match restart_outcome {
@@ -296,11 +397,17 @@ impl UpdateManager {
         &self,
         info: &UpdateInfo,
         progress: Option<Arc<F>>,
+        in_progress_template: UpdateStatusRecord,
     ) -> Result<SupervisorRestartOutcome>
     where
         F: Fn(ProgressInfo) + Send + Sync,
     {
         self.ctx.check_cancelled()?;
+        let progress_emitter = PhaseProgressEmitter {
+            progress: progress.as_ref(),
+            install_dir: &self.install_dir,
+            in_progress_template: &in_progress_template,
+        };
 
         // Phase 1: Check
         info!(version = %info.latest_version, "Starting update");
@@ -376,8 +483,21 @@ impl UpdateManager {
         let supervisor_was_running = !latest.supervisor_id.trim().is_empty()
             && supervisor_pid_file(&self.install_dir, &latest.supervisor_id).is_file();
 
-        lifecycle::request_supervisor_shutdown(&self.install_dir, &latest.supervisor_id).await?;
+        if supervisor_was_running {
+            progress_emitter
+                .run_with_heartbeat(
+                    6,
+                    finalize_phase::STOPPING_SUPERVISOR,
+                    91,
+                    HEARTBEAT_INTERVAL,
+                    lifecycle::request_supervisor_shutdown(&self.install_dir, &latest.supervisor_id),
+                )
+                .await?;
+        } else {
+            lifecycle::request_supervisor_shutdown(&self.install_dir, &latest.supervisor_id).await?;
+        }
 
+        progress_emitter.emit_substep(6, finalize_phase::PREPARING_SWAP, 92);
         if next_app_dir.exists() {
             tokio::fs::remove_dir_all(&next_app_dir).await?;
         }
@@ -392,6 +512,7 @@ impl UpdateManager {
             apply::find_previous_app_dir(&self.install_dir, &self.current_version)
         };
 
+        progress_emitter.emit_substep(6, finalize_phase::SWAPPING_APP_DIRECTORY, 93);
         atomic_rename(&extracted_final_dir, &next_app_dir)?;
 
         if active_app_dir.is_dir() {
@@ -411,17 +532,19 @@ impl UpdateManager {
             fallback_previous_app_dir.as_deref()
         };
 
-        if !latest.persistent_assets.is_empty() {
+        if !latest.persistent_assets.is_empty() && previous_app_dir_for_assets.is_some() {
+            progress_emitter.emit_substep(6, finalize_phase::COPYING_PERSISTENT_ASSETS, 94);
             if let Some(previous) = previous_app_dir_for_assets {
                 copy_persistent_assets(previous, &active_app_dir, &latest.persistent_assets)?;
-            } else {
-                debug!(
-                    version = %latest.version,
-                    "No previous app directory found; skipping persistent asset carry-over"
-                );
             }
+        } else if !latest.persistent_assets.is_empty() {
+            debug!(
+                version = %latest.version,
+                "No previous app directory found; skipping persistent asset carry-over"
+            );
         }
 
+        progress_emitter.emit_substep(6, finalize_phase::WRITING_RUNTIME_MANIFEST, 95);
         let storage_cfg = self.ctx.storage_config();
         let runtime_manifest_profile = InstallProfile::new(
             &self.app_id,
@@ -445,6 +568,7 @@ impl UpdateManager {
         write_runtime_manifest(&active_app_dir, &runtime_manifest_profile, &runtime_manifest_metadata)?;
 
         if !latest.shortcuts.is_empty() {
+            progress_emitter.emit_substep(6, finalize_phase::INSTALLING_SHORTCUTS, 96);
             match install_shortcuts(
                 &self.app_id,
                 latest.display_name(&self.app_id),
@@ -468,6 +592,7 @@ impl UpdateManager {
             }
         }
 
+        progress_emitter.emit_substep(6, finalize_phase::PRUNING_OLD_VERSIONS, 97);
         if previous_swap_dir.is_dir() {
             let previous_version_dir = self.install_dir.join(format!("app-{}", self.current_version));
             if !self.current_version.trim().is_empty()
@@ -509,10 +634,22 @@ impl UpdateManager {
         let prune_index = if let Some(cached) = &self.cached_index {
             Some(cached.clone())
         } else {
-            match self.storage.get_object(RELEASES_FILE_COMPRESSED).await {
-                Ok(data) => Some(decompress_release_index(&data)?),
-                Err(SurgeError::NotFound(_)) => None,
-                Err(e) => return Err(e),
+            match tokio::time::timeout(
+                PRUNE_INDEX_FETCH_TIMEOUT,
+                self.storage.get_object(RELEASES_FILE_COMPRESSED),
+            )
+            .await
+            {
+                Ok(Ok(data)) => Some(decompress_release_index(&data)?),
+                Ok(Err(SurgeError::NotFound(_))) => None,
+                Ok(Err(e)) => return Err(e),
+                Err(_) => {
+                    warn!(
+                        timeout_secs = PRUNE_INDEX_FETCH_TIMEOUT.as_secs(),
+                        "Timed out fetching release index for artifact pruning; skipping prune step"
+                    );
+                    None
+                }
             }
         };
         let retained_artifacts = if let Some(index) = prune_index {
@@ -541,9 +678,11 @@ impl UpdateManager {
             }
         }
 
+        progress_emitter.emit_substep(6, finalize_phase::POST_UPDATE_HOOK, 98);
         lifecycle::invoke_post_update_hook(&self.install_dir, &active_app_dir, latest);
 
         let restart_outcome = if supervisor_was_running {
+            progress_emitter.emit_substep(6, finalize_phase::RESTARTING_SUPERVISOR, 99);
             lifecycle::restart_supervisor_after_update(&self.install_dir, &active_app_dir, latest)
         } else {
             SupervisorRestartOutcome::NotApplicable
@@ -1706,6 +1845,158 @@ mod tests {
         let final_progress = observed.last().expect("expected final progress");
         assert_eq!(final_progress.phase, 6);
         assert_eq!(final_progress.total_percent, 100);
+
+        let finalize_labels: Vec<&'static str> = observed
+            .iter()
+            .filter(|progress| progress.phase == 6 && !progress.phase_label.is_empty())
+            .map(|progress| progress.phase_label)
+            .collect();
+        assert!(
+            finalize_labels.contains(&finalize_phase::PREPARING_SWAP),
+            "expected finalize substep '{}' in {:?}",
+            finalize_phase::PREPARING_SWAP,
+            finalize_labels
+        );
+        assert!(
+            finalize_labels.contains(&finalize_phase::SWAPPING_APP_DIRECTORY),
+            "expected finalize substep '{}' in {:?}",
+            finalize_phase::SWAPPING_APP_DIRECTORY,
+            finalize_labels
+        );
+        assert!(
+            finalize_labels.contains(&finalize_phase::WRITING_RUNTIME_MANIFEST),
+            "expected finalize substep '{}' in {:?}",
+            finalize_phase::WRITING_RUNTIME_MANIFEST,
+            finalize_labels
+        );
+        assert!(
+            finalize_labels.contains(&finalize_phase::PRUNING_OLD_VERSIONS),
+            "expected finalize substep '{}' in {:?}",
+            finalize_phase::PRUNING_OLD_VERSIONS,
+            finalize_labels
+        );
+        assert!(
+            finalize_labels.contains(&finalize_phase::POST_UPDATE_HOOK),
+            "expected finalize substep '{}' in {:?}",
+            finalize_phase::POST_UPDATE_HOOK,
+            finalize_labels
+        );
+    }
+
+    #[tokio::test]
+    async fn test_download_and_apply_persists_current_phase_for_finalize_substeps() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store_root = tmp.path().join("store");
+        let install_root = tmp.path().join("install");
+        let app_id = "test-app";
+        std::fs::create_dir_all(&store_root).unwrap();
+        std::fs::create_dir_all(&install_root).unwrap();
+        let app_store = app_scoped_store_root(&store_root, app_id);
+
+        let rid = current_rid();
+        let full_filename = format!("{app_id}-1.1.0-{rid}-full.tar.zst");
+        let full_path = app_store.join(&full_filename);
+
+        let mut packer = ArchivePacker::new(3).unwrap();
+        packer.add_buffer("payload.txt", b"new payload", 0o644).unwrap();
+        packer.finalize_to_file(&full_path).unwrap();
+
+        let full_size = std::fs::metadata(&full_path).unwrap().len() as i64;
+        let full_sha256 = sha256_hex_file(&full_path).unwrap();
+
+        let index = ReleaseIndex {
+            app_id: app_id.to_string(),
+            releases: vec![ReleaseEntry {
+                version: "1.1.0".to_string(),
+                channels: vec!["stable".to_string()],
+                os: current_os_label_for_tests(),
+                rid: rid.clone(),
+                is_genesis: true,
+                full_filename: full_filename.clone(),
+                full_size,
+                full_sha256,
+                full_compression_level: 0,
+                full_zstd_workers: 0,
+                deltas: Vec::new(),
+                preferred_delta_id: String::new(),
+                created_utc: chrono::Utc::now().to_rfc3339(),
+                release_notes: String::new(),
+                name: String::new(),
+                main_exe: app_id.to_string(),
+                install_directory: app_id.to_string(),
+                supervisor_id: String::new(),
+                icon: String::new(),
+                shortcuts: Vec::new(),
+                persistent_assets: Vec::new(),
+                installers: Vec::new(),
+                environment: std::collections::BTreeMap::new(),
+            }],
+            ..ReleaseIndex::default()
+        };
+        write_app_scoped_release_index(&store_root, app_id, &index);
+
+        let ctx = Arc::new(Context::new());
+        ctx.set_storage(
+            StorageProvider::Filesystem,
+            store_root.to_str().unwrap(),
+            "",
+            "",
+            "",
+            "",
+        );
+
+        let observed_phases = Arc::new(Mutex::new(Vec::<Option<String>>::new()));
+        let observed_phases_for_progress = Arc::clone(&observed_phases);
+        let status_path = status::update_status_path(&install_root);
+
+        let mut manager = UpdateManager::new(ctx, app_id, "1.0.0", "stable", install_root.to_str().unwrap()).unwrap();
+        let info = manager.check_for_updates().await.unwrap().unwrap();
+
+        manager
+            .download_and_apply(
+                &info,
+                Some(move |progress: ProgressInfo| {
+                    if progress.phase == 6
+                        && !progress.phase_label.is_empty()
+                        && let Ok(bytes) = std::fs::read(&status_path)
+                        && let Ok(record) = serde_json::from_slice::<status::UpdateStatusRecord>(&bytes)
+                    {
+                        observed_phases_for_progress
+                            .lock()
+                            .unwrap_or_else(std::sync::PoisonError::into_inner)
+                            .push(record.current_phase);
+                    }
+                }),
+            )
+            .await
+            .unwrap();
+
+        let observed_phases = observed_phases
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone();
+
+        assert!(
+            observed_phases
+                .iter()
+                .any(|phase| phase.as_deref() == Some(finalize_phase::PREPARING_SWAP)),
+            "expected current_phase to include '{}' in {:?}",
+            finalize_phase::PREPARING_SWAP,
+            observed_phases,
+        );
+        assert!(
+            observed_phases
+                .iter()
+                .any(|phase| phase.as_deref() == Some(finalize_phase::SWAPPING_APP_DIRECTORY)),
+            "expected current_phase to include '{}' in {:?}",
+            finalize_phase::SWAPPING_APP_DIRECTORY,
+            observed_phases,
+        );
+
+        // Final converged record clears current_phase.
+        let final_record = status::read_update_status(&install_root).unwrap().unwrap();
+        assert_eq!(final_record.state, status::UpdateConvergenceState::Converged);
+        assert!(final_record.current_phase.is_none());
     }
 
     #[tokio::test]

--- a/crates/surge-core/src/update/manager/apply.rs
+++ b/crates/surge-core/src/update/manager/apply.rs
@@ -173,6 +173,7 @@ where
                         u64::try_from(bytes_done.max(0)).unwrap_or(u64::MAX),
                         apply_delta_started_at,
                     ),
+                    ..ProgressInfo::default()
                 },
             );
         };
@@ -207,6 +208,7 @@ where
                     u64::try_from(apply_delta_bytes_done.max(0)).unwrap_or(u64::MAX),
                     apply_delta_started_at,
                 ),
+                ..ProgressInfo::default()
             },
         );
     }
@@ -225,6 +227,7 @@ where
                 u64::try_from(apply_delta_total_bytes.max(0)).unwrap_or(u64::MAX),
                 apply_delta_started_at,
             ),
+            ..ProgressInfo::default()
         },
     );
 
@@ -345,6 +348,7 @@ where
                 items_done: saturating_i64_from_u64(items_done),
                 items_total: saturating_i64_from_u64(items_total),
                 speed_bytes_per_sec: average_speed_bytes_per_sec(bytes_done, extract_started_at),
+                ..ProgressInfo::default()
             },
         );
     };

--- a/crates/surge-core/src/update/manager/artifacts.rs
+++ b/crates/surge-core/src/update/manager/artifacts.rs
@@ -116,6 +116,7 @@ where
                     .unwrap_or_else(std::sync::PoisonError::into_inner);
                 average_speed_bytes_per_sec(state.bytes_done(), state.started_at())
             },
+            ..ProgressInfo::default()
         },
     );
 

--- a/crates/surge-core/src/update/manager/finalize.rs
+++ b/crates/surge-core/src/update/manager/finalize.rs
@@ -1,0 +1,286 @@
+//! Phase 6 (finalize) execution for the update pipeline.
+//!
+//! Owns the substeps that run after the update payload is materialized on
+//! disk: stop the supervisor, atomic-swap the active app directory, copy
+//! persistent assets, write the runtime manifest, install shortcuts, prune
+//! old version snapshots and cached artifacts, run the post-update hook,
+//! and (re)start the supervisor. Each substep emits a labelled progress
+//! event and persists the same label into the in-progress
+//! [`UpdateStatusRecord`] via [`PhaseProgressEmitter`].
+
+use std::path::Path;
+use std::time::Duration;
+
+use tracing::{debug, warn};
+
+use crate::config::constants::RELEASES_FILE_COMPRESSED;
+use crate::error::{Result, SurgeError};
+use crate::install::{
+    InstallProfile, RuntimeManifestMetadata, copy_persistent_assets, prune_version_snapshots,
+    storage_provider_manifest_name, write_runtime_manifest,
+};
+use crate::platform::fs::atomic_rename;
+use crate::platform::shortcuts::install_shortcuts;
+use crate::releases::artifact_cache::prune_cached_artifacts;
+use crate::releases::manifest::decompress_release_index;
+use crate::releases::restore::{
+    retained_artifacts_for_cache_policy, retained_artifacts_for_cache_policy_without_index,
+};
+use crate::supervisor::state::supervisor_pid_file;
+
+use super::progress::{ProgressInfo, emit_progress};
+use super::progress_substep::{HEARTBEAT_INTERVAL, PhaseProgressEmitter, labels as finalize_phase};
+use super::{RELEASE_GRAPH_CHECKPOINT_FULLS, SupervisorRestartOutcome, UpdateInfo, UpdateManager, apply, lifecycle};
+
+/// Bound the post-finalize storage read used to pick which artifacts to keep
+/// in the local cache. Pruning is best-effort, so an unreachable storage
+/// backend must not stall the rest of finalize indefinitely.
+const PRUNE_INDEX_FETCH_TIMEOUT: Duration = Duration::from_secs(30);
+
+#[allow(clippy::too_many_lines)]
+pub(super) async fn finalize_update<F>(
+    manager: &UpdateManager,
+    info: &UpdateInfo,
+    extracted_final_dir: &Path,
+    staging_dir: &Path,
+    artifact_cache_dir: &Path,
+    progress_emitter: &PhaseProgressEmitter<'_, F>,
+) -> Result<SupervisorRestartOutcome>
+where
+    F: Fn(ProgressInfo) + Send + Sync,
+{
+    emit_progress(
+        progress_emitter.progress,
+        ProgressInfo {
+            phase: 6,
+            total_percent: 90,
+            ..ProgressInfo::default()
+        },
+    );
+    let latest = info
+        .apply_releases
+        .last()
+        .ok_or_else(|| SurgeError::Update("No latest release".to_string()))?;
+    let active_app_dir = manager.install_dir.join("app");
+    let next_app_dir = manager.install_dir.join(".surge-app-next");
+    let previous_swap_dir = manager.install_dir.join(".surge-app-prev");
+    let supervisor_was_running = !latest.supervisor_id.trim().is_empty()
+        && supervisor_pid_file(&manager.install_dir, &latest.supervisor_id).is_file();
+
+    if supervisor_was_running {
+        progress_emitter
+            .run_with_heartbeat(
+                6,
+                finalize_phase::STOPPING_SUPERVISOR,
+                91,
+                HEARTBEAT_INTERVAL,
+                lifecycle::request_supervisor_shutdown(&manager.install_dir, &latest.supervisor_id),
+            )
+            .await?;
+    } else {
+        lifecycle::request_supervisor_shutdown(&manager.install_dir, &latest.supervisor_id).await?;
+    }
+
+    progress_emitter.emit_substep(6, finalize_phase::PREPARING_SWAP, 92);
+    if next_app_dir.exists() {
+        tokio::fs::remove_dir_all(&next_app_dir).await?;
+    }
+    if previous_swap_dir.exists() {
+        tokio::fs::remove_dir_all(&previous_swap_dir).await?;
+    }
+
+    // Legacy installs may still be on `app-{version}` layout.
+    let fallback_previous_app_dir = if active_app_dir.is_dir() {
+        None
+    } else {
+        apply::find_previous_app_dir(&manager.install_dir, &manager.current_version)
+    };
+
+    progress_emitter.emit_substep(6, finalize_phase::SWAPPING_APP_DIRECTORY, 93);
+    atomic_rename(extracted_final_dir, &next_app_dir)?;
+
+    if active_app_dir.is_dir() {
+        atomic_rename(&active_app_dir, &previous_swap_dir)?;
+    }
+    if let Err(err) = atomic_rename(&next_app_dir, &active_app_dir) {
+        // Best effort rollback to previous active content.
+        if previous_swap_dir.is_dir() && !active_app_dir.exists() {
+            let _ = atomic_rename(&previous_swap_dir, &active_app_dir);
+        }
+        return Err(err);
+    }
+
+    let previous_app_dir_for_assets = if previous_swap_dir.is_dir() {
+        Some(previous_swap_dir.as_path())
+    } else {
+        fallback_previous_app_dir.as_deref()
+    };
+
+    if !latest.persistent_assets.is_empty() && previous_app_dir_for_assets.is_some() {
+        progress_emitter.emit_substep(6, finalize_phase::COPYING_PERSISTENT_ASSETS, 94);
+        if let Some(previous) = previous_app_dir_for_assets {
+            copy_persistent_assets(previous, &active_app_dir, &latest.persistent_assets)?;
+        }
+    } else if !latest.persistent_assets.is_empty() {
+        debug!(
+            version = %latest.version,
+            "No previous app directory found; skipping persistent asset carry-over"
+        );
+    }
+
+    progress_emitter.emit_substep(6, finalize_phase::WRITING_RUNTIME_MANIFEST, 95);
+    let storage_cfg = manager.ctx.storage_config();
+    let runtime_manifest_profile = InstallProfile::new(
+        &manager.app_id,
+        latest.display_name(&manager.app_id),
+        &latest.main_exe,
+        &latest.install_directory,
+        &latest.supervisor_id,
+        &latest.icon,
+        &latest.shortcuts,
+        &latest.persistent_assets,
+        &latest.environment,
+    );
+    let runtime_manifest_metadata = RuntimeManifestMetadata::new(
+        &latest.version,
+        &manager.channel,
+        storage_provider_manifest_name(storage_cfg.provider),
+        &storage_cfg.bucket,
+        &storage_cfg.region,
+        &storage_cfg.endpoint,
+    );
+    write_runtime_manifest(&active_app_dir, &runtime_manifest_profile, &runtime_manifest_metadata)?;
+
+    if !latest.shortcuts.is_empty() {
+        progress_emitter.emit_substep(6, finalize_phase::INSTALLING_SHORTCUTS, 96);
+        match install_shortcuts(
+            &manager.app_id,
+            latest.display_name(&manager.app_id),
+            &active_app_dir,
+            &latest.main_exe,
+            &latest.supervisor_id,
+            &latest.icon,
+            &latest.shortcuts,
+            &latest.environment,
+        ) {
+            Ok(()) => {
+                debug!(version = %latest.version, "Installed shortcuts");
+            }
+            Err(e) => {
+                warn!(
+                    version = %latest.version,
+                    error = %e,
+                    "Failed to install shortcuts (continuing)"
+                );
+            }
+        }
+    }
+
+    progress_emitter.emit_substep(6, finalize_phase::PRUNING_OLD_VERSIONS, 97);
+    if previous_swap_dir.is_dir() {
+        let previous_version_dir = manager.install_dir.join(format!("app-{}", manager.current_version));
+        if !manager.current_version.trim().is_empty()
+            && previous_version_dir != active_app_dir
+            && !previous_version_dir.exists()
+        {
+            if let Err(e) = atomic_rename(&previous_swap_dir, &previous_version_dir) {
+                warn!(
+                    previous = %previous_swap_dir.display(),
+                    target = %previous_version_dir.display(),
+                    error = %e,
+                    "Failed to preserve previous active directory snapshot"
+                );
+                let _ = tokio::fs::remove_dir_all(&previous_swap_dir).await;
+            }
+        } else {
+            let _ = tokio::fs::remove_dir_all(&previous_swap_dir).await;
+        }
+    }
+    match prune_version_snapshots(&manager.install_dir, manager.release_retention_limit) {
+        Ok(0) => {}
+        Ok(pruned) => {
+            debug!(
+                pruned,
+                retained = manager.release_retention_limit,
+                "Pruned stale installed app version snapshots"
+            );
+        }
+        Err(e) => {
+            warn!(error = %e, "Failed to prune installed app version snapshots");
+        }
+    }
+
+    // Clean up staging directory
+    if staging_dir.exists() {
+        let _ = tokio::fs::remove_dir_all(staging_dir).await;
+    }
+
+    let prune_index = if let Some(cached) = &manager.cached_index {
+        Some(cached.clone())
+    } else {
+        match tokio::time::timeout(
+            PRUNE_INDEX_FETCH_TIMEOUT,
+            manager.storage.get_object(RELEASES_FILE_COMPRESSED),
+        )
+        .await
+        {
+            Ok(Ok(data)) => Some(decompress_release_index(&data)?),
+            Ok(Err(SurgeError::NotFound(_))) => None,
+            Ok(Err(e)) => return Err(e),
+            Err(_) => {
+                warn!(
+                    timeout_secs = PRUNE_INDEX_FETCH_TIMEOUT.as_secs(),
+                    "Timed out fetching release index for artifact pruning; skipping prune step"
+                );
+                None
+            }
+        }
+    };
+    let retained_artifacts = if let Some(index) = prune_index {
+        Some(retained_artifacts_for_cache_policy(
+            &index,
+            manager.artifact_retention_policy,
+            &latest.full_filename,
+            RELEASE_GRAPH_CHECKPOINT_FULLS,
+        ))
+    } else {
+        retained_artifacts_for_cache_policy_without_index(manager.artifact_retention_policy, &latest.full_filename)
+    };
+    if let Some(retained_artifacts) = retained_artifacts {
+        match prune_cached_artifacts(artifact_cache_dir, &retained_artifacts) {
+            Ok(0) => {}
+            Ok(pruned) => {
+                debug!(
+                    pruned,
+                    retained = retained_artifacts.len(),
+                    "Pruned stale local artifact cache entries"
+                );
+            }
+            Err(e) => {
+                warn!(error = %e, "Failed to prune local artifact cache");
+            }
+        }
+    }
+
+    progress_emitter.emit_substep(6, finalize_phase::POST_UPDATE_HOOK, 98);
+    lifecycle::invoke_post_update_hook(&manager.install_dir, &active_app_dir, latest);
+
+    let restart_outcome = if supervisor_was_running {
+        progress_emitter.emit_substep(6, finalize_phase::RESTARTING_SUPERVISOR, 99);
+        lifecycle::restart_supervisor_after_update(&manager.install_dir, &active_app_dir, latest)
+    } else {
+        SupervisorRestartOutcome::NotApplicable
+    };
+
+    emit_progress(
+        progress_emitter.progress,
+        ProgressInfo {
+            phase: 6,
+            phase_percent: 100,
+            total_percent: 100,
+            ..ProgressInfo::default()
+        },
+    );
+
+    Ok(restart_outcome)
+}

--- a/crates/surge-core/src/update/manager/progress.rs
+++ b/crates/surge-core/src/update/manager/progress.rs
@@ -7,6 +7,11 @@ use std::time::Instant;
 pub struct ProgressInfo {
     /// Current phase (1 = check, 2 = download, 3 = verify, 4 = extract, 5 = apply_delta, 6 = finalize).
     pub phase: i32,
+    /// Optional substep label that describes what is happening inside the
+    /// current phase. Used to surface progress for phases that are stuck at
+    /// 100% bytes/items while finalization or base reconstruction work is
+    /// still running.
+    pub phase_label: &'static str,
     /// Percentage complete within the current phase (0-100).
     pub phase_percent: i32,
     /// Overall percentage complete (0-100).
@@ -27,6 +32,7 @@ impl Default for ProgressInfo {
     fn default() -> Self {
         Self {
             phase: 0,
+            phase_label: "",
             phase_percent: 0,
             total_percent: 0,
             bytes_done: 0,
@@ -143,6 +149,7 @@ impl DownloadProgressState {
             items_done: self.items_done,
             items_total: total_items,
             speed_bytes_per_sec: average_speed_bytes_per_sec(self.bytes_done, self.started_at),
+            ..ProgressInfo::default()
         }
     }
 }

--- a/crates/surge-core/src/update/manager/progress_substep.rs
+++ b/crates/surge-core/src/update/manager/progress_substep.rs
@@ -1,0 +1,116 @@
+//! Phase-substep progress emission for the finalize phase.
+//!
+//! The finalize phase of an update runs several substeps (supervisor
+//! shutdown, atomic directory swaps, persistent asset copy, cache pruning,
+//! post-update hook, supervisor restart) that historically reported nothing
+//! to the user once the bytes/items counter hit 100%. This module owns the
+//! helper that emits `ProgressInfo` with a `phase_label` for each substep,
+//! mirrors that label into the persisted in-progress
+//! [`UpdateStatusRecord`], and provides a heartbeat helper for substeps
+//! that can block silently for many seconds.
+//!
+//! Substep labels live in [`labels`] so the manager and tests reference the
+//! same canonical strings.
+
+use std::path::Path;
+use std::sync::Arc;
+use std::time::Duration;
+
+use tracing::warn;
+
+use super::progress::{ProgressInfo, emit_progress};
+use crate::update::status::{self, UpdateStatusRecord};
+
+/// Substep labels for the finalize phase. These appear in `ProgressInfo`
+/// events and on the persisted `current_phase` field of in-progress update
+/// status records so operators can tell a stuck "swapping app directory"
+/// apart from a stuck "starting supervisor".
+pub(crate) mod labels {
+    pub const STOPPING_SUPERVISOR: &str = "stopping supervisor";
+    pub const PREPARING_SWAP: &str = "preparing app swap";
+    pub const SWAPPING_APP_DIRECTORY: &str = "swapping app directory";
+    pub const COPYING_PERSISTENT_ASSETS: &str = "copying persistent assets";
+    pub const WRITING_RUNTIME_MANIFEST: &str = "writing runtime metadata";
+    pub const INSTALLING_SHORTCUTS: &str = "installing shortcuts";
+    pub const PRUNING_OLD_VERSIONS: &str = "pruning old versions and caches";
+    pub const POST_UPDATE_HOOK: &str = "running post-update hook";
+    pub const RESTARTING_SUPERVISOR: &str = "restarting supervisor";
+}
+
+/// Periodic re-emit interval for finalize substeps whose underlying work
+/// can block silently for many seconds (supervisor shutdown, post-update
+/// hook). Operators watching CLI output use this to distinguish "stuck"
+/// from "still running".
+pub(super) const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(5);
+
+/// Bundle of state used to emit phase progress and persist the current
+/// substep label to the update status record.
+pub(super) struct PhaseProgressEmitter<'a, F>
+where
+    F: Fn(ProgressInfo) + Send + Sync,
+{
+    pub(super) progress: Option<&'a Arc<F>>,
+    pub(super) install_dir: &'a Path,
+    pub(super) in_progress_template: &'a UpdateStatusRecord,
+}
+
+impl<F> PhaseProgressEmitter<'_, F>
+where
+    F: Fn(ProgressInfo) + Send + Sync,
+{
+    /// Run a future while periodically re-emitting the substep label so
+    /// observers see "still working" beats during long-running phases that
+    /// don't themselves report progress (supervisor shutdown, post-update
+    /// hook, supervisor restart). The label is emitted once up front, then
+    /// every `interval` until the future resolves.
+    pub(super) async fn run_with_heartbeat<Fut, T>(
+        &self,
+        phase: i32,
+        label: &'static str,
+        total_percent: i32,
+        interval: Duration,
+        future: Fut,
+    ) -> T
+    where
+        Fut: std::future::Future<Output = T>,
+    {
+        self.emit_substep(phase, label, total_percent);
+        tokio::pin!(future);
+        let mut ticker = tokio::time::interval(interval);
+        ticker.tick().await; // skip the immediate tick; we just emitted via emit_substep
+        loop {
+            tokio::select! {
+                result = &mut future => return result,
+                _ = ticker.tick() => {
+                    emit_progress(
+                        self.progress,
+                        ProgressInfo {
+                            phase,
+                            phase_label: label,
+                            total_percent,
+                            ..ProgressInfo::default()
+                        },
+                    );
+                }
+            }
+        }
+    }
+
+    /// Emit a progress event and best-effort persist the current substep
+    /// label to the in-progress status record.
+    pub(super) fn emit_substep(&self, phase: i32, label: &'static str, total_percent: i32) {
+        emit_progress(
+            self.progress,
+            ProgressInfo {
+                phase,
+                phase_label: label,
+                total_percent,
+                ..ProgressInfo::default()
+            },
+        );
+        let record = self.in_progress_template.clone().with_current_phase(label);
+        if let Err(e) = status::write_update_status(self.install_dir, &record) {
+            warn!(error = %e, phase = label, "Failed to persist in-progress substep status (continuing)");
+        }
+    }
+}

--- a/crates/surge-core/src/update/status.rs
+++ b/crates/surge-core/src/update/status.rs
@@ -82,6 +82,12 @@ pub struct UpdateStatusRecord {
     pub completed_at_utc: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reason: Option<String>,
+    /// Coarse-grained label for the substep currently in progress (for
+    /// example "downloading artifacts" or "swapping app directory"). Only
+    /// meaningful for `InProgress` records; observers can use it to tell
+    /// "stuck in finalize" apart from "stuck in download".
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub current_phase: Option<String>,
 }
 
 impl UpdateStatusRecord {
@@ -97,6 +103,7 @@ impl UpdateStatusRecord {
             attempted_at_utc: None,
             completed_at_utc: None,
             reason: None,
+            current_phase: None,
         }
     }
 
@@ -118,7 +125,19 @@ impl UpdateStatusRecord {
             attempted_at_utc: Some(attempted_at_utc),
             completed_at_utc: None,
             reason: None,
+            current_phase: None,
         }
+    }
+
+    /// Set the current substep label on an [`UpdateConvergenceState::InProgress`]
+    /// record. No-op for any other state.
+    #[must_use]
+    pub fn with_current_phase(mut self, phase: impl Into<String>) -> Self {
+        let label = phase.into();
+        if matches!(self.state, UpdateConvergenceState::InProgress) {
+            self.current_phase = Some(label);
+        }
+        self
     }
 
     #[must_use]
@@ -140,6 +159,7 @@ impl UpdateStatusRecord {
             attempted_at_utc,
             completed_at_utc: Some(completed_at_utc),
             reason: None,
+            current_phase: None,
         }
     }
 
@@ -163,6 +183,7 @@ impl UpdateStatusRecord {
             attempted_at_utc: Some(attempted_at_utc),
             completed_at_utc: Some(completed_at_utc),
             reason: Some(reason.to_string()),
+            current_phase: None,
         }
     }
 
@@ -185,6 +206,7 @@ impl UpdateStatusRecord {
             attempted_at_utc: Some(attempted_at_utc),
             completed_at_utc: None,
             reason: Some(reason.to_string()),
+            current_phase: None,
         }
     }
 }
@@ -323,6 +345,73 @@ mod tests {
     fn read_returns_none_when_file_missing() {
         let dir = tempfile::tempdir().unwrap();
         assert!(read_update_status(dir.path()).unwrap().is_none());
+    }
+
+    #[test]
+    fn with_current_phase_sets_only_for_in_progress_records() {
+        let in_progress = UpdateStatusRecord::in_progress(
+            "demo-app",
+            "9998.0.0",
+            "9999.0.0",
+            "stable",
+            "2026-05-11T14:00:00Z".to_string(),
+        )
+        .with_current_phase("swapping app directory");
+        assert_eq!(in_progress.current_phase.as_deref(), Some("swapping app directory"));
+
+        let converged = UpdateStatusRecord::converged(
+            "demo-app",
+            "9999.0.0",
+            "stable",
+            Some("2026-05-11T14:00:00Z".to_string()),
+            "2026-05-11T14:05:00Z".to_string(),
+            true,
+        )
+        .with_current_phase("ignored for non-in-progress records");
+        assert!(converged.current_phase.is_none());
+    }
+
+    #[test]
+    fn round_trip_in_progress_record_with_current_phase() {
+        let dir = tempfile::tempdir().unwrap();
+        let record = UpdateStatusRecord::in_progress(
+            "demo-app",
+            "9998.0.0",
+            "9999.0.0",
+            "stable",
+            "2026-05-11T14:00:00Z".to_string(),
+        )
+        .with_current_phase("stopping supervisor");
+
+        write_update_status(dir.path(), &record).unwrap();
+        let loaded = read_update_status(dir.path()).unwrap().unwrap();
+
+        assert_eq!(loaded.state, UpdateConvergenceState::InProgress);
+        assert_eq!(loaded.current_phase.as_deref(), Some("stopping supervisor"));
+    }
+
+    #[test]
+    fn in_progress_record_serializes_current_phase_only_when_set() {
+        let dir = tempfile::tempdir().unwrap();
+        let without_phase = UpdateStatusRecord::in_progress(
+            "demo-app",
+            "9998.0.0",
+            "9999.0.0",
+            "stable",
+            "2026-05-11T14:00:00Z".to_string(),
+        );
+        write_update_status(dir.path(), &without_phase).unwrap();
+        let raw = std::fs::read_to_string(update_status_path(dir.path())).unwrap();
+        assert!(
+            !raw.contains("current_phase"),
+            "expected current_phase to be skipped when None, got: {raw}"
+        );
+
+        let with_phase = without_phase.with_current_phase("swapping app directory");
+        write_update_status(dir.path(), &with_phase).unwrap();
+        let raw = std::fs::read_to_string(update_status_path(dir.path())).unwrap();
+        assert!(raw.contains("\"current_phase\""), "expected current_phase in: {raw}");
+        assert!(raw.contains("swapping app directory"), "expected label in: {raw}");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Closes #116.
- After \`Applying update... 100%\` the updater could continue silently for minutes while finalize ran supervisor shutdown, atomic directory swaps, persistent asset copy, cache pruning, post-update hook, and supervisor restart. Operators couldn't tell stuck from working, and SIGTERM left no useful breadcrumb.
- Finalize now emits a named substep at every boundary (e.g. \"stopping supervisor\", \"swapping app directory\", \"copying persistent assets\", \"running post-update hook\", \"restarting supervisor\"). Each substep also persists into \`UpdateStatusRecord.current_phase\` so \`.surge-update-status.json\` always reflects what the in-progress run is doing, even after a kill.
- \`ProgressInfo\` gains a non-FFI-breaking \`phase_label: &'static str\` field so callers/CLI surface the substep names. \`ProgressReporter::observe_update\` prints label transitions even when bytes/items haven't moved, so the user sees one line per substep instead of the old single \"100%\" line followed by silence.
- The supervisor-shutdown wait (longest definite blocker, up to 20s) is wrapped in a 5-second heartbeat that re-emits its label, so CLI output doesn't fall silent during that phase.
- The post-finalize release-index fetch used for cache pruning is bounded by a 30-second timeout; an unreachable storage backend now warns and skips pruning instead of stalling finalize forever.

## Test plan
- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo clippy --workspace --all-targets --all-features -- -D warnings\`
- [x] \`cargo clippy --workspace --lib --bins --examples -- -D warnings -D clippy::unwrap_used -D clippy::expect_used\`
- [x] \`cargo clippy --workspace --all-targets --all-features -- -D warnings -W clippy::pedantic\`
- [x] \`RUSTFLAGS=\"-D warnings\" cargo test --workspace\`
- [x] \`dotnet format dotnet/Surge.slnx --verify-no-changes\`
- [x] \`dotnet test dotnet/Surge.slnx --configuration Release\`
- [x] \`./scripts/sync-surge-core-vendor.sh --check\`
- [x] \`./scripts/check-version-sync.sh\`