### PR TITLE
Update .NET 10 SDK

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,7 +220,7 @@ jobs:
           submodules: true
       - uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: '10.0.202'
+          dotnet-version: '10.0.300'
       - uses: actions/cache@v5
         with:
           path: ~/.nuget/packages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -178,7 +178,7 @@ jobs:
           submodules: true
       - uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: '10.0.202'
+          dotnet-version: '10.0.300'
       - uses: actions/cache@v5
         with:
           path: ~/.nuget/packages


### PR DESCRIPTION
## Summary

- Update CI and release workflow .NET SDK pins to 10.0.300.

## Validation

- `dotnet build dotnet/Surge.slnx`
- `./scripts/sync-surge-core-vendor.sh --check`
- `./scripts/check-version-sync.sh`
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo test --workspace`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo clippy --workspace --lib --bins --examples -- -D warnings -D clippy::unwrap_used -D clippy::expect_used`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings -W clippy::pedantic`
- `dotnet format dotnet/Surge.slnx --verify-no-changes`
- `dotnet test dotnet/Surge.slnx --configuration Release`