### PR TITLE
fix(cli): converge forced remote runtime installs

### DIFF
--- a/crates/surge-cli/src/commands/install/mod.rs
+++ b/crates/surge-cli/src/commands/install/mod.rs
@@ -9,7 +9,6 @@ mod resolution;
 mod runtime;
 mod selection;
 
-use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::time::Instant;
@@ -457,13 +456,13 @@ mod tests {
         RemoteLaunchEnvironment, RemotePublishedInstallerPlan, RemoteTailscaleCachedState, RemoteTailscaleOperation,
         RemoteTailscaleTransferInputs, RemoteTailscaleTransferStrategy, build_remote_app_copy_activation_script,
         build_remote_installer_manifest, build_remote_paths_exist_probe, build_remote_process_verification_probe,
-        build_remote_stage_cleanup_command, build_remote_staged_installer_setup_command,
-        build_remote_stop_supervisor_command, missing_remote_installer_error, parse_remote_install_state,
-        parse_remote_launch_environment, parse_remote_staged_payload_identity, plan_remote_convergence,
-        plan_remote_published_installer, plan_remote_published_installer_without_manifest,
-        published_installer_public_url, remote_install_matches, remote_launch_environment_probe,
-        remote_staged_payload_identity, select_latest_remote_legacy_app_dir, select_remote_installer_mode,
-        select_remote_tailscale_transfer_strategy, should_skip_remote_install,
+        build_remote_runtime_start_command, build_remote_stage_cleanup_command,
+        build_remote_staged_installer_setup_command, build_remote_stop_supervisor_command,
+        missing_remote_installer_error, parse_remote_install_state, parse_remote_launch_environment,
+        parse_remote_staged_payload_identity, plan_remote_convergence, plan_remote_published_installer,
+        plan_remote_published_installer_without_manifest, published_installer_public_url, remote_install_matches,
+        remote_launch_environment_probe, remote_staged_payload_identity, select_latest_remote_legacy_app_dir,
+        select_remote_installer_mode, select_remote_tailscale_transfer_strategy, should_skip_remote_install,
         try_prepare_published_installer_for_tailscale,
     };
     use super::resolution::{
@@ -2258,7 +2257,51 @@ apps:
             true,
         )
         .expect("forced plan should resolve");
-        assert_eq!(forced.action, RemoteConvergenceAction::Reinstall);
+        assert_eq!(forced.action, RemoteConvergenceAction::ConvergeRuntime);
+        assert!(
+            forced
+                .reason
+                .as_deref()
+                .is_some_and(|reason| reason.contains("verify remote runtime convergence"))
+        );
+    }
+
+    #[test]
+    fn build_remote_runtime_start_command_restarts_through_supervisor() {
+        let mut environment = BTreeMap::new();
+        environment.insert("DISPLAY".to_string(), ":0".to_string());
+
+        let command = build_remote_runtime_start_command(
+            Path::new("/home/demo/.local/share/demo app"),
+            "demo",
+            "demo-supervisor",
+            "1.2.0",
+            &environment,
+        );
+
+        assert!(command.contains("export DISPLAY=':0'"));
+        assert!(command.contains("kill_matching \"$active_exe\""));
+        assert!(command.contains("kill_matching \"$install_root/app-\""));
+        assert!(command.contains("kill_matching \"surge-supervisor.*--id $supervisor_id\""));
+        assert!(command.contains("supervisor_bin=\"$active_app_dir/surge-supervisor\""));
+        assert!(command.contains("nohup \"$supervisor_bin\" run --id \"$supervisor_id\""));
+        assert!(command.contains("-- --surge-first-run \"$version\""));
+        assert!(command.contains("supervisor restart confirmed"));
+    }
+
+    #[test]
+    fn build_remote_runtime_start_command_restarts_direct_app_without_supervisor() {
+        let command = build_remote_runtime_start_command(
+            Path::new("/home/demo/.local/share/demo"),
+            "demo",
+            "",
+            "1.2.0",
+            &BTreeMap::new(),
+        );
+
+        assert!(command.contains("nohup \"$active_exe\" --surge-first-run \"$version\""));
+        assert!(command.contains("application restart requested"));
+        assert!(command.contains("supervisor_id=''"));
     }
 
     #[test]

--- a/crates/surge-cli/src/commands/install/remote/activation.rs
+++ b/crates/surge-cli/src/commands/install/remote/activation.rs
@@ -1,4 +1,6 @@
-use super::{BTreeMap, Path, PathBuf, Result, core_install, shell_single_quote};
+use std::collections::BTreeMap;
+
+use super::{Path, PathBuf, Result, core_install, shell_single_quote};
 
 pub(super) fn remote_linux_shortcut_icon_path(
     staged_app_dir: &Path,
@@ -55,7 +57,7 @@ pub(super) fn stage_remote_linux_shortcuts(
     Ok(())
 }
 
-fn shell_export_lines(environment: &BTreeMap<String, String>) -> String {
+pub(super) fn shell_export_lines(environment: &BTreeMap<String, String>) -> String {
     let mut lines = String::new();
     for (key, value) in environment {
         lines.push_str("export ");

--- a/crates/surge-cli/src/commands/install/remote/mod.rs
+++ b/crates/surge-cli/src/commands/install/remote/mod.rs
@@ -3,18 +3,18 @@
 mod activation;
 mod execution;
 mod published_installer;
+mod runtime;
 mod staging;
 mod state;
 mod types;
 
 use super::{
-    ArchiveAcquisition, AsyncBufReadExt, AsyncRead, AsyncReadExt, AsyncWriteExt, BTreeMap, BufReader,
-    CacheFetchOutcome, Command, InstallBehavior, InstallerManifest, InstallerRelease, InstallerRuntime,
-    InstallerStorage, InstallerUi, Instant, Path, PathBuf, RELEASES_FILE_COMPRESSED, ReleaseEntry, ReleaseIndex,
-    Result, Serialize, Stdio, StorageBackend, SurgeError, SurgeManifest, cache_path_for_key, compare_versions,
-    core_install, download_release_archive, fetch_or_reuse_file, host_can_build_installer_locally, infer_os_from_rid,
-    logline, make_progress_bar, make_spinner, release_install_profile, release_runtime_manifest_metadata,
-    shell_single_quote,
+    ArchiveAcquisition, AsyncBufReadExt, AsyncRead, AsyncReadExt, AsyncWriteExt, BufReader, CacheFetchOutcome, Command,
+    InstallBehavior, InstallerManifest, InstallerRelease, InstallerRuntime, InstallerStorage, InstallerUi, Instant,
+    Path, PathBuf, RELEASES_FILE_COMPRESSED, ReleaseEntry, ReleaseIndex, Result, Serialize, Stdio, StorageBackend,
+    SurgeError, SurgeManifest, cache_path_for_key, compare_versions, core_install, download_release_archive,
+    fetch_or_reuse_file, host_can_build_installer_locally, infer_os_from_rid, logline, make_progress_bar, make_spinner,
+    release_install_profile, release_runtime_manifest_metadata, shell_single_quote,
 };
 use crate::commands::pack;
 use serde::Deserialize;
@@ -28,6 +28,7 @@ pub(crate) use self::published_installer::{
     build_installer_for_tailscale, missing_remote_installer_error, plan_remote_published_installer,
     plan_remote_published_installer_without_manifest, try_prepare_published_installer_for_tailscale,
 };
+use self::runtime::{converge_current_remote_runtime, verify_remote_runtime_after_install};
 pub(crate) use self::staging::{
     deploy_remote_app_copy_for_tailscale, run_remote_staged_installer_setup, warn_if_remote_stage_cleanup_fails,
 };
@@ -46,6 +47,8 @@ pub(crate) use self::types::{
 pub(crate) use self::activation::build_remote_app_copy_activation_script;
 #[cfg(test)]
 pub(crate) use self::published_installer::{build_remote_installer_manifest, published_installer_public_url};
+#[cfg(test)]
+pub(crate) use self::runtime::{build_remote_process_verification_probe, build_remote_runtime_start_command};
 #[cfg(test)]
 pub(crate) use self::staging::{
     build_remote_paths_exist_probe, build_remote_stage_cleanup_command, build_remote_staged_installer_setup_command,
@@ -102,6 +105,22 @@ pub(super) async fn install_release_via_tailscale(
             "'{app_id}' v{} ({channel}) is already installed on '{file_target}', skipping.",
             release.version
         ));
+        return Ok(());
+    }
+
+    if convergence_plan.action == RemoteConvergenceAction::ConvergeRuntime {
+        if behavior.plan_only {
+            return Ok(());
+        }
+        if behavior.no_start {
+            logline::success(&format!(
+                "'{app_id}' v{} ({channel}) is package-current on '{file_target}'; runtime convergence was skipped because --no-start was supplied.",
+                release.version
+            ));
+            return Ok(());
+        }
+        let launch_env = detect_remote_launch_environment(ssh_target).await;
+        converge_current_remote_runtime(ssh_target, file_target, app_id, release, &launch_env).await?;
         return Ok(());
     }
 
@@ -453,6 +472,14 @@ fn log_remote_convergence_plan(
         RemoteConvergenceAction::RepairMetadata => {
             logline::info("Selected action only repairs runtime metadata; no package artifact should be downloaded.");
         }
+        RemoteConvergenceAction::ConvergeRuntime => {
+            if let Some(reason) = &plan.reason {
+                logline::info(&format!("Plan reason: {reason}"));
+            }
+            logline::info(
+                "Selected action verifies runtime state and restarts the supervisor only if runtime proof is missing.",
+            );
+        }
         RemoteConvergenceAction::Skip => {}
     }
 }
@@ -491,6 +518,7 @@ fn remote_action_label(action: RemoteConvergenceAction) -> &'static str {
         RemoteConvergenceAction::CleanInstall => "clean install",
         RemoteConvergenceAction::Update => "update existing install",
         RemoteConvergenceAction::RepairMetadata => "repair runtime metadata",
+        RemoteConvergenceAction::ConvergeRuntime => "converge runtime",
         RemoteConvergenceAction::Reinstall => "reinstall",
         RemoteConvergenceAction::Skip => "skip",
     }
@@ -501,100 +529,4 @@ fn update_strategy_label(strategy: ApplyStrategy) -> &'static str {
         ApplyStrategy::Full => "full package",
         ApplyStrategy::Delta => "delta",
     }
-}
-
-async fn verify_remote_runtime_after_install(
-    ssh_target: &str,
-    file_target: &str,
-    install_dir: &str,
-    app_id: &str,
-    release: &ReleaseEntry,
-    channel: &str,
-    storage_config: &surge_core::context::StorageConfig,
-    verify_started_process: bool,
-) -> Result<()> {
-    let state = check_remote_install_state(ssh_target, install_dir)
-        .await?
-        .ok_or_else(|| {
-            SurgeError::Update(format!(
-                "Remote runtime verification failed on '{file_target}': no runtime metadata found"
-            ))
-        })?;
-    if state.version.trim() == release.version.trim() && state.metadata_matches(channel, storage_config) {
-        logline::success(&format!(
-            "Verified remote runtime on '{file_target}': v{} ({channel}).",
-            release.version
-        ));
-        if verify_started_process {
-            verify_remote_started_process(ssh_target, file_target, app_id, release).await?;
-        }
-        return Ok(());
-    }
-
-    Err(SurgeError::Update(format!(
-        "Remote runtime verification failed on '{file_target}': found v{} channel {:?}, expected v{} channel '{}'.",
-        state.version, state.channel, release.version, channel
-    )))
-}
-
-async fn verify_remote_started_process(
-    ssh_target: &str,
-    file_target: &str,
-    app_id: &str,
-    release: &ReleaseEntry,
-) -> Result<()> {
-    let remote_home = execution::detect_remote_home_directory(ssh_target).await?;
-    let install_root = staging::remote_install_root(&remote_home, app_id, &release.install_directory)?;
-    let main_exe = if release.main_exe.trim().is_empty() {
-        app_id
-    } else {
-        release.main_exe.trim()
-    };
-    let probe =
-        build_remote_process_verification_probe(&install_root, main_exe, &release.supervisor_id, &release.version);
-    let command = format!("sh -c {}", shell_single_quote(&probe));
-    let output = execution::run_tailscale_capture(&["ssh", ssh_target, command.as_str()]).await?;
-    let result = output.trim();
-    if result == "ready" {
-        logline::success(&format!(
-            "Verified remote process on '{file_target}' for v{}.",
-            release.version
-        ));
-        return Ok(());
-    }
-
-    Err(SurgeError::Update(format!(
-        "Remote process verification failed on '{file_target}': {result}"
-    )))
-}
-
-pub(crate) fn build_remote_process_verification_probe(
-    install_root: &Path,
-    main_exe: &str,
-    supervisor_id: &str,
-    version: &str,
-) -> String {
-    format!(
-        "install_root={}; main_exe={}; supervisor_id={}; version={}; \
-active_exe=\"$install_root/app/$main_exe\"; app_seen=0; version_seen=0; supervisor_seen=0; \
-for cmdline in /proc/[0-9]*/cmdline; do \
-  [ -r \"$cmdline\" ] || continue; \
-  pid=\"${{cmdline%/cmdline}}\"; pid=\"${{pid##*/}}\"; \
-  case \"$pid\" in \"$$\"|\"$PPID\") continue ;; esac; \
-  cmd=\"$(tr '\\0' ' ' < \"$cmdline\" 2>/dev/null || true)\"; \
-  [ -n \"$cmd\" ] || continue; \
-  case \"$cmd\" in *\"$active_exe\"*) app_seen=1; case \"$cmd\" in *\"--surge-first-run $version\"*) version_seen=1 ;; esac ;; esac; \
-  if [ -n \"$supervisor_id\" ]; then \
-    case \"$cmd\" in *\"surge-supervisor\"*\"--id $supervisor_id\"*) supervisor_seen=1 ;; esac; \
-  fi; \
-done; \
-if [ \"$app_seen\" -ne 1 ]; then echo \"app process for $active_exe was not found\"; exit 0; fi; \
-if [ -n \"$version\" ] && [ \"$version_seen\" -ne 1 ]; then echo \"app process for $active_exe is running without --surge-first-run $version\"; exit 0; fi; \
-if [ -n \"$supervisor_id\" ] && [ \"$supervisor_seen\" -ne 1 ]; then echo \"supervisor process '$supervisor_id' was not found\"; exit 0; fi; \
-echo ready",
-        shell_single_quote(&install_root.to_string_lossy()),
-        shell_single_quote(main_exe),
-        shell_single_quote(supervisor_id.trim()),
-        shell_single_quote(version.trim())
-    )
 }

--- a/crates/surge-cli/src/commands/install/remote/published_installer.rs
+++ b/crates/surge-cli/src/commands/install/remote/published_installer.rs
@@ -1,9 +1,10 @@
 use super::types::{RemoteInstallerMode, RemoteLaunchEnvironment, RemotePublishedInstallerPlan};
 use super::{
-    BTreeMap, CacheFetchOutcome, InstallerManifest, InstallerRelease, InstallerRuntime, InstallerStorage, InstallerUi,
-    Path, PathBuf, RELEASES_FILE_COMPRESSED, ReleaseEntry, Result, StorageBackend, SurgeError, SurgeManifest,
+    CacheFetchOutcome, InstallerManifest, InstallerRelease, InstallerRuntime, InstallerStorage, InstallerUi, Path,
+    PathBuf, RELEASES_FILE_COMPRESSED, ReleaseEntry, Result, StorageBackend, SurgeError, SurgeManifest,
     cache_path_for_key, core_install, fetch_or_reuse_file, logline, pack,
 };
+use std::collections::BTreeMap;
 use surge_core::config::manifest::CacheManifestConfig;
 
 fn remote_installer_extension_for_rid(rid: &str) -> &'static str {

--- a/crates/surge-cli/src/commands/install/remote/runtime.rs
+++ b/crates/surge-cli/src/commands/install/remote/runtime.rs
@@ -1,0 +1,261 @@
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use super::{
+    ReleaseEntry, Result, SurgeError, activation, check_remote_install_state, execution, logline, published_installer,
+    run_tailscale_streaming, shell_single_quote, staging, types,
+};
+
+pub(crate) async fn converge_current_remote_runtime(
+    ssh_target: &str,
+    file_target: &str,
+    app_id: &str,
+    release: &ReleaseEntry,
+    launch_env: &types::RemoteLaunchEnvironment,
+) -> Result<()> {
+    logline::info(&format!(
+        "'{app_id}' v{} is package-current on '{file_target}'; verifying active runtime because --force was supplied.",
+        release.version
+    ));
+
+    match verify_remote_started_process(ssh_target, file_target, app_id, release).await {
+        Ok(()) => {
+            logline::success(&format!(
+                "Remote package-current/runtime-current proof confirmed on '{file_target}' for v{}.",
+                release.version
+            ));
+            Ok(())
+        }
+        Err(error) => {
+            logline::warn(&format!(
+                "Remote runtime proof is missing on '{file_target}'; restarting current install: {error}"
+            ));
+            restart_current_remote_runtime(ssh_target, file_target, app_id, release, launch_env).await?;
+            verify_remote_started_process(ssh_target, file_target, app_id, release).await?;
+            logline::success(&format!(
+                "Remote restart-performed/restart-confirmed proof succeeded on '{file_target}' for v{}.",
+                release.version
+            ));
+            Ok(())
+        }
+    }
+}
+
+async fn restart_current_remote_runtime(
+    ssh_target: &str,
+    file_target: &str,
+    app_id: &str,
+    release: &ReleaseEntry,
+    launch_env: &types::RemoteLaunchEnvironment,
+) -> Result<()> {
+    let remote_home = execution::detect_remote_home_directory(ssh_target).await?;
+    let install_root = staging::remote_install_root(&remote_home, app_id, &release.install_directory)?;
+    if !release.supervisor_id.trim().is_empty() {
+        staging::stop_remote_supervisor_if_running(ssh_target, &install_root, &release.supervisor_id).await?;
+    }
+
+    let main_exe = if release.main_exe.trim().is_empty() {
+        app_id
+    } else {
+        release.main_exe.trim()
+    };
+    let runtime_environment = published_installer::build_remote_runtime_environment(release, launch_env);
+    let restart_command = build_remote_runtime_start_command(
+        &install_root,
+        main_exe,
+        &release.supervisor_id,
+        &release.version,
+        &runtime_environment,
+    );
+    let ssh_command = format!("sh -lc {}", shell_single_quote(&restart_command));
+    logline::info(&format!("Restarting remote runtime on '{file_target}'..."));
+    run_tailscale_streaming(&["ssh", ssh_target, ssh_command.as_str()], "remote").await
+}
+
+pub(crate) fn build_remote_runtime_start_command(
+    install_root: &Path,
+    main_exe: &str,
+    supervisor_id: &str,
+    version: &str,
+    environment: &BTreeMap<String, String>,
+) -> String {
+    let install_root = shell_single_quote(&install_root.to_string_lossy());
+    let main_exe = shell_single_quote(main_exe);
+    let supervisor_id = shell_single_quote(supervisor_id.trim());
+    let version = shell_single_quote(version.trim());
+    let exports = activation::shell_export_lines(environment);
+
+    format!(
+        "set -eu\n\
+install_root={install_root}\n\
+active_app_dir=\"$install_root/app\"\n\
+main_exe={main_exe}\n\
+supervisor_id={supervisor_id}\n\
+version={version}\n\
+active_exe=\"$active_app_dir/$main_exe\"\n\
+{exports}\
+if [ ! -f \"$active_exe\" ]; then\n\
+  echo \"application executable missing at $active_exe\" >&2\n\
+  exit 1\n\
+fi\n\
+if [ ! -x \"$active_exe\" ]; then\n\
+  chmod +x \"$active_exe\" || true\n\
+fi\n\
+kill_matching() {{\n\
+  pattern=\"$1\"\n\
+  if ! command -v pgrep >/dev/null 2>&1; then\n\
+    return 0\n\
+  fi\n\
+  for pid in $(pgrep -u \"$(id -u)\" -f \"$pattern\" 2>/dev/null || true); do\n\
+    case \"$pid\" in \"$$\"|\"$PPID\") continue ;; esac\n\
+    kill \"$pid\" 2>/dev/null || true\n\
+  done\n\
+}}\n\
+kill_matching \"$active_exe\"\n\
+kill_matching \"$install_root/app-\"\n\
+kill_matching \"$install_root/app/\"\n\
+cd \"$install_root\"\n\
+if [ -n \"$supervisor_id\" ]; then\n\
+  kill_matching \"surge-supervisor.*--id $supervisor_id\"\n\
+  supervisor_bin=\"$active_app_dir/surge-supervisor\"\n\
+  pid_file=\"$install_root/.surge-supervisor-$supervisor_id.pid\"\n\
+  stop_file=\"$install_root/.surge-supervisor-$supervisor_id.stop\"\n\
+  if [ ! -f \"$supervisor_bin\" ]; then\n\
+    echo \"supervisor binary missing at $supervisor_bin\" >&2\n\
+    exit 1\n\
+  fi\n\
+  if [ ! -x \"$supervisor_bin\" ]; then\n\
+    chmod +x \"$supervisor_bin\" || true\n\
+  fi\n\
+  rm -f \"$stop_file\"\n\
+  if [ -n \"$version\" ]; then\n\
+    nohup \"$supervisor_bin\" run --id \"$supervisor_id\" --dir \"$install_root\" --exe \"$active_exe\" -- --surge-first-run \"$version\" >/dev/null 2>&1 &\n\
+  else\n\
+    nohup \"$supervisor_bin\" run --id \"$supervisor_id\" --dir \"$install_root\" --exe \"$active_exe\" -- --surge-first-run >/dev/null 2>&1 &\n\
+  fi\n\
+  i=0\n\
+  while [ ! -f \"$pid_file\" ]; do\n\
+    if [ \"$i\" -ge 50 ]; then\n\
+      echo \"supervisor restart was not confirmed: $pid_file did not appear\" >&2\n\
+      exit 1\n\
+    fi\n\
+    sleep 0.1\n\
+    i=$((i + 1))\n\
+  done\n\
+  echo \"supervisor restart confirmed\"\n\
+else\n\
+  if [ -n \"$version\" ]; then\n\
+    nohup \"$active_exe\" --surge-first-run \"$version\" >/dev/null 2>&1 &\n\
+  else\n\
+    nohup \"$active_exe\" --surge-first-run >/dev/null 2>&1 &\n\
+  fi\n\
+  echo \"application restart requested\"\n\
+fi\n"
+    )
+}
+
+pub(crate) async fn verify_remote_runtime_after_install(
+    ssh_target: &str,
+    file_target: &str,
+    install_dir: &str,
+    app_id: &str,
+    release: &ReleaseEntry,
+    channel: &str,
+    storage_config: &surge_core::context::StorageConfig,
+    verify_started_process: bool,
+) -> Result<()> {
+    let state = check_remote_install_state(ssh_target, install_dir)
+        .await?
+        .ok_or_else(|| {
+            SurgeError::Update(format!(
+                "Remote runtime verification failed on '{file_target}': no runtime metadata found"
+            ))
+        })?;
+    if state.version.trim() == release.version.trim() && state.metadata_matches(channel, storage_config) {
+        logline::success(&format!(
+            "Verified remote runtime on '{file_target}': v{} ({channel}).",
+            release.version
+        ));
+        if verify_started_process {
+            verify_remote_started_process(ssh_target, file_target, app_id, release).await?;
+        }
+        return Ok(());
+    }
+
+    Err(SurgeError::Update(format!(
+        "Remote runtime verification failed on '{file_target}': found v{} channel {:?}, expected v{} channel '{}'.",
+        state.version, state.channel, release.version, channel
+    )))
+}
+
+async fn verify_remote_started_process(
+    ssh_target: &str,
+    file_target: &str,
+    app_id: &str,
+    release: &ReleaseEntry,
+) -> Result<()> {
+    let remote_home = execution::detect_remote_home_directory(ssh_target).await?;
+    let install_root = staging::remote_install_root(&remote_home, app_id, &release.install_directory)?;
+    let main_exe = if release.main_exe.trim().is_empty() {
+        app_id
+    } else {
+        release.main_exe.trim()
+    };
+    let probe =
+        build_remote_process_verification_probe(&install_root, main_exe, &release.supervisor_id, &release.version);
+    let command = format!("sh -c {}", shell_single_quote(&probe));
+    let mut last_result = String::new();
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+    loop {
+        let output = execution::run_tailscale_capture(&["ssh", ssh_target, command.as_str()]).await?;
+        let result = output.trim();
+        if result == "ready" {
+            logline::success(&format!(
+                "Verified remote process on '{file_target}' for v{}.",
+                release.version
+            ));
+            return Ok(());
+        }
+        last_result.clear();
+        last_result.push_str(result);
+        if std::time::Instant::now() >= deadline {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+    }
+
+    Err(SurgeError::Update(format!(
+        "Remote process verification failed on '{file_target}': {last_result}"
+    )))
+}
+
+pub(crate) fn build_remote_process_verification_probe(
+    install_root: &Path,
+    main_exe: &str,
+    supervisor_id: &str,
+    version: &str,
+) -> String {
+    format!(
+        "install_root={}; main_exe={}; supervisor_id={}; version={}; \
+active_exe=\"$install_root/app/$main_exe\"; app_seen=0; version_seen=0; supervisor_seen=0; \
+for cmdline in /proc/[0-9]*/cmdline; do \
+  [ -r \"$cmdline\" ] || continue; \
+  pid=\"${{cmdline%/cmdline}}\"; pid=\"${{pid##*/}}\"; \
+  case \"$pid\" in \"$$\"|\"$PPID\") continue ;; esac; \
+  cmd=\"$(tr '\\0' ' ' < \"$cmdline\" 2>/dev/null || true)\"; \
+  [ -n \"$cmd\" ] || continue; \
+  case \"$cmd\" in *\"$active_exe\"*) app_seen=1; case \"$cmd\" in *\"--surge-first-run $version\"*) version_seen=1 ;; esac ;; esac; \
+  if [ -n \"$supervisor_id\" ]; then \
+    case \"$cmd\" in *\"surge-supervisor\"*\"--id $supervisor_id\"*) supervisor_seen=1 ;; esac; \
+  fi; \
+done; \
+if [ \"$app_seen\" -ne 1 ]; then echo \"app process for $active_exe was not found\"; exit 0; fi; \
+if [ -n \"$version\" ] && [ \"$version_seen\" -ne 1 ]; then echo \"app process for $active_exe is running without --surge-first-run $version\"; exit 0; fi; \
+if [ -n \"$supervisor_id\" ] && [ \"$supervisor_seen\" -ne 1 ]; then echo \"supervisor process '$supervisor_id' was not found\"; exit 0; fi; \
+echo ready",
+        shell_single_quote(&install_root.to_string_lossy()),
+        shell_single_quote(main_exe),
+        shell_single_quote(supervisor_id.trim()),
+        shell_single_quote(version.trim())
+    )
+}

--- a/crates/surge-cli/src/commands/install/remote/staging.rs
+++ b/crates/surge-cli/src/commands/install/remote/staging.rs
@@ -268,7 +268,11 @@ pub(crate) async fn cleanup_remote_staged_payload(ssh_node: &str, app_id: &str, 
     run_tailscale_streaming(&["ssh", ssh_node, ssh_command.as_str()], "remote").await
 }
 
-async fn stop_remote_supervisor_if_running(ssh_node: &str, install_root: &Path, supervisor_id: &str) -> Result<()> {
+pub(crate) async fn stop_remote_supervisor_if_running(
+    ssh_node: &str,
+    install_root: &Path,
+    supervisor_id: &str,
+) -> Result<()> {
     let Some(stop_command) = build_remote_stop_supervisor_command(install_root, supervisor_id) else {
         return Ok(());
     };

--- a/crates/surge-cli/src/commands/install/remote/state.rs
+++ b/crates/surge-cli/src/commands/install/remote/state.rs
@@ -163,7 +163,14 @@ pub(crate) fn plan_remote_convergence(
     let installed_version = Some(remote_state.version.clone());
     let metadata_matches = remote_state.metadata_matches(channel, storage_config);
     match compare_versions(&remote_state.version, &release.version) {
-        std::cmp::Ordering::Equal if metadata_matches && !force => Ok(RemoteConvergencePlan {
+        std::cmp::Ordering::Equal if metadata_matches && force => Ok(RemoteConvergencePlan {
+            action: RemoteConvergenceAction::ConvergeRuntime,
+            installed_version,
+            target_version: release.version.clone(),
+            update_info: None,
+            reason: Some("package metadata is current; --force will verify remote runtime convergence".to_string()),
+        }),
+        std::cmp::Ordering::Equal if metadata_matches => Ok(RemoteConvergencePlan {
             action: RemoteConvergenceAction::Skip,
             installed_version,
             target_version: release.version.clone(),

--- a/crates/surge-cli/src/commands/install/remote/types.rs
+++ b/crates/surge-cli/src/commands/install/remote/types.rs
@@ -122,6 +122,7 @@ pub(crate) enum RemoteConvergenceAction {
     CleanInstall,
     Update,
     RepairMetadata,
+    ConvergeRuntime,
     Reinstall,
     Skip,
 }


### PR DESCRIPTION
## Purpose

Fixes #122.

Forced tailscale installs now converge the remote runtime when package metadata is already current instead of blindly treating that state as a full reinstall or silently accepting stale process state.

## Behavior impact

- Adds a package-current runtime convergence plan for `surge install tailscale --force`.
- Verifies active app/supervisor process state before doing work.
- Restarts the current install through the supervisor path when runtime proof is missing, then confirms restart/runtime proof.
- Splits the remote runtime convergence/probe logic into a focused module to stay within the maintainability guardrail.
- Leaves normal non-force already-current installs unchanged.

## Test evidence

- `./scripts/sync-surge-core-vendor.sh --check`
- `./scripts/check-version-sync.sh`
- `cargo fmt --all -- --check`
- `./scripts/check-maintainability.sh`
- `RUSTFLAGS="-D warnings" cargo test --workspace` (passed outside sandbox because the lock-server test needs a local listener)
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo clippy --workspace --lib --bins --examples -- -D warnings -D clippy::unwrap_used -D clippy::expect_used`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings -W clippy::pedantic`
- `dotnet format dotnet/Surge.slnx --verify-no-changes` (passed outside sandbox because the formatter performs restore)
- `dotnet test dotnet/Surge.slnx --configuration Release`

## Migration notes

None.
