### PR TITLE
fix(cli): add remote setup phase watchdogs

### DIFF
--- a/crates/surge-cli/src/commands/install/remote/execution.rs
+++ b/crates/surge-cli/src/commands/install/remote/execution.rs
@@ -1,6 +1,7 @@
 use std::process::ExitStatus;
 use std::time::Duration;
 
+use super::watchdog::{RemoteSetupWatchdog, wait_for_tailscale_command_with_status_watchdog};
 use super::{
     AsyncBufReadExt, AsyncRead, AsyncReadExt, AsyncWriteExt, BufReader, Command, Instant, Path, Result, Stdio,
     SurgeError, logline, make_progress_bar, make_spinner, shell_single_quote,
@@ -329,6 +330,22 @@ pub(crate) async fn run_tailscale_capture(args: &[&str]) -> Result<String> {
 }
 
 pub(crate) async fn run_tailscale_streaming(args: &[&str], prefix: &str) -> Result<()> {
+    run_tailscale_streaming_inner(args, prefix, None).await
+}
+
+pub(crate) async fn run_tailscale_streaming_with_status_watchdog(
+    args: &[&str],
+    prefix: &str,
+    watchdog: RemoteSetupWatchdog,
+) -> Result<()> {
+    run_tailscale_streaming_inner(args, prefix, Some(watchdog)).await
+}
+
+async fn run_tailscale_streaming_inner(
+    args: &[&str],
+    prefix: &str,
+    watchdog: Option<RemoteSetupWatchdog>,
+) -> Result<()> {
     let mut child = Command::new("tailscale")
         .args(args)
         .stdout(Stdio::piped())
@@ -346,11 +363,25 @@ pub(crate) async fn run_tailscale_streaming(args: &[&str], prefix: &str) -> Resu
         .take()
         .ok_or_else(|| SurgeError::Platform("Failed to capture tailscale stderr".to_string()))?;
 
-    let stdout_task = tokio::spawn(relay_tailscale_output(stdout, prefix.to_string()));
-    let stderr_task = tokio::spawn(relay_tailscale_output(stderr, prefix.to_string()));
+    let (progress_tx, progress_rx) = tokio::sync::mpsc::unbounded_channel();
+    let stdout_task = tokio::spawn(relay_tailscale_output(
+        stdout,
+        prefix.to_string(),
+        watchdog.as_ref().map(|_| progress_tx.clone()),
+    ));
+    let stderr_task = tokio::spawn(relay_tailscale_output(
+        stderr,
+        prefix.to_string(),
+        watchdog.as_ref().map(|_| progress_tx.clone()),
+    ));
+    drop(progress_tx);
 
     let cmd = format!("tailscale {}", args.join(" "));
-    let status = wait_for_tailscale_command(&mut child, &cmd).await?;
+    let status = if let Some(watchdog) = watchdog {
+        wait_for_tailscale_command_with_status_watchdog(&mut child, &cmd, &watchdog, progress_rx).await?
+    } else {
+        wait_for_tailscale_command(&mut child, &cmd).await?
+    };
     let stdout = stdout_task
         .await
         .map_err(|e| SurgeError::Platform(format!("Failed to read tailscale stdout: {e}")))?
@@ -389,7 +420,11 @@ async fn wait_for_tailscale_command(child: &mut tokio::process::Child, cmd: &str
     )))
 }
 
-async fn relay_tailscale_output<R>(reader: R, prefix: String) -> std::io::Result<String>
+async fn relay_tailscale_output<R>(
+    reader: R,
+    prefix: String,
+    progress_tx: Option<tokio::sync::mpsc::UnboundedSender<()>>,
+) -> std::io::Result<String>
 where
     R: AsyncRead + Unpin + Send + 'static,
 {
@@ -408,6 +443,9 @@ where
         let trimmed = chunk.trim();
         if !trimmed.is_empty() {
             logline::subtle(&format!("{prefix}: {trimmed}"));
+            if let Some(progress_tx) = &progress_tx {
+                let _ = progress_tx.send(());
+            }
         }
         captured.push_str(&chunk);
     }

--- a/crates/surge-cli/src/commands/install/remote/mod.rs
+++ b/crates/surge-cli/src/commands/install/remote/mod.rs
@@ -7,6 +7,7 @@ mod runtime;
 mod staging;
 mod state;
 mod types;
+mod watchdog;
 
 use super::{
     ArchiveAcquisition, AsyncBufReadExt, AsyncRead, AsyncReadExt, AsyncWriteExt, BufReader, CacheFetchOutcome, Command,
@@ -22,7 +23,7 @@ use surge_core::update::manager::ApplyStrategy;
 
 pub(crate) use self::execution::{
     REMOTE_INSTALLER_FINAL_PATH, build_remote_installer_install_command, resolve_tailscale_targets,
-    run_tailscale_streaming, stream_file_to_tailscale_node_with_command,
+    run_tailscale_streaming, run_tailscale_streaming_with_status_watchdog, stream_file_to_tailscale_node_with_command,
 };
 pub(crate) use self::published_installer::{
     build_installer_for_tailscale, missing_remote_installer_error, plan_remote_published_installer,
@@ -42,6 +43,7 @@ pub(crate) use self::types::{
     RemoteTailscaleCachedState, RemoteTailscaleOperation, RemoteTailscaleTransferInputs,
     RemoteTailscaleTransferStrategy, ensure_supported_tailscale_rid,
 };
+pub(crate) use self::watchdog::RemoteSetupWatchdog;
 
 #[cfg(test)]
 pub(crate) use self::activation::build_remote_app_copy_activation_script;
@@ -394,7 +396,11 @@ pub(super) async fn install_release_via_tailscale(
     } else {
         logline::info(&format!("Running installer on '{file_target}'..."));
     }
-    run_tailscale_streaming(&["ssh", ssh_target, ssh_command.as_str()], "remote").await?;
+    let remote_home = execution::detect_remote_home_directory(ssh_target).await?;
+    let install_root_for_watchdog = staging::remote_install_root(&remote_home, app_id, &release.install_directory)?;
+    let watchdog = RemoteSetupWatchdog::new(ssh_target, &install_root_for_watchdog);
+    run_tailscale_streaming_with_status_watchdog(&["ssh", ssh_target, ssh_command.as_str()], "remote", watchdog)
+        .await?;
     if !behavior.mode.is_stage() {
         warn_if_remote_stage_cleanup_fails(ssh_target, app_id, release).await;
         verify_remote_runtime_after_install(

--- a/crates/surge-cli/src/commands/install/remote/staging.rs
+++ b/crates/surge-cli/src/commands/install/remote/staging.rs
@@ -3,14 +3,14 @@ use super::activation::{
 };
 use super::execution::{
     detect_remote_home_directory, run_tailscale_capture, run_tailscale_streaming,
-    stream_directory_to_tailscale_node_with_command,
+    run_tailscale_streaming_with_status_watchdog, stream_directory_to_tailscale_node_with_command,
 };
 use super::published_installer::build_remote_runtime_environment;
 use super::state::{check_remote_staged_payload_identity, remote_staged_payload_identity};
 use super::types::RemoteLaunchEnvironment;
 use super::{
-    ArchiveAcquisition, Path, PathBuf, ReleaseEntry, ReleaseIndex, Result, StorageBackend, SurgeError,
-    cache_path_for_key, core_install, download_release_archive, logline, release_install_profile,
+    ArchiveAcquisition, Path, PathBuf, ReleaseEntry, ReleaseIndex, RemoteSetupWatchdog, Result, StorageBackend,
+    SurgeError, cache_path_for_key, core_install, download_release_archive, logline, release_install_profile,
     release_runtime_manifest_metadata, shell_single_quote,
 };
 
@@ -251,7 +251,8 @@ pub(crate) async fn run_remote_staged_installer_setup(
         "Using pre-staged installer cache for '{app_id}' v{} on '{file_target}'.",
         release.version
     ));
-    run_tailscale_streaming(&["ssh", ssh_node, ssh_command.as_str()], "remote").await
+    let watchdog = RemoteSetupWatchdog::new(ssh_node, &install_root);
+    run_tailscale_streaming_with_status_watchdog(&["ssh", ssh_node, ssh_command.as_str()], "remote", watchdog).await
 }
 
 pub(crate) async fn warn_if_remote_stage_cleanup_fails(ssh_node: &str, app_id: &str, release: &ReleaseEntry) {

--- a/crates/surge-cli/src/commands/install/remote/watchdog.rs
+++ b/crates/surge-cli/src/commands/install/remote/watchdog.rs
@@ -1,0 +1,164 @@
+use std::process::ExitStatus;
+use std::time::{Duration, Instant};
+
+use serde::Deserialize;
+use surge_core::update::status::UPDATE_STATUS_FILE_NAME;
+
+use super::execution::run_tailscale_capture;
+use super::{Path, Result, SurgeError, logline, shell_single_quote};
+
+const TAILSCALE_STREAM_COMMAND_TIMEOUT: Duration = Duration::from_mins(30);
+const REMOTE_SETUP_STALE_PROGRESS_TIMEOUT: Duration = Duration::from_mins(2);
+const REMOTE_SETUP_WATCHDOG_POLL_INTERVAL: Duration = Duration::from_secs(1);
+
+#[derive(Debug, Clone)]
+pub(crate) struct RemoteSetupWatchdog {
+    ssh_node: String,
+    install_root: std::path::PathBuf,
+    stale_timeout: Duration,
+}
+
+impl RemoteSetupWatchdog {
+    pub(crate) fn new(ssh_node: &str, install_root: &Path) -> Self {
+        Self {
+            ssh_node: ssh_node.to_string(),
+            install_root: install_root.to_path_buf(),
+            stale_timeout: REMOTE_SETUP_STALE_PROGRESS_TIMEOUT,
+        }
+    }
+}
+
+pub(super) async fn wait_for_tailscale_command_with_status_watchdog(
+    child: &mut tokio::process::Child,
+    cmd: &str,
+    watchdog: &RemoteSetupWatchdog,
+    mut progress_rx: tokio::sync::mpsc::UnboundedReceiver<()>,
+) -> Result<ExitStatus> {
+    let started_at = Instant::now();
+    let mut last_progress_at = Instant::now();
+
+    loop {
+        if started_at.elapsed() >= TAILSCALE_STREAM_COMMAND_TIMEOUT {
+            let _ = child.kill().await;
+            return Err(SurgeError::Platform(format!(
+                "Timed out after {}s running {cmd}",
+                TAILSCALE_STREAM_COMMAND_TIMEOUT.as_secs()
+            )));
+        }
+
+        if last_progress_at.elapsed() >= watchdog.stale_timeout {
+            let status = read_remote_update_status(watchdog).await?;
+            if let Some(status) = status.as_ref() {
+                if status.is_terminal_failure() {
+                    let _ = child.kill().await;
+                    return Err(SurgeError::Platform(format!(
+                        "Remote setup failed{}",
+                        status.format_context()
+                    )));
+                }
+                if status.has_recent_progress(watchdog.stale_timeout) {
+                    logline::subtle(&format!("remote: setup still in progress{}", status.format_context()));
+                    last_progress_at = Instant::now();
+                    continue;
+                }
+            }
+
+            let _ = child.kill().await;
+            let context = status.map_or_else(String::new, |status| status.format_context());
+            return Err(SurgeError::Platform(format!(
+                "Timed out after {}s without fresh remote setup progress{context}",
+                watchdog.stale_timeout.as_secs()
+            )));
+        }
+
+        tokio::select! {
+            status = child.wait() => {
+                return status.map_err(|e| SurgeError::Platform(format!("Failed to wait for tailscale command: {e}")));
+            }
+            progress = progress_rx.recv() => {
+                if progress.is_some() {
+                    last_progress_at = Instant::now();
+                }
+            }
+            () = tokio::time::sleep(REMOTE_SETUP_WATCHDOG_POLL_INTERVAL) => {}
+        }
+    }
+}
+
+async fn read_remote_update_status(watchdog: &RemoteSetupWatchdog) -> Result<Option<RemoteUpdateStatusSnapshot>> {
+    let status_path = watchdog.install_root.join(UPDATE_STATUS_FILE_NAME);
+    let script = format!(
+        "status_path={}; if [ -f \"$status_path\" ]; then cat \"$status_path\"; fi",
+        shell_single_quote(&status_path.to_string_lossy())
+    );
+    let command = format!("sh -c {}", shell_single_quote(&script));
+    let raw = run_tailscale_capture(&["ssh", watchdog.ssh_node.as_str(), command.as_str()]).await?;
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Ok(None);
+    }
+    serde_json::from_str(trimmed)
+        .map(Some)
+        .map_err(|e| SurgeError::Config(format!("Failed to decode remote update status: {e}")))
+}
+
+#[derive(Debug, Deserialize)]
+struct RemoteUpdateStatusSnapshot {
+    state: String,
+    #[serde(default)]
+    reason: Option<String>,
+    #[serde(default)]
+    last_progress_at_utc: Option<String>,
+    #[serde(default)]
+    current_phase: Option<String>,
+    #[serde(default)]
+    last_completed_phase: Option<String>,
+    #[serde(default)]
+    failure_phase: Option<String>,
+    #[serde(default)]
+    retry_safe: Option<bool>,
+}
+
+impl RemoteUpdateStatusSnapshot {
+    fn has_recent_progress(&self, stale_timeout: Duration) -> bool {
+        let Some(last_progress_at_utc) = self.last_progress_at_utc.as_deref() else {
+            return false;
+        };
+        let Ok(parsed) = chrono::DateTime::parse_from_rfc3339(last_progress_at_utc) else {
+            return false;
+        };
+        match chrono::Utc::now()
+            .signed_duration_since(parsed.with_timezone(&chrono::Utc))
+            .to_std()
+        {
+            Ok(age) => age <= stale_timeout,
+            Err(_) => true,
+        }
+    }
+
+    fn is_terminal_failure(&self) -> bool {
+        self.state == "failed" || self.state == "pending_restart"
+    }
+
+    fn format_context(&self) -> String {
+        let mut parts = vec![format!("state={}", self.state)];
+        if let Some(phase) = self
+            .failure_phase
+            .as_deref()
+            .or(self.current_phase.as_deref())
+            .or(self.last_completed_phase.as_deref())
+        {
+            parts.push(format!("phase={phase}"));
+        }
+        if let Some(last_progress) = self.last_progress_at_utc.as_deref() {
+            parts.push(format!("last_progress_at_utc={last_progress}"));
+        }
+        if let Some(reason) = self.reason.as_deref() {
+            parts.push(format!("reason={reason}"));
+        }
+        if let Some(retry_safe) = self.retry_safe {
+            parts.push(format!("retry_safe={retry_safe}"));
+        }
+        format!(" ({})", parts.join(", "))
+    }
+}

--- a/crates/surge-cli/src/commands/setup.rs
+++ b/crates/surge-cli/src/commands/setup.rs
@@ -17,6 +17,7 @@ use surge_core::releases::restore::RestoreProgress;
 use surge_core::update::manager::ProgressInfo;
 
 mod convergence;
+mod status;
 
 const PACKAGE_PROGRESS_LOG_INTERVAL: Duration = Duration::from_secs(10);
 const PACKAGE_PROGRESS_PERCENT_STEP: u64 = 10;
@@ -187,7 +188,7 @@ pub async fn execute(dir: &Path, no_start: bool, stage: bool, reinstall: bool) -
     let install_root = default_install_root(&manifest.app_id, &manifest.runtime.install_directory)?;
 
     if stage {
-        let package = resolve_package(dir, &manifest, &install_root).await?;
+        let package = resolve_package(dir, &manifest, &install_root, None).await?;
         ensure_stage_cache_entry(&package, &manifest, &install_root)?;
         prune_setup_artifact_cache(&install_root, &package, &manifest);
         persist_staged_installer_cache(dir, &manifest, &install_root)?;
@@ -204,49 +205,75 @@ pub async fn execute(dir: &Path, no_start: bool, stage: bool, reinstall: bool) -
         return Ok(());
     }
 
-    if let Err(e) = super::stop_supervisor(&install_root, &manifest.runtime.supervisor_id).await {
-        logline::warn(&format!("Could not stop supervisor: {e}"));
-    }
-    stop_running_app(&install_root, &manifest.runtime.main_exe)?;
+    let setup_status = status::SetupStatus::new(&manifest, &install_root);
+    let setup_result: Result<()> = async {
+        setup_status.record_phase(status::PHASE_STAGE_RECEIVED);
+        setup_status.record_completed_phase(status::PHASE_STAGE_RECEIVED);
+        setup_status.record_phase(status::PHASE_SUPERVISOR_STOP_REQUESTED);
+        if let Err(e) = super::stop_supervisor(&install_root, &manifest.runtime.supervisor_id).await {
+            logline::warn(&format!("Could not stop supervisor: {e}"));
+        }
+        stop_running_app(&install_root, &manifest.runtime.main_exe)?;
+        setup_status.record_completed_phase(status::PHASE_SUPERVISOR_STOP_REQUESTED);
 
-    let package = resolve_package(dir, &manifest, &install_root).await?;
+        setup_status.record_phase(status::PHASE_RELEASE_RESOLVED);
+        let package = resolve_package(dir, &manifest, &install_root, Some(&setup_status)).await?;
+        setup_status.record_completed_phase(status::PHASE_PACKAGE_DOWNLOADED);
 
-    let profile = InstallProfile::from_installer_manifest(&manifest, &manifest.runtime.shortcuts);
+        let profile = InstallProfile::from_installer_manifest(&manifest, &manifest.runtime.shortcuts);
 
-    core_install::install_package_locally_at_root(&profile, package.path(), &install_root)?;
-    let active_app_dir = install_root.join("app");
-    let runtime_manifest = core_install::RuntimeManifestMetadata::new(
-        &manifest.version,
-        &manifest.channel,
-        &manifest.storage.provider,
-        &manifest.storage.bucket,
-        &manifest.storage.region,
-        &manifest.storage.endpoint,
-    );
-    core_install::write_runtime_manifest(&active_app_dir, &profile, &runtime_manifest)?;
-
-    prune_setup_artifact_cache(&install_root, &package, &manifest);
-
-    logline::success(&format!(
-        "Installed '{}' to '{}'",
-        manifest.app_id,
-        install_root.display()
-    ));
-
-    if !no_start {
-        match core_install::auto_start_after_install_sequence(
-            &profile,
-            &install_root,
-            &active_app_dir,
+        setup_status.record_phase(status::PHASE_APP_SWAP_STARTED);
+        core_install::install_package_locally_at_root(&profile, package.path(), &install_root)?;
+        let active_app_dir = install_root.join("app");
+        setup_status.record_completed_phase(status::PHASE_PERSISTENT_ASSETS_COPIED);
+        let runtime_manifest = core_install::RuntimeManifestMetadata::new(
             &manifest.version,
-        ) {
-            Ok(pid) => {
-                logline::success(&format!("Started '{}' (pid {pid})", manifest.runtime.name));
-            }
-            Err(e) => {
-                logline::warn(&format!("Auto-start failed: {e}"));
+            &manifest.channel,
+            &manifest.storage.provider,
+            &manifest.storage.bucket,
+            &manifest.storage.region,
+            &manifest.storage.endpoint,
+        );
+        core_install::write_runtime_manifest(&active_app_dir, &profile, &runtime_manifest)?;
+
+        prune_setup_artifact_cache(&install_root, &package, &manifest);
+
+        logline::success(&format!(
+            "Installed '{}' to '{}'",
+            manifest.app_id,
+            install_root.display()
+        ));
+
+        if no_start {
+            setup_status.record_converged(false);
+        } else {
+            setup_status.record_phase(status::PHASE_SUPERVISOR_RESTART_REQUESTED);
+            match core_install::auto_start_after_install_sequence(
+                &profile,
+                &install_root,
+                &active_app_dir,
+                &manifest.version,
+            ) {
+                Ok(pid) => {
+                    logline::success(&format!("Started '{}' (pid {pid})", manifest.runtime.name));
+                    setup_status.record_completed_phase(status::PHASE_SUPERVISOR_RESTART_CONFIRMED);
+                    setup_status.record_converged(!manifest.runtime.supervisor_id.trim().is_empty());
+                }
+                Err(e) => {
+                    let reason = format!("Auto-start failed: {e}");
+                    logline::warn(&reason);
+                    setup_status.record_pending_restart(&reason);
+                }
             }
         }
+
+        Ok(())
+    }
+    .await;
+
+    if let Err(e) = setup_result {
+        setup_status.record_failed(&e.to_string());
+        return Err(e);
     }
 
     Ok(())
@@ -254,7 +281,12 @@ pub async fn execute(dir: &Path, no_start: bool, stage: bool, reinstall: bool) -
 
 /// Resolve the full package: prefer bundled payload, then the persistent
 /// artifact cache, then release-graph reconstruction/download into that cache.
-async fn resolve_package(dir: &Path, manifest: &InstallerManifest, install_root: &Path) -> Result<ResolvedPackage> {
+async fn resolve_package(
+    dir: &Path,
+    manifest: &InstallerManifest,
+    install_root: &Path,
+    setup_status: Option<&status::SetupStatus>,
+) -> Result<ResolvedPackage> {
     let full_filename = manifest.release.full_filename.trim();
     let download_progress = Mutex::new(ProgressReporter::new("Downloading package..."));
     let restore_progress = Mutex::new(ProgressReporter::new("Preparing package..."));
@@ -269,6 +301,9 @@ async fn resolve_package(dir: &Path, manifest: &InstallerManifest, install_root:
                     .lock()
                     .unwrap_or_else(std::sync::PoisonError::into_inner);
                 if let Some(message) = reporter.observe_bytes(done, total) {
+                    if let Some(setup_status) = setup_status {
+                        setup_status.record_phase(status::PHASE_PACKAGE_DOWNLOADING);
+                    }
                     logline::subtle(&message);
                 }
             }),
@@ -277,6 +312,9 @@ async fn resolve_package(dir: &Path, manifest: &InstallerManifest, install_root:
                     .lock()
                     .unwrap_or_else(std::sync::PoisonError::into_inner);
                 if let Some(message) = reporter.observe_restore(update) {
+                    if let Some(setup_status) = setup_status {
+                        setup_status.record_phase(status::PHASE_PACKAGE_DOWNLOADING);
+                    }
                     logline::subtle(&message);
                 }
             }),
@@ -777,6 +815,58 @@ mod tests {
         assert!(runtime_yaml.contains("id: demo-app"));
         assert!(runtime_yaml.contains("version: 1.2.3"));
         assert!(runtime_yaml.contains("channel: stable"));
+
+        let status_record = surge_core::update::status::read_update_status(&install_root)
+            .expect("read update status")
+            .expect("status record");
+        assert_eq!(
+            status_record.state,
+            surge_core::update::status::UpdateConvergenceState::Converged
+        );
+        assert_eq!(status_record.app_id, "demo-app");
+        assert_eq!(status_record.target_version, "1.2.3");
+        assert_eq!(status_record.installed_version, "1.2.3");
+        assert!(status_record.completed_at_utc.is_some());
+    }
+
+    #[tokio::test]
+    async fn execute_records_failed_status_with_phase_context() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let installer_dir = temp_dir.path().join("installer");
+        let install_root = temp_dir.path().join("installed-app");
+        let store_root = temp_dir.path().join("store");
+        let full_filename = "demo-app-1.2.3-full.tar.zst";
+
+        std::fs::create_dir_all(&installer_dir).expect("installer dir");
+        std::fs::create_dir_all(&store_root).expect("store dir");
+
+        let manifest = make_manifest(&install_root, &store_root, full_filename, "offline");
+        let installer_yaml = serde_yaml::to_string(&manifest).expect("installer yaml");
+        std::fs::write(installer_dir.join("installer.yml"), installer_yaml).expect("installer manifest");
+
+        let err = execute(&installer_dir, true, false, false)
+            .await
+            .expect_err("setup should fail without bundled payload");
+        let status_record = surge_core::update::status::read_update_status(&install_root)
+            .expect("read update status")
+            .expect("status record");
+
+        assert_eq!(
+            status_record.state,
+            surge_core::update::status::UpdateConvergenceState::Failed
+        );
+        assert_eq!(
+            status_record.failure_phase.as_deref(),
+            Some(status::PHASE_RELEASE_RESOLVED)
+        );
+        assert_eq!(status_record.retry_safe, Some(true));
+        assert!(
+            status_record
+                .reason
+                .as_deref()
+                .unwrap_or_default()
+                .contains(&err.to_string())
+        );
     }
 
     #[tokio::test]
@@ -865,7 +955,7 @@ mod tests {
 
         let manifest = make_manifest(&install_root, &store_root, full_filename, "online");
         write_release_index(&store_root, &manifest, &stored_archive);
-        let package = resolve_package(&installer_dir, &manifest, &install_root)
+        let package = resolve_package(&installer_dir, &manifest, &install_root, None)
             .await
             .expect("downloaded package");
 

--- a/crates/surge-cli/src/commands/setup/status.rs
+++ b/crates/surge-cli/src/commands/setup/status.rs
@@ -1,0 +1,136 @@
+use std::path::{Path, PathBuf};
+
+use serde::Deserialize;
+use surge_core::config::installer::InstallerManifest;
+use surge_core::install::RUNTIME_MANIFEST_RELATIVE_PATH;
+use surge_core::update::status::{self as update_status, FailureContext, UpdateStatusRecord, write_update_status};
+
+pub(super) const PHASE_STAGE_RECEIVED: &str = "stage received";
+pub(super) const PHASE_RELEASE_RESOLVED: &str = "release or delta resolved";
+pub(super) const PHASE_PACKAGE_DOWNLOADING: &str = "package downloading";
+pub(super) const PHASE_PACKAGE_DOWNLOADED: &str = "package downloaded";
+pub(super) const PHASE_SUPERVISOR_STOP_REQUESTED: &str = "supervisor stop requested";
+pub(super) const PHASE_APP_SWAP_STARTED: &str = "app swap started";
+pub(super) const PHASE_PERSISTENT_ASSETS_COPIED: &str = "persistent assets copied";
+pub(super) const PHASE_SUPERVISOR_RESTART_REQUESTED: &str = "supervisor restart requested";
+pub(super) const PHASE_SUPERVISOR_RESTART_CONFIRMED: &str = "supervisor restart confirmed";
+
+const NOT_INSTALLED_VERSION: &str = "not_installed";
+
+#[derive(Debug)]
+pub(super) struct SetupStatus {
+    install_root: PathBuf,
+    app_id: String,
+    installed_version: String,
+    target_version: String,
+    channel: String,
+    attempted_at_utc: String,
+}
+
+impl SetupStatus {
+    pub(super) fn new(manifest: &InstallerManifest, install_root: &Path) -> Self {
+        Self {
+            install_root: install_root.to_path_buf(),
+            app_id: manifest.app_id.trim().to_string(),
+            installed_version: installed_version(install_root),
+            target_version: manifest.version.trim().to_string(),
+            channel: manifest.channel.trim().to_string(),
+            attempted_at_utc: update_status::now_utc_rfc3339(),
+        }
+    }
+
+    pub(super) fn record_phase(&self, phase: &'static str) {
+        let now = update_status::now_utc_rfc3339();
+        let mut record = self.in_progress_record().with_current_phase_at(phase, now);
+        if let Some(existing) = self.current_record() {
+            record.last_completed_phase = existing.last_completed_phase;
+        }
+        self.write(&record);
+    }
+
+    pub(super) fn record_completed_phase(&self, phase: &'static str) {
+        let record = self
+            .in_progress_record()
+            .with_completed_phase_at(phase, update_status::now_utc_rfc3339());
+        self.write(&record);
+    }
+
+    pub(super) fn record_converged(&self, supervisor_restart_confirmed: bool) {
+        self.write(&UpdateStatusRecord::converged(
+            &self.app_id,
+            &self.target_version,
+            &self.channel,
+            Some(self.attempted_at_utc.clone()),
+            update_status::now_utc_rfc3339(),
+            supervisor_restart_confirmed,
+        ));
+    }
+
+    pub(super) fn record_pending_restart(&self, reason: &str) {
+        self.write(&UpdateStatusRecord::pending_restart(
+            &self.app_id,
+            &self.target_version,
+            &self.target_version,
+            &self.channel,
+            self.attempted_at_utc.clone(),
+            update_status::now_utc_rfc3339(),
+            reason,
+        ));
+    }
+
+    pub(super) fn record_failed(&self, reason: &str) {
+        let current = self.current_record();
+        self.write(&UpdateStatusRecord::failed_with_context(
+            &self.app_id,
+            &self.installed_version,
+            &self.target_version,
+            &self.channel,
+            self.attempted_at_utc.clone(),
+            reason,
+            FailureContext::from_record(current.as_ref(), true),
+        ));
+    }
+
+    fn in_progress_record(&self) -> UpdateStatusRecord {
+        UpdateStatusRecord::in_progress(
+            &self.app_id,
+            &self.installed_version,
+            &self.target_version,
+            &self.channel,
+            self.attempted_at_utc.clone(),
+        )
+    }
+
+    fn current_record(&self) -> Option<UpdateStatusRecord> {
+        update_status::read_update_status(&self.install_root)
+            .ok()
+            .flatten()
+            .filter(|record| record.app_id == self.app_id && record.target_version == self.target_version)
+    }
+
+    fn write(&self, record: &UpdateStatusRecord) {
+        let _ = write_update_status(&self.install_root, record);
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct RuntimeManifest {
+    #[serde(default)]
+    version: String,
+}
+
+fn installed_version(install_root: &Path) -> String {
+    let path = install_root.join("app").join(RUNTIME_MANIFEST_RELATIVE_PATH);
+    let Ok(bytes) = std::fs::read(path) else {
+        return NOT_INSTALLED_VERSION.to_string();
+    };
+    let Ok(manifest) = serde_yaml::from_slice::<RuntimeManifest>(&bytes) else {
+        return NOT_INSTALLED_VERSION.to_string();
+    };
+    let version = manifest.version.trim();
+    if version.is_empty() {
+        NOT_INSTALLED_VERSION.to_string()
+    } else {
+        version.to_string()
+    }
+}

--- a/crates/surge-cli/src/commands/status.rs
+++ b/crates/surge-cli/src/commands/status.rs
@@ -39,6 +39,21 @@ pub(crate) fn execute(install_dir: &Path, as_json: bool) -> Result<()> {
             if let Some(reason) = record.reason.as_deref() {
                 logline::info(&format!("reason: {reason}"));
             }
+            if let Some(last_progress) = record.last_progress_at_utc.as_deref() {
+                logline::info(&format!("last_progress_at_utc: {last_progress}"));
+            }
+            if let Some(current_phase) = record.current_phase.as_deref() {
+                logline::info(&format!("current_phase: {current_phase}"));
+            }
+            if let Some(last_completed_phase) = record.last_completed_phase.as_deref() {
+                logline::info(&format!("last_completed_phase: {last_completed_phase}"));
+            }
+            if let Some(failure_phase) = record.failure_phase.as_deref() {
+                logline::info(&format!("failure_phase: {failure_phase}"));
+            }
+            if let Some(retry_safe) = record.retry_safe {
+                logline::info(&format!("retry_safe: {retry_safe}"));
+            }
         }
         None => {
             let path = update_status_path(install_dir);

--- a/crates/surge-core/src/update/manager.rs
+++ b/crates/surge-core/src/update/manager.rs
@@ -18,7 +18,7 @@ use crate::context::Context;
 use crate::error::{Result, SurgeError};
 use crate::releases::manifest::{ReleaseEntry, ReleaseIndex};
 use crate::storage::{StorageBackend, create_storage_backend};
-use crate::update::status::{self, UpdateStatusRecord};
+use crate::update::status::{self, FailureContext, UpdateStatusRecord};
 
 use self::apply::materialize_update_payload;
 use self::artifacts::prepare_update_artifacts;
@@ -26,7 +26,7 @@ use self::finalize::finalize_update;
 use self::lifecycle::SupervisorRestartOutcome;
 pub use self::progress::ProgressInfo;
 use self::progress::emit_progress;
-use self::progress_substep::PhaseProgressEmitter;
+use self::progress_substep::{PhaseProgressEmitter, labels as update_phase};
 pub use self::release_index::plan_update_from_index;
 use self::release_index::{load_release_index as load_release_index_impl, resolve_update_info};
 
@@ -271,13 +271,15 @@ impl UpdateManager {
                 Ok(())
             }
             Err(e) => {
-                let record = UpdateStatusRecord::failed(
+                let status_context = status::read_update_status(&self.install_dir).ok().flatten();
+                let record = UpdateStatusRecord::failed_with_context(
                     &self.app_id,
                     &pre_attempt_version,
                     &target_version,
                     &self.channel,
                     attempted_at_utc,
                     &e.to_string(),
+                    FailureContext::from_record(status_context.as_ref(), true),
                 );
                 if let Err(write_err) = status::write_update_status(&self.install_dir, &record) {
                     warn!(error = %write_err, "Failed to persist failed-update status (continuing)");
@@ -312,6 +314,7 @@ impl UpdateManager {
                 ..ProgressInfo::default()
             },
         );
+        progress_emitter.emit_substep(1, update_phase::RELEASE_RESOLVED, 1);
 
         if info.apply_releases.is_empty() {
             return Err(SurgeError::Update("No releases to apply".to_string()));
@@ -329,6 +332,7 @@ impl UpdateManager {
                 ..ProgressInfo::default()
             },
         );
+        progress_emitter.emit_completed_phase(update_phase::RELEASE_RESOLVED);
 
         // Phase 2: Download
         emit_progress(
@@ -341,13 +345,16 @@ impl UpdateManager {
                 ..ProgressInfo::default()
             },
         );
+        progress_emitter.emit_substep(2, update_phase::PACKAGE_DOWNLOAD_STARTED, 10);
 
         let artifact_cache_dir = self.install_dir.join(".surge-cache").join("artifacts");
         tokio::fs::create_dir_all(&artifact_cache_dir).await?;
         prepare_update_artifacts(self, info, &staging_dir, &artifact_cache_dir, progress.as_ref()).await?;
+        progress_emitter.emit_completed_phase(update_phase::PACKAGE_DOWNLOADED);
 
         let extract_dir = staging_dir.join("extracted");
         tokio::fs::create_dir_all(&extract_dir).await?;
+        progress_emitter.emit_substep(5, update_phase::PACKAGE_APPLY_STARTED, 60);
         let extracted_final_dir = materialize_update_payload(
             self,
             info,
@@ -357,6 +364,7 @@ impl UpdateManager {
             progress.as_ref(),
         )
         .await?;
+        progress_emitter.emit_completed_phase(update_phase::PACKAGE_APPLY_COMPLETED);
 
         // Phase 6: Finalize
         let restart_outcome = finalize_update(
@@ -1289,7 +1297,13 @@ mod tests {
             "failed record preserves pre-attempt version"
         );
         assert_eq!(status_record.target_version, "1.1.0");
-        assert!(status_record.completed_at_utc.is_none());
+        assert!(status_record.completed_at_utc.is_some());
+        assert_eq!(
+            status_record.failure_phase.as_deref(),
+            Some(finalize_phase::PACKAGE_DOWNLOAD_STARTED)
+        );
+        assert_eq!(status_record.retry_safe, Some(true));
+        assert!(status_record.last_progress_at_utc.is_some());
         let reason = status_record
             .reason
             .as_deref()

--- a/crates/surge-core/src/update/manager/progress_substep.rs
+++ b/crates/surge-core/src/update/manager/progress_substep.rs
@@ -26,6 +26,11 @@ use crate::update::status::{self, UpdateStatusRecord};
 /// status records so operators can tell a stuck "swapping app directory"
 /// apart from a stuck "starting supervisor".
 pub(crate) mod labels {
+    pub const RELEASE_RESOLVED: &str = "release or delta resolved";
+    pub const PACKAGE_DOWNLOAD_STARTED: &str = "package download started";
+    pub const PACKAGE_DOWNLOADED: &str = "package downloaded";
+    pub const PACKAGE_APPLY_STARTED: &str = "package apply started";
+    pub const PACKAGE_APPLY_COMPLETED: &str = "package apply completed";
     pub const STOPPING_SUPERVISOR: &str = "stopping supervisor";
     pub const PREPARING_SWAP: &str = "preparing app swap";
     pub const SWAPPING_APP_DIRECTORY: &str = "swapping app directory";
@@ -91,6 +96,7 @@ where
                             ..ProgressInfo::default()
                         },
                     );
+                    self.persist_current_phase(label);
                 }
             }
         }
@@ -108,7 +114,24 @@ where
                 ..ProgressInfo::default()
             },
         );
-        let record = self.in_progress_template.clone().with_current_phase(label);
+        self.persist_current_phase(label);
+    }
+
+    pub(super) fn emit_completed_phase(&self, label: &'static str) {
+        let record = self
+            .in_progress_template
+            .clone()
+            .with_completed_phase_at(label, status::now_utc_rfc3339());
+        if let Err(e) = status::write_update_status(self.install_dir, &record) {
+            warn!(error = %e, phase = label, "Failed to persist completed phase status (continuing)");
+        }
+    }
+
+    fn persist_current_phase(&self, label: &'static str) {
+        let record = self
+            .in_progress_template
+            .clone()
+            .with_current_phase_at(label, status::now_utc_rfc3339());
         if let Err(e) = status::write_update_status(self.install_dir, &record) {
             warn!(error = %e, phase = label, "Failed to persist in-progress substep status (continuing)");
         }

--- a/crates/surge-core/src/update/status.rs
+++ b/crates/surge-core/src/update/status.rs
@@ -82,12 +82,25 @@ pub struct UpdateStatusRecord {
     pub completed_at_utc: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reason: Option<String>,
+    /// Last time the active updater wrote progress for this transaction.
+    /// Observers use this as a durable heartbeat for remote setup watchdogs.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_progress_at_utc: Option<String>,
     /// Coarse-grained label for the substep currently in progress (for
     /// example "downloading artifacts" or "swapping app directory"). Only
     /// meaningful for `InProgress` records; observers can use it to tell
     /// "stuck in finalize" apart from "stuck in download".
     #[serde(skip_serializing_if = "Option::is_none")]
     pub current_phase: Option<String>,
+    /// Most recent phase that completed before the current or terminal state.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_completed_phase: Option<String>,
+    /// Phase active when a terminal failure was recorded.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub failure_phase: Option<String>,
+    /// Whether retrying the same setup/update command is expected to be safe.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub retry_safe: Option<bool>,
 }
 
 impl UpdateStatusRecord {
@@ -103,7 +116,11 @@ impl UpdateStatusRecord {
             attempted_at_utc: None,
             completed_at_utc: None,
             reason: None,
+            last_progress_at_utc: None,
             current_phase: None,
+            last_completed_phase: None,
+            failure_phase: None,
+            retry_safe: None,
         }
     }
 
@@ -125,17 +142,43 @@ impl UpdateStatusRecord {
             attempted_at_utc: Some(attempted_at_utc),
             completed_at_utc: None,
             reason: None,
+            last_progress_at_utc: None,
             current_phase: None,
+            last_completed_phase: None,
+            failure_phase: None,
+            retry_safe: None,
         }
     }
 
     /// Set the current substep label on an [`UpdateConvergenceState::InProgress`]
     /// record. No-op for any other state.
     #[must_use]
-    pub fn with_current_phase(mut self, phase: impl Into<String>) -> Self {
+    pub fn with_current_phase(self, phase: impl Into<String>) -> Self {
+        self.with_current_phase_at(phase, now_utc_rfc3339())
+    }
+
+    #[must_use]
+    pub fn with_current_phase_at(mut self, phase: impl Into<String>, progress_at_utc: String) -> Self {
         let label = phase.into();
         if matches!(self.state, UpdateConvergenceState::InProgress) {
             self.current_phase = Some(label);
+            self.last_progress_at_utc = Some(progress_at_utc);
+        }
+        self
+    }
+
+    #[must_use]
+    pub fn with_completed_phase(self, phase: impl Into<String>) -> Self {
+        self.with_completed_phase_at(phase, now_utc_rfc3339())
+    }
+
+    #[must_use]
+    pub fn with_completed_phase_at(mut self, phase: impl Into<String>, progress_at_utc: String) -> Self {
+        let label = phase.into();
+        if matches!(self.state, UpdateConvergenceState::InProgress) {
+            self.last_completed_phase = Some(label);
+            self.current_phase = None;
+            self.last_progress_at_utc = Some(progress_at_utc);
         }
         self
     }
@@ -159,7 +202,11 @@ impl UpdateStatusRecord {
             attempted_at_utc,
             completed_at_utc: Some(completed_at_utc),
             reason: None,
+            last_progress_at_utc: None,
             current_phase: None,
+            last_completed_phase: None,
+            failure_phase: None,
+            retry_safe: None,
         }
     }
 
@@ -183,7 +230,11 @@ impl UpdateStatusRecord {
             attempted_at_utc: Some(attempted_at_utc),
             completed_at_utc: Some(completed_at_utc),
             reason: Some(reason.to_string()),
+            last_progress_at_utc: None,
             current_phase: None,
+            last_completed_phase: None,
+            failure_phase: Some("supervisor restart requested".to_string()),
+            retry_safe: Some(true),
         }
     }
 
@@ -206,7 +257,65 @@ impl UpdateStatusRecord {
             attempted_at_utc: Some(attempted_at_utc),
             completed_at_utc: None,
             reason: Some(reason.to_string()),
+            last_progress_at_utc: None,
             current_phase: None,
+            last_completed_phase: None,
+            failure_phase: None,
+            retry_safe: Some(true),
+        }
+    }
+
+    #[must_use]
+    pub fn failed_with_context(
+        app_id: &str,
+        installed_version: &str,
+        target_version: &str,
+        channel: &str,
+        attempted_at_utc: String,
+        reason: &str,
+        context: FailureContext,
+    ) -> Self {
+        Self {
+            state: UpdateConvergenceState::Failed,
+            installed_version: installed_version.to_string(),
+            target_version: target_version.to_string(),
+            channel: channel.to_string(),
+            app_id: app_id.to_string(),
+            supervisor_restart_confirmed: false,
+            attempted_at_utc: Some(attempted_at_utc),
+            completed_at_utc: Some(now_utc_rfc3339()),
+            reason: Some(reason.to_string()),
+            last_progress_at_utc: context.last_progress_at_utc,
+            current_phase: None,
+            last_completed_phase: context.last_completed_phase,
+            failure_phase: context.failure_phase,
+            retry_safe: Some(context.retry_safe),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct FailureContext {
+    pub failure_phase: Option<String>,
+    pub last_completed_phase: Option<String>,
+    pub last_progress_at_utc: Option<String>,
+    pub retry_safe: bool,
+}
+
+impl FailureContext {
+    #[must_use]
+    pub fn from_record(record: Option<&UpdateStatusRecord>, retry_safe: bool) -> Self {
+        let Some(record) = record else {
+            return Self {
+                retry_safe,
+                ..Self::default()
+            };
+        };
+        Self {
+            failure_phase: record.current_phase.clone().or_else(|| record.failure_phase.clone()),
+            last_completed_phase: record.last_completed_phase.clone(),
+            last_progress_at_utc: record.last_progress_at_utc.clone(),
+            retry_safe,
         }
     }
 }


### PR DESCRIPTION
Fixes #123.

Purpose:
- Persist setup/update phase heartbeats and terminal phase context in the update status record.
- Surface current phase, last completed phase, failure phase, retry safety, and last progress through surge status.
- Fail tailscale remote setup runs when remote progress goes stale, using the remote status file for phase and reason context.

Behavior impact:
- Remote setup no longer waits opaquely when the remote command stops producing fresh progress.
- Failed setup/update records include phase context and retry-safe metadata.
- Existing status records remain readable because the new fields are optional.

Validation:
- ./scripts/sync-surge-core-vendor.sh --check
- ./scripts/check-version-sync.sh
- cargo fmt --all -- --check
- ./scripts/check-maintainability.sh
- RUSTFLAGS="-D warnings" cargo test --workspace (passed with escalation after sandbox listener permission failure)
- cargo clippy --all-targets --all-features -- -D warnings
- cargo clippy --workspace --lib --bins --examples -- -D warnings -D clippy::unwrap_used -D clippy::expect_used
- cargo clippy --workspace --all-targets --all-features -- -D warnings -W clippy::pedantic
- dotnet format dotnet/Surge.slnx --verify-no-changes (passed with escalation after sandbox restore failure)
- dotnet test dotnet/Surge.slnx --configuration Release