### PR TITLE
fix(cli): add resumable remote staging

### DIFF
--- a/crates/surge-cli/src/commands/install/remote/execution.rs
+++ b/crates/surge-cli/src/commands/install/remote/execution.rs
@@ -6,6 +6,7 @@ use super::{
     AsyncBufReadExt, AsyncRead, AsyncReadExt, AsyncWriteExt, BufReader, Command, Instant, Path, Result, Stdio,
     SurgeError, logline, make_progress_bar, make_spinner, shell_single_quote,
 };
+use tokio::io::AsyncSeekExt;
 
 const REMOTE_COPY_CONFIRMATION_TIMEOUT: Duration = Duration::from_mins(10);
 const TAILSCALE_STREAM_COMMAND_TIMEOUT: Duration = Duration::from_mins(30);
@@ -19,7 +20,8 @@ pub(crate) const REMOTE_INSTALLER_PARTIAL_PATH: &str = "/tmp/.surge-installer.pa
 /// The script writes to a `.partial` file, verifies size and hash, then renames
 /// to the final path. On any failure the partial file is cleaned up and the
 /// stderr contains an actionable reason that callers can surface to the user.
-pub(crate) fn build_remote_installer_install_command(expected_size: u64, expected_sha256: &str) -> String {
+#[cfg(test)]
+fn build_remote_installer_install_command(expected_size: u64, expected_sha256: &str) -> String {
     let partial = REMOTE_INSTALLER_PARTIAL_PATH;
     let final_path = REMOTE_INSTALLER_FINAL_PATH;
     let expected_sha256 = expected_sha256.trim();
@@ -189,10 +191,134 @@ pub(crate) async fn stream_directory_to_tailscale_node_with_command(
     Ok(())
 }
 
-pub(crate) async fn stream_file_to_tailscale_node_with_command(
+pub(crate) async fn stream_directory_entries_to_tailscale_node_with_command(
+    node: &str,
+    local_dir: &Path,
+    entries: &[String],
+    remote_command: &str,
+) -> Result<()> {
+    if entries.is_empty() {
+        return Ok(());
+    }
+
+    let list_file = tempfile::NamedTempFile::new()
+        .map_err(|e| SurgeError::Platform(format!("Failed to create tar entry list: {e}")))?;
+    std::fs::write(list_file.path(), entries.join("\n"))
+        .map_err(|e| SurgeError::Platform(format!("Failed to write tar entry list: {e}")))?;
+
+    let ssh_command = format!("sh -lc {}", shell_single_quote(remote_command));
+    let local_dir_str = local_dir.to_string_lossy().to_string();
+    let list_path = list_file.path().to_string_lossy().to_string();
+    let mut tar_child = Command::new("tar")
+        .args(["-C", local_dir_str.as_str(), "-cf", "-", "-T", list_path.as_str()])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|e| {
+            SurgeError::Platform(format!(
+                "Failed to archive selected entries from '{}' for transfer: {e}",
+                local_dir.display()
+            ))
+        })?;
+    let mut remote_child = Command::new("tailscale")
+        .args(["ssh", node, ssh_command.as_str()])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true)
+        .spawn()
+        .map_err(|e| SurgeError::Platform(format!("Failed to run tailscale ssh stream copy: {e}")))?;
+
+    let mut tar_stdout = tar_child
+        .stdout
+        .take()
+        .ok_or_else(|| SurgeError::Platform("Failed to capture local tar stdout".to_string()))?;
+    let mut remote_stdin = remote_child
+        .stdin
+        .take()
+        .ok_or_else(|| SurgeError::Platform("Failed to capture tailscale ssh stdin".to_string()))?;
+
+    let transfer_message = format!(
+        "Streaming {} staged entr{} to '{node}'",
+        entries.len(),
+        if entries.len() == 1 { "y" } else { "ies" }
+    );
+    let transfer_spinner = make_spinner(&transfer_message);
+    let transfer_result: Result<()> = async {
+        let mut buffer = vec![0_u8; 128 * 1024];
+        loop {
+            let read_bytes = tar_stdout.read(&mut buffer).await.map_err(|e| {
+                SurgeError::Platform(format!(
+                    "Failed to read selected staged entries from '{}': {e}",
+                    local_dir.display()
+                ))
+            })?;
+            if read_bytes == 0 {
+                break;
+            }
+            remote_stdin.write_all(&buffer[..read_bytes]).await.map_err(|e| {
+                SurgeError::Platform(format!("Failed to stream selected staged entries to '{node}': {e}"))
+            })?;
+            if let Some(spinner) = transfer_spinner.as_ref() {
+                spinner.tick();
+            }
+        }
+        remote_stdin
+            .flush()
+            .await
+            .map_err(|e| SurgeError::Platform(format!("Failed to flush selected staged entries to '{node}': {e}")))?;
+        Ok(())
+    }
+    .await;
+    drop(remote_stdin);
+
+    if let Some(spinner) = &transfer_spinner {
+        spinner.finish_and_clear();
+    }
+
+    if let Err(err) = transfer_result {
+        let _ = tar_child.kill().await;
+        let _ = remote_child.kill().await;
+        return Err(err);
+    }
+
+    let tar_output = tar_child
+        .wait_with_output()
+        .await
+        .map_err(|e| SurgeError::Platform(format!("Failed to wait for local tar process: {e}")))?;
+    if !tar_output.status.success() {
+        let stderr = String::from_utf8_lossy(&tar_output.stderr).trim().to_string();
+        return Err(SurgeError::Platform(if stderr.is_empty() {
+            format!("Command failed: tar -C '{}' -cf - -T <entry-list>", local_dir.display())
+        } else {
+            format!(
+                "Command failed: tar -C '{}' -cf - -T <entry-list>: {stderr}",
+                local_dir.display()
+            )
+        }));
+    }
+
+    let remote_output = remote_child
+        .wait_with_output()
+        .await
+        .map_err(|e| SurgeError::Platform(format!("Failed to wait for tailscale ssh stream copy: {e}")))?;
+    if !remote_output.status.success() {
+        let stderr = String::from_utf8_lossy(&remote_output.stderr).trim().to_string();
+        return Err(SurgeError::Platform(if stderr.is_empty() {
+            format!("Command failed: tailscale ssh {node} sh -lc <stream-copy>")
+        } else {
+            format!("Command failed: tailscale ssh {node} sh -lc <stream-copy>: {stderr}")
+        }));
+    }
+
+    Ok(())
+}
+
+pub(crate) async fn stream_file_to_tailscale_node_with_command_from_offset(
     node: &str,
     local_file: &Path,
     remote_command: &str,
+    offset: u64,
 ) -> Result<()> {
     let ssh_command = format!("sh -lc {}", shell_single_quote(remote_command));
     let mut child = Command::new("tailscale")
@@ -209,6 +335,20 @@ pub(crate) async fn stream_file_to_tailscale_node_with_command(
         .map_err(|e| SurgeError::Platform(format!("Failed to open '{}' for transfer: {e}", local_file.display())))?;
 
     let transfer_total_bytes = tokio::fs::metadata(local_file).await.map_or(0, |meta| meta.len());
+    if offset > transfer_total_bytes {
+        return Err(SurgeError::Platform(format!(
+            "Cannot resume '{}' from byte {offset}; file is only {transfer_total_bytes} bytes",
+            local_file.display()
+        )));
+    }
+    if offset > 0 {
+        local_reader.seek(std::io::SeekFrom::Start(offset)).await.map_err(|e| {
+            SurgeError::Platform(format!(
+                "Failed to seek '{}' to resume offset {offset}: {e}",
+                local_file.display()
+            ))
+        })?;
+    }
     let transfer_message = format!("Streaming '{}' to '{node}'", local_file.display());
     let transfer_bar = if transfer_total_bytes > 0 {
         make_progress_bar(&transfer_message, transfer_total_bytes)
@@ -222,7 +362,7 @@ pub(crate) async fn stream_file_to_tailscale_node_with_command(
         .take()
         .ok_or_else(|| SurgeError::Platform("Failed to capture tailscale ssh stdin".to_string()))?;
 
-    let mut transferred_bytes = 0_u64;
+    let mut transferred_bytes = offset;
     let mut buffer = vec![0_u8; 128 * 1024];
     loop {
         let read_bytes = local_reader.read(&mut buffer).await.map_err(|e| {

--- a/crates/surge-cli/src/commands/install/remote/installer_stage.rs
+++ b/crates/surge-cli/src/commands/install/remote/installer_stage.rs
@@ -1,0 +1,174 @@
+use std::path::Path;
+
+use super::execution::{
+    REMOTE_INSTALLER_FINAL_PATH, REMOTE_INSTALLER_PARTIAL_PATH, run_tailscale_capture,
+    stream_file_to_tailscale_node_with_command_from_offset,
+};
+use super::{Result, SurgeError, logline, shell_single_quote};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum InstallerStageState {
+    Complete,
+    Missing,
+    Partial(u64),
+    Discard,
+}
+
+pub(crate) async fn stage_installer_file_for_tailscale(
+    ssh_target: &str,
+    file_target: &str,
+    installer_path: &Path,
+    expected_size: u64,
+    expected_sha256: &str,
+) -> Result<()> {
+    let state = probe_remote_installer_stage(ssh_target, expected_size, expected_sha256).await?;
+    match state {
+        InstallerStageState::Complete => {
+            logline::success(&format!(
+                "Verified staged installer already present on '{file_target}'; skipping upload."
+            ));
+            Ok(())
+        }
+        InstallerStageState::Partial(offset) => {
+            logline::info(&format!(
+                "Resuming staged installer upload to '{file_target}' from byte {offset} of {expected_size}."
+            ));
+            let command = build_remote_installer_resume_command(expected_size, expected_sha256, offset);
+            stream_file_to_tailscale_node_with_command_from_offset(ssh_target, installer_path, &command, offset).await
+        }
+        InstallerStageState::Missing => {
+            logline::info(&format!("Creating remote installer stage on '{file_target}'."));
+            let command = build_remote_installer_resume_command(expected_size, expected_sha256, 0);
+            stream_file_to_tailscale_node_with_command_from_offset(ssh_target, installer_path, &command, 0).await
+        }
+        InstallerStageState::Discard => {
+            logline::warn(&format!(
+                "Discarding incompatible remote installer stage on '{file_target}' and uploading from the beginning."
+            ));
+            let command = build_remote_installer_resume_command(expected_size, expected_sha256, 0);
+            stream_file_to_tailscale_node_with_command_from_offset(ssh_target, installer_path, &command, 0).await
+        }
+    }
+}
+
+async fn probe_remote_installer_stage(
+    ssh_target: &str,
+    expected_size: u64,
+    expected_sha256: &str,
+) -> Result<InstallerStageState> {
+    let command = format!(
+        "sh -c {}",
+        shell_single_quote(&build_remote_installer_stage_probe_command(
+            expected_size,
+            expected_sha256
+        ))
+    );
+    let output = run_tailscale_capture(&["ssh", ssh_target, command.as_str()]).await?;
+    parse_installer_stage_probe(output.trim())
+}
+
+fn parse_installer_stage_probe(output: &str) -> Result<InstallerStageState> {
+    if output == "complete" {
+        return Ok(InstallerStageState::Complete);
+    }
+    if output == "missing" {
+        return Ok(InstallerStageState::Missing);
+    }
+    if output == "discard" {
+        return Ok(InstallerStageState::Discard);
+    }
+    if let Some(size) = output.strip_prefix("partial ") {
+        let size = size
+            .trim()
+            .parse::<u64>()
+            .map_err(|e| SurgeError::Platform(format!("Remote installer stage returned invalid partial size: {e}")))?;
+        return Ok(InstallerStageState::Partial(size));
+    }
+    Err(SurgeError::Platform(format!(
+        "Remote installer stage probe returned unexpected output: {output}"
+    )))
+}
+
+fn build_remote_installer_stage_probe_command(expected_size: u64, expected_sha256: &str) -> String {
+    let expected_sha256 = expected_sha256.trim();
+    format!(
+        "set -eu; \
+final_path={REMOTE_INSTALLER_FINAL_PATH}; partial={REMOTE_INSTALLER_PARTIAL_PATH}; \
+expected_size='{expected_size}'; expected_sha256='{expected_sha256}'; \
+hash_file() {{ if command -v sha256sum >/dev/null 2>&1; then sha256sum \"$1\" | awk '{{print $1}}'; \
+elif command -v shasum >/dev/null 2>&1; then shasum -a 256 \"$1\" | awk '{{print $1}}'; \
+else return 1; fi; }}; \
+if [ -f \"$final_path\" ]; then \
+  final_size=\"$(wc -c < \"$final_path\" | tr -d '[:space:]')\"; \
+  if [ \"$final_size\" = \"$expected_size\" ] && [ \"$(hash_file \"$final_path\")\" = \"$expected_sha256\" ]; then echo complete; exit 0; fi; \
+fi; \
+if [ -f \"$partial\" ]; then \
+  partial_size=\"$(wc -c < \"$partial\" | tr -d '[:space:]')\"; \
+  if [ \"$partial_size\" -gt \"$expected_size\" ]; then echo discard; exit 0; fi; \
+  echo \"partial $partial_size\"; exit 0; \
+fi; \
+echo missing"
+    )
+}
+
+fn build_remote_installer_resume_command(expected_size: u64, expected_sha256: &str, offset: u64) -> String {
+    let expected_sha256 = expected_sha256.trim();
+    format!(
+        "set -eu; \
+final_path={REMOTE_INSTALLER_FINAL_PATH}; partial={REMOTE_INSTALLER_PARTIAL_PATH}; \
+expected_size='{expected_size}'; expected_sha256='{expected_sha256}'; expected_offset='{offset}'; \
+if [ \"$expected_offset\" = 0 ]; then rm -f \"$partial\"; fi; \
+actual_offset=0; if [ -f \"$partial\" ]; then actual_offset=\"$(wc -c < \"$partial\" | tr -d '[:space:]')\"; fi; \
+if [ \"$actual_offset\" != \"$expected_offset\" ]; then \
+  echo \"remote installer partial changed before resume: expected $expected_offset bytes, got $actual_offset bytes\" >&2; exit 1; \
+fi; \
+cat >> \"$partial\"; \
+actual_size=\"$(wc -c < \"$partial\" | tr -d '[:space:]')\"; \
+if [ \"$actual_size\" != \"$expected_size\" ]; then \
+  echo \"remote installer size mismatch at $partial: expected $expected_size bytes, got $actual_size bytes\" >&2; exit 1; \
+fi; \
+if command -v sha256sum >/dev/null 2>&1; then actual_sha256=\"$(sha256sum \"$partial\" | awk '{{print $1}}')\"; \
+elif command -v shasum >/dev/null 2>&1; then actual_sha256=\"$(shasum -a 256 \"$partial\" | awk '{{print $1}}')\"; \
+else echo 'remote host has no sha256sum or shasum command available to verify installer transfer' >&2; exit 1; fi; \
+if [ \"$actual_sha256\" != \"$expected_sha256\" ]; then \
+  echo \"remote installer sha256 mismatch at $partial: expected $expected_sha256, got $actual_sha256\" >&2; rm -f \"$partial\"; exit 1; \
+fi; \
+chmod +x \"$partial\"; mv \"$partial\" \"$final_path\""
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_installer_stage_probe_reads_states() {
+        assert_eq!(
+            parse_installer_stage_probe("complete").unwrap(),
+            InstallerStageState::Complete
+        );
+        assert_eq!(
+            parse_installer_stage_probe("missing").unwrap(),
+            InstallerStageState::Missing
+        );
+        assert_eq!(
+            parse_installer_stage_probe("discard").unwrap(),
+            InstallerStageState::Discard
+        );
+        assert_eq!(
+            parse_installer_stage_probe("partial 42").unwrap(),
+            InstallerStageState::Partial(42)
+        );
+    }
+
+    #[test]
+    fn resume_command_appends_and_verifies_partial() {
+        let command = build_remote_installer_resume_command(100, "abc123", 40);
+
+        assert!(command.contains("expected_offset='40'"));
+        assert!(command.contains("cat >> \"$partial\""));
+        assert!(command.contains("sha256sum"));
+        assert!(command.contains("shasum -a 256"));
+        assert!(command.contains("mv \"$partial\" \"$final_path\""));
+    }
+}

--- a/crates/surge-cli/src/commands/install/remote/mod.rs
+++ b/crates/surge-cli/src/commands/install/remote/mod.rs
@@ -2,13 +2,16 @@
 
 mod activation;
 mod execution;
+mod installer_stage;
 mod published_installer;
 mod runtime;
+mod stage_manifest;
 mod staging;
 mod state;
 mod types;
 mod watchdog;
 
+use self::installer_stage::stage_installer_file_for_tailscale;
 use super::{
     ArchiveAcquisition, AsyncBufReadExt, AsyncRead, AsyncReadExt, AsyncWriteExt, BufReader, CacheFetchOutcome, Command,
     InstallBehavior, InstallerManifest, InstallerRelease, InstallerRuntime, InstallerStorage, InstallerUi, Instant,
@@ -22,8 +25,8 @@ use serde::Deserialize;
 use surge_core::update::manager::ApplyStrategy;
 
 pub(crate) use self::execution::{
-    REMOTE_INSTALLER_FINAL_PATH, build_remote_installer_install_command, resolve_tailscale_targets,
-    run_tailscale_streaming, run_tailscale_streaming_with_status_watchdog, stream_file_to_tailscale_node_with_command,
+    REMOTE_INSTALLER_FINAL_PATH, resolve_tailscale_targets, run_tailscale_streaming,
+    run_tailscale_streaming_with_status_watchdog,
 };
 pub(crate) use self::published_installer::{
     build_installer_for_tailscale, missing_remote_installer_error, plan_remote_published_installer,
@@ -373,12 +376,18 @@ pub(super) async fn install_release_via_tailscale(
         .len();
     let installer_sha256 = surge_core::crypto::sha256::sha256_hex_file(&installer_path)?;
     logline::info(&format!(
-        "Transferring installer to '{file_target}' ({}, sha256 {})...",
+        "Preparing installer stage on '{file_target}' ({}, sha256 {})...",
         crate::formatters::format_bytes(installer_size),
         &installer_sha256[..installer_sha256.len().min(12)],
     ));
-    let install_command = build_remote_installer_install_command(installer_size, &installer_sha256);
-    stream_file_to_tailscale_node_with_command(ssh_target, &installer_path, &install_command).await?;
+    stage_installer_file_for_tailscale(
+        ssh_target,
+        file_target,
+        &installer_path,
+        installer_size,
+        &installer_sha256,
+    )
+    .await?;
 
     let no_start_flag = if behavior.no_start { " --no-start" } else { "" };
     let stage_flag = if behavior.mode.is_stage() { " --stage" } else { "" };

--- a/crates/surge-cli/src/commands/install/remote/stage_manifest.rs
+++ b/crates/surge-cli/src/commands/install/remote/stage_manifest.rs
@@ -1,0 +1,162 @@
+use std::path::{Path, PathBuf};
+
+use super::{Result, SurgeError};
+
+pub(crate) const REMOTE_STAGE_MANIFEST_FILE: &str = ".surge-stage-manifest.tsv";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RemoteStageManifest {
+    entries: Vec<RemoteStageEntry>,
+}
+
+impl RemoteStageManifest {
+    pub(crate) fn build(stage_root: &Path) -> Result<Self> {
+        let mut entries = Vec::new();
+        collect_entries(stage_root, stage_root, &mut entries)?;
+        entries.sort_by(|left, right| left.path.cmp(&right.path));
+        Ok(Self { entries })
+    }
+
+    pub(crate) fn write_to_stage_root(&self, stage_root: &Path) -> Result<PathBuf> {
+        let path = stage_root.join(REMOTE_STAGE_MANIFEST_FILE);
+        std::fs::write(&path, self.to_tsv())?;
+        Ok(path)
+    }
+
+    pub(crate) fn entries(&self) -> &[RemoteStageEntry] {
+        &self.entries
+    }
+
+    fn to_tsv(&self) -> String {
+        let mut lines = vec!["# surge remote stage manifest v1".to_string()];
+        for entry in &self.entries {
+            lines.push(format!("{}\t{}\t{}", entry.sha256, entry.size, entry.path));
+        }
+        lines.push(String::new());
+        lines.join("\n")
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RemoteStageEntry {
+    pub(crate) path: String,
+    size: u64,
+    sha256: String,
+}
+
+fn collect_entries(root: &Path, dir: &Path, entries: &mut Vec<RemoteStageEntry>) -> Result<()> {
+    for entry in std::fs::read_dir(dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        let file_type = entry.file_type()?;
+        if file_type.is_dir() {
+            collect_entries(root, &path, entries)?;
+            continue;
+        }
+        if !file_type.is_file() {
+            continue;
+        }
+        let rel = path.strip_prefix(root).map_err(|e| {
+            SurgeError::Platform(format!(
+                "Failed to relativize staged path '{}' under '{}': {e}",
+                path.display(),
+                root.display()
+            ))
+        })?;
+        if rel == Path::new(REMOTE_STAGE_MANIFEST_FILE) {
+            continue;
+        }
+        let rel = rel.to_string_lossy().replace('\\', "/");
+        if rel.contains('\n') || rel.contains('\t') {
+            return Err(SurgeError::Config(format!(
+                "Remote stage path '{rel}' cannot contain tabs or newlines"
+            )));
+        }
+        let metadata = entry.metadata()?;
+        entries.push(RemoteStageEntry {
+            path: rel,
+            size: metadata.len(),
+            sha256: surge_core::crypto::sha256::sha256_hex_file(&path)?,
+        });
+    }
+    Ok(())
+}
+
+pub(crate) fn build_remote_stage_verify_command(install_root: &Path, expected_manifest_sha256: &str) -> String {
+    let install_root = super::shell_single_quote(&install_root.to_string_lossy());
+    let expected_manifest_sha256 = expected_manifest_sha256.trim();
+    format!(
+        "set -eu; \
+install_root={install_root}; \
+stage_dir=\"$install_root/.surge-transfer-stage\"; \
+manifest=\"$stage_dir/{REMOTE_STAGE_MANIFEST_FILE}\"; \
+if [ ! -d \"$stage_dir\" ] || [ ! -f \"$manifest\" ]; then echo STAGE_MISSING; exit 0; fi; \
+if command -v sha256sum >/dev/null 2>&1; then hash_cmd='sha256sum'; \
+elif command -v shasum >/dev/null 2>&1; then hash_cmd='shasum -a 256'; \
+else echo STAGE_UNVERIFIABLE; exit 0; fi; \
+manifest_sha=\"$($hash_cmd \"$manifest\" | awk '{{print $1}}')\"; \
+if [ \"$manifest_sha\" != '{expected_manifest_sha256}' ]; then echo STAGE_MISSING; exit 0; fi; \
+missing=0; \
+while IFS='	' read -r expected_sha expected_size rel; do \
+  case \"$expected_sha\" in ''|'#'*) continue ;; esac; \
+  path=\"$stage_dir/$rel\"; \
+  if [ ! -f \"$path\" ]; then echo \"MISSING	$rel\"; missing=1; continue; fi; \
+  actual_size=\"$(wc -c < \"$path\" | tr -d '[:space:]')\"; \
+  if [ \"$actual_size\" != \"$expected_size\" ]; then echo \"INVALID	$rel\"; missing=1; continue; fi; \
+  actual_sha=\"$($hash_cmd \"$path\" | awk '{{print $1}}')\"; \
+  if [ \"$actual_sha\" != \"$expected_sha\" ]; then echo \"INVALID	$rel\"; missing=1; continue; fi; \
+done < \"$manifest\"; \
+if [ \"$missing\" = 0 ]; then echo STAGE_READY; fi"
+    )
+}
+
+pub(crate) fn build_remote_stage_prepare_command(install_root: &Path, discard_existing: bool) -> String {
+    let install_root = super::shell_single_quote(&install_root.to_string_lossy());
+    let cleanup = if discard_existing {
+        "rm -rf \"$stage_dir\"; "
+    } else {
+        ""
+    };
+    format!(
+        "set -eu; \
+command -v tar >/dev/null 2>&1 || {{ echo 'Remote host is missing tar' >&2; exit 1; }}; \
+install_root={install_root}; \
+stage_dir=\"$install_root/.surge-transfer-stage\"; \
+mkdir -p \"$install_root\"; {cleanup}mkdir -p \"$stage_dir\"; \
+tar -C \"$stage_dir\" -xf -"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stage_manifest_lists_files_with_hashes() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let root = temp_dir.path();
+        std::fs::create_dir_all(root.join("app")).expect("app dir");
+        std::fs::write(root.join("app").join("demo"), b"demo").expect("demo file");
+        std::fs::write(root.join(".surge-staged-release.json"), b"{}").expect("marker");
+        std::fs::write(root.join(REMOTE_STAGE_MANIFEST_FILE), b"old").expect("old manifest");
+
+        let manifest = RemoteStageManifest::build(root).expect("manifest");
+        let paths: Vec<_> = manifest.entries().iter().map(|entry| entry.path.as_str()).collect();
+
+        assert_eq!(paths, vec![".surge-staged-release.json", "app/demo"]);
+    }
+
+    #[test]
+    fn verify_command_reports_ready_or_missing_entries() {
+        let command = build_remote_stage_verify_command(Path::new("/tmp/demo app"), "abc123");
+
+        assert!(command.contains(".surge-transfer-stage"));
+        assert!(command.contains(REMOTE_STAGE_MANIFEST_FILE));
+        assert!(command.contains("abc123"));
+        assert!(command.contains("STAGE_READY"));
+        assert!(command.contains("MISSING"));
+        assert!(command.contains("INVALID"));
+        assert!(command.contains("sha256sum"));
+        assert!(command.contains("shasum -a 256"));
+    }
+}

--- a/crates/surge-cli/src/commands/install/remote/staging.rs
+++ b/crates/surge-cli/src/commands/install/remote/staging.rs
@@ -3,9 +3,13 @@ use super::activation::{
 };
 use super::execution::{
     detect_remote_home_directory, run_tailscale_capture, run_tailscale_streaming,
-    run_tailscale_streaming_with_status_watchdog, stream_directory_to_tailscale_node_with_command,
+    run_tailscale_streaming_with_status_watchdog, stream_directory_entries_to_tailscale_node_with_command,
+    stream_directory_to_tailscale_node_with_command,
 };
 use super::published_installer::build_remote_runtime_environment;
+use super::stage_manifest::{
+    RemoteStageManifest, build_remote_stage_prepare_command, build_remote_stage_verify_command,
+};
 use super::state::{check_remote_staged_payload_identity, remote_staged_payload_identity};
 use super::types::RemoteLaunchEnvironment;
 use super::{
@@ -206,16 +210,18 @@ pub(crate) async fn deploy_remote_app_copy_for_tailscale(
         stage_remote_linux_shortcuts(&stage_root, &rendered)?;
     }
 
-    let transfer_command = format!(
-        "command -v tar >/dev/null 2>&1 || {{ echo 'Remote host is missing tar' >&2; exit 1; }}; \
-install_root={}; stage_dir=\"$install_root/.surge-transfer-stage\"; \
-mkdir -p \"$install_root\"; rm -rf \"$stage_dir\"; mkdir -p \"$stage_dir\"; tar -C \"$stage_dir\" -xf -",
-        shell_single_quote(&install_root.to_string_lossy())
-    );
-    logline::info(&format!(
-        "Streaming extracted app payload to '{file_target}' for host-mismatch remote deployment..."
-    ));
-    stream_directory_to_tailscale_node_with_command(ssh_target, &stage_root, &transfer_command).await?;
+    let stage_manifest = RemoteStageManifest::build(&stage_root)?;
+    let stage_manifest_path = stage_manifest.write_to_stage_root(&stage_root)?;
+    let stage_manifest_sha256 = surge_core::crypto::sha256::sha256_hex_file(&stage_manifest_path)?;
+    sync_remote_app_copy_stage(
+        ssh_target,
+        file_target,
+        &install_root,
+        &stage_root,
+        &stage_manifest,
+        &stage_manifest_sha256,
+    )
+    .await?;
 
     if stage {
         return Ok(());
@@ -253,6 +259,114 @@ pub(crate) async fn run_remote_staged_installer_setup(
     ));
     let watchdog = RemoteSetupWatchdog::new(ssh_node, &install_root);
     run_tailscale_streaming_with_status_watchdog(&["ssh", ssh_node, ssh_command.as_str()], "remote", watchdog).await
+}
+
+async fn sync_remote_app_copy_stage(
+    ssh_target: &str,
+    file_target: &str,
+    install_root: &Path,
+    stage_root: &Path,
+    manifest: &RemoteStageManifest,
+    manifest_sha256: &str,
+) -> Result<()> {
+    let verify_command = format!(
+        "sh -c {}",
+        shell_single_quote(&build_remote_stage_verify_command(install_root, manifest_sha256))
+    );
+    let verify_output = run_tailscale_capture(&["ssh", ssh_target, verify_command.as_str()]).await?;
+    let action = parse_stage_verify_output(&verify_output)?;
+
+    match action {
+        RemoteStageSyncAction::Ready => {
+            logline::success(&format!(
+                "Verified resumable remote app stage on '{file_target}'; skipping payload upload."
+            ));
+            Ok(())
+        }
+        RemoteStageSyncAction::Create => {
+            logline::info(&format!(
+                "Creating resumable remote app stage on '{file_target}' for host-mismatch deployment..."
+            ));
+            let transfer_command = build_remote_stage_prepare_command(install_root, true);
+            stream_directory_to_tailscale_node_with_command(ssh_target, stage_root, &transfer_command).await?;
+            verify_remote_app_copy_stage(ssh_target, install_root, manifest_sha256).await
+        }
+        RemoteStageSyncAction::Resume(mut entries) => {
+            entries.push(super::stage_manifest::REMOTE_STAGE_MANIFEST_FILE.to_string());
+            entries.sort();
+            entries.dedup();
+            let known: std::collections::BTreeSet<&str> =
+                manifest.entries().iter().map(|entry| entry.path.as_str()).collect();
+            let filtered: Vec<String> = entries
+                .into_iter()
+                .filter(|entry| {
+                    entry == super::stage_manifest::REMOTE_STAGE_MANIFEST_FILE || known.contains(entry.as_str())
+                })
+                .collect();
+            logline::info(&format!(
+                "Resuming remote app stage on '{file_target}' with {} missing or invalid entr{}.",
+                filtered.len(),
+                if filtered.len() == 1 { "y" } else { "ies" }
+            ));
+            let transfer_command = build_remote_stage_prepare_command(install_root, false);
+            stream_directory_entries_to_tailscale_node_with_command(
+                ssh_target,
+                stage_root,
+                &filtered,
+                &transfer_command,
+            )
+            .await?;
+            verify_remote_app_copy_stage(ssh_target, install_root, manifest_sha256).await
+        }
+    }
+}
+
+async fn verify_remote_app_copy_stage(ssh_target: &str, install_root: &Path, manifest_sha256: &str) -> Result<()> {
+    let verify_command = format!(
+        "sh -c {}",
+        shell_single_quote(&build_remote_stage_verify_command(install_root, manifest_sha256))
+    );
+    let verify_output = run_tailscale_capture(&["ssh", ssh_target, verify_command.as_str()]).await?;
+    match parse_stage_verify_output(&verify_output)? {
+        RemoteStageSyncAction::Ready => Ok(()),
+        other => Err(SurgeError::Platform(format!(
+            "Remote app stage verification failed after transfer: {other:?}"
+        ))),
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum RemoteStageSyncAction {
+    Ready,
+    Create,
+    Resume(Vec<String>),
+}
+
+fn parse_stage_verify_output(output: &str) -> Result<RemoteStageSyncAction> {
+    let mut entries = Vec::new();
+    for line in output.lines().map(str::trim).filter(|line| !line.is_empty()) {
+        match line {
+            "STAGE_READY" => return Ok(RemoteStageSyncAction::Ready),
+            "STAGE_MISSING" | "STAGE_UNVERIFIABLE" => return Ok(RemoteStageSyncAction::Create),
+            _ => {
+                if let Some((kind, path)) = line.split_once('\t')
+                    && (kind == "MISSING" || kind == "INVALID")
+                    && !path.trim().is_empty()
+                {
+                    entries.push(path.trim().to_string());
+                    continue;
+                }
+                return Err(SurgeError::Platform(format!(
+                    "Remote app stage verification returned unexpected output: {line}"
+                )));
+            }
+        }
+    }
+    if entries.is_empty() {
+        Ok(RemoteStageSyncAction::Create)
+    } else {
+        Ok(RemoteStageSyncAction::Resume(entries))
+    }
 }
 
 pub(crate) async fn warn_if_remote_stage_cleanup_fails(ssh_node: &str, app_id: &str, release: &ReleaseEntry) {


### PR DESCRIPTION
Fixes #124.

Purpose:
- Resume tailscale installer uploads from verified remote partial files.
- Add manifest-verified app-copy staging for host-mismatch remote deployment.
- Reuse valid remote app stages, discard incompatible stages, and stream only missing or invalid manifest entries when possible.

Behavior impact:
- Retried remote installer uploads can continue from the remote partial byte count instead of always starting at byte zero.
- Host-mismatch app-copy stages now carry expected file size and hash metadata and are verified before activation.
- The local command reports whether it is creating, resuming, verifying, or discarding a remote stage.

Validation:
- ./scripts/sync-surge-core-vendor.sh --check
- ./scripts/check-version-sync.sh
- cargo fmt --all -- --check
- ./scripts/check-maintainability.sh
- RUSTFLAGS="-D warnings" cargo test --workspace (passed with escalation for local listener tests)
- cargo clippy --all-targets --all-features -- -D warnings
- cargo clippy --workspace --lib --bins --examples -- -D warnings -D clippy::unwrap_used -D clippy::expect_used
- cargo clippy --workspace --all-targets --all-features -- -D warnings -W clippy::pedantic
- dotnet format dotnet/Surge.slnx --verify-no-changes (passed with escalation after sandbox restore failure)
- dotnet test dotnet/Surge.slnx --configuration Release