### PR TITLE
Fix remote update recovery fallbacks

### DIFF
--- a/crates/surge-cli/src/commands/install/mod.rs
+++ b/crates/surge-cli/src/commands/install/mod.rs
@@ -462,7 +462,8 @@ mod tests {
         parse_remote_staged_payload_identity, plan_remote_convergence, plan_remote_published_installer,
         plan_remote_published_installer_without_manifest, published_installer_public_url, remote_install_matches,
         remote_launch_environment_probe, remote_staged_payload_identity, select_latest_remote_legacy_app_dir,
-        select_remote_installer_mode, select_remote_tailscale_transfer_strategy, should_skip_remote_install,
+        select_remote_installer_mode, select_remote_tailscale_transfer_strategy,
+        select_remote_tailscale_transfer_strategy_for_convergence, should_skip_remote_install,
         try_prepare_published_installer_for_tailscale,
     };
     use super::resolution::{
@@ -527,6 +528,7 @@ mod tests {
     fn remote_state(version: &str, channel: &str, storage: &surge_core::context::StorageConfig) -> RemoteInstallState {
         RemoteInstallState {
             version: version.to_string(),
+            active_executable_exists: true,
             channel: Some(channel.to_string()),
             storage_provider: Some(core_install::storage_provider_manifest_name(storage.provider).to_string()),
             storage_bucket: Some(storage.bucket.clone()),
@@ -953,6 +955,22 @@ mod tests {
                 cached_state: RemoteTailscaleCachedState::InstallerCache,
             }),
             RemoteTailscaleTransferStrategy::StagedInstallerCache
+        );
+    }
+
+    #[test]
+    fn select_remote_tailscale_transfer_strategy_uses_resumable_app_copy_for_reinstall_repairs() {
+        assert_eq!(
+            select_remote_tailscale_transfer_strategy_for_convergence(
+                RemoteTailscaleTransferInputs {
+                    host_installer_availability: RemoteHostInstallerAvailability::Available,
+                    installer_mode: RemoteInstallerMode::Online,
+                    operation: RemoteTailscaleOperation::Install,
+                    cached_state: RemoteTailscaleCachedState::None,
+                },
+                RemoteConvergenceAction::Reinstall
+            ),
+            RemoteTailscaleTransferStrategy::AppCopy
         );
     }
 
@@ -2125,10 +2143,11 @@ apps:
     #[test]
     fn parse_remote_install_state_extracts_version_and_channel() {
         let state = parse_remote_install_state(
-            "version=1.2.3\nchannel=production\nprovider=filesystem\nbucket=/srv/releases\nregion=\nendpoint=\n",
+            "version=1.2.3\nactive_executable_exists=true\nchannel=production\nprovider=filesystem\nbucket=/srv/releases\nregion=\nendpoint=\n",
         )
         .expect("remote install state should parse");
         assert_eq!(state.version, "1.2.3");
+        assert!(state.active_executable_exists);
         assert_eq!(state.channel.as_deref(), Some("production"));
         assert_eq!(state.storage_provider.as_deref(), Some("filesystem"));
         assert_eq!(state.storage_bucket.as_deref(), Some("/srv/releases"));
@@ -2143,6 +2162,7 @@ apps:
     fn remote_install_matches_requires_matching_channel_and_version() {
         let production = RemoteInstallState {
             version: "1.2.3".to_string(),
+            active_executable_exists: true,
             channel: Some("production".to_string()),
             storage_provider: None,
             storage_bucket: None,
@@ -2151,6 +2171,7 @@ apps:
         };
         let test = RemoteInstallState {
             version: "1.2.3".to_string(),
+            active_executable_exists: true,
             channel: Some("test".to_string()),
             storage_provider: None,
             storage_bucket: None,
@@ -2168,6 +2189,7 @@ apps:
     fn force_flag_bypasses_remote_install_skip() {
         let remote_state = RemoteInstallState {
             version: "1.2.3".to_string(),
+            active_executable_exists: true,
             channel: Some("test".to_string()),
             storage_provider: None,
             storage_bucket: None,
@@ -2263,6 +2285,39 @@ apps:
                 .reason
                 .as_deref()
                 .is_some_and(|reason| reason.contains("verify remote runtime convergence"))
+        );
+    }
+
+    #[test]
+    fn remote_convergence_plan_reinstalls_current_install_when_active_executable_is_missing() {
+        let storage = storage_config("/srv/releases");
+        let target = release("1.2.0", "test", "linux-x64", "demo-1.2.0-linux-x64-full.tar.zst");
+        let index = ReleaseIndex {
+            app_id: "demo".to_string(),
+            releases: vec![target.clone()],
+            ..ReleaseIndex::default()
+        };
+        let mut state = remote_state("1.2.0", "test", &storage);
+        state.active_executable_exists = false;
+
+        let plan = plan_remote_convergence(
+            Some(&state),
+            &index,
+            "demo",
+            "linux-x64",
+            &target,
+            "test",
+            &storage,
+            RemoteInstallerMode::Online,
+            false,
+        )
+        .expect("plan should resolve");
+
+        assert_eq!(plan.action, RemoteConvergenceAction::Reinstall);
+        assert!(
+            plan.reason
+                .as_deref()
+                .is_some_and(|reason| reason.contains("active executable is missing"))
         );
     }
 

--- a/crates/surge-cli/src/commands/install/remote/execution.rs
+++ b/crates/surge-cli/src/commands/install/remote/execution.rs
@@ -1,3 +1,4 @@
+use std::future::Future;
 use std::process::ExitStatus;
 use std::time::Duration;
 
@@ -9,6 +10,7 @@ use super::{
 use tokio::io::AsyncSeekExt;
 
 const REMOTE_COPY_CONFIRMATION_TIMEOUT: Duration = Duration::from_mins(10);
+const REMOTE_STREAM_PROGRESS_TIMEOUT: Duration = Duration::from_mins(3);
 const TAILSCALE_STREAM_COMMAND_TIMEOUT: Duration = Duration::from_mins(30);
 
 pub(crate) const REMOTE_INSTALLER_FINAL_PATH: &str = "/tmp/.surge-installer";
@@ -89,108 +91,6 @@ pub(crate) async fn detect_remote_home_directory(ssh_node: &str) -> Result<std::
     Ok(std::path::PathBuf::from(home))
 }
 
-pub(crate) async fn stream_directory_to_tailscale_node_with_command(
-    node: &str,
-    local_dir: &Path,
-    remote_command: &str,
-) -> Result<()> {
-    let ssh_command = format!("sh -lc {}", shell_single_quote(remote_command));
-    let local_dir_str = local_dir.to_string_lossy().to_string();
-    let mut tar_child = Command::new("tar")
-        .args(["-C", local_dir_str.as_str(), "-cf", "-", "."])
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .map_err(|e| SurgeError::Platform(format!("Failed to archive '{}' for transfer: {e}", local_dir.display())))?;
-    let mut remote_child = Command::new("tailscale")
-        .args(["ssh", node, ssh_command.as_str()])
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .kill_on_drop(true)
-        .spawn()
-        .map_err(|e| SurgeError::Platform(format!("Failed to run tailscale ssh stream copy: {e}")))?;
-
-    let mut tar_stdout = tar_child
-        .stdout
-        .take()
-        .ok_or_else(|| SurgeError::Platform("Failed to capture local tar stdout".to_string()))?;
-    let mut remote_stdin = remote_child
-        .stdin
-        .take()
-        .ok_or_else(|| SurgeError::Platform("Failed to capture tailscale ssh stdin".to_string()))?;
-
-    let transfer_message = format!("Streaming '{}' to '{node}'", local_dir.display());
-    let transfer_spinner = make_spinner(&transfer_message);
-    let transfer_result: Result<()> = async {
-        let mut buffer = vec![0_u8; 128 * 1024];
-        loop {
-            let read_bytes = tar_stdout.read(&mut buffer).await.map_err(|e| {
-                SurgeError::Platform(format!(
-                    "Failed to read archived directory '{}' for transfer: {e}",
-                    local_dir.display()
-                ))
-            })?;
-            if read_bytes == 0 {
-                break;
-            }
-            remote_stdin.write_all(&buffer[..read_bytes]).await.map_err(|e| {
-                SurgeError::Platform(format!("Failed to stream '{}' to '{node}': {e}", local_dir.display()))
-            })?;
-            if let Some(spinner) = transfer_spinner.as_ref() {
-                spinner.tick();
-            }
-        }
-        remote_stdin.flush().await.map_err(|e| {
-            SurgeError::Platform(format!(
-                "Failed to flush transfer stream to '{node}' for '{}': {e}",
-                local_dir.display()
-            ))
-        })?;
-        Ok(())
-    }
-    .await;
-    drop(remote_stdin);
-
-    if let Some(spinner) = &transfer_spinner {
-        spinner.finish_and_clear();
-    }
-
-    if let Err(err) = transfer_result {
-        let _ = tar_child.kill().await;
-        let _ = remote_child.kill().await;
-        return Err(err);
-    }
-
-    let tar_output = tar_child
-        .wait_with_output()
-        .await
-        .map_err(|e| SurgeError::Platform(format!("Failed to wait for local tar process: {e}")))?;
-    if !tar_output.status.success() {
-        let stderr = String::from_utf8_lossy(&tar_output.stderr).trim().to_string();
-        return Err(SurgeError::Platform(if stderr.is_empty() {
-            format!("Command failed: tar -C '{}' -cf - .", local_dir.display())
-        } else {
-            format!("Command failed: tar -C '{}' -cf - .: {stderr}", local_dir.display())
-        }));
-    }
-
-    let remote_output = remote_child
-        .wait_with_output()
-        .await
-        .map_err(|e| SurgeError::Platform(format!("Failed to wait for tailscale ssh stream copy: {e}")))?;
-    if !remote_output.status.success() {
-        let stderr = String::from_utf8_lossy(&remote_output.stderr).trim().to_string();
-        return Err(SurgeError::Platform(if stderr.is_empty() {
-            format!("Command failed: tailscale ssh {node} sh -lc <stream-copy>")
-        } else {
-            format!("Command failed: tailscale ssh {node} sh -lc <stream-copy>: {stderr}")
-        }));
-    }
-
-    Ok(())
-}
-
 pub(crate) async fn stream_directory_entries_to_tailscale_node_with_command(
     node: &str,
     local_dir: &Path,
@@ -247,26 +147,28 @@ pub(crate) async fn stream_directory_entries_to_tailscale_node_with_command(
     let transfer_result: Result<()> = async {
         let mut buffer = vec![0_u8; 128 * 1024];
         loop {
-            let read_bytes = tar_stdout.read(&mut buffer).await.map_err(|e| {
-                SurgeError::Platform(format!(
-                    "Failed to read selected staged entries from '{}': {e}",
-                    local_dir.display()
-                ))
-            })?;
+            let read_bytes = await_transfer_progress(
+                tar_stdout.read(&mut buffer),
+                format!("reading selected staged entries from '{}'", local_dir.display()),
+            )
+            .await?;
             if read_bytes == 0 {
                 break;
             }
-            remote_stdin.write_all(&buffer[..read_bytes]).await.map_err(|e| {
-                SurgeError::Platform(format!("Failed to stream selected staged entries to '{node}': {e}"))
-            })?;
+            await_transfer_progress(
+                remote_stdin.write_all(&buffer[..read_bytes]),
+                format!("streaming selected staged entries to '{node}'"),
+            )
+            .await?;
             if let Some(spinner) = transfer_spinner.as_ref() {
                 spinner.tick();
             }
         }
-        remote_stdin
-            .flush()
-            .await
-            .map_err(|e| SurgeError::Platform(format!("Failed to flush selected staged entries to '{node}': {e}")))?;
+        await_transfer_progress(
+            remote_stdin.flush(),
+            format!("flushing selected staged entries to '{node}'"),
+        )
+        .await?;
         Ok(())
     }
     .await;
@@ -365,15 +267,19 @@ pub(crate) async fn stream_file_to_tailscale_node_with_command_from_offset(
     let mut transferred_bytes = offset;
     let mut buffer = vec![0_u8; 128 * 1024];
     loop {
-        let read_bytes = local_reader.read(&mut buffer).await.map_err(|e| {
-            SurgeError::Platform(format!("Failed to read '{}' for transfer: {e}", local_file.display()))
-        })?;
+        let read_bytes = await_transfer_progress(
+            local_reader.read(&mut buffer),
+            format!("reading '{}'", local_file.display()),
+        )
+        .await?;
         if read_bytes == 0 {
             break;
         }
-        child_stdin.write_all(&buffer[..read_bytes]).await.map_err(|e| {
-            SurgeError::Platform(format!("Failed to stream '{}' to '{node}': {e}", local_file.display()))
-        })?;
+        await_transfer_progress(
+            child_stdin.write_all(&buffer[..read_bytes]),
+            format!("streaming '{}' to '{node}'", local_file.display()),
+        )
+        .await?;
         transferred_bytes = transferred_bytes.saturating_add(u64::try_from(read_bytes).unwrap_or(0));
 
         if let Some(bar) = transfer_bar.as_ref() {
@@ -398,12 +304,11 @@ pub(crate) async fn stream_file_to_tailscale_node_with_command_from_offset(
         }
     }
 
-    child_stdin.flush().await.map_err(|e| {
-        SurgeError::Platform(format!(
-            "Failed to flush transfer stream to '{node}' for '{}': {e}",
-            local_file.display()
-        ))
-    })?;
+    await_transfer_progress(
+        child_stdin.flush(),
+        format!("flushing transfer stream to '{node}' for '{}'", local_file.display()),
+    )
+    .await?;
     drop(child_stdin);
 
     if let Some(bar) = &transfer_bar {
@@ -446,6 +351,20 @@ pub(crate) async fn stream_file_to_tailscale_node_with_command_from_offset(
     }
 
     Ok(())
+}
+
+async fn await_transfer_progress<T, Fut>(future: Fut, operation: String) -> Result<T>
+where
+    Fut: Future<Output = std::io::Result<T>>,
+{
+    match tokio::time::timeout(REMOTE_STREAM_PROGRESS_TIMEOUT, future).await {
+        Ok(Ok(value)) => Ok(value),
+        Ok(Err(error)) => Err(SurgeError::Platform(format!("Failed while {operation}: {error}"))),
+        Err(_) => Err(SurgeError::Platform(format!(
+            "Timed out after {}s without transfer progress while {operation}; rerun to resume the staged transfer",
+            REMOTE_STREAM_PROGRESS_TIMEOUT.as_secs()
+        ))),
+    }
 }
 
 pub(crate) async fn run_tailscale_capture(args: &[&str]) -> Result<String> {

--- a/crates/surge-cli/src/commands/install/remote/mod.rs
+++ b/crates/surge-cli/src/commands/install/remote/mod.rs
@@ -39,7 +39,7 @@ pub(crate) use self::staging::{
 pub(crate) use self::state::{
     check_remote_install_state, detect_remote_launch_environment, remote_install_matches,
     remote_staged_installer_matches_release, remote_staged_payload_matches_release, select_remote_installer_mode,
-    select_remote_tailscale_transfer_strategy, verify_remote_stage_readiness,
+    select_remote_tailscale_transfer_strategy_for_convergence, verify_remote_stage_readiness,
 };
 pub(crate) use self::types::{
     RemoteConvergenceAction, RemoteConvergencePlan, RemoteHostInstallerAvailability, RemoteInstallerMode,
@@ -63,7 +63,7 @@ pub(crate) use self::staging::{
 pub(crate) use self::state::{
     parse_remote_install_state, parse_remote_launch_environment, parse_remote_staged_payload_identity,
     plan_remote_convergence, remote_launch_environment_probe, remote_staged_payload_identity,
-    should_skip_remote_install,
+    select_remote_tailscale_transfer_strategy, should_skip_remote_install,
 };
 #[cfg(test)]
 pub(crate) use self::types::{RemoteInstallState, RemoteLaunchEnvironment, RemotePublishedInstallerPlan};
@@ -91,7 +91,12 @@ pub(super) async fn install_release_via_tailscale(
     } else {
         release.install_directory.trim()
     };
-    let remote_state = check_remote_install_state(ssh_target, install_dir).await?;
+    let main_exe_name = if release.main_exe.trim().is_empty() {
+        app_id
+    } else {
+        release.main_exe.trim()
+    };
+    let remote_state = check_remote_install_state(ssh_target, install_dir, main_exe_name).await?;
     let convergence_plan = state::plan_remote_convergence(
         remote_state.as_ref(),
         index,
@@ -187,26 +192,29 @@ pub(super) async fn install_release_via_tailscale(
     let transfer_strategy = if prefer_update_setup {
         RemoteTailscaleTransferStrategy::Installer { prefer_published: true }
     } else {
-        select_remote_tailscale_transfer_strategy(RemoteTailscaleTransferInputs {
-            host_installer_availability: if host_can_build_installer {
-                RemoteHostInstallerAvailability::Available
-            } else {
-                RemoteHostInstallerAvailability::Unavailable
+        select_remote_tailscale_transfer_strategy_for_convergence(
+            RemoteTailscaleTransferInputs {
+                host_installer_availability: if host_can_build_installer {
+                    RemoteHostInstallerAvailability::Available
+                } else {
+                    RemoteHostInstallerAvailability::Unavailable
+                },
+                installer_mode,
+                operation: if behavior.mode.is_stage() {
+                    RemoteTailscaleOperation::Stage
+                } else {
+                    RemoteTailscaleOperation::Install
+                },
+                cached_state: if has_matching_pre_staged_installer_cache {
+                    RemoteTailscaleCachedState::InstallerCache
+                } else if has_matching_pre_staged_app_copy_payload {
+                    RemoteTailscaleCachedState::AppCopyPayload
+                } else {
+                    RemoteTailscaleCachedState::None
+                },
             },
-            installer_mode,
-            operation: if behavior.mode.is_stage() {
-                RemoteTailscaleOperation::Stage
-            } else {
-                RemoteTailscaleOperation::Install
-            },
-            cached_state: if has_matching_pre_staged_installer_cache {
-                RemoteTailscaleCachedState::InstallerCache
-            } else if has_matching_pre_staged_app_copy_payload {
-                RemoteTailscaleCachedState::AppCopyPayload
-            } else {
-                RemoteTailscaleCachedState::None
-            },
-        })
+            convergence_plan.action,
+        )
     };
     if matches!(transfer_strategy, RemoteTailscaleTransferStrategy::AppCopy) {
         deploy_remote_app_copy_for_tailscale(

--- a/crates/surge-cli/src/commands/install/remote/runtime.rs
+++ b/crates/surge-cli/src/commands/install/remote/runtime.rs
@@ -164,7 +164,12 @@ pub(crate) async fn verify_remote_runtime_after_install(
     storage_config: &surge_core::context::StorageConfig,
     verify_started_process: bool,
 ) -> Result<()> {
-    let state = check_remote_install_state(ssh_target, install_dir)
+    let main_exe_name = if release.main_exe.trim().is_empty() {
+        app_id
+    } else {
+        release.main_exe.trim()
+    };
+    let state = check_remote_install_state(ssh_target, install_dir, main_exe_name)
         .await?
         .ok_or_else(|| {
             SurgeError::Update(format!(

--- a/crates/surge-cli/src/commands/install/remote/staging.rs
+++ b/crates/surge-cli/src/commands/install/remote/staging.rs
@@ -4,13 +4,12 @@ use super::activation::{
 use super::execution::{
     detect_remote_home_directory, run_tailscale_capture, run_tailscale_streaming,
     run_tailscale_streaming_with_status_watchdog, stream_directory_entries_to_tailscale_node_with_command,
-    stream_directory_to_tailscale_node_with_command,
 };
 use super::published_installer::build_remote_runtime_environment;
 use super::stage_manifest::{
     RemoteStageManifest, build_remote_stage_prepare_command, build_remote_stage_verify_command,
 };
-use super::state::{check_remote_staged_payload_identity, remote_staged_payload_identity};
+use super::state::remote_staged_payload_identity;
 use super::types::RemoteLaunchEnvironment;
 use super::{
     ArchiveAcquisition, Path, PathBuf, ReleaseEntry, ReleaseIndex, RemoteSetupWatchdog, Result, StorageBackend,
@@ -118,34 +117,6 @@ pub(crate) async fn deploy_remote_app_copy_for_tailscale(
     } else {
         release.main_exe.trim()
     };
-
-    if !stage
-        && let Some(remote_staged_payload) = check_remote_staged_payload_identity(ssh_target, &install_root).await
-        && remote_staged_payload == staged_payload_identity
-    {
-        logline::success(&format!(
-            "Using pre-staged payload for '{app_id}' v{} on '{file_target}'.",
-            release.version
-        ));
-        stop_remote_supervisor_if_running(ssh_target, &install_root, &release.supervisor_id).await?;
-        let legacy_app_dir = if release.persistent_assets.is_empty() {
-            None
-        } else {
-            detect_remote_legacy_app_dir(ssh_target, &install_root).await?
-        };
-        let activation_script = build_remote_app_copy_activation_script(
-            &install_root,
-            main_exe_name,
-            &release.version,
-            &runtime_environment,
-            &release.persistent_assets,
-            legacy_app_dir.as_deref(),
-            no_start,
-        )?;
-        let ssh_command = format!("sh -lc {}", shell_single_quote(&activation_script));
-        logline::info(&format!("Activating pre-staged install on '{file_target}'..."));
-        return run_tailscale_streaming(&["ssh", ssh_target, ssh_command.as_str()], "remote").await;
-    }
 
     std::fs::create_dir_all(download_dir)?;
     let local_package = download_dir.join(Path::new(full_filename).file_name().unwrap_or_default());
@@ -288,7 +259,23 @@ async fn sync_remote_app_copy_stage(
                 "Creating resumable remote app stage on '{file_target}' for host-mismatch deployment..."
             ));
             let transfer_command = build_remote_stage_prepare_command(install_root, true);
-            stream_directory_to_tailscale_node_with_command(ssh_target, stage_root, &transfer_command).await?;
+            stream_directory_entries_to_tailscale_node_with_command(
+                ssh_target,
+                stage_root,
+                &[super::stage_manifest::REMOTE_STAGE_MANIFEST_FILE.to_string()],
+                &transfer_command,
+            )
+            .await?;
+
+            let transfer_command = build_remote_stage_prepare_command(install_root, false);
+            let entries: Vec<String> = manifest.entries().iter().map(|entry| entry.path.clone()).collect();
+            stream_directory_entries_to_tailscale_node_with_command(
+                ssh_target,
+                stage_root,
+                &entries,
+                &transfer_command,
+            )
+            .await?;
             verify_remote_app_copy_stage(ssh_target, install_root, manifest_sha256).await
         }
         RemoteStageSyncAction::Resume(mut entries) => {

--- a/crates/surge-cli/src/commands/install/remote/state.rs
+++ b/crates/surge-cli/src/commands/install/remote/state.rs
@@ -49,12 +49,28 @@ pub(crate) fn select_remote_tailscale_transfer_strategy(
     }
 }
 
+pub(crate) fn select_remote_tailscale_transfer_strategy_for_convergence(
+    inputs: RemoteTailscaleTransferInputs,
+    convergence_action: RemoteConvergenceAction,
+) -> RemoteTailscaleTransferStrategy {
+    if inputs.operation == RemoteTailscaleOperation::Install
+        && matches!(convergence_action, RemoteConvergenceAction::Reinstall)
+    {
+        return RemoteTailscaleTransferStrategy::AppCopy;
+    }
+
+    select_remote_tailscale_transfer_strategy(inputs)
+}
+
 pub(crate) async fn check_remote_install_state(
     ssh_node: &str,
     install_dir: &str,
+    main_exe: &str,
 ) -> Result<Option<RemoteInstallState>> {
     let probe = format!(
-        r#"manifest="$HOME/.local/share/{}/app/.surge/runtime.yml";
+        r#"app_dir="$HOME/.local/share/{}/app";
+main_exe="{}";
+manifest="$app_dir/.surge/runtime.yml";
 if [ ! -f "$manifest" ]; then
   exit 0
 fi
@@ -64,8 +80,13 @@ provider="$(sed -n 's/^provider:[[:space:]]*//p' "$manifest" | head -n1)"
 bucket="$(sed -n 's/^bucket:[[:space:]]*//p' "$manifest" | head -n1)"
 region="$(sed -n 's/^region:[[:space:]]*//p' "$manifest" | head -n1)"
 endpoint="$(sed -n 's/^endpoint:[[:space:]]*//p' "$manifest" | head -n1)"
-printf 'version=%s\nchannel=%s\nprovider=%s\nbucket=%s\nregion=%s\nendpoint=%s\n' "$version" "$channel" "$provider" "$bucket" "$region" "$endpoint""#,
+active_executable_exists=false
+if [ -n "$main_exe" ] && [ -f "$app_dir/$main_exe" ]; then
+  active_executable_exists=true
+fi
+printf 'version=%s\nactive_executable_exists=%s\nchannel=%s\nprovider=%s\nbucket=%s\nregion=%s\nendpoint=%s\n' "$version" "$active_executable_exists" "$channel" "$provider" "$bucket" "$region" "$endpoint""#,
         install_dir.replace('\'', ""),
+        main_exe.replace('\'', ""),
     );
     let command = format!("sh -c {}", shell_single_quote(&probe));
     run_tailscale_capture(&["ssh", ssh_node, command.as_str()])
@@ -80,6 +101,7 @@ printf 'version=%s\nchannel=%s\nprovider=%s\nbucket=%s\nregion=%s\nendpoint=%s\n
 
 pub(crate) fn parse_remote_install_state(output: &str) -> Option<RemoteInstallState> {
     let mut version = None;
+    let mut active_executable_exists = false;
     let mut channel = None;
     let mut storage_provider = None;
     let mut storage_bucket = None;
@@ -100,6 +122,11 @@ pub(crate) fn parse_remote_install_state(output: &str) -> Option<RemoteInstallSt
             if !value.is_empty() {
                 channel = Some(value.to_string());
             }
+            continue;
+        }
+
+        if let Some(value) = line.strip_prefix("active_executable_exists=") {
+            active_executable_exists = matches!(value.trim(), "true" | "1" | "yes");
             continue;
         }
 
@@ -137,6 +164,7 @@ pub(crate) fn parse_remote_install_state(output: &str) -> Option<RemoteInstallSt
 
     version.map(|version| RemoteInstallState {
         version,
+        active_executable_exists,
         channel,
         storage_provider,
         storage_bucket,
@@ -163,6 +191,15 @@ pub(crate) fn plan_remote_convergence(
     let installed_version = Some(remote_state.version.clone());
     let metadata_matches = remote_state.metadata_matches(channel, storage_config);
     match compare_versions(&remote_state.version, &release.version) {
+        std::cmp::Ordering::Equal if metadata_matches && !remote_state.active_executable_exists => {
+            Ok(RemoteConvergencePlan {
+                action: RemoteConvergenceAction::Reinstall,
+                installed_version,
+                target_version: release.version.clone(),
+                update_info: None,
+                reason: Some("package metadata is current but the active executable is missing".to_string()),
+            })
+        }
         std::cmp::Ordering::Equal if metadata_matches && force => Ok(RemoteConvergencePlan {
             action: RemoteConvergenceAction::ConvergeRuntime,
             installed_version,

--- a/crates/surge-cli/src/commands/install/remote/types.rs
+++ b/crates/surge-cli/src/commands/install/remote/types.rs
@@ -92,6 +92,7 @@ pub(crate) struct RemoteTailscaleTransferInputs {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct RemoteInstallState {
     pub(crate) version: String,
+    pub(crate) active_executable_exists: bool,
     pub(crate) channel: Option<String>,
     pub(crate) storage_provider: Option<String>,
     pub(crate) storage_bucket: Option<String>,

--- a/crates/surge-core/src/update/manager.rs
+++ b/crates/surge-core/src/update/manager.rs
@@ -2236,6 +2236,142 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_download_and_apply_delta_falls_back_to_full_when_rebuilt_archive_hash_mismatches() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store_root = tmp.path().join("store");
+        let install_root = tmp.path().join("install");
+        let app_id = "test-app";
+        std::fs::create_dir_all(&store_root).unwrap();
+        std::fs::create_dir_all(&install_root).unwrap();
+        let app_store = app_scoped_store_root(&store_root, app_id);
+
+        let rid = current_rid();
+        let os = current_os_label_for_tests();
+
+        let mut packer_v1 = ArchivePacker::new(3).unwrap();
+        packer_v1.add_buffer("payload.txt", b"v1 payload", 0o644).unwrap();
+        let full_v1 = packer_v1.finalize().unwrap();
+
+        let mut packer_v2 = ArchivePacker::new(3).unwrap();
+        packer_v2.add_buffer("payload.txt", b"v2 payload", 0o644).unwrap();
+        let full_v2 = packer_v2.finalize().unwrap();
+
+        let mut packer_wrong_v2 = ArchivePacker::new(3).unwrap();
+        packer_wrong_v2
+            .add_buffer("payload.txt", b"wrong v2 payload", 0o644)
+            .unwrap();
+        let wrong_full_v2 = packer_wrong_v2.finalize().unwrap();
+
+        let patch_wrong_v2 = bsdiff_buffers(&full_v1, &wrong_full_v2).unwrap();
+        let delta_wrong_v2 = zstd::encode_all(patch_wrong_v2.as_slice(), 3).unwrap();
+
+        let full_v1_name = format!("{app_id}-1.0.0-{rid}-full.tar.zst");
+        let full_v2_name = format!("{app_id}-1.1.0-{rid}-full.tar.zst");
+        let delta_v2_name = format!("{app_id}-1.1.0-{rid}-delta.tar.zst");
+
+        std::fs::write(app_store.join(&full_v1_name), &full_v1).unwrap();
+        std::fs::write(app_store.join(&full_v2_name), &full_v2).unwrap();
+        std::fs::write(app_store.join(&delta_v2_name), &delta_wrong_v2).unwrap();
+
+        let index = ReleaseIndex {
+            app_id: app_id.to_string(),
+            releases: vec![
+                ReleaseEntry {
+                    version: "1.0.0".to_string(),
+                    channels: vec!["stable".to_string()],
+                    os: os.clone(),
+                    rid: rid.clone(),
+                    is_genesis: true,
+                    full_filename: full_v1_name.clone(),
+                    full_size: full_v1.len() as i64,
+                    full_sha256: sha256_hex(&full_v1),
+                    full_compression_level: 0,
+                    full_zstd_workers: 0,
+                    deltas: Vec::new(),
+                    preferred_delta_id: String::new(),
+                    created_utc: chrono::Utc::now().to_rfc3339(),
+                    release_notes: String::new(),
+                    name: String::new(),
+                    main_exe: app_id.to_string(),
+                    install_directory: app_id.to_string(),
+                    supervisor_id: String::new(),
+                    icon: String::new(),
+                    shortcuts: Vec::new(),
+                    persistent_assets: Vec::new(),
+                    installers: Vec::new(),
+                    environment: std::collections::BTreeMap::new(),
+                },
+                ReleaseEntry {
+                    version: "1.1.0".to_string(),
+                    channels: vec!["stable".to_string()],
+                    os,
+                    rid: rid.clone(),
+                    is_genesis: false,
+                    full_filename: full_v2_name.clone(),
+                    full_size: full_v2.len() as i64,
+                    full_sha256: sha256_hex(&full_v2),
+                    full_compression_level: 0,
+                    full_zstd_workers: 0,
+                    deltas: vec![DeltaArtifact::bsdiff_zstd(
+                        "primary",
+                        "1.0.0",
+                        &delta_v2_name,
+                        delta_wrong_v2.len() as i64,
+                        &sha256_hex(&delta_wrong_v2),
+                    )],
+                    preferred_delta_id: "primary".to_string(),
+                    created_utc: chrono::Utc::now().to_rfc3339(),
+                    release_notes: String::new(),
+                    name: String::new(),
+                    main_exe: app_id.to_string(),
+                    install_directory: app_id.to_string(),
+                    supervisor_id: String::new(),
+                    icon: String::new(),
+                    shortcuts: Vec::new(),
+                    persistent_assets: Vec::new(),
+                    installers: Vec::new(),
+                    environment: std::collections::BTreeMap::new(),
+                },
+            ],
+            ..ReleaseIndex::default()
+        };
+
+        write_app_scoped_release_index(&store_root, app_id, &index);
+
+        let ctx = Arc::new(Context::new());
+        ctx.set_storage(
+            StorageProvider::Filesystem,
+            store_root.to_str().unwrap(),
+            "",
+            "",
+            "",
+            "",
+        );
+
+        let mut manager = UpdateManager::new(ctx, app_id, "1.0.0", "stable", install_root.to_str().unwrap()).unwrap();
+        let info = manager.check_for_updates().await.unwrap().unwrap();
+        assert_eq!(info.apply_strategy, ApplyStrategy::Delta);
+        manager
+            .download_and_apply(&info, None::<fn(ProgressInfo)>)
+            .await
+            .unwrap();
+
+        let installed = std::fs::read_to_string(install_root.join("app").join("payload.txt")).unwrap();
+        assert_eq!(installed, "v2 payload");
+        assert!(
+            install_root
+                .join(".surge-cache")
+                .join("artifacts")
+                .join(&full_v2_name)
+                .is_file()
+        );
+
+        let status = status::read_update_status(&install_root).unwrap().unwrap();
+        assert_eq!(status.state, status::UpdateConvergenceState::Converged);
+        assert_eq!(status.installed_version, "1.1.0");
+    }
+
+    #[tokio::test]
     async fn test_download_and_apply_delta_rebuilds_current_full_from_installed_app_when_cache_chain_is_missing() {
         let tmp = tempfile::tempdir().unwrap();
         let store_root = tmp.path().join("store");

--- a/crates/surge-core/src/update/manager/apply.rs
+++ b/crates/surge-core/src/update/manager/apply.rs
@@ -13,7 +13,7 @@ use crate::error::{Result, SurgeError};
 use crate::pack::builder::build_canonical_archive_from_directory;
 use crate::platform::detect::current_rid;
 use crate::platform::fs::write_file_atomic;
-use crate::releases::artifact_cache::cache_path_for_key;
+use crate::releases::artifact_cache::{cache_path_for_key, fetch_or_reuse_file};
 use crate::releases::delta::{
     DeltaApplyProgress, apply_delta_patch_with_progress, decode_delta_patch, is_supported_delta,
 };
@@ -41,7 +41,22 @@ where
     F: Fn(ProgressInfo) + Send + Sync,
 {
     if matches!(info.apply_strategy, ApplyStrategy::Delta) {
-        materialize_delta_payload(manager, info, staging_dir, artifact_cache_dir, extract_dir, progress).await
+        match materialize_delta_payload(manager, info, staging_dir, artifact_cache_dir, extract_dir, progress).await {
+            Ok(path) => Ok(path),
+            Err(SurgeError::Cancelled) => Err(SurgeError::Cancelled),
+            Err(delta_error) => {
+                materialize_full_payload_after_delta_failure(
+                    manager,
+                    info,
+                    staging_dir,
+                    artifact_cache_dir,
+                    extract_dir,
+                    progress,
+                    delta_error,
+                )
+                .await
+            }
+        }
     } else {
         materialize_full_payload(info, staging_dir, extract_dir, progress)
     }
@@ -56,18 +71,40 @@ fn materialize_full_payload<F>(
 where
     F: Fn(ProgressInfo) + Send + Sync,
 {
+    materialize_full_payload_with_progress_range(info, staging_dir, extract_dir, progress, 60, 75, 80, 85)
+}
+
+fn materialize_full_payload_with_progress_range<F>(
+    info: &UpdateInfo,
+    staging_dir: &Path,
+    extract_dir: &Path,
+    progress: Option<&Arc<F>>,
+    extract_total_percent_start: i32,
+    extract_total_percent_end: i32,
+    apply_total_percent_start: i32,
+    apply_total_percent_end: i32,
+) -> Result<PathBuf>
+where
+    F: Fn(ProgressInfo) + Send + Sync,
+{
     let latest = info
         .apply_releases
         .last()
         .ok_or_else(|| SurgeError::Update("No latest release".to_string()))?;
     let archive_path = staging_dir.join(&latest.full_filename);
-    extract_archive_with_progress(&archive_path, extract_dir, progress, 60, 75)?;
+    extract_archive_with_progress(
+        &archive_path,
+        extract_dir,
+        progress,
+        extract_total_percent_start,
+        extract_total_percent_end,
+    )?;
 
     emit_progress(
         progress,
         ProgressInfo {
             phase: 5,
-            total_percent: 80,
+            total_percent: apply_total_percent_start,
             ..ProgressInfo::default()
         },
     );
@@ -76,12 +113,96 @@ where
         ProgressInfo {
             phase: 5,
             phase_percent: 100,
-            total_percent: 85,
+            total_percent: apply_total_percent_end,
             ..ProgressInfo::default()
         },
     );
 
     Ok(extract_dir.to_path_buf())
+}
+
+async fn materialize_full_payload_after_delta_failure<F>(
+    manager: &UpdateManager,
+    info: &UpdateInfo,
+    staging_dir: &Path,
+    artifact_cache_dir: &Path,
+    extract_dir: &Path,
+    progress: Option<&Arc<F>>,
+    delta_error: SurgeError,
+) -> Result<PathBuf>
+where
+    F: Fn(ProgressInfo) + Send + Sync,
+{
+    let latest = info
+        .apply_releases
+        .last()
+        .ok_or_else(|| SurgeError::Update("No latest release".to_string()))?;
+
+    warn!(
+        version = %latest.version,
+        error = %delta_error,
+        "Delta materialization failed; falling back to the full package"
+    );
+
+    let cache_path = cache_path_for_key(artifact_cache_dir, &latest.full_filename)?;
+    let download_started_at = Instant::now();
+    let full_size = u64::try_from(latest.full_size.max(0)).unwrap_or(u64::MAX);
+    emit_progress(
+        progress,
+        ProgressInfo {
+            phase: 2,
+            phase_label: "download full package fallback",
+            total_percent: 60,
+            bytes_total: saturating_i64_from_u64(full_size),
+            items_total: 1,
+            ..ProgressInfo::default()
+        },
+    );
+    let progress_for_download = progress.cloned();
+    let download_progress = move |done: u64, total: u64| {
+        let total = total.max(done).max(full_size);
+        let phase_percent = clamp_progress_percent_u64(done, total);
+        emit_progress(
+            progress_for_download.as_ref(),
+            ProgressInfo {
+                phase: 2,
+                phase_label: "download full package fallback",
+                phase_percent,
+                total_percent: phase_total_percent(60, 15, phase_percent),
+                bytes_done: saturating_i64_from_u64(done),
+                bytes_total: saturating_i64_from_u64(total),
+                items_done: i64::from(phase_percent == 100),
+                items_total: 1,
+                speed_bytes_per_sec: average_speed_bytes_per_sec(done, download_started_at),
+            },
+        );
+    };
+
+    fetch_or_reuse_file(
+        manager.storage.as_ref(),
+        &latest.full_filename,
+        &cache_path,
+        &latest.full_sha256,
+        Some(&download_progress),
+    )
+    .await
+    .map_err(|fallback_error| {
+        SurgeError::Update(format!(
+            "Delta materialization failed: {delta_error}; full package fallback failed: {fallback_error}"
+        ))
+    })?;
+
+    let stage_path = staging_dir.join(&latest.full_filename);
+    if let Some(parent) = stage_path.parent() {
+        tokio::fs::create_dir_all(parent).await?;
+    }
+    tokio::fs::copy(&cache_path, &stage_path).await?;
+    if extract_dir.exists() {
+        tokio::fs::remove_dir_all(extract_dir).await?;
+    }
+    tokio::fs::create_dir_all(extract_dir).await?;
+
+    materialize_full_payload_with_progress_range(info, staging_dir, extract_dir, progress, 75, 90, 90, 90)
 }
 
 async fn materialize_delta_payload<F>(


### PR DESCRIPTION
## Summary
- Fall back to the target full package when a delta rebuild fails validation, instead of failing the update attempt outright.
- Route forced remote repair reinstalls through resumable app-copy staging.
- Stage the transfer manifest before payload entries and add transfer inactivity timeouts so interrupted app-copy repairs can be rerun and resumed.
- Require manifest-backed verification before activating a pre-staged app-copy payload.
- Treat current-version installs with a missing active executable as reinstall-required instead of runtime-restart-only.

## Findings
- A valid-looking delta can still rebuild to bytes that do not match the target full-package hash. The updater previously surfaced that as a terminal update failure even when the full package was available.
- Forced remote repairs could use a path that was less resilient on slow or unstable links.
- The app-copy staging path wrote its manifest late in the stream, so an interrupted transfer could leave files on disk without enough metadata for the next run to resume them.
- Long-running stream copies had no inactivity cutoff, which could leave a repair session waiting indefinitely instead of failing into a retryable state.
- A retry could trust an identity marker before the full staged payload had been verified.
- A partially activated repair could leave package metadata current while the active executable was missing; the repair planner then needed a reinstall, not just a runtime restart.

## Validation
- `cargo test -p surge-core test_download_and_apply_delta`
- `cargo test -p surge-cli select_remote_tailscale_transfer_strategy`
- `cargo test -p surge-cli stage_manifest`
- `cargo test -p surge-cli installer_stage`
- `cargo test -p surge-cli remote_convergence_plan`
- `cargo test -p surge-cli parse_remote_install_state`
- `RUSTFLAGS="-D warnings" cargo check -p surge-cli -p surge-core`