### PR TITLE
Fix remote artifact resume

### DIFF
--- a/crates/surge-cli/src/commands/install/mod.rs
+++ b/crates/surge-cli/src/commands/install/mod.rs
@@ -917,7 +917,7 @@ mod tests {
                 operation: RemoteTailscaleOperation::Install,
                 cached_state: RemoteTailscaleCachedState::None,
             }),
-            RemoteTailscaleTransferStrategy::AppCopy
+            RemoteTailscaleTransferStrategy::Installer { prefer_published: true }
         );
     }
 
@@ -959,7 +959,7 @@ mod tests {
     }
 
     #[test]
-    fn select_remote_tailscale_transfer_strategy_uses_resumable_app_copy_for_reinstall_repairs() {
+    fn select_remote_tailscale_transfer_strategy_uses_online_installer_for_online_reinstall_repairs() {
         assert_eq!(
             select_remote_tailscale_transfer_strategy_for_convergence(
                 RemoteTailscaleTransferInputs {
@@ -970,7 +970,43 @@ mod tests {
                 },
                 RemoteConvergenceAction::Reinstall
             ),
-            RemoteTailscaleTransferStrategy::AppCopy
+            RemoteTailscaleTransferStrategy::Installer { prefer_published: true }
+        );
+        assert_eq!(
+            select_remote_tailscale_transfer_strategy_for_convergence(
+                RemoteTailscaleTransferInputs {
+                    host_installer_availability: RemoteHostInstallerAvailability::Available,
+                    installer_mode: RemoteInstallerMode::Online,
+                    operation: RemoteTailscaleOperation::Install,
+                    cached_state: RemoteTailscaleCachedState::InstallerCache,
+                },
+                RemoteConvergenceAction::Reinstall
+            ),
+            RemoteTailscaleTransferStrategy::StagedInstallerCache
+        );
+        assert_eq!(
+            select_remote_tailscale_transfer_strategy_for_convergence(
+                RemoteTailscaleTransferInputs {
+                    host_installer_availability: RemoteHostInstallerAvailability::Available,
+                    installer_mode: RemoteInstallerMode::Offline,
+                    operation: RemoteTailscaleOperation::Install,
+                    cached_state: RemoteTailscaleCachedState::None,
+                },
+                RemoteConvergenceAction::Reinstall
+            ),
+            RemoteTailscaleTransferStrategy::Installer { prefer_published: true }
+        );
+        assert_eq!(
+            select_remote_tailscale_transfer_strategy_for_convergence(
+                RemoteTailscaleTransferInputs {
+                    host_installer_availability: RemoteHostInstallerAvailability::Unavailable,
+                    installer_mode: RemoteInstallerMode::Online,
+                    operation: RemoteTailscaleOperation::Install,
+                    cached_state: RemoteTailscaleCachedState::None,
+                },
+                RemoteConvergenceAction::Reinstall
+            ),
+            RemoteTailscaleTransferStrategy::Installer { prefer_published: true }
         );
     }
 

--- a/crates/surge-cli/src/commands/install/remote/execution.rs
+++ b/crates/surge-cli/src/commands/install/remote/execution.rs
@@ -9,7 +9,6 @@ use super::{
 };
 use tokio::io::AsyncSeekExt;
 
-const REMOTE_COPY_CONFIRMATION_TIMEOUT: Duration = Duration::from_mins(10);
 const REMOTE_STREAM_PROGRESS_TIMEOUT: Duration = Duration::from_mins(3);
 const TAILSCALE_STREAM_COMMAND_TIMEOUT: Duration = Duration::from_mins(30);
 
@@ -216,11 +215,12 @@ pub(crate) async fn stream_directory_entries_to_tailscale_node_with_command(
     Ok(())
 }
 
-pub(crate) async fn stream_file_to_tailscale_node_with_command_from_offset(
+pub(crate) async fn stream_file_to_tailscale_node_with_command_from_offset_timeout(
     node: &str,
     local_file: &Path,
     remote_command: &str,
     offset: u64,
+    confirmation_timeout: Duration,
 ) -> Result<()> {
     let ssh_command = format!("sh -lc {}", shell_single_quote(remote_command));
     let mut child = Command::new("tailscale")
@@ -324,7 +324,7 @@ pub(crate) async fn stream_file_to_tailscale_node_with_command_from_offset(
         logline::subtle("Waiting for remote copy confirmation...");
     }
 
-    let output = tokio::time::timeout(REMOTE_COPY_CONFIRMATION_TIMEOUT, child.wait_with_output()).await;
+    let output = tokio::time::timeout(confirmation_timeout, child.wait_with_output()).await;
     if let Some(spinner) = finalize_spinner {
         spinner.finish_and_clear();
     }
@@ -335,7 +335,7 @@ pub(crate) async fn stream_file_to_tailscale_node_with_command_from_offset(
         Err(_) => {
             return Err(SurgeError::Platform(format!(
                 "Timed out after {}s waiting for remote copy confirmation to '{node}'",
-                REMOTE_COPY_CONFIRMATION_TIMEOUT.as_secs()
+                confirmation_timeout.as_secs()
             )));
         }
     };

--- a/crates/surge-cli/src/commands/install/remote/installer_stage.rs
+++ b/crates/surge-cli/src/commands/install/remote/installer_stage.rs
@@ -1,8 +1,10 @@
+use std::io::{Read, Seek, SeekFrom, Write};
 use std::path::Path;
+use std::time::Duration;
 
 use super::execution::{
     REMOTE_INSTALLER_FINAL_PATH, REMOTE_INSTALLER_PARTIAL_PATH, run_tailscale_capture,
-    stream_file_to_tailscale_node_with_command_from_offset,
+    stream_file_to_tailscale_node_with_command_from_offset_timeout,
 };
 use super::{Result, SurgeError, logline, shell_single_quote};
 
@@ -14,6 +16,9 @@ enum InstallerStageState {
     Discard,
 }
 
+const INSTALLER_STAGE_CHUNK_BYTES: u64 = 256 * 1024;
+const INSTALLER_STAGE_CONFIRMATION_TIMEOUT: Duration = Duration::from_secs(90);
+
 pub(crate) async fn stage_installer_file_for_tailscale(
     ssh_target: &str,
     file_target: &str,
@@ -21,6 +26,7 @@ pub(crate) async fn stage_installer_file_for_tailscale(
     expected_size: u64,
     expected_sha256: &str,
 ) -> Result<()> {
+    cleanup_remote_installer_transfer_helpers(ssh_target, file_target).await?;
     let state = probe_remote_installer_stage(ssh_target, expected_size, expected_sha256).await?;
     match state {
         InstallerStageState::Complete => {
@@ -33,22 +39,111 @@ pub(crate) async fn stage_installer_file_for_tailscale(
             logline::info(&format!(
                 "Resuming staged installer upload to '{file_target}' from byte {offset} of {expected_size}."
             ));
-            let command = build_remote_installer_resume_command(expected_size, expected_sha256, offset);
-            stream_file_to_tailscale_node_with_command_from_offset(ssh_target, installer_path, &command, offset).await
+            stream_installer_chunks_for_tailscale(
+                ssh_target,
+                file_target,
+                installer_path,
+                expected_size,
+                expected_sha256,
+                offset,
+            )
+            .await
         }
         InstallerStageState::Missing => {
             logline::info(&format!("Creating remote installer stage on '{file_target}'."));
-            let command = build_remote_installer_resume_command(expected_size, expected_sha256, 0);
-            stream_file_to_tailscale_node_with_command_from_offset(ssh_target, installer_path, &command, 0).await
+            stream_installer_chunks_for_tailscale(
+                ssh_target,
+                file_target,
+                installer_path,
+                expected_size,
+                expected_sha256,
+                0,
+            )
+            .await
         }
         InstallerStageState::Discard => {
             logline::warn(&format!(
                 "Discarding incompatible remote installer stage on '{file_target}' and uploading from the beginning."
             ));
-            let command = build_remote_installer_resume_command(expected_size, expected_sha256, 0);
-            stream_file_to_tailscale_node_with_command_from_offset(ssh_target, installer_path, &command, 0).await
+            stream_installer_chunks_for_tailscale(
+                ssh_target,
+                file_target,
+                installer_path,
+                expected_size,
+                expected_sha256,
+                0,
+            )
+            .await
         }
     }
+}
+
+async fn stream_installer_chunks_for_tailscale(
+    ssh_target: &str,
+    file_target: &str,
+    installer_path: &Path,
+    expected_size: u64,
+    expected_sha256: &str,
+    mut offset: u64,
+) -> Result<()> {
+    while offset < expected_size {
+        let next_offset = offset.saturating_add(INSTALLER_STAGE_CHUNK_BYTES).min(expected_size);
+        let chunk_len = next_offset.saturating_sub(offset);
+        let chunk = create_installer_chunk(installer_path, offset, chunk_len)?;
+        let command = build_remote_installer_chunk_command(expected_size, expected_sha256, offset, next_offset);
+        logline::subtle(&format!(
+            "Uploading staged installer chunk to '{file_target}' ({next_offset}/{expected_size} bytes)."
+        ));
+        stream_file_to_tailscale_node_with_command_from_offset_timeout(
+            ssh_target,
+            chunk.path(),
+            &command,
+            0,
+            INSTALLER_STAGE_CONFIRMATION_TIMEOUT,
+        )
+        .await?;
+        offset = next_offset;
+    }
+    Ok(())
+}
+
+fn create_installer_chunk(installer_path: &Path, offset: u64, len: u64) -> Result<tempfile::NamedTempFile> {
+    let mut source = std::fs::File::open(installer_path)?;
+    source.seek(SeekFrom::Start(offset))?;
+    let len = usize::try_from(len)
+        .map_err(|_| SurgeError::Platform(format!("Installer chunk length is too large: {len} bytes")))?;
+    let mut bytes = vec![0_u8; len];
+    source.read_exact(&mut bytes)?;
+
+    let mut chunk = tempfile::NamedTempFile::new()?;
+    chunk.write_all(&bytes)?;
+    chunk.flush()?;
+    Ok(chunk)
+}
+
+async fn cleanup_remote_installer_transfer_helpers(ssh_target: &str, file_target: &str) -> Result<()> {
+    let command = format!(
+        "sh -c {}",
+        shell_single_quote(&build_remote_installer_transfer_cleanup_command())
+    );
+    let output = run_tailscale_capture(&["ssh", ssh_target, command.as_str()]).await?;
+    if output.trim() == "cleaned" {
+        logline::subtle(&format!(
+            "Cleared stale remote installer transfer helpers on '{file_target}'."
+        ));
+    }
+    Ok(())
+}
+
+fn build_remote_installer_transfer_cleanup_command() -> String {
+    "set -eu; \
+partial=/tmp/.surge-installer.partial; \
+pattern='[.]surge-installer|[.]surge-transfer-stage'; \
+pids=\"$(ps -eo pid=,ppid=,args= | awk -v self=\"$$\" -v parent=\"$PPID\" -v pattern=\"$pattern\" '$1 != self && $1 != parent && $0 ~ pattern { print $1 }')\"; \
+if [ -n \"$pids\" ]; then kill $pids 2>/dev/null || true; cleaned=1; else cleaned=0; fi; \
+rm -f \"$partial\".chunk.*; \
+if [ \"$cleaned\" = 1 ]; then echo cleaned; else echo none; fi"
+        .to_string()
 }
 
 async fn probe_remote_installer_stage(
@@ -93,7 +188,7 @@ fn build_remote_installer_stage_probe_command(expected_size: u64, expected_sha25
     let expected_sha256 = expected_sha256.trim();
     format!(
         "set -eu; \
-final_path={REMOTE_INSTALLER_FINAL_PATH}; partial={REMOTE_INSTALLER_PARTIAL_PATH}; \
+final_path={REMOTE_INSTALLER_FINAL_PATH}; partial={REMOTE_INSTALLER_PARTIAL_PATH}; meta=\"$partial.meta\"; \
 expected_size='{expected_size}'; expected_sha256='{expected_sha256}'; \
 hash_file() {{ if command -v sha256sum >/dev/null 2>&1; then sha256sum \"$1\" | awk '{{print $1}}'; \
 elif command -v shasum >/dev/null 2>&1; then shasum -a 256 \"$1\" | awk '{{print $1}}'; \
@@ -103,6 +198,9 @@ if [ -f \"$final_path\" ]; then \
   if [ \"$final_size\" = \"$expected_size\" ] && [ \"$(hash_file \"$final_path\")\" = \"$expected_sha256\" ]; then echo complete; exit 0; fi; \
 fi; \
 if [ -f \"$partial\" ]; then \
+  if [ ! -f \"$meta\" ]; then echo discard; exit 0; fi; \
+  meta_size=\"$(awk '{{print $1}}' \"$meta\")\"; meta_sha=\"$(awk '{{print $2}}' \"$meta\")\"; \
+  if [ \"$meta_size\" != \"$expected_size\" ] || [ \"$meta_sha\" != \"$expected_sha256\" ]; then echo discard; exit 0; fi; \
   partial_size=\"$(wc -c < \"$partial\" | tr -d '[:space:]')\"; \
   if [ \"$partial_size\" -gt \"$expected_size\" ]; then echo discard; exit 0; fi; \
   echo \"partial $partial_size\"; exit 0; \
@@ -111,29 +209,58 @@ echo missing"
     )
 }
 
-fn build_remote_installer_resume_command(expected_size: u64, expected_sha256: &str, offset: u64) -> String {
+fn build_remote_installer_chunk_command(
+    expected_size: u64,
+    expected_sha256: &str,
+    expected_offset: u64,
+    expected_next_offset: u64,
+) -> String {
     let expected_sha256 = expected_sha256.trim();
-    format!(
-        "set -eu; \
-final_path={REMOTE_INSTALLER_FINAL_PATH}; partial={REMOTE_INSTALLER_PARTIAL_PATH}; \
-expected_size='{expected_size}'; expected_sha256='{expected_sha256}'; expected_offset='{offset}'; \
-if [ \"$expected_offset\" = 0 ]; then rm -f \"$partial\"; fi; \
-actual_offset=0; if [ -f \"$partial\" ]; then actual_offset=\"$(wc -c < \"$partial\" | tr -d '[:space:]')\"; fi; \
-if [ \"$actual_offset\" != \"$expected_offset\" ]; then \
-  echo \"remote installer partial changed before resume: expected $expected_offset bytes, got $actual_offset bytes\" >&2; exit 1; \
-fi; \
-cat >> \"$partial\"; \
-actual_size=\"$(wc -c < \"$partial\" | tr -d '[:space:]')\"; \
-if [ \"$actual_size\" != \"$expected_size\" ]; then \
-  echo \"remote installer size mismatch at $partial: expected $expected_size bytes, got $actual_size bytes\" >&2; exit 1; \
-fi; \
-if command -v sha256sum >/dev/null 2>&1; then actual_sha256=\"$(sha256sum \"$partial\" | awk '{{print $1}}')\"; \
+    let expected_chunk_size = expected_next_offset.saturating_sub(expected_offset);
+    let reset = if expected_offset == 0 {
+        "rm -f \"$partial\" \"$final_path\" \"$meta\"; printf '%s\t%s\n' \"$expected_size\" \"$expected_sha256\" > \"$meta\"; "
+    } else {
+        "if [ ! -f \"$meta\" ]; then echo 'remote installer partial metadata is missing' >&2; exit 1; fi; \
+meta_size=\"$(awk '{print $1}' \"$meta\")\"; meta_sha=\"$(awk '{print $2}' \"$meta\")\"; \
+if [ \"$meta_size\" != \"$expected_size\" ] || [ \"$meta_sha\" != \"$expected_sha256\" ]; then \
+  echo 'remote installer partial metadata does not match this installer' >&2; rm -f \"$partial\" \"$meta\"; exit 1; \
+fi; "
+    };
+    let finalize = if expected_next_offset == expected_size {
+        format!(
+            "if command -v sha256sum >/dev/null 2>&1; then actual_sha256=\"$(sha256sum \"$partial\" | awk '{{print $1}}')\"; \
 elif command -v shasum >/dev/null 2>&1; then actual_sha256=\"$(shasum -a 256 \"$partial\" | awk '{{print $1}}')\"; \
 else echo 'remote host has no sha256sum or shasum command available to verify installer transfer' >&2; exit 1; fi; \
-if [ \"$actual_sha256\" != \"$expected_sha256\" ]; then \
-  echo \"remote installer sha256 mismatch at $partial: expected $expected_sha256, got $actual_sha256\" >&2; rm -f \"$partial\"; exit 1; \
+if [ \"$actual_sha256\" != '{expected_sha256}' ]; then \
+  echo \"remote installer sha256 mismatch at $partial: expected {expected_sha256}, got $actual_sha256\" >&2; rm -f \"$partial\"; exit 1; \
 fi; \
-chmod +x \"$partial\"; mv \"$partial\" \"$final_path\""
+chmod +x \"$partial\"; mv \"$partial\" \"$final_path\"; rm -f \"$meta\""
+        )
+    } else {
+        "echo chunk".to_string()
+    };
+
+    format!(
+        "set -eu; \
+final_path={REMOTE_INSTALLER_FINAL_PATH}; partial={REMOTE_INSTALLER_PARTIAL_PATH}; meta=\"$partial.meta\"; \
+expected_size='{expected_size}'; expected_sha256='{expected_sha256}'; expected_offset='{expected_offset}'; expected_next_offset='{expected_next_offset}'; expected_chunk_size='{expected_chunk_size}'; \
+chunk=\"$partial.chunk.$expected_offset.$$\"; \
+trap 'rm -f \"$chunk\"' EXIT; \
+{reset}actual_offset=0; if [ -f \"$partial\" ]; then actual_offset=\"$(wc -c < \"$partial\" | tr -d '[:space:]')\"; fi; \
+if [ \"$actual_offset\" != \"$expected_offset\" ]; then \
+  echo \"remote installer partial changed before chunk append: expected $expected_offset bytes, got $actual_offset bytes\" >&2; exit 1; \
+fi; \
+cat > \"$chunk\"; \
+chunk_size=\"$(wc -c < \"$chunk\" | tr -d '[:space:]')\"; \
+if [ \"$chunk_size\" != \"$expected_chunk_size\" ]; then \
+  echo \"remote installer chunk size mismatch at $chunk: expected $expected_chunk_size bytes, got $chunk_size bytes\" >&2; exit 1; \
+fi; \
+cat \"$chunk\" >> \"$partial\"; \
+actual_size=\"$(wc -c < \"$partial\" | tr -d '[:space:]')\"; \
+if [ \"$actual_size\" != \"$expected_next_offset\" ]; then \
+  echo \"remote installer chunk size mismatch at $partial: expected $expected_next_offset bytes, got $actual_size bytes\" >&2; rm -f \"$partial\"; exit 1; \
+fi; \
+{finalize}"
     )
 }
 
@@ -162,13 +289,27 @@ mod tests {
     }
 
     #[test]
-    fn resume_command_appends_and_verifies_partial() {
-        let command = build_remote_installer_resume_command(100, "abc123", 40);
+    fn chunk_command_appends_expected_range_and_finalizes_last_chunk() {
+        let command = build_remote_installer_chunk_command(100, "abc123", 40, 80);
 
         assert!(command.contains("expected_offset='40'"));
-        assert!(command.contains("cat >> \"$partial\""));
-        assert!(command.contains("sha256sum"));
-        assert!(command.contains("shasum -a 256"));
-        assert!(command.contains("mv \"$partial\" \"$final_path\""));
+        assert!(command.contains("expected_next_offset='80'"));
+        assert!(command.contains("cat > \"$chunk\""));
+        assert!(command.contains("cat \"$chunk\" >> \"$partial\""));
+        assert!(!command.contains("mv \"$partial\" \"$final_path\""));
+
+        let final_command = build_remote_installer_chunk_command(100, "abc123", 80, 100);
+
+        assert!(final_command.contains("sha256sum"));
+        assert!(final_command.contains("mv \"$partial\" \"$final_path\""));
+    }
+
+    #[test]
+    fn cleanup_command_uses_self_safe_transfer_patterns() {
+        let command = build_remote_installer_transfer_cleanup_command();
+
+        assert!(command.contains("pattern='[.]surge-installer|[.]surge-transfer-stage'"));
+        assert!(command.contains("$1 != self && $1 != parent"));
+        assert!(command.contains("kill $pids"));
     }
 }

--- a/crates/surge-cli/src/commands/install/remote/state.rs
+++ b/crates/surge-cli/src/commands/install/remote/state.rs
@@ -36,6 +36,10 @@ pub(crate) fn select_remote_tailscale_transfer_strategy(
         return RemoteTailscaleTransferStrategy::StagedInstallerCache;
     }
 
+    if inputs.operation == RemoteTailscaleOperation::Install && inputs.installer_mode == RemoteInstallerMode::Online {
+        return RemoteTailscaleTransferStrategy::Installer { prefer_published: true };
+    }
+
     if inputs.host_installer_availability == RemoteHostInstallerAvailability::Unavailable
         || matches!(inputs.installer_mode, RemoteInstallerMode::Offline)
             && (inputs.operation == RemoteTailscaleOperation::Stage
@@ -56,7 +60,7 @@ pub(crate) fn select_remote_tailscale_transfer_strategy_for_convergence(
     if inputs.operation == RemoteTailscaleOperation::Install
         && matches!(convergence_action, RemoteConvergenceAction::Reinstall)
     {
-        return RemoteTailscaleTransferStrategy::AppCopy;
+        return select_remote_tailscale_transfer_strategy(inputs);
     }
 
     select_remote_tailscale_transfer_strategy(inputs)

--- a/crates/surge-core/src/installer_package.rs
+++ b/crates/surge-core/src/installer_package.rs
@@ -4,7 +4,9 @@ use std::path::{Path, PathBuf};
 use crate::config::constants::RELEASES_FILE_COMPRESSED;
 use crate::config::installer::InstallerManifest;
 use crate::error::{Result, SurgeError};
-use crate::releases::artifact_cache::{cache_path_for_key, cached_artifact_matches, prune_cached_artifacts};
+use crate::releases::artifact_cache::{
+    cache_path_for_key, cached_artifact_matches, fetch_or_reuse_file, prune_cached_artifacts,
+};
 use crate::releases::manifest::{ReleaseEntry, ReleaseIndex, decompress_release_index};
 use crate::releases::restore::{
     RestoreOptions, RestoreProgressCallback, restore_full_archive_for_version_with_options,
@@ -149,9 +151,14 @@ pub async fn resolve_installer_package(
     }
 
     notify_stage(options.stage, InstallerPackageStage::DownloadingPackage);
-    backend
-        .download_to_file(full_filename, &cached_package_path, options.download_progress)
-        .await?;
+    fetch_or_reuse_file(
+        &*backend,
+        full_filename,
+        &cached_package_path,
+        &manifest.release.full_sha256,
+        options.download_progress,
+    )
+    .await?;
 
     Ok(ResolvedInstallerPackage {
         path: cached_package_path,

--- a/crates/surge-core/src/releases/artifact_cache.rs
+++ b/crates/surge-core/src/releases/artifact_cache.rs
@@ -70,27 +70,83 @@ pub async fn fetch_or_reuse_file(
     if let Some(parent) = destination.parent() {
         std::fs::create_dir_all(parent)?;
     }
-    let tmp_path = temporary_download_path(destination)?;
-    let download_result = storage.download_to_file(key, &tmp_path, progress).await;
+    let resumable = !expected.is_empty() && storage.supports_resumable_downloads();
+    let (download_path, resume_offset, keep_partial_on_error) = if resumable {
+        let partial_path = partial_download_path(destination)?;
+        let resume_offset = prepare_resumable_download(storage, key, &partial_path, expected).await?;
+        (partial_path, resume_offset, true)
+    } else {
+        let tmp_path = temporary_download_path(destination)?;
+        remove_file_if_exists(&partial_download_path(destination)?);
+        (tmp_path, 0, false)
+    };
+    if resume_offset > 0 && sha256_matches_file(&download_path, expected)? {
+        atomic_rename(&download_path, destination)?;
+        return if had_local && !expected.is_empty() {
+            Ok(CacheFetchOutcome::DownloadedAfterInvalidLocal)
+        } else {
+            Ok(CacheFetchOutcome::DownloadedFresh)
+        };
+    }
+
+    let download_result = if resume_offset > 0 {
+        storage
+            .download_to_file_from_offset(key, &download_path, resume_offset, progress)
+            .await
+    } else {
+        storage.download_to_file(key, &download_path, progress).await
+    };
     if let Err(error) = download_result {
-        remove_file_if_exists(&tmp_path);
+        if !keep_partial_on_error {
+            remove_file_if_exists(&download_path);
+        }
         return Err(error);
     }
 
-    if !expected.is_empty() && !sha256_matches_file(&tmp_path, expected)? {
-        remove_file_if_exists(&tmp_path);
+    if !expected.is_empty() && !sha256_matches_file(&download_path, expected)? {
+        remove_file_if_exists(&download_path);
         return Err(SurgeError::Storage(format!(
             "SHA-256 mismatch for '{key}' after download"
         )));
     }
 
-    atomic_rename(&tmp_path, destination)?;
+    atomic_rename(&download_path, destination)?;
 
     if had_local && !expected.is_empty() {
         Ok(CacheFetchOutcome::DownloadedAfterInvalidLocal)
     } else {
         Ok(CacheFetchOutcome::DownloadedFresh)
     }
+}
+
+async fn prepare_resumable_download(
+    storage: &dyn StorageBackend,
+    key: &str,
+    partial_path: &Path,
+    expected_sha256: &str,
+) -> Result<u64> {
+    let partial_size = std::fs::metadata(partial_path).map_or(0, |metadata| metadata.len());
+    if partial_size == 0 {
+        return Ok(0);
+    }
+
+    let remote_size = match storage.head_object(key).await {
+        Ok(info) => u64::try_from(info.size).unwrap_or(0),
+        Err(_) => 0,
+    };
+    if remote_size > 0 && partial_size > remote_size {
+        remove_file_if_exists(partial_path);
+        return Ok(0);
+    }
+    if remote_size > 0 && partial_size == remote_size {
+        if sha256_matches_file(partial_path, expected_sha256)? {
+            return Ok(partial_size);
+        }
+        remove_file_if_exists(partial_path);
+        return Ok(0);
+    }
+
+    Ok(partial_size)
 }
 
 struct CacheFileLock {
@@ -156,6 +212,16 @@ fn temporary_download_path(destination: &Path) -> Result<PathBuf> {
     let path = temp.path().to_path_buf();
     drop(temp);
     Ok(path)
+}
+
+fn partial_download_path(destination: &Path) -> Result<PathBuf> {
+    let file_name = destination.file_name().and_then(|name| name.to_str()).ok_or_else(|| {
+        SurgeError::Storage(format!(
+            "Cannot create partial cache path for destination without file name: {}",
+            destination.display()
+        ))
+    })?;
+    Ok(destination.with_file_name(format!(".{file_name}.partial")))
 }
 
 fn remove_file_if_exists(path: &Path) {
@@ -240,6 +306,7 @@ mod tests {
     use super::*;
     use crate::crypto::sha256::sha256_hex;
     use crate::storage::{ListResult, ObjectInfo, TransferProgress, filesystem::FilesystemBackend};
+    use std::io::Write;
     use std::sync::{
         Arc,
         atomic::{AtomicBool, AtomicUsize, Ordering},
@@ -249,6 +316,8 @@ mod tests {
     struct SlowBackend {
         payload: Vec<u8>,
         downloads: AtomicUsize,
+        range_downloads: AtomicUsize,
+        resumable: bool,
     }
 
     #[async_trait::async_trait]
@@ -285,6 +354,29 @@ mod tests {
             self.downloads.fetch_add(1, Ordering::SeqCst);
             tokio::time::sleep(Duration::from_millis(50)).await;
             tokio::fs::write(dest, &self.payload).await?;
+            if let Some(progress) = progress {
+                let len = self.payload.len() as u64;
+                progress(len, len);
+            }
+            Ok(())
+        }
+
+        fn supports_resumable_downloads(&self) -> bool {
+            self.resumable
+        }
+
+        async fn download_to_file_from_offset(
+            &self,
+            _key: &str,
+            dest: &Path,
+            offset: u64,
+            progress: Option<&TransferProgress<'_>>,
+        ) -> Result<()> {
+            self.range_downloads.fetch_add(1, Ordering::SeqCst);
+            let start =
+                usize::try_from(offset).map_err(|e| SurgeError::Storage(format!("invalid test offset: {e}")))?;
+            let mut file = OpenOptions::new().append(true).open(dest)?;
+            file.write_all(&self.payload[start..])?;
             if let Some(progress) = progress {
                 let len = self.payload.len() as u64;
                 progress(len, len);
@@ -394,6 +486,8 @@ mod tests {
         let backend = Arc::new(SlowBackend {
             payload,
             downloads: AtomicUsize::new(0),
+            range_downloads: AtomicUsize::new(0),
+            resumable: false,
         });
 
         let first_backend = Arc::clone(&backend);
@@ -451,6 +545,8 @@ mod tests {
         let backend = SlowBackend {
             payload,
             downloads: AtomicUsize::new(0),
+            range_downloads: AtomicUsize::new(0),
+            resumable: false,
         };
         let observed_final_path_during_download = Arc::new(AtomicBool::new(false));
         let observed = Arc::clone(&observed_final_path_during_download);
@@ -471,6 +567,113 @@ mod tests {
             std::fs::read(destination).expect("cache file should exist"),
             b"remote-payload"
         );
+    }
+
+    #[tokio::test]
+    async fn fetch_or_reuse_file_resumes_existing_partial_download() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let destination = tmp.path().join("artifact.bin");
+        let payload = b"remote-payload".to_vec();
+        let partial_path = partial_download_path(&destination).expect("partial path");
+        std::fs::write(&partial_path, b"remote-").expect("write partial");
+
+        let backend = SlowBackend {
+            payload: payload.clone(),
+            downloads: AtomicUsize::new(0),
+            range_downloads: AtomicUsize::new(0),
+            resumable: true,
+        };
+
+        let outcome = fetch_or_reuse_file(&backend, "artifact.bin", &destination, &sha256_hex(&payload), None)
+            .await
+            .expect("fetch should succeed");
+
+        assert_eq!(outcome, CacheFetchOutcome::DownloadedFresh);
+        assert_eq!(backend.downloads.load(Ordering::SeqCst), 0);
+        assert_eq!(backend.range_downloads.load(Ordering::SeqCst), 1);
+        assert_eq!(std::fs::read(&destination).expect("cache file should exist"), payload);
+        assert!(!partial_path.exists());
+    }
+
+    #[tokio::test]
+    async fn fetch_or_reuse_file_keeps_resumable_partial_after_download_error() {
+        struct FailingResumeBackend;
+
+        #[async_trait::async_trait]
+        impl StorageBackend for FailingResumeBackend {
+            fn supports_resumable_downloads(&self) -> bool {
+                true
+            }
+
+            async fn put_object(&self, _key: &str, _data: &[u8], _content_type: &str) -> Result<()> {
+                unimplemented!("test backend is read-only")
+            }
+
+            async fn get_object(&self, _key: &str) -> Result<Vec<u8>> {
+                unimplemented!("test backend only supports file downloads")
+            }
+
+            async fn head_object(&self, _key: &str) -> Result<ObjectInfo> {
+                Ok(ObjectInfo {
+                    size: 14,
+                    ..ObjectInfo::default()
+                })
+            }
+
+            async fn delete_object(&self, _key: &str) -> Result<()> {
+                unimplemented!("test backend is read-only")
+            }
+
+            async fn list_objects(&self, _prefix: &str, _marker: Option<&str>, _max_keys: i32) -> Result<ListResult> {
+                Ok(ListResult::default())
+            }
+
+            async fn download_to_file(
+                &self,
+                _key: &str,
+                _dest: &Path,
+                _progress: Option<&TransferProgress<'_>>,
+            ) -> Result<()> {
+                Err(SurgeError::Storage("simulated transfer failure".to_string()))
+            }
+
+            async fn download_to_file_from_offset(
+                &self,
+                _key: &str,
+                _dest: &Path,
+                _offset: u64,
+                _progress: Option<&TransferProgress<'_>>,
+            ) -> Result<()> {
+                Err(SurgeError::Storage("simulated transfer failure".to_string()))
+            }
+
+            async fn upload_from_file(
+                &self,
+                _key: &str,
+                _src: &Path,
+                _progress: Option<&TransferProgress<'_>>,
+            ) -> Result<()> {
+                unimplemented!("test backend is read-only")
+            }
+        }
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let destination = tmp.path().join("artifact.bin");
+        let partial_path = partial_download_path(&destination).expect("partial path");
+        std::fs::write(&partial_path, b"remote-").expect("write partial");
+
+        let result = fetch_or_reuse_file(
+            &FailingResumeBackend,
+            "artifact.bin",
+            &destination,
+            &sha256_hex(b"remote-payload"),
+            None,
+        )
+        .await;
+
+        assert!(result.is_err());
+        assert_eq!(std::fs::read(&partial_path).expect("partial should remain"), b"remote-");
+        assert!(!destination.exists());
     }
 
     #[test]

--- a/crates/surge-core/src/releases/restore/recovery.rs
+++ b/crates/surge-core/src/releases/restore/recovery.rs
@@ -1,4 +1,9 @@
+use std::collections::BTreeMap;
 use std::path::Path;
+use std::sync::{
+    Arc, Mutex,
+    atomic::{AtomicI64, Ordering},
+};
 
 use crate::crypto::sha256::sha256_hex;
 use crate::error::{Result, SurgeError};
@@ -6,7 +11,7 @@ use crate::platform::fs::write_file_atomic;
 use crate::releases::artifact_cache::{cache_path_for_key, fetch_or_reuse_file};
 use crate::releases::delta::{apply_delta_patch, decode_delta_patch};
 use crate::releases::manifest::{ReleaseEntry, ReleaseIndex};
-use crate::storage::StorageBackend;
+use crate::storage::{StorageBackend, TransferProgress};
 use futures_util::stream::{self, StreamExt};
 
 use super::candidate::select_restore_candidate;
@@ -182,20 +187,57 @@ async fn prefetch_artifacts_to_cache(
 ) -> Result<()> {
     const PREFETCH_CONCURRENCY: usize = 4;
 
-    let mut items_done = 0i64;
-    let mut bytes_done = 0i64;
+    let completed_items = Arc::new(AtomicI64::new(0));
+    let downloaded_bytes_by_key = Arc::new(Mutex::new(BTreeMap::<String, i64>::new()));
     let mut prefetch_stream = stream::iter(specs.iter().cloned())
-        .map(|spec| async move {
-            let cache_path = cache_path_for_key(cache_root, &spec.key)?;
-            fetch_or_reuse_file(storage, &spec.key, &cache_path, &spec.sha256, None).await?;
-            Ok::<i64, SurgeError>(spec.size.max(0))
+        .map(|spec| {
+            let completed_items = Arc::clone(&completed_items);
+            let downloaded_bytes_by_key = Arc::clone(&downloaded_bytes_by_key);
+            async move {
+                let cache_path = cache_path_for_key(cache_root, &spec.key)?;
+                let progress_callback: Option<Box<TransferProgress<'_>>> = progress.map(|callback| {
+                    let completed_items = Arc::clone(&completed_items);
+                    let downloaded_bytes_by_key = Arc::clone(&downloaded_bytes_by_key);
+                    let key = spec.key.clone();
+                    Box::new(move |done: u64, _total: u64| {
+                        let bytes_done = {
+                            let mut state = downloaded_bytes_by_key
+                                .lock()
+                                .unwrap_or_else(std::sync::PoisonError::into_inner);
+                            state.insert(key.clone(), i64::try_from(done).unwrap_or(i64::MAX));
+                            state.values().copied().fold(0i64, i64::saturating_add)
+                        };
+                        callback(RestoreProgress {
+                            items_done: completed_items.load(Ordering::SeqCst),
+                            items_total,
+                            bytes_done,
+                            bytes_total,
+                        });
+                    }) as Box<TransferProgress<'_>>
+                });
+                fetch_or_reuse_file(
+                    storage,
+                    &spec.key,
+                    &cache_path,
+                    &spec.sha256,
+                    progress_callback.as_deref(),
+                )
+                .await?;
+                Ok::<(String, i64), SurgeError>((spec.key, spec.size.max(0)))
+            }
         })
         .buffer_unordered(PREFETCH_CONCURRENCY);
 
     while let Some(result) = prefetch_stream.next().await {
-        let size = result?;
-        items_done = items_done.saturating_add(1);
-        bytes_done = bytes_done.saturating_add(size);
+        let (key, size) = result?;
+        let items_done = completed_items.fetch_add(1, Ordering::SeqCst).saturating_add(1);
+        let bytes_done = {
+            let mut state = downloaded_bytes_by_key
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            state.insert(key, size);
+            state.values().copied().fold(0i64, i64::saturating_add)
+        };
         if let Some(callback) = progress {
             callback(RestoreProgress {
                 items_done,

--- a/crates/surge-core/src/storage/azure/auth.rs
+++ b/crates/surge-core/src/storage/azure/auth.rs
@@ -58,6 +58,7 @@ impl AzureBlobBackend {
         query_params: &[(String, String)],
         content_length: Option<usize>,
         content_type: &str,
+        range_header: Option<&str>,
         extra_headers: &[(String, String)],
     ) -> Vec<(String, String)> {
         let now = Utc::now();
@@ -97,6 +98,7 @@ impl AzureBlobBackend {
             Some(n) if n > 0 => n.to_string(),
             _ => String::new(),
         };
+        let range_header = range_header.unwrap_or_default();
 
         let string_to_sign = format!(
             "{method}\n\
@@ -110,7 +112,7 @@ impl AzureBlobBackend {
              \n\
              \n\
              \n\
-             \n\
+             {range_header}\n\
              {canonicalized_headers}\n\
              {canonicalized_resource}"
         );

--- a/crates/surge-core/src/storage/azure/requests.rs
+++ b/crates/surge-core/src/storage/azure/requests.rs
@@ -6,7 +6,10 @@ use tracing::debug;
 
 use crate::context::StorageConfig;
 use crate::error::{Result, SurgeError};
-use crate::storage::{ListResult, ObjectInfo, StorageBackend, TransferProgress, download_response_to_file};
+use crate::storage::{
+    ListResult, ObjectInfo, StorageBackend, TransferProgress, download_response_to_file,
+    download_response_to_file_from_offset,
+};
 
 use super::AzureBlobBackend;
 use super::auth::decode_account_key;
@@ -124,6 +127,7 @@ impl StorageBackend for AzureBlobBackend {
             &[],
             Some(data.len()),
             content_type,
+            None,
             &extra_headers,
         );
 
@@ -149,7 +153,7 @@ impl StorageBackend for AzureBlobBackend {
         let mut req = self.client.get(&url);
         if self.has_credentials() {
             let resource_path = format!("/{}/{}", self.container, full_key);
-            let headers = self.sign_request("GET", &resource_path, &[], None, "", &[]);
+            let headers = self.sign_request("GET", &resource_path, &[], None, "", None, &[]);
             for (name, value) in &headers {
                 req = req.header(name.as_str(), value.as_str());
             }
@@ -174,7 +178,7 @@ impl StorageBackend for AzureBlobBackend {
         let mut req = self.client.head(&url);
         if self.has_credentials() {
             let resource_path = format!("/{}/{}", self.container, full_key);
-            let headers = self.sign_request("HEAD", &resource_path, &[], None, "", &[]);
+            let headers = self.sign_request("HEAD", &resource_path, &[], None, "", None, &[]);
             for (name, value) in &headers {
                 req = req.header(name.as_str(), value.as_str());
             }
@@ -225,7 +229,7 @@ impl StorageBackend for AzureBlobBackend {
         let url = self.blob_url(&full_key);
         let resource_path = format!("/{}/{}", self.container, full_key);
 
-        let headers = self.sign_request("DELETE", &resource_path, &[], None, "", &[]);
+        let headers = self.sign_request("DELETE", &resource_path, &[], None, "", None, &[]);
 
         let mut req = self.client.delete(&url);
         for (name, value) in &headers {
@@ -267,7 +271,7 @@ impl StorageBackend for AzureBlobBackend {
         let mut req = self.client.get(&url);
         if self.has_credentials() {
             let resource_path = format!("/{}", self.container);
-            let headers = self.sign_request("GET", &resource_path, &query_params, None, "", &[]);
+            let headers = self.sign_request("GET", &resource_path, &query_params, None, "", None, &[]);
             for (name, value) in &headers {
                 req = req.header(name.as_str(), value.as_str());
             }
@@ -288,7 +292,7 @@ impl StorageBackend for AzureBlobBackend {
         let mut req = self.client.get(&url);
         if self.has_credentials() {
             let resource_path = format!("/{}/{}", self.container, full_key);
-            let headers = self.sign_request("GET", &resource_path, &[], None, "", &[]);
+            let headers = self.sign_request("GET", &resource_path, &[], None, "", None, &[]);
             for (name, value) in &headers {
                 req = req.header(name.as_str(), value.as_str());
             }
@@ -307,6 +311,60 @@ impl StorageBackend for AzureBlobBackend {
         Ok(())
     }
 
+    fn supports_resumable_downloads(&self) -> bool {
+        true
+    }
+
+    async fn download_to_file_from_offset(
+        &self,
+        key: &str,
+        dest: &Path,
+        offset: u64,
+        progress: Option<&TransferProgress<'_>>,
+    ) -> Result<()> {
+        if offset == 0 {
+            return self.download_to_file(key, dest, progress).await;
+        }
+
+        let full_key = self.full_key(key);
+        let url = self.blob_url(&full_key);
+        let range_header = format!("bytes={offset}-");
+
+        let mut req = self
+            .client
+            .get(&url)
+            .header(reqwest::header::RANGE, range_header.as_str());
+        if self.has_credentials() {
+            let resource_path = format!("/{}/{}", self.container, full_key);
+            let headers = self.sign_request("GET", &resource_path, &[], None, "", Some(&range_header), &[]);
+            for (name, value) in &headers {
+                req = req.header(name.as_str(), value.as_str());
+            }
+        }
+
+        let resp = req.send().await?;
+        let status = resp.status();
+        if status != reqwest::StatusCode::PARTIAL_CONTENT {
+            let body = resp.text().await.unwrap_or_default();
+            if !status.is_success() {
+                return Self::check_response_status(status, &full_key, &body);
+            }
+            return Err(SurgeError::Storage(format!(
+                "Azure blob '{full_key}' did not honor resumable range request from byte {offset} (HTTP {status})"
+            )));
+        }
+
+        download_response_to_file_from_offset(resp, dest, offset, progress).await?;
+
+        debug!(
+            key = %full_key,
+            dest = %dest.display(),
+            offset,
+            "Azure resumable download completed"
+        );
+        Ok(())
+    }
+
     async fn upload_from_file(&self, key: &str, src: &Path, progress: Option<&TransferProgress<'_>>) -> Result<()> {
         self.require_credentials("upload")?;
         let data = tokio::fs::read(src).await?;
@@ -322,6 +380,7 @@ impl StorageBackend for AzureBlobBackend {
             &[],
             Some(data.len()),
             "application/octet-stream",
+            None,
             &extra_headers,
         );
 

--- a/crates/surge-core/src/storage/filesystem.rs
+++ b/crates/surge-core/src/storage/filesystem.rs
@@ -1,6 +1,7 @@
 //! Filesystem storage backend for local/testing deployments.
 
 use async_trait::async_trait;
+use std::io::{Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 
 use crate::error::{Result, SurgeError};
@@ -44,6 +45,10 @@ fn i64_size_from_u64(size: u64) -> Result<i64> {
 
 #[async_trait]
 impl StorageBackend for FilesystemBackend {
+    fn supports_resumable_downloads(&self) -> bool {
+        true
+    }
+
     async fn put_object(&self, key: &str, data: &[u8], _content_type: &str) -> Result<()> {
         let path = self.resolve_key(key);
         if let Some(parent) = path.parent() {
@@ -125,6 +130,63 @@ impl StorageBackend for FilesystemBackend {
             return Err(SurgeError::NotFound(format!("Object not found: {key}")));
         }
         copy_file_with_progress(&source, dest, progress)?;
+        Ok(())
+    }
+
+    async fn download_to_file_from_offset(
+        &self,
+        key: &str,
+        dest: &Path,
+        offset: u64,
+        progress: Option<&TransferProgress<'_>>,
+    ) -> Result<()> {
+        if offset == 0 {
+            return self.download_to_file(key, dest, progress).await;
+        }
+
+        let source = self.resolve_key(key);
+        if !source.exists() {
+            return Err(SurgeError::NotFound(format!("Object not found: {key}")));
+        }
+
+        let total = std::fs::metadata(&source)?.len();
+        if offset > total {
+            return Err(SurgeError::Storage(format!(
+                "Cannot resume object '{key}' from byte {offset}; object is only {total} bytes"
+            )));
+        }
+
+        let existing_len = std::fs::metadata(dest).map_or(0, |metadata| metadata.len());
+        if existing_len != offset {
+            return Err(SurgeError::Storage(format!(
+                "Cannot resume download into '{}': expected {offset} bytes, found {existing_len}",
+                dest.display()
+            )));
+        }
+
+        let mut input = std::fs::File::open(&source)?;
+        input.seek(SeekFrom::Start(offset))?;
+        if let Some(parent) = dest.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let mut output = std::fs::OpenOptions::new().create(true).append(true).open(dest)?;
+        let mut done = offset;
+        let mut buffer = vec![0_u8; 128 * 1024];
+        if let Some(cb) = progress {
+            cb(done, total.max(done));
+        }
+        loop {
+            let read = input.read(&mut buffer)?;
+            if read == 0 {
+                break;
+            }
+            output.write_all(&buffer[..read])?;
+            done = done.saturating_add(u64::try_from(read).unwrap_or(u64::MAX));
+            if let Some(cb) = progress {
+                cb(done, total.max(done));
+            }
+        }
+        output.flush()?;
         Ok(())
     }
 

--- a/crates/surge-core/src/storage/mod.rs
+++ b/crates/surge-core/src/storage/mod.rs
@@ -74,9 +74,73 @@ pub(crate) async fn download_response_to_file(
     Ok(())
 }
 
+pub(crate) async fn download_response_to_file_from_offset(
+    response: Response,
+    dest: &std::path::Path,
+    offset: u64,
+    progress: Option<&TransferProgress<'_>>,
+) -> Result<()> {
+    if offset == 0 {
+        return download_response_to_file(response, dest, progress).await;
+    }
+
+    let existing_len = tokio::fs::metadata(dest).await.map_or(0, |metadata| metadata.len());
+    if existing_len != offset {
+        return Err(SurgeError::Storage(format!(
+            "Cannot resume download into '{}': expected {offset} bytes, found {existing_len}",
+            dest.display()
+        )));
+    }
+
+    let remaining_total = response.content_length().unwrap_or(0);
+    let total = offset.saturating_add(remaining_total);
+
+    if let Some(parent) = dest.parent() {
+        tokio::fs::create_dir_all(parent).await?;
+    }
+
+    let mut file = tokio::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(dest)
+        .await?;
+    let mut done = offset;
+    let mut reported = false;
+    let mut stream = response.bytes_stream();
+
+    if let Some(cb) = progress {
+        cb(done, total.max(done));
+        reported = true;
+    }
+
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk?;
+        file.write_all(&chunk).await?;
+        done = done.saturating_add(u64::try_from(chunk.len()).unwrap_or(u64::MAX));
+        if let Some(cb) = progress {
+            cb(done, total.max(done));
+            reported = true;
+        }
+    }
+
+    file.flush().await?;
+
+    if let Some(cb) = progress
+        && (!reported || done < total)
+    {
+        cb(done, total.max(done));
+    }
+
+    Ok(())
+}
+
 /// Abstract storage backend interface.
 #[async_trait]
 pub trait StorageBackend: Send + Sync {
+    fn supports_resumable_downloads(&self) -> bool {
+        false
+    }
+
     /// Upload an object from bytes.
     async fn put_object(&self, key: &str, data: &[u8], content_type: &str) -> Result<()>;
 
@@ -99,6 +163,21 @@ pub trait StorageBackend: Send + Sync {
         dest: &std::path::Path,
         progress: Option<&TransferProgress<'_>>,
     ) -> Result<()>;
+
+    async fn download_to_file_from_offset(
+        &self,
+        key: &str,
+        dest: &std::path::Path,
+        offset: u64,
+        progress: Option<&TransferProgress<'_>>,
+    ) -> Result<()> {
+        if offset == 0 {
+            return self.download_to_file(key, dest, progress).await;
+        }
+        Err(SurgeError::Storage(
+            "Storage backend does not support resumable downloads".to_string(),
+        ))
+    }
 
     /// Upload a file to storage.
     async fn upload_from_file(


### PR DESCRIPTION
Summary
- Prefer published online installers for forced remote repairs instead of falling back to full app-copy staging.
- Make remote installer staging chunked, metadata-scoped, and cleanup-safe so interrupted transfers can resume without stale helper corruption.
- Add resumable artifact-cache downloads for range-capable storage backends and report restore download progress so setup watchdogs do not time out during active slow transfers.

Sanitized findings
- During a production-style remote repair, slow or unstable links repeatedly restarted large package downloads from byte zero because partial package files were random temporary files.
- Interrupted transfer helpers could survive a cancelled CLI and keep a remote stream open, making the next attempt append to or wait on stale state.
- The remote setup watchdog could classify an active package download as stale because restore prefetch only reported progress after a full artifact completed.

Validation
- ./scripts/sync-surge-core-vendor.sh --check
- ./scripts/check-version-sync.sh
- cargo fmt --all -- --check
- RUSTFLAGS='-D warnings' cargo test --workspace (rerun outside sandbox for local listener test)
- cargo clippy --all-targets --all-features -- -D warnings
- cargo clippy --workspace --lib --bins --examples -- -D warnings -D clippy::unwrap_used -D clippy::expect_used
- cargo clippy --workspace --all-targets --all-features -- -D warnings -W clippy::pedantic
- dotnet format dotnet/Surge.slnx --verify-no-changes
- dotnet test dotnet/Surge.slnx --configuration Release