### PR TITLE
ci: avoid cached cargo binaries in Rust jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,9 @@ jobs:
         with:
           submodules: true
       - uses: Swatinem/rust-cache@v2
+        with:
+          cache-bin: false
+          prefix-key: v1-rust-no-bin
       - run: rustup component add clippy
       - run: cargo clippy --all-targets --all-features -- -D warnings
 
@@ -77,6 +80,9 @@ jobs:
         with:
           submodules: true
       - uses: Swatinem/rust-cache@v2
+        with:
+          cache-bin: false
+          prefix-key: v1-rust-no-bin
       - run: rustup component add clippy
       - run: cargo clippy --workspace --lib --bins --examples -- -D warnings -D clippy::unwrap_used -D clippy::expect_used
 
@@ -88,6 +94,9 @@ jobs:
         with:
           submodules: true
       - uses: Swatinem/rust-cache@v2
+        with:
+          cache-bin: false
+          prefix-key: v1-rust-no-bin
       - run: rustup component add clippy
       - name: Run pedantic audit (non-blocking)
         run: |
@@ -117,7 +126,9 @@ jobs:
           submodules: true
       - uses: Swatinem/rust-cache@v2
         with:
+          cache-bin: false
           key: ${{ matrix.cache_key }}
+          prefix-key: v1-rust-no-bin
       - run: cargo test --release
 
   rust-artifacts:
@@ -186,7 +197,9 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         if: matrix.build_strategy != 'ubuntu18-container'
         with:
+          cache-bin: false
           key: ${{ matrix.cache_key }}
+          prefix-key: v1-rust-no-bin
       - run: cargo build --release
         if: matrix.build_strategy != 'ubuntu18-container'
       - name: Build Linux arm64 artifacts in Ubuntu 18.04

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -143,7 +143,9 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         if: matrix.build_strategy != 'ubuntu18-container'
         with:
+          cache-bin: false
           key: ${{ matrix.cache_key }}
+          prefix-key: v1-rust-no-bin
       - run: cargo build --release
         if: matrix.build_strategy != 'ubuntu18-container'
       - name: Build Linux arm64 artifacts in Ubuntu 18.04
@@ -201,6 +203,9 @@ jobs:
           ref: ${{ github.event.release.tag_name }}
           submodules: true
       - uses: Swatinem/rust-cache@v2
+        with:
+          cache-bin: false
+          prefix-key: v1-rust-no-bin
       - name: Validate crates.io API token
         run: |
           if [ -z "${CARGO_REGISTRY_TOKEN}" ]; then


### PR DESCRIPTION
Purpose
- Prevent Rust cache restores from overwriting toolchain shims such as cargo.
- Bump the Rust cache prefix so the failed macOS job cannot reuse the poisoned cache that invoked rustup-init during cargo test.

Behavior impact
- CI and release workflows still cache dependencies and build outputs, but no longer restore ~/.cargo/bin.
- No product/runtime behavior changes.

Test evidence
- node -e js-yaml parse for .github/workflows/ci.yml and .github/workflows/release.yml
- git diff --check
- ./scripts/sync-surge-core-vendor.sh --check
- ./scripts/check-version-sync.sh
- cargo fmt --all -- --check
- RUSTFLAGS="-D warnings" cargo test --workspace
- RUSTFLAGS="-D warnings" cargo clippy --all-targets --all-features -- -D warnings
- cargo clippy --workspace --lib --bins --examples -- -D warnings -D clippy::unwrap_used -D clippy::expect_used
- cargo clippy --workspace --all-targets --all-features -- -D warnings -W clippy::pedantic
- dotnet format dotnet/Surge.slnx --verify-no-changes
- dotnet test dotnet/Surge.slnx --configuration Release

Migration notes
- None.