### PR TITLE
fix(core): recover stalled update attempts

### DIFF
--- a/crates/surge-core/src/releases/artifact_cache.rs
+++ b/crates/surge-core/src/releases/artifact_cache.rs
@@ -596,6 +596,95 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn fetch_or_reuse_file_accepts_resumable_backend_restart_after_range_http_200() {
+        struct RestartingResumeBackend {
+            payload: Vec<u8>,
+            range_downloads: AtomicUsize,
+        }
+
+        #[async_trait::async_trait]
+        impl StorageBackend for RestartingResumeBackend {
+            fn supports_resumable_downloads(&self) -> bool {
+                true
+            }
+
+            async fn put_object(&self, _key: &str, _data: &[u8], _content_type: &str) -> Result<()> {
+                unimplemented!("test backend is read-only")
+            }
+
+            async fn get_object(&self, _key: &str) -> Result<Vec<u8>> {
+                unimplemented!("test backend only supports file downloads")
+            }
+
+            async fn head_object(&self, _key: &str) -> Result<ObjectInfo> {
+                Ok(ObjectInfo {
+                    size: i64::try_from(self.payload.len()).expect("payload length should fit i64"),
+                    ..ObjectInfo::default()
+                })
+            }
+
+            async fn delete_object(&self, _key: &str) -> Result<()> {
+                unimplemented!("test backend is read-only")
+            }
+
+            async fn list_objects(&self, _prefix: &str, _marker: Option<&str>, _max_keys: i32) -> Result<ListResult> {
+                Ok(ListResult::default())
+            }
+
+            async fn download_to_file(
+                &self,
+                _key: &str,
+                dest: &Path,
+                _progress: Option<&TransferProgress<'_>>,
+            ) -> Result<()> {
+                tokio::fs::write(dest, &self.payload).await?;
+                Ok(())
+            }
+
+            async fn download_to_file_from_offset(
+                &self,
+                _key: &str,
+                dest: &Path,
+                _offset: u64,
+                _progress: Option<&TransferProgress<'_>>,
+            ) -> Result<()> {
+                self.range_downloads.fetch_add(1, Ordering::SeqCst);
+                tokio::fs::write(dest, &self.payload).await?;
+                Ok(())
+            }
+
+            async fn upload_from_file(
+                &self,
+                _key: &str,
+                _src: &Path,
+                _progress: Option<&TransferProgress<'_>>,
+            ) -> Result<()> {
+                unimplemented!("test backend is read-only")
+            }
+        }
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let destination = tmp.path().join("artifact.bin");
+        let payload = b"remote-payload".to_vec();
+        let partial_path = partial_download_path(&destination).expect("partial path");
+        std::fs::write(&partial_path, b"remote-").expect("write partial");
+
+        let backend = RestartingResumeBackend {
+            payload: payload.clone(),
+            range_downloads: AtomicUsize::new(0),
+        };
+
+        let outcome = fetch_or_reuse_file(&backend, "artifact.bin", &destination, &sha256_hex(&payload), None)
+            .await
+            .expect("fetch should accept restarted full response");
+
+        assert_eq!(outcome, CacheFetchOutcome::DownloadedFresh);
+        assert_eq!(backend.range_downloads.load(Ordering::SeqCst), 1);
+        assert_eq!(std::fs::read(&destination).expect("cache file should exist"), payload);
+        assert!(!partial_path.exists());
+    }
+
+    #[tokio::test]
     async fn fetch_or_reuse_file_keeps_resumable_partial_after_download_error() {
         struct FailingResumeBackend;
 

--- a/crates/surge-core/src/storage/azure/requests.rs
+++ b/crates/surge-core/src/storage/azure/requests.rs
@@ -111,6 +111,23 @@ impl AzureBlobBackend {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ResumableDownloadResponseAction {
+    AppendFromOffset,
+    RestartFromZero,
+    Error,
+}
+
+fn resumable_download_response_action(status: reqwest::StatusCode) -> ResumableDownloadResponseAction {
+    if status == reqwest::StatusCode::PARTIAL_CONTENT {
+        ResumableDownloadResponseAction::AppendFromOffset
+    } else if status.is_success() {
+        ResumableDownloadResponseAction::RestartFromZero
+    } else {
+        ResumableDownloadResponseAction::Error
+    }
+}
+
 #[async_trait]
 impl StorageBackend for AzureBlobBackend {
     async fn put_object(&self, key: &str, data: &[u8], content_type: &str) -> Result<()> {
@@ -344,17 +361,25 @@ impl StorageBackend for AzureBlobBackend {
 
         let resp = req.send().await?;
         let status = resp.status();
-        if status != reqwest::StatusCode::PARTIAL_CONTENT {
-            let body = resp.text().await.unwrap_or_default();
-            if !status.is_success() {
+        match resumable_download_response_action(status) {
+            ResumableDownloadResponseAction::AppendFromOffset => {
+                download_response_to_file_from_offset(resp, dest, offset, progress).await?;
+            }
+            ResumableDownloadResponseAction::RestartFromZero => {
+                debug!(
+                    key = %full_key,
+                    dest = %dest.display(),
+                    offset,
+                    status = %status,
+                    "Azure blob ignored resumable range request; restarting download from byte zero"
+                );
+                download_response_to_file(resp, dest, progress).await?;
+            }
+            ResumableDownloadResponseAction::Error => {
+                let body = resp.text().await.unwrap_or_default();
                 return Self::check_response_status(status, &full_key, &body);
             }
-            return Err(SurgeError::Storage(format!(
-                "Azure blob '{full_key}' did not honor resumable range request from byte {offset} (HTTP {status})"
-            )));
         }
-
-        download_response_to_file_from_offset(resp, dest, offset, progress).await?;
 
         debug!(
             key = %full_key,
@@ -399,5 +424,26 @@ impl StorageBackend for AzureBlobBackend {
             cb(total, total);
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn azure_resume_http_200_restarts_from_zero_instead_of_reusing_partial() {
+        assert_eq!(
+            resumable_download_response_action(reqwest::StatusCode::OK),
+            ResumableDownloadResponseAction::RestartFromZero
+        );
+        assert_eq!(
+            resumable_download_response_action(reqwest::StatusCode::PARTIAL_CONTENT),
+            ResumableDownloadResponseAction::AppendFromOffset
+        );
+        assert_eq!(
+            resumable_download_response_action(reqwest::StatusCode::RANGE_NOT_SATISFIABLE),
+            ResumableDownloadResponseAction::Error
+        );
     }
 }

--- a/crates/surge-core/src/update/manager.rs
+++ b/crates/surge-core/src/update/manager.rs
@@ -10,6 +10,7 @@ mod release_index;
 
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::time::Duration;
 
 use tracing::{info, warn};
 
@@ -18,7 +19,7 @@ use crate::context::Context;
 use crate::error::{Result, SurgeError};
 use crate::releases::manifest::{ReleaseEntry, ReleaseIndex};
 use crate::storage::{StorageBackend, create_storage_backend};
-use crate::update::status::{self, FailureContext, UpdateStatusRecord};
+use crate::update::status::{self, FailureContext, UpdateStatusRecord, UpdateWorkerGuard};
 
 use self::apply::materialize_update_payload;
 use self::artifacts::prepare_update_artifacts;
@@ -58,6 +59,7 @@ pub struct UpdateInfo {
 
 const DEFAULT_RELEASE_RETENTION_LIMIT: usize = 1;
 pub(super) const RELEASE_GRAPH_CHECKPOINT_FULLS: usize = 3;
+const ABANDONED_IN_PROGRESS_TIMEOUT: Duration = Duration::from_mins(5);
 
 /// Manages checking for and applying application updates.
 pub struct UpdateManager {
@@ -220,6 +222,27 @@ impl UpdateManager {
         let pre_attempt_version = self.current_version.clone();
         let target_version = info.latest_version.clone();
 
+        if let Some(failed) = status::fail_abandoned_in_progress_update(
+            &self.install_dir,
+            &self.app_id,
+            &target_version,
+            &self.channel,
+            ABANDONED_IN_PROGRESS_TIMEOUT,
+        )? {
+            let phase = failed.failure_phase.as_deref().unwrap_or("unknown");
+            return Err(SurgeError::Update(format!(
+                "Previous update attempt stalled at phase '{phase}'; retry is safe"
+            )));
+        }
+
+        let _worker_guard = match UpdateWorkerGuard::record(&self.install_dir, &self.app_id, &target_version) {
+            Ok(guard) => Some(guard),
+            Err(e) => {
+                warn!(error = %e, "Failed to persist update worker marker (continuing)");
+                None
+            }
+        };
+
         let in_progress_record = UpdateStatusRecord::in_progress(
             &self.app_id,
             &pre_attempt_version,
@@ -255,15 +278,18 @@ impl UpdateManager {
                         completed_at_utc,
                         true,
                     ),
-                    SupervisorRestartOutcome::Unconfirmed { reason } => UpdateStatusRecord::pending_restart(
-                        &self.app_id,
-                        &target_version,
-                        &target_version,
-                        &self.channel,
-                        attempted_at_utc,
-                        completed_at_utc,
-                        &reason,
-                    ),
+                    SupervisorRestartOutcome::Unconfirmed { reason } => {
+                        UpdateStatusRecord::pending_restart_with_failure_phase(
+                            &self.app_id,
+                            &target_version,
+                            &target_version,
+                            &self.channel,
+                            attempted_at_utc,
+                            completed_at_utc,
+                            &reason,
+                            status::RESTART_HANDOFF_FAILED_PHASE,
+                        )
+                    }
                 };
                 if let Err(e) = status::write_update_status(&self.install_dir, &record) {
                     warn!(error = %e, "Failed to persist post-update convergence status (continuing)");
@@ -354,16 +380,22 @@ impl UpdateManager {
 
         let extract_dir = staging_dir.join("extracted");
         tokio::fs::create_dir_all(&extract_dir).await?;
-        progress_emitter.emit_substep(5, update_phase::PACKAGE_APPLY_STARTED, 60);
-        let extracted_final_dir = materialize_update_payload(
-            self,
-            info,
-            &staging_dir,
-            &artifact_cache_dir,
-            &extract_dir,
-            progress.as_ref(),
-        )
-        .await?;
+        let extracted_final_dir = progress_emitter
+            .run_with_heartbeat(
+                5,
+                update_phase::PACKAGE_APPLY_STARTED,
+                60,
+                progress_substep::HEARTBEAT_INTERVAL,
+                materialize_update_payload(
+                    self,
+                    info,
+                    &staging_dir,
+                    &artifact_cache_dir,
+                    &extract_dir,
+                    progress.as_ref(),
+                ),
+            )
+            .await?;
         progress_emitter.emit_completed_phase(update_phase::PACKAGE_APPLY_COMPLETED);
 
         // Phase 6: Finalize
@@ -669,6 +701,93 @@ mod tests {
         .unwrap_err();
         assert!(err.to_string().contains("Timed out waiting for supervisor"));
         assert!(stop_file.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_restart_supervisor_handoff_starts_new_child_after_watched_process_exits() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let install_dir = tmp.path();
+        let active_app_dir = install_dir.join("app");
+        std::fs::create_dir_all(&active_app_dir).unwrap();
+
+        let supervisor_path = active_app_dir.join(crate::platform::process::supervisor_binary_name());
+        std::fs::write(
+            &supervisor_path,
+            r#"#!/bin/sh
+id=""
+dir=""
+pid=""
+exe=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    watch) shift ;;
+    --id) id="$2"; shift 2 ;;
+    --dir) dir="$2"; shift 2 ;;
+    --pid) pid="$2"; shift 2 ;;
+    --exe) exe="$2"; shift 2 ;;
+    --) shift; break ;;
+    *) shift ;;
+  esac
+done
+echo $$ > "$dir/.surge-supervisor-$id.pid"
+while kill -0 "$pid" 2>/dev/null; do
+  sleep 0.05
+done
+"$exe" "$@" &
+wait $!
+"#,
+        )
+        .unwrap();
+        let mut permissions = std::fs::metadata(&supervisor_path).unwrap().permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&supervisor_path, permissions).unwrap();
+
+        let app_path = active_app_dir.join("demo-app");
+        std::fs::write(
+            &app_path,
+            r"#!/bin/sh
+echo started > new-child-started
+",
+        )
+        .unwrap();
+        let mut permissions = std::fs::metadata(&app_path).unwrap().permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&app_path, permissions).unwrap();
+
+        let mut watched_child = std::process::Command::new("sh")
+            .arg("-c")
+            .arg("while true; do sleep 1; done")
+            .spawn()
+            .unwrap();
+
+        let mut latest = make_entry("1.1.0", "stable", &current_os_label_for_tests(), &current_rid());
+        latest.main_exe = "demo-app".to_string();
+        latest.supervisor_id = "demo-supervisor".to_string();
+
+        let outcome = lifecycle::restart_supervisor_after_update_with_pid(
+            install_dir,
+            &active_app_dir,
+            &latest,
+            watched_child.id(),
+        );
+        let confirmed = matches!(outcome, SupervisorRestartOutcome::Confirmed);
+
+        watched_child.kill().unwrap();
+        watched_child.wait().unwrap();
+        assert!(confirmed);
+
+        let started_path = install_dir.join("new-child-started");
+        let deadline = std::time::Instant::now() + Duration::from_secs(2);
+        while !started_path.exists() && std::time::Instant::now() < deadline {
+            std::thread::sleep(Duration::from_millis(50));
+        }
+        assert!(
+            started_path.exists(),
+            "new child should start after watched process exits"
+        );
     }
 
     #[tokio::test]

--- a/crates/surge-core/src/update/manager/lifecycle.rs
+++ b/crates/surge-core/src/update/manager/lifecycle.rs
@@ -143,6 +143,15 @@ pub(super) fn restart_supervisor_after_update(
     active_app_dir: &Path,
     latest: &ReleaseEntry,
 ) -> SupervisorRestartOutcome {
+    restart_supervisor_after_update_with_pid(install_dir, active_app_dir, latest, current_pid())
+}
+
+pub(super) fn restart_supervisor_after_update_with_pid(
+    install_dir: &Path,
+    active_app_dir: &Path,
+    latest: &ReleaseEntry,
+    watched_pid: u32,
+) -> SupervisorRestartOutcome {
     let supervisor_id = latest.supervisor_id.trim();
     if supervisor_id.is_empty() {
         return SupervisorRestartOutcome::NotApplicable;
@@ -183,7 +192,7 @@ pub(super) fn restart_supervisor_after_update(
     };
 
     let install_dir_str = install_dir.to_string_lossy();
-    let pid_str = current_pid().to_string();
+    let pid_str = watched_pid.to_string();
     let exe_path_str = exe_path.to_string_lossy();
     let mut args: Vec<&str> = vec![
         "watch",

--- a/crates/surge-core/src/update/manager/progress_substep.rs
+++ b/crates/surge-core/src/update/manager/progress_substep.rs
@@ -128,10 +128,16 @@ where
     }
 
     fn persist_current_phase(&self, label: &'static str) {
-        let record = self
+        let mut record = self
             .in_progress_template
             .clone()
             .with_current_phase_at(label, status::now_utc_rfc3339());
+        if let Ok(Some(existing)) = status::read_update_status(self.install_dir)
+            && existing.app_id == record.app_id
+            && existing.target_version == record.target_version
+        {
+            record.last_completed_phase = existing.last_completed_phase;
+        }
         if let Err(e) = status::write_update_status(self.install_dir, &record) {
             warn!(error = %e, phase = label, "Failed to persist in-progress substep status (continuing)");
         }

--- a/crates/surge-core/src/update/status.rs
+++ b/crates/surge-core/src/update/status.rs
@@ -26,6 +26,8 @@ use crate::platform::fs::write_file_atomic;
 use crate::supervisor::state::supervisor_pid_file;
 
 pub const UPDATE_STATUS_FILE_NAME: &str = ".surge-update-status.json";
+pub const RESTART_HANDOFF_FAILED_PHASE: &str = "restart handoff failed";
+const UPDATE_WORKER_FILE_NAME: &str = ".surge-update-worker.json";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -101,6 +103,56 @@ pub struct UpdateStatusRecord {
     /// Whether retrying the same setup/update command is expected to be safe.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub retry_safe: Option<bool>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct UpdateWorkerRecord {
+    pid: u32,
+    app_id: String,
+    target_version: String,
+    started_at_utc: String,
+}
+
+pub struct UpdateWorkerGuard {
+    path: PathBuf,
+    pid: u32,
+    app_id: String,
+    target_version: String,
+}
+
+impl UpdateWorkerGuard {
+    pub fn record(install_dir: &Path, app_id: &str, target_version: &str) -> Result<Self> {
+        let record = UpdateWorkerRecord {
+            pid: std::process::id(),
+            app_id: app_id.to_string(),
+            target_version: target_version.to_string(),
+            started_at_utc: now_utc_rfc3339(),
+        };
+        let path = update_worker_path(install_dir);
+        let json = serde_json::to_vec_pretty(&record)
+            .map_err(|e| SurgeError::Config(format!("Failed to encode update worker marker: {e}")))?;
+        write_file_atomic(&path, &json)?;
+        Ok(Self {
+            path,
+            pid: record.pid,
+            app_id: record.app_id,
+            target_version: record.target_version,
+        })
+    }
+}
+
+impl Drop for UpdateWorkerGuard {
+    fn drop(&mut self) {
+        let Ok(raw) = std::fs::read(&self.path) else {
+            return;
+        };
+        let Ok(record) = serde_json::from_slice::<UpdateWorkerRecord>(&raw) else {
+            return;
+        };
+        if record.pid == self.pid && record.app_id == self.app_id && record.target_version == self.target_version {
+            let _ = std::fs::remove_file(&self.path);
+        }
+    }
 }
 
 impl UpdateStatusRecord {
@@ -220,6 +272,29 @@ impl UpdateStatusRecord {
         completed_at_utc: String,
         reason: &str,
     ) -> Self {
+        Self::pending_restart_with_failure_phase(
+            app_id,
+            installed_version,
+            target_version,
+            channel,
+            attempted_at_utc,
+            completed_at_utc,
+            reason,
+            "supervisor restart requested",
+        )
+    }
+
+    #[must_use]
+    pub fn pending_restart_with_failure_phase(
+        app_id: &str,
+        installed_version: &str,
+        target_version: &str,
+        channel: &str,
+        attempted_at_utc: String,
+        completed_at_utc: String,
+        reason: &str,
+        failure_phase: &str,
+    ) -> Self {
         Self {
             state: UpdateConvergenceState::PendingRestart,
             installed_version: installed_version.to_string(),
@@ -233,7 +308,7 @@ impl UpdateStatusRecord {
             last_progress_at_utc: None,
             current_phase: None,
             last_completed_phase: None,
-            failure_phase: Some("supervisor restart requested".to_string()),
+            failure_phase: Some(failure_phase.to_string()),
             retry_safe: Some(true),
         }
     }
@@ -325,6 +400,11 @@ pub fn update_status_path(install_dir: &Path) -> PathBuf {
     install_dir.join(UPDATE_STATUS_FILE_NAME)
 }
 
+#[must_use]
+fn update_worker_path(install_dir: &Path) -> PathBuf {
+    install_dir.join(UPDATE_WORKER_FILE_NAME)
+}
+
 /// Read the persisted update status record from `install_dir`, if any.
 ///
 /// Returns `Ok(None)` when no record has been written yet (clean install that
@@ -347,6 +427,99 @@ pub fn write_update_status(install_dir: &Path, record: &UpdateStatusRecord) -> R
         .map_err(|e| SurgeError::Config(format!("Failed to encode update status: {e}")))?;
     write_file_atomic(&path, &json)?;
     Ok(())
+}
+
+pub fn fail_abandoned_in_progress_update(
+    install_dir: &Path,
+    app_id: &str,
+    target_version: &str,
+    channel: &str,
+    stale_after: Duration,
+) -> Result<Option<UpdateStatusRecord>> {
+    fail_abandoned_in_progress_update_at(
+        install_dir,
+        app_id,
+        target_version,
+        channel,
+        stale_after,
+        chrono::Utc::now(),
+    )
+}
+
+fn fail_abandoned_in_progress_update_at(
+    install_dir: &Path,
+    app_id: &str,
+    target_version: &str,
+    channel: &str,
+    stale_after: Duration,
+    now: chrono::DateTime<chrono::Utc>,
+) -> Result<Option<UpdateStatusRecord>> {
+    let Some(record) = read_update_status(install_dir)? else {
+        return Ok(None);
+    };
+    if record.state != UpdateConvergenceState::InProgress
+        || record.app_id != app_id
+        || record.target_version != target_version
+        || record.channel != channel
+    {
+        return Ok(None);
+    }
+    let Some(age) = stale_progress_age(&record, now) else {
+        return Ok(None);
+    };
+    if age < stale_after || matching_worker_is_current(install_dir, &record) {
+        return Ok(None);
+    }
+
+    let phase = record
+        .current_phase
+        .as_deref()
+        .or(record.failure_phase.as_deref())
+        .unwrap_or("unknown");
+    let attempted_at_utc = record.attempted_at_utc.clone().unwrap_or_else(now_utc_rfc3339);
+    let failed = UpdateStatusRecord::failed_with_context(
+        &record.app_id,
+        &record.installed_version,
+        &record.target_version,
+        &record.channel,
+        attempted_at_utc,
+        &format!(
+            "previous update attempt abandoned after {}s without progress at phase '{phase}'",
+            age.as_secs()
+        ),
+        FailureContext::from_record(Some(&record), true),
+    );
+    write_update_status(install_dir, &failed)?;
+    Ok(Some(failed))
+}
+
+fn stale_progress_age(record: &UpdateStatusRecord, now: chrono::DateTime<chrono::Utc>) -> Option<Duration> {
+    let timestamp = record
+        .last_progress_at_utc
+        .as_deref()
+        .or(record.attempted_at_utc.as_deref())?;
+    let parsed = chrono::DateTime::parse_from_rfc3339(timestamp).ok()?;
+    now.signed_duration_since(parsed.with_timezone(&chrono::Utc))
+        .to_std()
+        .ok()
+}
+
+fn matching_worker_is_current(install_dir: &Path, record: &UpdateStatusRecord) -> bool {
+    let Ok(Some(worker)) = read_update_worker(install_dir) else {
+        return false;
+    };
+    worker.pid == std::process::id() && worker.app_id == record.app_id && worker.target_version == record.target_version
+}
+
+fn read_update_worker(install_dir: &Path) -> Result<Option<UpdateWorkerRecord>> {
+    let path = update_worker_path(install_dir);
+    if !path.is_file() {
+        return Ok(None);
+    }
+    let raw = std::fs::read(&path)?;
+    serde_json::from_slice(&raw)
+        .map(Some)
+        .map_err(|e| SurgeError::Config(format!("Failed to decode {}: {e}", path.display())))
 }
 
 #[must_use]
@@ -430,6 +603,24 @@ mod tests {
     }
 
     #[test]
+    fn pending_restart_can_classify_restart_handoff_failure() {
+        let record = UpdateStatusRecord::pending_restart_with_failure_phase(
+            "demo-app",
+            "9999.0.0",
+            "9999.0.0",
+            "stable",
+            "2026-05-11T14:00:00Z".to_string(),
+            "2026-05-11T14:05:00Z".to_string(),
+            "supervisor pid file never appeared after restart",
+            RESTART_HANDOFF_FAILED_PHASE,
+        );
+
+        assert_eq!(record.state, UpdateConvergenceState::PendingRestart);
+        assert_eq!(record.failure_phase.as_deref(), Some(RESTART_HANDOFF_FAILED_PHASE));
+        assert_eq!(record.retry_safe, Some(true));
+    }
+
+    #[test]
     fn round_trip_failed_record_preserves_pre_attempt_version() {
         let dir = tempfile::tempdir().unwrap();
         let record = UpdateStatusRecord::failed(
@@ -497,6 +688,84 @@ mod tests {
 
         assert_eq!(loaded.state, UpdateConvergenceState::InProgress);
         assert_eq!(loaded.current_phase.as_deref(), Some("stopping supervisor"));
+    }
+
+    #[test]
+    fn stale_in_progress_package_apply_becomes_retry_safe_failed_when_abandoned() {
+        let dir = tempfile::tempdir().unwrap();
+        let record = UpdateStatusRecord::in_progress(
+            "demo-app",
+            "9998.0.0",
+            "9999.0.0",
+            "stable",
+            "2026-05-15T20:00:00Z".to_string(),
+        )
+        .with_current_phase_at("package apply started", "2026-05-15T20:01:00Z".to_string());
+        write_update_status(dir.path(), &record).unwrap();
+
+        let now = chrono::DateTime::parse_from_rfc3339("2026-05-15T20:10:00Z")
+            .unwrap()
+            .with_timezone(&chrono::Utc);
+        let failed = fail_abandoned_in_progress_update_at(
+            dir.path(),
+            "demo-app",
+            "9999.0.0",
+            "stable",
+            Duration::from_mins(1),
+            now,
+        )
+        .unwrap()
+        .expect("stale record should transition");
+
+        assert_eq!(failed.state, UpdateConvergenceState::Failed);
+        assert_eq!(failed.installed_version, "9998.0.0");
+        assert_eq!(failed.target_version, "9999.0.0");
+        assert_eq!(failed.failure_phase.as_deref(), Some("package apply started"));
+        assert_eq!(failed.retry_safe, Some(true));
+        assert!(
+            failed
+                .reason
+                .as_deref()
+                .unwrap_or_default()
+                .contains("abandoned after 540s without progress")
+        );
+
+        let persisted = read_update_status(dir.path()).unwrap().unwrap();
+        assert_eq!(persisted.state, UpdateConvergenceState::Failed);
+        assert_eq!(persisted.failure_phase.as_deref(), Some("package apply started"));
+    }
+
+    #[test]
+    fn stale_in_progress_owned_by_current_worker_is_left_in_progress() {
+        let dir = tempfile::tempdir().unwrap();
+        let record = UpdateStatusRecord::in_progress(
+            "demo-app",
+            "9998.0.0",
+            "9999.0.0",
+            "stable",
+            "2026-05-15T20:00:00Z".to_string(),
+        )
+        .with_current_phase_at("package apply started", "2026-05-15T20:01:00Z".to_string());
+        write_update_status(dir.path(), &record).unwrap();
+        let _worker = UpdateWorkerGuard::record(dir.path(), "demo-app", "9999.0.0").unwrap();
+
+        let now = chrono::DateTime::parse_from_rfc3339("2026-05-15T20:10:00Z")
+            .unwrap()
+            .with_timezone(&chrono::Utc);
+        let result = fail_abandoned_in_progress_update_at(
+            dir.path(),
+            "demo-app",
+            "9999.0.0",
+            "stable",
+            Duration::from_mins(1),
+            now,
+        )
+        .unwrap();
+
+        assert!(result.is_none());
+        let persisted = read_update_status(dir.path()).unwrap().unwrap();
+        assert_eq!(persisted.state, UpdateConvergenceState::InProgress);
+        assert_eq!(persisted.current_phase.as_deref(), Some("package apply started"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- recover Azure resumable range requests that receive HTTP 200 OK by restarting the partial download from byte zero
- add update worker markers and package-apply heartbeats so stale in-progress status can become retry-safe failed state
- classify unconfirmed supervisor restart handoff as a specific pending-restart failure phase

Fixes #133. Uses downstream evidence from fintermobilityas/youpark#1051 without including deployment identifiers.

## Verification
- ./scripts/sync-surge-core-vendor.sh --check
- ./scripts/check-version-sync.sh
- cargo fmt --all -- --check
- RUSTFLAGS="-D warnings" cargo test --workspace
- cargo clippy --all-targets --all-features -- -D warnings
- cargo clippy --workspace --lib --bins --examples -- -D warnings -D clippy::unwrap_used -D clippy::expect_used
- cargo clippy --workspace --all-targets --all-features -- -D warnings -W clippy::pedantic
- dotnet format dotnet/Surge.slnx --verify-no-changes
- dotnet test dotnet/Surge.slnx --configuration Release

Note: the first sandboxed workspace test run failed because the sandbox denied an existing local lock-server listener test; the same command passed outside the sandbox.