### PR TITLE
Fix remote runtime proof argument order

### DIFF
--- a/crates/surge-cli/src/commands/install/mod.rs
+++ b/crates/surge-cli/src/commands/install/mod.rs
@@ -1101,10 +1101,12 @@ mod tests {
         );
 
         assert!(probe.contains("active_exe=\"$install_root/app/$main_exe\""));
-        assert!(probe.contains("--surge-first-run $version"));
+        assert!(probe.contains("cmd_tokens=\" $cmd \""));
+        assert!(probe.contains("*\" --surge-first-run $version \"*|*\" $version --surge-first-run \"*"));
         assert!(probe.contains("surge-supervisor"));
         assert!(probe.contains("--id $supervisor_id"));
         assert!(probe.contains("app process for $active_exe was not found"));
+        assert!(probe.contains("app process for $active_exe is running without --surge-first-run proof for $version"));
         assert!(probe.contains("supervisor process '$supervisor_id' was not found"));
     }
 

--- a/crates/surge-cli/src/commands/install/remote/runtime.rs
+++ b/crates/surge-cli/src/commands/install/remote/runtime.rs
@@ -249,13 +249,13 @@ for cmdline in /proc/[0-9]*/cmdline; do \
   case \"$pid\" in \"$$\"|\"$PPID\") continue ;; esac; \
   cmd=\"$(tr '\\0' ' ' < \"$cmdline\" 2>/dev/null || true)\"; \
   [ -n \"$cmd\" ] || continue; \
-  case \"$cmd\" in *\"$active_exe\"*) app_seen=1; case \"$cmd\" in *\"--surge-first-run $version\"*) version_seen=1 ;; esac ;; esac; \
+  case \"$cmd\" in *\"$active_exe\"*) app_seen=1; cmd_tokens=\" $cmd \"; case \"$cmd_tokens\" in *\" --surge-first-run $version \"*|*\" $version --surge-first-run \"*) version_seen=1 ;; esac ;; esac; \
   if [ -n \"$supervisor_id\" ]; then \
     case \"$cmd\" in *\"surge-supervisor\"*\"--id $supervisor_id\"*) supervisor_seen=1 ;; esac; \
   fi; \
 done; \
 if [ \"$app_seen\" -ne 1 ]; then echo \"app process for $active_exe was not found\"; exit 0; fi; \
-if [ -n \"$version\" ] && [ \"$version_seen\" -ne 1 ]; then echo \"app process for $active_exe is running without --surge-first-run $version\"; exit 0; fi; \
+if [ -n \"$version\" ] && [ \"$version_seen\" -ne 1 ]; then echo \"app process for $active_exe is running without --surge-first-run proof for $version\"; exit 0; fi; \
 if [ -n \"$supervisor_id\" ] && [ \"$supervisor_seen\" -ne 1 ]; then echo \"supervisor process '$supervisor_id' was not found\"; exit 0; fi; \
 echo ready",
         shell_single_quote(&install_root.to_string_lossy()),


### PR DESCRIPTION
## Summary
- accept either adjacent token order for remote first-run runtime proof checks
- keep the proof scoped to the active app executable before accepting it
- update generated-probe coverage for the accepted token forms

## Impact
A forced remote convergence can now avoid a false missing-proof result when a downstream process retains the expected version and first-run flag in the opposite order. This does not include customer, site, host, application, or downstream release identifiers.

## Validation
- ./scripts/sync-surge-core-vendor.sh --check
- ./scripts/check-version-sync.sh
- cargo fmt --all -- --check
- RUSTFLAGS="-D warnings" cargo test --workspace
- cargo clippy --all-targets --all-features -- -D warnings
- cargo clippy --workspace --lib --bins --examples -- -D warnings -D clippy::unwrap_used -D clippy::expect_used
- cargo clippy --workspace --all-targets --all-features -- -D warnings -W clippy::pedantic
- dotnet format dotnet/Surge.slnx --verify-no-changes
- dotnet test dotnet/Surge.slnx --configuration Release