### PR TITLE
Fix restart handoff convergence proof

### DIFF
--- a/crates/surge-cli/src/commands/install/mod.rs
+++ b/crates/surge-cli/src/commands/install/mod.rs
@@ -1101,13 +1101,43 @@ mod tests {
         );
 
         assert!(probe.contains("active_exe=\"$install_root/app/$main_exe\""));
-        assert!(probe.contains("cmd_tokens=\" $cmd \""));
+        assert!(probe.contains("contains_target_first_run()"));
+        assert!(probe.contains("watched_pid_is_running()"));
         assert!(probe.contains("*\" --surge-first-run $version \"*|*\" $version --surge-first-run \"*"));
         assert!(probe.contains("surge-supervisor"));
         assert!(probe.contains("--id $supervisor_id"));
         assert!(probe.contains("app process for $active_exe was not found"));
         assert!(probe.contains("app process for $active_exe is running without --surge-first-run proof for $version"));
+        assert!(probe.contains("stale app process for $active_exe is still running without target proof for $version"));
+        assert!(probe.contains("supervisor process '$supervisor_id' is still waiting for the previous child"));
+        assert!(probe.contains("supervisor process '$supervisor_id' is running with stale first-run proof"));
         assert!(probe.contains("supervisor process '$supervisor_id' was not found"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn build_remote_process_verification_probe_is_valid_shell_syntax() {
+        use std::io::Write;
+
+        let probe = build_remote_process_verification_probe(
+            Path::new("/home/demo/apps/demo-app"),
+            "demoapp",
+            "demo-supervisor",
+            "1.2.3",
+        );
+        let mut child = std::process::Command::new("sh")
+            .arg("-n")
+            .stdin(std::process::Stdio::piped())
+            .spawn()
+            .expect("shell syntax checker should start");
+        child
+            .stdin
+            .as_mut()
+            .expect("stdin should be piped")
+            .write_all(probe.as_bytes())
+            .expect("probe should be written to shell");
+        let status = child.wait().expect("shell syntax checker should exit");
+        assert!(status.success(), "probe failed shell syntax check with {status}");
     }
 
     #[test]

--- a/crates/surge-cli/src/commands/install/remote/runtime.rs
+++ b/crates/surge-cli/src/commands/install/remote/runtime.rs
@@ -241,23 +241,34 @@ pub(crate) fn build_remote_process_verification_probe(
     version: &str,
 ) -> String {
     format!(
-        "install_root={}; main_exe={}; supervisor_id={}; version={}; \
-active_exe=\"$install_root/app/$main_exe\"; app_seen=0; version_seen=0; supervisor_seen=0; \
-for cmdline in /proc/[0-9]*/cmdline; do \
-  [ -r \"$cmdline\" ] || continue; \
-  pid=\"${{cmdline%/cmdline}}\"; pid=\"${{pid##*/}}\"; \
-  case \"$pid\" in \"$$\"|\"$PPID\") continue ;; esac; \
-  cmd=\"$(tr '\\0' ' ' < \"$cmdline\" 2>/dev/null || true)\"; \
-  [ -n \"$cmd\" ] || continue; \
-  case \"$cmd\" in *\"$active_exe\"*) app_seen=1; cmd_tokens=\" $cmd \"; case \"$cmd_tokens\" in *\" --surge-first-run $version \"*|*\" $version --surge-first-run \"*) version_seen=1 ;; esac ;; esac; \
-  if [ -n \"$supervisor_id\" ]; then \
-    case \"$cmd\" in *\"surge-supervisor\"*\"--id $supervisor_id\"*) supervisor_seen=1 ;; esac; \
-  fi; \
-done; \
-if [ \"$app_seen\" -ne 1 ]; then echo \"app process for $active_exe was not found\"; exit 0; fi; \
-if [ -n \"$version\" ] && [ \"$version_seen\" -ne 1 ]; then echo \"app process for $active_exe is running without --surge-first-run proof for $version\"; exit 0; fi; \
-if [ -n \"$supervisor_id\" ] && [ \"$supervisor_seen\" -ne 1 ]; then echo \"supervisor process '$supervisor_id' was not found\"; exit 0; fi; \
-echo ready",
+        r#"install_root={}; main_exe={}; supervisor_id={}; version={};
+active_exe="$install_root/app/$main_exe"; app_seen=0; target_app_seen=0; stale_app_seen=0; supervisor_seen=0; stale_supervisor_seen=0; waiting_supervisor_seen=0;
+contains_target_first_run() {{ cmd_tokens=" $1 "; case "$cmd_tokens" in *" --surge-first-run $version "*|*" $version --surge-first-run "*) return 0 ;; esac; return 1; }}
+watched_pid_is_running() {{ case "$1" in *" watch "*" --pid "*) rest="${{1#* --pid }}"; watched_pid="${{rest%% *}}"; case "$watched_pid" in ""|*[!0-9]*) return 1 ;; esac; kill -0 "$watched_pid" 2>/dev/null ;; esac; return 1; }}
+for cmdline in /proc/[0-9]*/cmdline; do
+  [ -r "$cmdline" ] || continue;
+  pid="${{cmdline%/cmdline}}"; pid="${{pid##*/}}";
+  case "$pid" in "$$"|"$PPID") continue ;; esac;
+  cmd="$(tr '\0' ' ' < "$cmdline" 2>/dev/null || true)";
+  [ -n "$cmd" ] || continue;
+  case "$cmd" in *"surge-supervisor"*) ;; *"$active_exe"*) app_seen=1; if contains_target_first_run "$cmd"; then target_app_seen=1; else stale_app_seen=1; fi ;; esac;
+  if [ -n "$supervisor_id" ]; then
+    case "$cmd" in *"surge-supervisor"*"--id $supervisor_id"*)
+      supervisor_seen=1;
+      if watched_pid_is_running "$cmd"; then waiting_supervisor_seen=1; fi;
+      case " $cmd " in *" --surge-first-run "*) if ! contains_target_first_run "$cmd"; then stale_supervisor_seen=1; fi ;; esac
+    ;; esac;
+  fi;
+done;
+if [ "$target_app_seen" -ne 1 ]; then
+  if [ "$app_seen" -eq 1 ]; then echo "app process for $active_exe is running without --surge-first-run proof for $version"; else echo "app process for $active_exe was not found"; fi;
+  exit 0;
+fi;
+if [ "$stale_app_seen" -eq 1 ]; then echo "stale app process for $active_exe is still running without target proof for $version"; exit 0; fi;
+if [ -n "$supervisor_id" ] && [ "$waiting_supervisor_seen" -eq 1 ]; then echo "supervisor process '$supervisor_id' is still waiting for the previous child"; exit 0; fi;
+if [ -n "$supervisor_id" ] && [ "$stale_supervisor_seen" -eq 1 ]; then echo "supervisor process '$supervisor_id' is running with stale first-run proof"; exit 0; fi;
+if [ -n "$supervisor_id" ] && [ "$supervisor_seen" -ne 1 ]; then echo "supervisor process '$supervisor_id' was not found"; exit 0; fi;
+echo ready"#,
         shell_single_quote(&install_root.to_string_lossy()),
         shell_single_quote(main_exe),
         shell_single_quote(supervisor_id.trim()),

--- a/crates/surge-core/src/update/manager.rs
+++ b/crates/surge-core/src/update/manager.rs
@@ -270,15 +270,7 @@ impl UpdateManager {
                         completed_at_utc,
                         false,
                     ),
-                    SupervisorRestartOutcome::Confirmed => UpdateStatusRecord::converged(
-                        &self.app_id,
-                        &target_version,
-                        &self.channel,
-                        Some(attempted_at_utc),
-                        completed_at_utc,
-                        true,
-                    ),
-                    SupervisorRestartOutcome::Unconfirmed { reason } => {
+                    SupervisorRestartOutcome::PendingRestart { reason, failure_phase } => {
                         UpdateStatusRecord::pending_restart_with_failure_phase(
                             &self.app_id,
                             &target_version,
@@ -287,7 +279,7 @@ impl UpdateManager {
                             attempted_at_utc,
                             completed_at_utc,
                             &reason,
-                            status::RESTART_HANDOFF_FAILED_PHASE,
+                            failure_phase,
                         )
                     }
                 };
@@ -773,13 +765,23 @@ echo started > new-child-started
             &latest,
             watched_child.id(),
         );
-        let confirmed = matches!(outcome, SupervisorRestartOutcome::Confirmed);
+        assert!(matches!(
+            outcome,
+            SupervisorRestartOutcome::PendingRestart {
+                failure_phase: status::RESTART_HANDOFF_WAITING_FOR_OLD_CHILD_PHASE,
+                ..
+            }
+        ));
+
+        let started_path = install_dir.join("new-child-started");
+        assert!(
+            !started_path.exists(),
+            "new child should not start while watched process is still running"
+        );
 
         watched_child.kill().unwrap();
         watched_child.wait().unwrap();
-        assert!(confirmed);
 
-        let started_path = install_dir.join("new-child-started");
         let deadline = std::time::Instant::now() + Duration::from_secs(2);
         while !started_path.exists() && std::time::Instant::now() < deadline {
             std::thread::sleep(Duration::from_millis(50));

--- a/crates/surge-core/src/update/manager/lifecycle.rs
+++ b/crates/surge-core/src/update/manager/lifecycle.rs
@@ -7,7 +7,9 @@ use crate::error::{Result, SurgeError};
 use crate::platform::process::{ProcessHandle, current_pid, spawn_detached, spawn_process, supervisor_binary_name};
 use crate::releases::manifest::ReleaseEntry;
 use crate::supervisor::state::{read_restart_args, supervisor_pid_file, supervisor_stop_file};
-use crate::update::status::confirm_supervisor_restart;
+use crate::update::status::{
+    RESTART_HANDOFF_FAILED_PHASE, RESTART_HANDOFF_WAITING_FOR_OLD_CHILD_PHASE, confirm_supervisor_restart,
+};
 
 const SUPERVISOR_RESTART_CONFIRM_TIMEOUT: Duration = Duration::from_secs(5);
 
@@ -16,12 +18,13 @@ pub(super) enum SupervisorRestartOutcome {
     /// No supervisor was configured for this release (or wasn't running before
     /// the update) so there is no post-update restart to confirm.
     NotApplicable,
-    /// Supervisor restart was confirmed by observing the supervisor pid file
-    /// within `SUPERVISOR_RESTART_CONFIRM_TIMEOUT` after the spawn.
-    Confirmed,
-    /// Supervisor restart could not be confirmed within the timeout window.
-    /// The reason describes why (spawn failure, missing binary, no pid file).
-    Unconfirmed { reason: String },
+    /// The target package is installed, but restart handoff is still pending.
+    /// The supervisor writes the converged record only after the old child exits
+    /// and a replacement target child stays active.
+    PendingRestart {
+        reason: String,
+        failure_phase: &'static str,
+    },
 }
 
 pub(super) async fn request_supervisor_shutdown(install_dir: &Path, supervisor_id: &str) -> Result<()> {
@@ -163,8 +166,9 @@ pub(super) fn restart_supervisor_after_update_with_pid(
             supervisor = %supervisor_path.display(),
             "Cannot restart supervisor after update because the bundled binary is missing"
         );
-        return SupervisorRestartOutcome::Unconfirmed {
+        return SupervisorRestartOutcome::PendingRestart {
             reason: format!("supervisor binary missing at {}", supervisor_path.display()),
+            failure_phase: RESTART_HANDOFF_FAILED_PHASE,
         };
     }
 
@@ -174,8 +178,9 @@ pub(super) fn restart_supervisor_after_update_with_pid(
             exe = %exe_path.display(),
             "Cannot restart supervisor after update because the application executable is missing"
         );
-        return SupervisorRestartOutcome::Unconfirmed {
+        return SupervisorRestartOutcome::PendingRestart {
             reason: format!("application executable missing at {}", exe_path.display()),
+            failure_phase: RESTART_HANDOFF_FAILED_PHASE,
         };
     }
 
@@ -220,22 +225,30 @@ pub(super) fn restart_supervisor_after_update_with_pid(
                 error = %e,
                 "Failed to restart supervisor after update (continuing)"
             );
-            return SupervisorRestartOutcome::Unconfirmed {
+            return SupervisorRestartOutcome::PendingRestart {
                 reason: format!("spawn failed: {e}"),
+                failure_phase: RESTART_HANDOFF_FAILED_PHASE,
             };
         }
     }
 
     if confirm_supervisor_restart(install_dir, supervisor_id, SUPERVISOR_RESTART_CONFIRM_TIMEOUT) {
-        SupervisorRestartOutcome::Confirmed
+        SupervisorRestartOutcome::PendingRestart {
+            reason: format!(
+                "supervisor handoff accepted; waiting for previous child pid {watched_pid} to exit and target version {} to start",
+                latest.version
+            ),
+            failure_phase: RESTART_HANDOFF_WAITING_FOR_OLD_CHILD_PHASE,
+        }
     } else {
         let timeout_ms = u64::try_from(SUPERVISOR_RESTART_CONFIRM_TIMEOUT.as_millis()).unwrap_or(u64::MAX);
         warn!(
             supervisor_id,
             timeout_ms, "Supervisor pid file did not appear after restart within timeout window"
         );
-        SupervisorRestartOutcome::Unconfirmed {
+        SupervisorRestartOutcome::PendingRestart {
             reason: format!("supervisor pid file did not appear within {timeout_ms}ms after restart"),
+            failure_phase: RESTART_HANDOFF_FAILED_PHASE,
         }
     }
 }

--- a/crates/surge-core/src/update/status.rs
+++ b/crates/surge-core/src/update/status.rs
@@ -3,9 +3,8 @@
 //! After a channel promotion, operators need a reliable signal that distinguishes:
 //! - **`Idle`** — the install completed but no update has been attempted since.
 //! - **`InProgress`** — an update is currently being applied.
-//! - **`Converged`** — the latest update applied to disk and the supervisor restart
-//!   (or the install-time auto-start) was confirmed by observing the supervisor pid
-//!   file.
+//! - **`Converged`** — the latest update applied to disk and the supervisor handoff
+//!   (or the install-time auto-start) proved a replacement runtime is active.
 //! - **`PendingRestart`** — the latest update applied to disk but the supervisor
 //!   restart could not be confirmed within the post-update window. The runtime
 //!   process may still be running an older binary even though `installed_version`
@@ -25,8 +24,14 @@ use crate::error::{Result, SurgeError};
 use crate::platform::fs::write_file_atomic;
 use crate::supervisor::state::supervisor_pid_file;
 
+mod handoff;
+
+pub use handoff::{
+    RESTART_HANDOFF_FAILED_PHASE, RESTART_HANDOFF_TARGET_CHILD_EXITED_PHASE,
+    RESTART_HANDOFF_WAITING_FOR_OLD_CHILD_PHASE, mark_restart_handoff_converged, mark_restart_handoff_pending,
+};
+
 pub const UPDATE_STATUS_FILE_NAME: &str = ".surge-update-status.json";
-pub const RESTART_HANDOFF_FAILED_PHASE: &str = "restart handoff failed";
 const UPDATE_WORKER_FILE_NAME: &str = ".surge-update-worker.json";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -73,10 +78,10 @@ pub struct UpdateStatusRecord {
     pub target_version: String,
     pub channel: String,
     pub app_id: String,
-    /// True when a supervisor was configured for this release and its pid file
-    /// was observed after the post-update restart, or when no supervisor was
-    /// configured (in which case there is nothing to restart and the field
-    /// carries no signal).
+    /// True when a supervisor was configured for this release and the post-update
+    /// handoff proved a target-version child is active. When no supervisor was
+    /// configured this is false and carries no signal; read `state` for
+    /// convergence.
     pub supervisor_restart_confirmed: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub attempted_at_utc: Option<String>,

--- a/crates/surge-core/src/update/status/handoff.rs
+++ b/crates/surge-core/src/update/status/handoff.rs
@@ -1,0 +1,109 @@
+use std::path::Path;
+
+use crate::error::Result;
+
+use super::{UpdateConvergenceState, UpdateStatusRecord, now_utc_rfc3339, read_update_status, write_update_status};
+
+pub const RESTART_HANDOFF_FAILED_PHASE: &str = "restart handoff failed";
+pub const RESTART_HANDOFF_WAITING_FOR_OLD_CHILD_PHASE: &str = "restart handoff waiting for old child";
+pub const RESTART_HANDOFF_TARGET_CHILD_EXITED_PHASE: &str = "restart handoff target child exited";
+
+pub fn mark_restart_handoff_pending(
+    install_dir: &Path,
+    target_version: &str,
+    reason: &str,
+    failure_phase: &str,
+) -> Result<Option<UpdateStatusRecord>> {
+    let Some(existing) = read_matching_handoff_record(install_dir, target_version)? else {
+        return Ok(None);
+    };
+
+    let attempted_at_utc = existing.attempted_at_utc.unwrap_or_else(now_utc_rfc3339);
+    let record = UpdateStatusRecord::pending_restart_with_failure_phase(
+        &existing.app_id,
+        &existing.target_version,
+        &existing.target_version,
+        &existing.channel,
+        attempted_at_utc,
+        now_utc_rfc3339(),
+        reason,
+        failure_phase,
+    );
+    write_update_status(install_dir, &record)?;
+    Ok(Some(record))
+}
+
+pub fn mark_restart_handoff_converged(install_dir: &Path, target_version: &str) -> Result<Option<UpdateStatusRecord>> {
+    let Some(existing) = read_matching_handoff_record(install_dir, target_version)? else {
+        return Ok(None);
+    };
+
+    let record = UpdateStatusRecord::converged(
+        &existing.app_id,
+        &existing.target_version,
+        &existing.channel,
+        existing.attempted_at_utc,
+        now_utc_rfc3339(),
+        true,
+    );
+    write_update_status(install_dir, &record)?;
+    Ok(Some(record))
+}
+
+fn read_matching_handoff_record(install_dir: &Path, target_version: &str) -> Result<Option<UpdateStatusRecord>> {
+    let Some(record) = read_update_status(install_dir)? else {
+        return Ok(None);
+    };
+    if record.target_version.trim() != target_version.trim() {
+        return Ok(None);
+    }
+    if matches!(
+        record.state,
+        UpdateConvergenceState::InProgress | UpdateConvergenceState::PendingRestart
+    ) {
+        return Ok(Some(record));
+    }
+    Ok(None)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn restart_handoff_helpers_distinguish_child_exit_and_convergence() {
+        let dir = tempfile::tempdir().unwrap();
+        let record = UpdateStatusRecord::pending_restart_with_failure_phase(
+            "demo-app",
+            "9999.0.0",
+            "9999.0.0",
+            "stable",
+            "2026-05-11T14:00:00Z".to_string(),
+            "2026-05-11T14:05:00Z".to_string(),
+            "waiting for previous child to exit",
+            RESTART_HANDOFF_WAITING_FOR_OLD_CHILD_PHASE,
+        );
+        write_update_status(dir.path(), &record).unwrap();
+
+        let child_exited = mark_restart_handoff_pending(
+            dir.path(),
+            "9999.0.0",
+            "target child exited before restart handoff completed",
+            RESTART_HANDOFF_TARGET_CHILD_EXITED_PHASE,
+        )
+        .unwrap()
+        .expect("matching record should update");
+        assert_eq!(child_exited.state, UpdateConvergenceState::PendingRestart);
+        assert_eq!(
+            child_exited.failure_phase.as_deref(),
+            Some(RESTART_HANDOFF_TARGET_CHILD_EXITED_PHASE)
+        );
+
+        let converged = mark_restart_handoff_converged(dir.path(), "9999.0.0")
+            .unwrap()
+            .expect("matching record should converge");
+        assert_eq!(converged.state, UpdateConvergenceState::Converged);
+        assert!(converged.supervisor_restart_confirmed);
+        assert_eq!(converged.attempted_at_utc.as_deref(), Some("2026-05-11T14:00:00Z"));
+    }
+}

--- a/crates/surge-supervisor/src/main.rs
+++ b/crates/surge-supervisor/src/main.rs
@@ -2,13 +2,18 @@
 #![allow(clippy::cast_possible_wrap)]
 
 use std::path::{Path, PathBuf};
-use std::process::{Child, Command, ExitCode};
+use std::process::{Child, Command, ExitCode, ExitStatus};
 
 use clap::{Parser, Subcommand};
 use surge_core::supervisor::state::{supervisor_pid_file, supervisor_stop_file};
+use surge_core::update::status::{
+    RESTART_HANDOFF_TARGET_CHILD_EXITED_PHASE, mark_restart_handoff_converged, mark_restart_handoff_pending,
+};
 #[cfg(windows)]
 use sysinfo::{Pid, ProcessesToUpdate, System};
 use thiserror::Error;
+
+const RESTART_HANDOFF_STABILITY_WINDOW: std::time::Duration = std::time::Duration::from_secs(4);
 
 #[derive(Parser)]
 #[command(
@@ -178,6 +183,7 @@ fn run_supervisor(
     // args are drained so crash-restarts don't re-fire lifecycle callbacks.
     let mut lifecycle_args: Vec<String> = args.iter().filter(|a| a.starts_with("--surge-")).cloned().collect();
     let regular_args: Vec<String> = args.iter().filter(|a| !a.starts_with("--surge-")).cloned().collect();
+    let mut pending_handoff_version = watched_pid.and_then(|_| first_run_version(args));
     let mut watched_pid = watched_pid;
 
     loop {
@@ -216,17 +222,15 @@ fn run_supervisor(
 
         tracing::info!("Child process started with PID {}", child.id());
 
-        let status = match wait_for_child_or_stop(&mut child, &shutdown, &stop_file)? {
-            WaitOutcome::Exited(status) => status,
-            WaitOutcome::ObservedProcessExited => unreachable!(),
-            WaitOutcome::StopRequested => {
-                tracing::info!("Stop requested, exiting supervisor loop and leaving child running");
-                break;
-            }
-            WaitOutcome::ShutdownRequested => {
-                tracing::info!("Shutdown signal received, child terminated and supervisor loop is exiting");
-                break;
-            }
+        let Some(status) = wait_for_supervised_child(
+            &mut child,
+            &shutdown,
+            &stop_file,
+            install_dir,
+            &mut pending_handoff_version,
+        )?
+        else {
+            break;
         };
 
         if shutdown.load(std::sync::atomic::Ordering::Acquire) || stop_file.exists() {
@@ -254,6 +258,100 @@ fn run_supervisor(
     Ok(())
 }
 
+fn first_run_version(args: &[String]) -> Option<String> {
+    args.iter().enumerate().find_map(|(index, arg)| {
+        if arg != "--surge-first-run" {
+            return None;
+        }
+        args.get(index + 1)
+            .filter(|candidate| !candidate.starts_with("--"))
+            .or_else(|| {
+                index
+                    .checked_sub(1)
+                    .and_then(|prev| args.get(prev))
+                    .filter(|candidate| !candidate.starts_with("--"))
+            })
+            .map(|version| version.trim().to_string())
+            .filter(|version| !version.is_empty())
+    })
+}
+
+fn record_restart_handoff_converged(install_dir: &Path, version: &str) {
+    match mark_restart_handoff_converged(install_dir, version) {
+        Ok(Some(_)) => {
+            tracing::info!(version, "Restart handoff converged after target child startup");
+        }
+        Ok(None) => {}
+        Err(e) => {
+            tracing::warn!(version, error = %e, "Failed to record restart handoff convergence");
+        }
+    }
+}
+
+fn record_restart_handoff_child_exited(install_dir: &Path, version: &str, status: ExitStatus) {
+    let reason = format!("target child exited with {status} before restart handoff completed");
+    match mark_restart_handoff_pending(install_dir, version, &reason, RESTART_HANDOFF_TARGET_CHILD_EXITED_PHASE) {
+        Ok(Some(_)) => {
+            tracing::warn!(version, %status, "Restart handoff target child exited before startup proof completed");
+        }
+        Ok(None) => {}
+        Err(e) => {
+            tracing::warn!(version, error = %e, "Failed to record restart handoff child exit");
+        }
+    }
+}
+
+fn wait_for_supervised_child(
+    child: &mut Child,
+    shutdown: &std::sync::Arc<std::sync::atomic::AtomicBool>,
+    stop_file: &Path,
+    install_dir: &Path,
+    pending_handoff_version: &mut Option<String>,
+) -> Result<Option<ExitStatus>, SupervisorError> {
+    let Some(version) = pending_handoff_version.clone() else {
+        return wait_for_child_exit_status(child, shutdown, stop_file);
+    };
+
+    match wait_for_child_startup_or_stop(child, shutdown, stop_file, RESTART_HANDOFF_STABILITY_WINDOW)? {
+        StartupOutcome::Running => {
+            record_restart_handoff_converged(install_dir, &version);
+            *pending_handoff_version = None;
+            wait_for_child_exit_status(child, shutdown, stop_file)
+        }
+        StartupOutcome::Exited(status) => {
+            record_restart_handoff_child_exited(install_dir, &version, status);
+            Ok(Some(status))
+        }
+        StartupOutcome::StopRequested => {
+            tracing::info!("Stop requested, exiting supervisor loop and leaving child running");
+            Ok(None)
+        }
+        StartupOutcome::ShutdownRequested => {
+            tracing::info!("Shutdown signal received, child terminated and supervisor loop is exiting");
+            Ok(None)
+        }
+    }
+}
+
+fn wait_for_child_exit_status(
+    child: &mut Child,
+    shutdown: &std::sync::Arc<std::sync::atomic::AtomicBool>,
+    stop_file: &Path,
+) -> Result<Option<ExitStatus>, SupervisorError> {
+    match wait_for_child_or_stop(child, shutdown, stop_file)? {
+        WaitOutcome::Exited(status) => Ok(Some(status)),
+        WaitOutcome::ObservedProcessExited => unreachable!(),
+        WaitOutcome::StopRequested => {
+            tracing::info!("Stop requested, exiting supervisor loop and leaving child running");
+            Ok(None)
+        }
+        WaitOutcome::ShutdownRequested => {
+            tracing::info!("Shutdown signal received, child terminated and supervisor loop is exiting");
+            Ok(None)
+        }
+    }
+}
+
 fn write_pid_file(path: &Path) -> Result<(), SupervisorError> {
     let pid = std::process::id();
     std::fs::write(path, pid.to_string())?;
@@ -266,6 +364,42 @@ enum WaitOutcome {
     ObservedProcessExited,
     StopRequested,
     ShutdownRequested,
+}
+
+enum StartupOutcome {
+    Running,
+    Exited(std::process::ExitStatus),
+    StopRequested,
+    ShutdownRequested,
+}
+
+fn wait_for_child_startup_or_stop(
+    child: &mut Child,
+    shutdown: &std::sync::Arc<std::sync::atomic::AtomicBool>,
+    stop_file: &Path,
+    stable_for: std::time::Duration,
+) -> Result<StartupOutcome, SupervisorError> {
+    let deadline = std::time::Instant::now() + stable_for;
+    loop {
+        if shutdown.load(std::sync::atomic::Ordering::Acquire) {
+            terminate_child_process(child)?;
+            return Ok(StartupOutcome::ShutdownRequested);
+        }
+
+        if stop_file.exists() {
+            return Ok(StartupOutcome::StopRequested);
+        }
+
+        if let Some(status) = child.try_wait()? {
+            return Ok(StartupOutcome::Exited(status));
+        }
+
+        if std::time::Instant::now() >= deadline {
+            return Ok(StartupOutcome::Running);
+        }
+
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    }
 }
 
 fn wait_for_pid_or_stop(

--- a/dotnet/Surge.NET.Tests/SurgeUpdateStatusTests.cs
+++ b/dotnet/Surge.NET.Tests/SurgeUpdateStatusTests.cs
@@ -46,7 +46,8 @@ namespace Surge.Tests
                   "supervisor_restart_confirmed": false,
                   "attempted_at_utc": "2026-05-11T14:00:00Z",
                   "completed_at_utc": "2026-05-11T14:05:00Z",
-                  "reason": "supervisor pid file did not appear within 5000ms after restart"
+                  "reason": "supervisor handoff accepted; waiting for previous child pid 1234 to exit",
+                  "failure_phase": "restart handoff waiting for old child"
                 }
                 """;
 
@@ -54,7 +55,8 @@ namespace Surge.Tests
             Assert.NotNull(status);
             Assert.Equal(SurgeUpdateConvergenceState.PendingRestart, status!.State);
             Assert.False(status.SupervisorRestartConfirmed);
-            Assert.Contains("supervisor pid file did not appear", status.Reason);
+            Assert.Contains("waiting for previous child", status.Reason);
+            Assert.Equal("restart handoff waiting for old child", status.FailurePhase);
         }
 
         [Fact]

--- a/dotnet/Surge.NET/SurgeUpdateStatus.cs
+++ b/dotnet/Surge.NET/SurgeUpdateStatus.cs
@@ -21,8 +21,8 @@ namespace Surge
         /// <summary>An update is currently being applied.</summary>
         InProgress,
         /// <summary>
-        /// Latest update applied to disk and the supervisor restart was confirmed
-        /// by observing the supervisor pid file.
+        /// Latest update applied to disk and the supervisor handoff proved a
+        /// replacement runtime is active.
         /// </summary>
         Converged,
         /// <summary>
@@ -73,9 +73,9 @@ namespace Surge
         public string Channel { get; init; } = "";
 
         /// <summary>
-        /// True when a supervisor was configured for this release and its pid
-        /// file was observed after the post-update restart. When no supervisor
-        /// was configured this is false and carries no signal — read
+        /// True when a supervisor was configured for this release and the
+        /// post-update handoff proved a target-version child is active. When no
+        /// supervisor was configured this is false and carries no signal — read
         /// <see cref="State"/> for convergence.
         /// </summary>
         public bool SupervisorRestartConfirmed { get; init; }
@@ -91,6 +91,13 @@ namespace Surge
         /// and <see cref="SurgeUpdateConvergenceState.PendingRestart"/> records.
         /// </summary>
         public string? Reason { get; init; }
+
+        /// <summary>
+        /// Phase active when a terminal failure or pending restart state was
+        /// recorded. For restart handoff records this distinguishes cases such
+        /// as waiting for the previous child from target child exit.
+        /// </summary>
+        public string? FailurePhase { get; init; }
 
         /// <summary>
         /// Read the persisted update convergence record from <paramref name="installDirectory"/>.
@@ -142,6 +149,7 @@ namespace Surge
                 AttemptedAtUtc = NullIfEmpty(GetString(fields, "attempted_at_utc")),
                 CompletedAtUtc = NullIfEmpty(GetString(fields, "completed_at_utc")),
                 Reason = NullIfEmpty(GetString(fields, "reason")),
+                FailurePhase = NullIfEmpty(GetString(fields, "failure_phase")),
             };
         }
 


### PR DESCRIPTION
## Summary
- keep self-update status in `pending_restart` after the watcher accepts a handoff instead of treating PID-file existence as convergence
- let the supervisor mark the handoff `converged` only after the watched child exits and a target child stays active, and record target-child early exit as a distinct `failure_phase`
- tighten remote process verification so stale app processes, stale supervisor first-run proof, or a watcher still waiting on the old child cannot pass
- expose `failure_phase` through `SurgeUpdateStatus`
- split the handoff status helpers into a focused submodule to keep the maintainability guardrail green

Fixes #140.

## Validation
- `./scripts/sync-surge-core-vendor.sh --check`
- `./scripts/check-version-sync.sh`
- `cargo fmt --all -- --check`
- `./scripts/check-maintainability.sh`
- `RUSTFLAGS="-D warnings" cargo test --workspace`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo clippy --workspace --lib --bins --examples -- -D warnings -D clippy::unwrap_used -D clippy::expect_used`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings -W clippy::pedantic`
- `dotnet format dotnet/Surge.slnx --verify-no-changes`
- `dotnet test dotnet/Surge.slnx --configuration Release`

Note: the sandboxed `cargo test --workspace` attempt could not bind the local listener used by the lock-server test, and the sandboxed `dotnet format` attempt failed during restore/workspace setup. Both commands were rerun outside the sandbox and passed.