### PR TITLE
Fix restart handoff convergence after supervised updates

### DIFF
--- a/crates/surge-core/src/update/manager/lifecycle.rs
+++ b/crates/surge-core/src/update/manager/lifecycle.rs
@@ -196,26 +196,17 @@ pub(super) fn restart_supervisor_after_update_with_pid(
         }
     };
 
-    let install_dir_str = install_dir.to_string_lossy();
-    let pid_str = watched_pid.to_string();
-    let exe_path_str = exe_path.to_string_lossy();
-    let mut args: Vec<&str> = vec![
-        "watch",
-        "--id",
+    let args = supervisor_watch_args(
         supervisor_id,
-        "--dir",
-        &install_dir_str,
-        "--pid",
-        &pid_str,
-        "--exe",
-        &exe_path_str,
-    ];
-    if !restart_args.is_empty() {
-        args.push("--");
-        args.extend(restart_args.iter().map(String::as_str));
-    }
+        install_dir,
+        watched_pid,
+        &latest.version,
+        &exe_path,
+        &restart_args,
+    );
+    let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
 
-    match spawn_detached(&supervisor_path, &args, Some(install_dir), &latest.environment) {
+    match spawn_detached(&supervisor_path, &arg_refs, Some(install_dir), &latest.environment) {
         Ok(handle) => {
             info!(pid = handle.pid(), supervisor_id, "Restarted supervisor after update");
         }
@@ -250,5 +241,74 @@ pub(super) fn restart_supervisor_after_update_with_pid(
             reason: format!("supervisor pid file did not appear within {timeout_ms}ms after restart"),
             failure_phase: RESTART_HANDOFF_FAILED_PHASE,
         }
+    }
+}
+
+fn supervisor_watch_args(
+    supervisor_id: &str,
+    install_dir: &Path,
+    watched_pid: u32,
+    handoff_version: &str,
+    exe_path: &Path,
+    restart_args: &[String],
+) -> Vec<String> {
+    let mut args = vec![
+        "watch".to_string(),
+        "--id".to_string(),
+        supervisor_id.to_string(),
+        "--dir".to_string(),
+        install_dir.to_string_lossy().into_owned(),
+        "--pid".to_string(),
+        watched_pid.to_string(),
+        "--handoff-version".to_string(),
+        handoff_version.to_string(),
+        "--exe".to_string(),
+        exe_path.to_string_lossy().into_owned(),
+    ];
+    if !restart_args.is_empty() {
+        args.push("--".to_string());
+        args.extend(restart_args.iter().cloned());
+    }
+    args
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use super::*;
+
+    #[test]
+    fn supervisor_watch_args_include_handoff_version_before_child_args() {
+        let restart_args = vec!["--app-mode".to_string(), "service".to_string()];
+
+        let args = supervisor_watch_args(
+            "demo-supervisor",
+            Path::new("/opt/demo"),
+            42,
+            "2.0.0",
+            Path::new("/opt/demo/app/demo"),
+            &restart_args,
+        );
+
+        assert_eq!(
+            args,
+            vec![
+                "watch",
+                "--id",
+                "demo-supervisor",
+                "--dir",
+                "/opt/demo",
+                "--pid",
+                "42",
+                "--handoff-version",
+                "2.0.0",
+                "--exe",
+                "/opt/demo/app/demo",
+                "--",
+                "--app-mode",
+                "service",
+            ]
+        );
     }
 }

--- a/crates/surge-supervisor/src/main.rs
+++ b/crates/surge-supervisor/src/main.rs
@@ -65,6 +65,10 @@ enum Commands {
         #[arg(long)]
         pid: u32,
 
+        /// Target version whose update handoff should converge after replacement child startup
+        #[arg(long)]
+        handoff_version: Option<String>,
+
         /// Path to the application executable
         #[arg(long)]
         exe: PathBuf,
@@ -118,7 +122,7 @@ fn main() -> ExitCode {
             verbose,
         } => {
             init_tracing(verbose);
-            if let Err(e) = run_supervisor(&id, &dir, &exe, &args, None) {
+            if let Err(e) = run_supervisor(&id, &dir, &exe, &args, None, None) {
                 tracing::error!("{e}");
                 return ExitCode::FAILURE;
             }
@@ -128,12 +132,13 @@ fn main() -> ExitCode {
             id,
             dir,
             pid,
+            handoff_version,
             exe,
             args,
             verbose,
         } => {
             init_tracing(verbose);
-            if let Err(e) = run_supervisor(&id, &dir, &exe, &args, Some(pid)) {
+            if let Err(e) = run_supervisor(&id, &dir, &exe, &args, Some(pid), handoff_version.as_deref()) {
                 tracing::error!("{e}");
                 return ExitCode::FAILURE;
             }
@@ -158,6 +163,7 @@ fn run_supervisor(
     exe_path: &Path,
     args: &[String],
     watched_pid: Option<u32>,
+    handoff_version: Option<&str>,
 ) -> Result<(), SupervisorError> {
     tracing::info!(
         "Surge supervisor '{supervisor_id}' starting, exe: {}",
@@ -183,7 +189,7 @@ fn run_supervisor(
     // args are drained so crash-restarts don't re-fire lifecycle callbacks.
     let mut lifecycle_args: Vec<String> = args.iter().filter(|a| a.starts_with("--surge-")).cloned().collect();
     let regular_args: Vec<String> = args.iter().filter(|a| !a.starts_with("--surge-")).cloned().collect();
-    let mut pending_handoff_version = watched_pid.and_then(|_| first_run_version(args));
+    let mut pending_handoff_version = pending_restart_handoff_version(watched_pid, handoff_version, args);
     let mut watched_pid = watched_pid;
 
     loop {
@@ -256,6 +262,19 @@ fn run_supervisor(
 
     tracing::info!("Supervisor '{supervisor_id}' exiting");
     Ok(())
+}
+
+fn pending_restart_handoff_version(
+    watched_pid: Option<u32>,
+    handoff_version: Option<&str>,
+    args: &[String],
+) -> Option<String> {
+    watched_pid?;
+    handoff_version
+        .map(str::trim)
+        .filter(|version| !version.is_empty())
+        .map(ToOwned::to_owned)
+        .or_else(|| first_run_version(args))
 }
 
 fn first_run_version(args: &[String]) -> Option<String> {
@@ -536,4 +555,67 @@ fn ctrlc_handler(shutdown: std::sync::Arc<std::sync::atomic::AtomicBool>) {
             }
         }
     });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pending_handoff_version_uses_explicit_watch_target() {
+        let args = vec!["--app-mode".to_string()];
+
+        let version = pending_restart_handoff_version(Some(42), Some(" 2.0.0 "), &args);
+
+        assert_eq!(version.as_deref(), Some("2.0.0"));
+    }
+
+    #[test]
+    fn pending_handoff_version_falls_back_to_first_run_arg() {
+        let args = vec!["--surge-first-run".to_string(), "2.0.0".to_string()];
+
+        let version = pending_restart_handoff_version(Some(42), None, &args);
+
+        assert_eq!(version.as_deref(), Some("2.0.0"));
+    }
+
+    #[test]
+    fn pending_handoff_version_requires_watched_pid() {
+        let args = vec!["--surge-first-run".to_string(), "2.0.0".to_string()];
+
+        let version = pending_restart_handoff_version(None, Some("2.0.0"), &args);
+
+        assert_eq!(version, None);
+    }
+
+    #[test]
+    fn watch_command_accepts_handoff_version_before_trailing_args() {
+        let cli = Cli::try_parse_from([
+            "surge-supervisor",
+            "watch",
+            "--id",
+            "demo-supervisor",
+            "--dir",
+            "/tmp/demo",
+            "--pid",
+            "42",
+            "--handoff-version",
+            "2.0.0",
+            "--exe",
+            "/tmp/demo/demo-app",
+            "--",
+            "--app-mode",
+        ])
+        .unwrap();
+
+        let Commands::Watch {
+            handoff_version, args, ..
+        } = cli.command
+        else {
+            panic!("expected watch command");
+        };
+
+        assert_eq!(handoff_version.as_deref(), Some("2.0.0"));
+        assert_eq!(args, vec!["--app-mode"]);
+    }
 }


### PR DESCRIPTION
## Summary
- pass an explicit handoff target version when the update manager restarts a supervisor in watch mode
- let the supervisor use that target to converge pending restart status after the replacement child is stable
- keep replacement child arguments unchanged while retaining the existing lifecycle-arg fallback for older watch invocations

## Validation
- ./scripts/sync-surge-core-vendor.sh --check
- ./scripts/check-version-sync.sh
- cargo fmt --all -- --check
- RUSTFLAGS="-D warnings" cargo test --workspace
- cargo clippy --all-targets --all-features -- -D warnings
- cargo clippy --workspace --lib --bins --examples -- -D warnings -D clippy::unwrap_used -D clippy::expect_used
- cargo clippy --workspace --all-targets --all-features -- -D warnings -W clippy::pedantic
- dotnet format dotnet/Surge.slnx --verify-no-changes
- dotnet test dotnet/Surge.slnx --configuration Release