### PR TITLE
Add install platform compatibility preflight

### DIFF
--- a/crates/surge-cli/src/cli.rs
+++ b/crates/surge-cli/src/cli.rs
@@ -408,6 +408,9 @@ pub(crate) struct InstallOptions {
     #[arg(long)]
     pub(crate) force: bool,
 
+    #[command(flatten)]
+    pub(crate) compatibility_options: InstallCompatibilityOptions,
+
     /// Local cache directory for downloaded packages
     #[arg(long, default_value = ".surge/install-cache")]
     pub(crate) download_dir: PathBuf,
@@ -442,6 +445,13 @@ pub(crate) struct InstallStageOptions {
     /// Verify that the selected release is already staged and ready for the next tailscale install
     #[arg(long, conflicts_with = "stage")]
     pub(crate) verify_stage: bool,
+}
+
+#[derive(Args, Clone)]
+pub(crate) struct InstallCompatibilityOptions {
+    /// Continue an install even when explicit target compatibility metadata does not match the host
+    #[arg(long)]
+    pub(crate) allow_platform_mismatch: bool,
 }
 
 #[cfg(test)]
@@ -519,6 +529,18 @@ mod tests {
         };
 
         assert!(options.force);
+    }
+
+    #[test]
+    fn install_platform_mismatch_flag_parses() {
+        let cli = Cli::try_parse_from(["surge", "install", "tailscale", "my-node", "--allow-platform-mismatch"])
+            .expect("install command with --allow-platform-mismatch should parse");
+
+        let Commands::Install { options, .. } = cli.command else {
+            panic!("expected install command");
+        };
+
+        assert!(options.compatibility_options.allow_platform_mismatch);
     }
 
     #[test]

--- a/crates/surge-cli/src/commands/init.rs
+++ b/crates/surge-cli/src/commands/init.rs
@@ -103,6 +103,7 @@ pub async fn execute(
                 persistent_assets: vec![],
                 installers: vec![],
                 environment: BTreeMap::new(),
+                compatibility: None,
             }],
             target: None,
         }],

--- a/crates/surge-cli/src/commands/install/compatibility/evaluation.rs
+++ b/crates/surge-cli/src/commands/install/compatibility/evaluation.rs
@@ -1,0 +1,375 @@
+use surge_core::config::manifest::{GpuCompatibilityConfig, OsReleaseCompatibilityConfig, TargetCompatibilityConfig};
+
+use super::fingerprint::{ProbeValue, RuntimeFingerprint};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum CompatibilityVerdict {
+    Compatible,
+    Incompatible,
+    Unknown,
+}
+
+impl CompatibilityVerdict {
+    pub(super) const fn as_str(self) -> &'static str {
+        match self {
+            Self::Compatible => "compatible",
+            Self::Incompatible => "incompatible",
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct CompatibilityEvaluation {
+    pub(super) verdict: CompatibilityVerdict,
+    pub(super) reasons: Vec<String>,
+}
+
+pub(super) fn evaluate_compatibility(
+    compatibility: &TargetCompatibilityConfig,
+    fingerprint: &RuntimeFingerprint,
+) -> CompatibilityEvaluation {
+    let mut incompatible = Vec::new();
+    let mut unknown = Vec::new();
+    let mut compatible = Vec::new();
+
+    if let Some(os_release) = &compatibility.os_release {
+        evaluate_os_release(
+            os_release,
+            fingerprint,
+            &mut compatible,
+            &mut incompatible,
+            &mut unknown,
+        );
+    }
+    if let Some(gpu) = &compatibility.gpu {
+        evaluate_gpu(gpu, fingerprint, &mut compatible, &mut incompatible, &mut unknown);
+    }
+    for (path, pattern) in &compatibility.files {
+        evaluate_probe_value(
+            &format!("file '{path}'"),
+            pattern,
+            fingerprint.files.get(path),
+            &mut compatible,
+            &mut incompatible,
+            &mut unknown,
+        );
+    }
+    for (package, pattern) in &compatibility.packages {
+        evaluate_probe_value(
+            &format!("package '{package}'"),
+            pattern,
+            fingerprint.packages.get(package),
+            &mut compatible,
+            &mut incompatible,
+            &mut unknown,
+        );
+    }
+
+    if incompatible.is_empty() {
+        if unknown.is_empty() {
+            CompatibilityEvaluation {
+                verdict: CompatibilityVerdict::Compatible,
+                reasons: compatible,
+            }
+        } else {
+            CompatibilityEvaluation {
+                verdict: CompatibilityVerdict::Unknown,
+                reasons: unknown,
+            }
+        }
+    } else {
+        CompatibilityEvaluation {
+            verdict: CompatibilityVerdict::Incompatible,
+            reasons: incompatible,
+        }
+    }
+}
+
+fn evaluate_os_release(
+    expected: &OsReleaseCompatibilityConfig,
+    fingerprint: &RuntimeFingerprint,
+    compatible: &mut Vec<String>,
+    incompatible: &mut Vec<String>,
+    unknown: &mut Vec<String>,
+) {
+    if let Some(expected_id) = expected.id.as_deref().map(str::trim).filter(|value| !value.is_empty()) {
+        match fingerprint.os_release.get("ID") {
+            Some(actual_id) if os_id_matches(expected_id, actual_id, fingerprint.os_release.get("ID_LIKE")) => {
+                compatible.push(format!("os-release id '{actual_id}' matches '{expected_id}'"));
+            }
+            Some(actual_id) => incompatible.push(format!("os-release id expected '{expected_id}', got '{actual_id}'")),
+            None => unknown.push(format!(
+                "os-release id expected '{expected_id}', but /etc/os-release did not expose ID"
+            )),
+        }
+    }
+
+    if let Some(expected_version) = expected
+        .version_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        match fingerprint.os_release.get("VERSION_ID") {
+            Some(actual_version) if wildcard_matches(expected_version, actual_version) => {
+                compatible.push(format!(
+                    "os-release version-id '{actual_version}' matches '{expected_version}'"
+                ));
+            }
+            Some(actual_version) => incompatible.push(format!(
+                "os-release version-id expected '{expected_version}', got '{actual_version}'"
+            )),
+            None => unknown.push(format!(
+                "os-release version-id expected '{expected_version}', but /etc/os-release did not expose VERSION_ID"
+            )),
+        }
+    }
+
+    if let Some(expected_id_like) = expected
+        .id_like
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        match fingerprint.os_release.get("ID_LIKE") {
+            Some(actual_id_like) if os_id_like_matches(expected_id_like, actual_id_like) => {
+                compatible.push(format!(
+                    "os-release id-like '{actual_id_like}' contains '{expected_id_like}'"
+                ));
+            }
+            Some(actual_id_like) => incompatible.push(format!(
+                "os-release id-like expected '{expected_id_like}', got '{actual_id_like}'"
+            )),
+            None => unknown.push(format!(
+                "os-release id-like expected '{expected_id_like}', but /etc/os-release did not expose ID_LIKE"
+            )),
+        }
+    }
+}
+
+fn os_id_matches(expected: &str, actual: &str, id_like: Option<&String>) -> bool {
+    wildcard_matches(&expected.to_ascii_lowercase(), &actual.to_ascii_lowercase())
+        || id_like.is_some_and(|value| os_id_like_matches(expected, value))
+}
+
+fn os_id_like_matches(expected: &str, actual_id_like: &str) -> bool {
+    let expected = expected.to_ascii_lowercase();
+    actual_id_like
+        .split_whitespace()
+        .any(|part| wildcard_matches(&expected, &part.to_ascii_lowercase()))
+}
+
+fn evaluate_gpu(
+    expected: &GpuCompatibilityConfig,
+    fingerprint: &RuntimeFingerprint,
+    compatible: &mut Vec<String>,
+    incompatible: &mut Vec<String>,
+    unknown: &mut Vec<String>,
+) {
+    let Some(expected_vendor) = expected
+        .vendor
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    else {
+        return;
+    };
+    let expected_vendor = expected_vendor.to_ascii_lowercase();
+    let actual = fingerprint.gpu.trim().to_ascii_lowercase();
+    if actual.is_empty() || actual == "unknown" {
+        unknown.push(format!(
+            "gpu vendor expected '{expected_vendor}', but GPU vendor could not be detected"
+        ));
+    } else if expected_vendor == "required" {
+        if actual == "none" {
+            incompatible.push("gpu required, but no GPU was detected".to_string());
+        } else {
+            compatible.push(format!("gpu vendor '{actual}' satisfies required GPU"));
+        }
+    } else if actual == expected_vendor {
+        compatible.push(format!("gpu vendor '{actual}' matches '{expected_vendor}'"));
+    } else {
+        incompatible.push(format!("gpu vendor expected '{expected_vendor}', got '{actual}'"));
+    }
+}
+
+fn evaluate_probe_value(
+    label: &str,
+    pattern: &str,
+    actual: Option<&ProbeValue>,
+    compatible: &mut Vec<String>,
+    incompatible: &mut Vec<String>,
+    unknown: &mut Vec<String>,
+) {
+    match actual {
+        Some(ProbeValue::Present(value)) if wildcard_matches(pattern, value) => {
+            compatible.push(format!("{label} matches '{pattern}'"));
+        }
+        Some(ProbeValue::Present(value)) => incompatible.push(format!(
+            "{label} expected '{pattern}', got '{}'",
+            trim_for_display(value)
+        )),
+        Some(ProbeValue::Missing) => incompatible.push(format!("{label} is missing")),
+        Some(ProbeValue::Unknown) | None => unknown.push(format!("{label} could not be probed")),
+    }
+}
+
+fn trim_for_display(value: &str) -> String {
+    const MAX_DISPLAY_LEN: usize = 160;
+    let collapsed = value.split_whitespace().collect::<Vec<_>>().join(" ");
+    if collapsed.len() <= MAX_DISPLAY_LEN {
+        collapsed
+    } else {
+        format!("{}...", &collapsed[..MAX_DISPLAY_LEN])
+    }
+}
+
+fn wildcard_matches(pattern: &str, value: &str) -> bool {
+    let pattern = pattern.as_bytes();
+    let value = value.as_bytes();
+    let mut pattern_index = 0;
+    let mut value_index = 0;
+    let mut star_index = None;
+    let mut star_value_index = 0;
+
+    while value_index < value.len() {
+        if pattern_index < pattern.len()
+            && (pattern[pattern_index] == b'?' || pattern[pattern_index] == value[value_index])
+        {
+            pattern_index += 1;
+            value_index += 1;
+        } else if pattern_index < pattern.len() && pattern[pattern_index] == b'*' {
+            star_index = Some(pattern_index);
+            star_value_index = value_index;
+            pattern_index += 1;
+        } else if let Some(star) = star_index {
+            pattern_index = star + 1;
+            star_value_index += 1;
+            value_index = star_value_index;
+        } else {
+            return false;
+        }
+    }
+
+    while pattern_index < pattern.len() && pattern[pattern_index] == b'*' {
+        pattern_index += 1;
+    }
+
+    pattern_index == pattern.len()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use super::*;
+
+    fn compatibility() -> TargetCompatibilityConfig {
+        let mut files = BTreeMap::new();
+        files.insert(
+            "/etc/example_runtime_release".to_string(),
+            "R35.*REVISION: 1.*".to_string(),
+        );
+        let mut packages = BTreeMap::new();
+        packages.insert("example-dnn-runtime".to_string(), "8.4.*".to_string());
+        TargetCompatibilityConfig {
+            os_release: Some(OsReleaseCompatibilityConfig {
+                id: Some("ubuntu".to_string()),
+                version_id: Some("24.04".to_string()),
+                id_like: None,
+            }),
+            gpu: Some(GpuCompatibilityConfig {
+                vendor: Some("nvidia".to_string()),
+            }),
+            files,
+            packages,
+        }
+    }
+
+    fn compatible_fingerprint() -> RuntimeFingerprint {
+        let mut os_release = BTreeMap::new();
+        os_release.insert("ID".to_string(), "ubuntu".to_string());
+        os_release.insert("VERSION_ID".to_string(), "24.04".to_string());
+        let mut files = BTreeMap::new();
+        files.insert(
+            "/etc/example_runtime_release".to_string(),
+            ProbeValue::Present("R35.4.1 REVISION: 1.2".to_string()),
+        );
+        let mut packages = BTreeMap::new();
+        packages.insert(
+            "example-dnn-runtime".to_string(),
+            ProbeValue::Present("8.4.2-1".to_string()),
+        );
+        RuntimeFingerprint {
+            os_release,
+            arch: "x86_64".to_string(),
+            kernel: "6.8.0".to_string(),
+            gpu: "nvidia".to_string(),
+            files,
+            packages,
+        }
+    }
+
+    #[test]
+    fn evaluates_compatible_runtime() {
+        let evaluation = evaluate_compatibility(&compatibility(), &compatible_fingerprint());
+
+        assert_eq!(evaluation.verdict, CompatibilityVerdict::Compatible);
+    }
+
+    #[test]
+    fn detects_explicit_incompatibility() {
+        let mut fingerprint = compatible_fingerprint();
+        fingerprint
+            .os_release
+            .insert("VERSION_ID".to_string(), "22.04".to_string());
+
+        let evaluation = evaluate_compatibility(&compatibility(), &fingerprint);
+
+        assert_eq!(evaluation.verdict, CompatibilityVerdict::Incompatible);
+        assert!(
+            evaluation
+                .reasons
+                .iter()
+                .any(|reason| reason.contains("version-id expected '24.04'"))
+        );
+    }
+
+    #[test]
+    fn detects_missing_runtime_marker() {
+        let mut fingerprint = compatible_fingerprint();
+        fingerprint
+            .files
+            .insert("/etc/example_runtime_release".to_string(), ProbeValue::Missing);
+
+        let evaluation = evaluate_compatibility(&compatibility(), &fingerprint);
+
+        assert_eq!(evaluation.verdict, CompatibilityVerdict::Incompatible);
+        assert!(
+            evaluation
+                .reasons
+                .iter()
+                .any(|reason| reason == "file '/etc/example_runtime_release' is missing")
+        );
+    }
+
+    #[test]
+    fn reports_unknown_when_package_manager_cannot_probe() {
+        let mut fingerprint = compatible_fingerprint();
+        fingerprint
+            .packages
+            .insert("example-dnn-runtime".to_string(), ProbeValue::Unknown);
+
+        let evaluation = evaluate_compatibility(&compatibility(), &fingerprint);
+
+        assert_eq!(evaluation.verdict, CompatibilityVerdict::Unknown);
+    }
+
+    #[test]
+    fn wildcard_supports_runtime_patterns() {
+        assert!(wildcard_matches("8.4.*", "8.4.2-1"));
+        assert!(wildcard_matches("R35.*REVISION: 1.*", "R35.4 REVISION: 1.0"));
+        assert!(!wildcard_matches("8.4.*", "8.5.0"));
+    }
+}

--- a/crates/surge-cli/src/commands/install/compatibility/fingerprint.rs
+++ b/crates/surge-cli/src/commands/install/compatibility/fingerprint.rs
@@ -1,0 +1,358 @@
+use std::collections::BTreeMap;
+use std::fmt::Write as _;
+use std::process::Command as StdCommand;
+
+use surge_core::config::manifest::TargetCompatibilityConfig;
+use surge_core::error::{Result, SurgeError};
+
+use super::super::{remote, shell_single_quote};
+
+const FINGERPRINT_BEGIN: &str = "__SURGE_FINGERPRINT_BEGIN__";
+const OS_RELEASE_BEGIN: &str = "__SURGE_OS_RELEASE_BEGIN__";
+const OS_RELEASE_END: &str = "__SURGE_OS_RELEASE_END__";
+const FIELD_PREFIX: &str = "__SURGE_FIELD\t";
+const FILE_PREFIX: &str = "__SURGE_FILE\t";
+const PACKAGE_PREFIX: &str = "__SURGE_PACKAGE\t";
+const PROBE_MISSING: &str = "__SURGE_MISSING__";
+const PROBE_UNKNOWN: &str = "__SURGE_UNKNOWN__";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum ProbeValue {
+    Present(String),
+    Missing,
+    Unknown,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(super) struct RuntimeFingerprint {
+    pub(super) os_release: BTreeMap<String, String>,
+    pub(super) arch: String,
+    pub(super) kernel: String,
+    pub(super) gpu: String,
+    pub(super) files: BTreeMap<String, ProbeValue>,
+    pub(super) packages: BTreeMap<String, ProbeValue>,
+}
+
+pub(super) async fn collect_remote_runtime_fingerprint(
+    ssh_target: &str,
+    compatibility: &TargetCompatibilityConfig,
+) -> Result<RuntimeFingerprint> {
+    let probe = build_runtime_fingerprint_probe(compatibility);
+    let command = format!("sh -c {}", shell_single_quote(&probe));
+    let output = remote::run_tailscale_capture(&["ssh", ssh_target, command.as_str()]).await?;
+    parse_runtime_fingerprint_output(&output)
+}
+
+pub(super) fn collect_local_runtime_fingerprint(compatibility: &TargetCompatibilityConfig) -> RuntimeFingerprint {
+    let mut fingerprint = RuntimeFingerprint {
+        os_release: parse_os_release(&std::fs::read_to_string("/etc/os-release").unwrap_or_default()),
+        arch: command_stdout("uname", &["-m"]).unwrap_or_else(|| std::env::consts::ARCH.to_string()),
+        kernel: command_stdout("uname", &["-r"]).unwrap_or_default(),
+        gpu: detect_local_gpu_vendor(),
+        files: BTreeMap::new(),
+        packages: BTreeMap::new(),
+    };
+
+    for path in compatibility.files.keys() {
+        let value = match std::fs::read_to_string(path) {
+            Ok(content) => ProbeValue::Present(content),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => ProbeValue::Missing,
+            Err(_) => ProbeValue::Unknown,
+        };
+        fingerprint.files.insert(path.clone(), value);
+    }
+
+    for package in compatibility.packages.keys() {
+        fingerprint
+            .packages
+            .insert(package.clone(), probe_local_package_version(package));
+    }
+
+    fingerprint
+}
+
+fn command_stdout(command: &str, args: &[&str]) -> Option<String> {
+    let output = StdCommand::new(command).args(args).output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let value = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    (!value.is_empty()).then_some(value)
+}
+
+fn detect_local_gpu_vendor() -> String {
+    if StdCommand::new("nvidia-smi")
+        .arg("-L")
+        .output()
+        .is_ok_and(|output| output.status.success())
+    {
+        return "nvidia".to_string();
+    }
+
+    if let Some(lspci) = command_stdout("lspci", &[]) {
+        let lower = lspci.to_ascii_lowercase();
+        if lower.contains("nvidia") {
+            return "nvidia".to_string();
+        }
+        if lower.contains("vga") || lower.contains("3d controller") || lower.contains("display controller") {
+            return "other".to_string();
+        }
+        return "none".to_string();
+    }
+
+    "unknown".to_string()
+}
+
+fn probe_local_package_version(package: &str) -> ProbeValue {
+    if command_exists("dpkg-query") {
+        return command_stdout("dpkg-query", &["-W", "-f=${Version}", package])
+            .map_or(ProbeValue::Missing, ProbeValue::Present);
+    }
+    if command_exists("rpm") {
+        return command_stdout("rpm", &["-q", "--qf", "%{VERSION}-%{RELEASE}", package])
+            .map_or(ProbeValue::Missing, ProbeValue::Present);
+    }
+    if command_exists("apk") {
+        if !StdCommand::new("apk")
+            .args(["info", "-e", package])
+            .output()
+            .is_ok_and(|output| output.status.success())
+        {
+            return ProbeValue::Missing;
+        }
+        return command_stdout("apk", &["info", "-v", package])
+            .map(|value| {
+                value
+                    .lines()
+                    .next()
+                    .map_or_else(String::new, ToOwned::to_owned)
+                    .trim_start_matches(package)
+                    .trim_start_matches('-')
+                    .to_string()
+            })
+            .filter(|value| !value.is_empty())
+            .map_or(ProbeValue::Unknown, ProbeValue::Present);
+    }
+    ProbeValue::Unknown
+}
+
+fn command_exists(command: &str) -> bool {
+    StdCommand::new(command)
+        .arg("--version")
+        .output()
+        .is_ok_and(|output| output.status.success())
+}
+
+fn build_runtime_fingerprint_probe(compatibility: &TargetCompatibilityConfig) -> String {
+    let mut script = String::from(
+        r#"set +e
+echo __SURGE_FINGERPRINT_BEGIN__
+echo __SURGE_OS_RELEASE_BEGIN__
+cat /etc/os-release 2>/dev/null || true
+echo __SURGE_OS_RELEASE_END__
+printf '__SURGE_FIELD\tarch\t%s\n' "$(uname -m 2>/dev/null || true)"
+printf '__SURGE_FIELD\tkernel\t%s\n' "$(uname -r 2>/dev/null || true)"
+gpu=unknown
+if command -v nvidia-smi >/dev/null 2>&1 && nvidia-smi -L >/dev/null 2>&1; then
+  gpu=nvidia
+elif command -v lspci >/dev/null 2>&1; then
+  pci="$(lspci 2>/dev/null || true)"
+  if printf '%s\n' "$pci" | grep -qi nvidia; then
+    gpu=nvidia
+  elif printf '%s\n' "$pci" | grep -Eqi 'vga|3d controller|display controller'; then
+    gpu=other
+  else
+    gpu=none
+  fi
+fi
+printf '__SURGE_FIELD\tgpu\t%s\n' "$gpu"
+probe_package_version() {
+  pkg="$1"
+  if command -v dpkg-query >/dev/null 2>&1; then
+    dpkg-query -W -f='${Version}' "$pkg" 2>/dev/null || printf '%s' __SURGE_MISSING__
+  elif command -v rpm >/dev/null 2>&1; then
+    rpm -q --qf '%{VERSION}-%{RELEASE}' "$pkg" 2>/dev/null || printf '%s' __SURGE_MISSING__
+  elif command -v apk >/dev/null 2>&1; then
+    if apk info -e "$pkg" >/dev/null 2>&1; then
+      apk info -v "$pkg" 2>/dev/null | sed -n '1p'
+    else
+      printf '%s' __SURGE_MISSING__
+    fi
+  else
+    printf '%s' __SURGE_UNKNOWN__
+  fi
+}
+"#,
+    );
+
+    for path in compatibility.files.keys() {
+        let quoted_path = shell_single_quote(path);
+        let display_path = path.replace('\t', " ");
+        let quoted_display_path = shell_single_quote(&display_path);
+        let _ = write!(
+            script,
+            "display_path={quoted_display_path}\nif [ -r {quoted_path} ]; then\n  value=\"$(head -c 65536 {quoted_path} 2>/dev/null | tr '\\n' '\\r')\"\n  printf '__SURGE_FILE\\t%s\\tpresent\\t%s\\n' \"$display_path\" \"$value\"\nelse\n  printf '__SURGE_FILE\\t%s\\tmissing\\t\\n' \"$display_path\"\nfi\n"
+        );
+    }
+
+    for package in compatibility.packages.keys() {
+        let quoted_package = shell_single_quote(package);
+        let display_package = package.replace('\t', " ");
+        let quoted_display_package = shell_single_quote(&display_package);
+        let _ = write!(
+            script,
+            "display_package={quoted_display_package}\nvalue=\"$(probe_package_version {quoted_package})\"\nprintf '__SURGE_PACKAGE\\t%s\\t%s\\n' \"$display_package\" \"$value\"\n"
+        );
+    }
+
+    script
+}
+
+fn parse_runtime_fingerprint_output(output: &str) -> Result<RuntimeFingerprint> {
+    let mut fingerprint = RuntimeFingerprint::default();
+    let mut os_release = String::new();
+    let mut in_os_release = false;
+    let mut saw_begin = false;
+
+    for line in output.lines() {
+        if line == FINGERPRINT_BEGIN {
+            saw_begin = true;
+            continue;
+        }
+        if line == OS_RELEASE_BEGIN {
+            in_os_release = true;
+            continue;
+        }
+        if line == OS_RELEASE_END {
+            in_os_release = false;
+            fingerprint.os_release = parse_os_release(&os_release);
+            continue;
+        }
+        if in_os_release {
+            os_release.push_str(line);
+            os_release.push('\n');
+            continue;
+        }
+        if let Some(rest) = line.strip_prefix(FIELD_PREFIX) {
+            parse_field(rest, &mut fingerprint);
+            continue;
+        }
+        if let Some(rest) = line.strip_prefix(FILE_PREFIX) {
+            parse_file(rest, &mut fingerprint);
+            continue;
+        }
+        if let Some(rest) = line.strip_prefix(PACKAGE_PREFIX) {
+            parse_package(rest, &mut fingerprint);
+        }
+    }
+
+    if !saw_begin {
+        return Err(SurgeError::Platform(
+            "Remote platform fingerprint probe did not return the expected marker".to_string(),
+        ));
+    }
+
+    Ok(fingerprint)
+}
+
+fn parse_field(rest: &str, fingerprint: &mut RuntimeFingerprint) {
+    let mut parts = rest.splitn(2, '\t');
+    let key = parts.next().unwrap_or_default();
+    let value = parts.next().unwrap_or_default().trim();
+    match key {
+        "arch" => fingerprint.arch = value.to_string(),
+        "kernel" => fingerprint.kernel = value.to_string(),
+        "gpu" => fingerprint.gpu = value.to_string(),
+        _ => {}
+    }
+}
+
+fn parse_file(rest: &str, fingerprint: &mut RuntimeFingerprint) {
+    let mut parts = rest.splitn(3, '\t');
+    let path = parts.next().unwrap_or_default().to_string();
+    let state = parts.next().unwrap_or_default();
+    let value = parts.next().unwrap_or_default().replace('\r', "\n");
+    fingerprint.files.insert(path, parse_probe_value(state, &value));
+}
+
+fn parse_package(rest: &str, fingerprint: &mut RuntimeFingerprint) {
+    let mut parts = rest.splitn(2, '\t');
+    let package = parts.next().unwrap_or_default().to_string();
+    let value = parts.next().unwrap_or_default();
+    fingerprint
+        .packages
+        .insert(package, parse_probe_value("present", value));
+}
+
+fn parse_probe_value(state: &str, value: &str) -> ProbeValue {
+    match state {
+        "missing" => ProbeValue::Missing,
+        "present" if value.trim() == PROBE_MISSING => ProbeValue::Missing,
+        "present" if value.trim() == PROBE_UNKNOWN => ProbeValue::Unknown,
+        "present" => ProbeValue::Present(value.trim().to_string()),
+        _ => ProbeValue::Unknown,
+    }
+}
+
+fn parse_os_release(contents: &str) -> BTreeMap<String, String> {
+    let mut values = BTreeMap::new();
+    for line in contents.lines().map(str::trim) {
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let Some((key, value)) = line.split_once('=') else {
+            continue;
+        };
+        let key = key.trim();
+        if key.is_empty() {
+            continue;
+        }
+        values.insert(key.to_string(), unquote_os_release_value(value.trim()));
+    }
+    values
+}
+
+fn unquote_os_release_value(value: &str) -> String {
+    if value.len() >= 2
+        && ((value.starts_with('"') && value.ends_with('"')) || (value.starts_with('\'') && value.ends_with('\'')))
+    {
+        value[1..value.len() - 1].to_string()
+    } else {
+        value.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_remote_fingerprint_output() {
+        let output = "\
+noise
+__SURGE_FINGERPRINT_BEGIN__
+__SURGE_OS_RELEASE_BEGIN__
+ID=ubuntu
+VERSION_ID=\"24.04\"
+__SURGE_OS_RELEASE_END__
+__SURGE_FIELD\tarch\tx86_64
+__SURGE_FIELD\tkernel\t6.8.0
+__SURGE_FIELD\tgpu\tnvidia
+__SURGE_FILE\t/etc/example_runtime_release\tpresent\tR35.4 REVISION: 1.0
+__SURGE_PACKAGE\texample-dnn-runtime\t8.4.1-1
+";
+
+        let fingerprint = parse_runtime_fingerprint_output(output).unwrap();
+
+        assert_eq!(fingerprint.os_release.get("ID").map(String::as_str), Some("ubuntu"));
+        assert_eq!(fingerprint.arch, "x86_64");
+        assert_eq!(
+            fingerprint.files.get("/etc/example_runtime_release"),
+            Some(&ProbeValue::Present("R35.4 REVISION: 1.0".to_string()))
+        );
+        assert_eq!(
+            fingerprint.packages.get("example-dnn-runtime"),
+            Some(&ProbeValue::Present("8.4.1-1".to_string()))
+        );
+    }
+}

--- a/crates/surge-cli/src/commands/install/compatibility/mod.rs
+++ b/crates/surge-cli/src/commands/install/compatibility/mod.rs
@@ -1,0 +1,94 @@
+mod evaluation;
+mod fingerprint;
+
+use surge_core::config::manifest::TargetCompatibilityConfig;
+use surge_core::error::{Result, SurgeError};
+
+use self::evaluation::{CompatibilityVerdict, evaluate_compatibility};
+use self::fingerprint::{RuntimeFingerprint, collect_local_runtime_fingerprint, collect_remote_runtime_fingerprint};
+use super::logline;
+
+#[derive(Debug, Clone, Copy)]
+pub(super) enum CompatibilityInstallTarget<'a> {
+    Local,
+    Tailscale { ssh_target: &'a str, file_target: &'a str },
+}
+
+pub(super) async fn run_platform_compatibility_preflight(
+    target: CompatibilityInstallTarget<'_>,
+    selected_rid: &str,
+    compatibility: &TargetCompatibilityConfig,
+    allow_platform_mismatch: bool,
+) -> Result<()> {
+    if compatibility.is_empty() {
+        return Ok(());
+    }
+
+    let fingerprint = match target {
+        CompatibilityInstallTarget::Local => collect_local_runtime_fingerprint(compatibility),
+        CompatibilityInstallTarget::Tailscale { ssh_target, .. } => {
+            collect_remote_runtime_fingerprint(ssh_target, compatibility).await?
+        }
+    };
+    log_fingerprint(target, &fingerprint);
+
+    let evaluation = evaluate_compatibility(compatibility, &fingerprint);
+    logline::info(&format!(
+        "Compatibility verdict for RID '{selected_rid}': {}",
+        evaluation.verdict.as_str()
+    ));
+    for reason in &evaluation.reasons {
+        logline::info(&format!("Compatibility detail: {reason}"));
+    }
+
+    if evaluation.verdict == CompatibilityVerdict::Incompatible {
+        let reason = evaluation.reasons.join("; ");
+        if allow_platform_mismatch {
+            logline::warn(&format!(
+                "Platform compatibility mismatch overridden by --allow-platform-mismatch for RID '{selected_rid}': {reason}"
+            ));
+        } else {
+            return Err(SurgeError::Platform(format!(
+                "Selected target RID '{selected_rid}' is incompatible with the install host: {reason}. Use --allow-platform-mismatch to override in an emergency."
+            )));
+        }
+    } else if evaluation.verdict == CompatibilityVerdict::Unknown {
+        logline::warn(&format!(
+            "Platform compatibility for RID '{selected_rid}' is unknown; continuing because no explicit incompatibility was detected."
+        ));
+    }
+
+    Ok(())
+}
+
+fn log_fingerprint(target: CompatibilityInstallTarget<'_>, fingerprint: &RuntimeFingerprint) {
+    let os_id = fingerprint.os_release.get("ID").map_or("unknown", String::as_str);
+    let os_version = fingerprint
+        .os_release
+        .get("VERSION_ID")
+        .map_or("unknown", String::as_str);
+    let arch = if fingerprint.arch.is_empty() {
+        "unknown"
+    } else {
+        fingerprint.arch.as_str()
+    };
+    let kernel = if fingerprint.kernel.is_empty() {
+        "unknown"
+    } else {
+        fingerprint.kernel.as_str()
+    };
+    let gpu = if fingerprint.gpu.is_empty() {
+        "unknown"
+    } else {
+        fingerprint.gpu.as_str()
+    };
+
+    match target {
+        CompatibilityInstallTarget::Local => logline::info(&format!(
+            "Local runtime fingerprint: os={os_id} version={os_version} arch={arch} kernel={kernel} gpu={gpu}"
+        )),
+        CompatibilityInstallTarget::Tailscale { file_target, .. } => logline::info(&format!(
+            "Remote runtime fingerprint for {file_target}: os={os_id} version={os_version} arch={arch} kernel={kernel} gpu={gpu}"
+        )),
+    }
+}

--- a/crates/surge-cli/src/commands/install/mod.rs
+++ b/crates/surge-cli/src/commands/install/mod.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::cast_precision_loss, clippy::too_many_lines)]
 
+mod compatibility;
 mod local;
 mod profile;
 mod progress;
@@ -25,6 +26,7 @@ pub(crate) use self::runtime::{
     release_runtime_manifest_metadata, stop_running_supervisor,
 };
 
+use self::compatibility::{CompatibilityInstallTarget, run_platform_compatibility_preflight};
 use self::local::install_selected_release_locally;
 use self::profile::{
     build_rid_candidates, derive_base_rid, detect_local_profile, warn_if_local_rid_looks_incompatible,
@@ -69,7 +71,21 @@ pub struct InstallBehavior {
     pub plan_only: bool,
     pub no_start: bool,
     pub force: bool,
+    pub platform_mismatch: PlatformMismatchPolicy,
     pub mode: InstallMode,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum PlatformMismatchPolicy {
+    #[default]
+    Reject,
+    Allow,
+}
+
+impl PlatformMismatchPolicy {
+    fn allows_mismatch(self) -> bool {
+        matches!(self, Self::Allow)
+    }
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -327,6 +343,36 @@ pub async fn execute(
             "Release {} ({selected_rid}) has no full package filename",
             release.version
         )));
+    }
+
+    let compatibility_rid = if release.rid.trim().is_empty() {
+        rid_candidates.first().map(String::as_str).unwrap_or_default()
+    } else {
+        release.rid.as_str()
+    };
+    if let Some(compatibility) = manifest
+        .as_ref()
+        .and_then(|manifest| manifest.find_target(&app_id, compatibility_rid))
+        .and_then(|target| target.compatibility)
+        .filter(|compatibility| !compatibility.is_empty())
+    {
+        let compatibility_target = match &install_target {
+            InstallTarget::Local => CompatibilityInstallTarget::Local,
+            InstallTarget::Tailscale {
+                ssh_target,
+                file_target,
+            } => CompatibilityInstallTarget::Tailscale {
+                ssh_target,
+                file_target,
+            },
+        };
+        run_platform_compatibility_preflight(
+            compatibility_target,
+            compatibility_rid,
+            &compatibility,
+            behavior.platform_mismatch.allows_mismatch(),
+        )
+        .await?;
     }
 
     if behavior.mode.is_verify_stage() {
@@ -1547,6 +1593,7 @@ apps:
                 plan_only: false,
                 no_start: true,
                 force: false,
+                platform_mismatch: PlatformMismatchPolicy::Reject,
                 mode: InstallMode::Install,
             },
             &download_dir,

--- a/crates/surge-cli/src/commands/install/remote/mod.rs
+++ b/crates/surge-cli/src/commands/install/remote/mod.rs
@@ -25,7 +25,7 @@ use serde::Deserialize;
 use surge_core::update::manager::ApplyStrategy;
 
 pub(crate) use self::execution::{
-    REMOTE_INSTALLER_FINAL_PATH, resolve_tailscale_targets, run_tailscale_streaming,
+    REMOTE_INSTALLER_FINAL_PATH, resolve_tailscale_targets, run_tailscale_capture, run_tailscale_streaming,
     run_tailscale_streaming_with_status_watchdog,
 };
 pub(crate) use self::published_installer::{

--- a/crates/surge-cli/src/main.rs
+++ b/crates/surge-cli/src/main.rs
@@ -317,6 +317,11 @@ async fn run(cli: Cli) -> surge_core::error::Result<()> {
                     plan_only: options.plan_only,
                     no_start: options.no_start,
                     force: options.force,
+                    platform_mismatch: if options.compatibility_options.allow_platform_mismatch {
+                        commands::install::PlatformMismatchPolicy::Allow
+                    } else {
+                        commands::install::PlatformMismatchPolicy::Reject
+                    },
                     mode: if options.stage_options.verify_stage {
                         commands::install::InstallMode::VerifyStage
                     } else if options.stage_options.stage {

--- a/crates/surge-core/src/config/manifest/mod.rs
+++ b/crates/surge-core/src/config/manifest/mod.rs
@@ -10,11 +10,11 @@ use serde_yaml::Value;
 use crate::error::{Result, SurgeError};
 
 pub use self::types::{
-    AppConfig, CacheManifestConfig, ChannelManifestConfig, InstallArtifactCacheManifestConfig,
+    AppConfig, CacheManifestConfig, ChannelManifestConfig, GpuCompatibilityConfig, InstallArtifactCacheManifestConfig,
     InstallArtifactCachePolicy, InstallArtifactCacheRetention, InstallerType, LockManifestConfig,
-    PackCompressionFormat, PackCompressionManifestConfig, PackDeltaManifestConfig, PackDeltaStrategy,
-    PackManifestConfig, PackPolicy, PackRetentionManifestConfig, ShortcutLocation, StorageManifestConfig,
-    SurgeManifest, TargetConfig,
+    OsReleaseCompatibilityConfig, PackCompressionFormat, PackCompressionManifestConfig, PackDeltaManifestConfig,
+    PackDeltaStrategy, PackManifestConfig, PackPolicy, PackRetentionManifestConfig, ShortcutLocation,
+    StorageManifestConfig, SurgeManifest, TargetCompatibilityConfig, TargetConfig,
 };
 
 impl SurgeManifest {
@@ -83,6 +83,54 @@ apps:
         let manifest = SurgeManifest::parse(yaml).expect("manifest should parse");
         assert_eq!(manifest.apps.len(), 1);
         assert_eq!(manifest.apps[0].id, "explicit-id");
+    }
+
+    #[test]
+    fn parse_target_compatibility_rules() {
+        let yaml = br#"schema: 1
+storage:
+  provider: filesystem
+  bucket: /tmp/store
+apps:
+  - id: demo
+    target:
+      rid: linux-x64
+      compatibility:
+        os-release:
+          id: ubuntu
+          version-id: "24.04"
+        gpu:
+          vendor: nvidia
+        files:
+          /etc/example_runtime_release: "R35.*"
+        packages:
+          example-dnn-runtime: "8.4.*"
+"#;
+
+        let manifest = SurgeManifest::parse(yaml).expect("manifest should parse");
+        let target = manifest
+            .find_target("demo", "linux-x64")
+            .expect("target should resolve");
+        let compatibility = target.compatibility.expect("compatibility should parse");
+
+        assert_eq!(
+            compatibility
+                .os_release
+                .as_ref()
+                .and_then(|os_release| os_release.id.as_deref()),
+            Some("ubuntu")
+        );
+        assert_eq!(
+            compatibility
+                .files
+                .get("/etc/example_runtime_release")
+                .map(String::as_str),
+            Some("R35.*")
+        );
+        assert_eq!(
+            compatibility.packages.get("example-dnn-runtime").map(String::as_str),
+            Some("8.4.*")
+        );
     }
 
     #[test]

--- a/crates/surge-core/src/config/manifest/types.rs
+++ b/crates/surge-core/src/config/manifest/types.rs
@@ -176,6 +176,58 @@ pub struct TargetConfig {
     pub installers: Vec<String>,
     #[serde(default)]
     pub environment: BTreeMap<String, String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub compatibility: Option<TargetCompatibilityConfig>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct TargetCompatibilityConfig {
+    #[serde(
+        default,
+        rename = "os-release",
+        alias = "os_release",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub os_release: Option<OsReleaseCompatibilityConfig>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub gpu: Option<GpuCompatibilityConfig>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub files: BTreeMap<String, String>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub packages: BTreeMap<String, String>,
+}
+
+impl TargetCompatibilityConfig {
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.os_release.is_none() && self.gpu.is_none() && self.files.is_empty() && self.packages.is_empty()
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct OsReleaseCompatibilityConfig {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    #[serde(
+        default,
+        rename = "version-id",
+        alias = "version_id",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub version_id: Option<String>,
+    #[serde(
+        default,
+        rename = "id-like",
+        alias = "id_like",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub id_like: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct GpuCompatibilityConfig {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub vendor: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]


### PR DESCRIPTION
## Summary
- Add target compatibility metadata for OS release, GPU, file markers, and package versions.
- Probe local and tailscale install targets before transfer/apply and report the runtime fingerprint plus compatibility verdict.
- Reject explicit incompatibility before install unless `--allow-platform-mismatch` is supplied.

## Behavior impact
- Existing manifests without compatibility metadata keep the current install behavior.
- `surge install tailscale --plan-only` now includes the remote runtime fingerprint and compatibility verdict when a selected target declares compatibility rules.

## Tests
- ./scripts/sync-surge-core-vendor.sh --check
- ./scripts/check-version-sync.sh
- cargo fmt --all -- --check
- ./scripts/check-maintainability.sh
- RUSTFLAGS="-D warnings" cargo test --workspace
- cargo clippy --all-targets --all-features -- -D warnings
- cargo clippy --workspace --lib --bins --examples -- -D warnings -D clippy::unwrap_used -D clippy::expect_used
- cargo clippy --workspace --all-targets --all-features -- -D warnings -W clippy::pedantic
- dotnet format dotnet/Surge.slnx --verify-no-changes
- dotnet test dotnet/Surge.slnx --configuration Release