### PR TITLE
Respect remote app identity during install convergence

### DIFF
--- a/crates/surge-cli/src/commands/install/mod.rs
+++ b/crates/surge-cli/src/commands/install/mod.rs
@@ -573,6 +573,7 @@ mod tests {
 
     fn remote_state(version: &str, channel: &str, storage: &surge_core::context::StorageConfig) -> RemoteInstallState {
         RemoteInstallState {
+            app_id: Some("demo".to_string()),
             version: version.to_string(),
             active_executable_exists: true,
             channel: Some(channel.to_string()),
@@ -2258,9 +2259,10 @@ apps:
     #[test]
     fn parse_remote_install_state_extracts_version_and_channel() {
         let state = parse_remote_install_state(
-            "version=1.2.3\nactive_executable_exists=true\nchannel=production\nprovider=filesystem\nbucket=/srv/releases\nregion=\nendpoint=\n",
+            "id=demo\nversion=1.2.3\nactive_executable_exists=true\nchannel=production\nprovider=filesystem\nbucket=/srv/releases\nregion=\nendpoint=\n",
         )
         .expect("remote install state should parse");
+        assert_eq!(state.app_id.as_deref(), Some("demo"));
         assert_eq!(state.version, "1.2.3");
         assert!(state.active_executable_exists);
         assert_eq!(state.channel.as_deref(), Some("production"));
@@ -2274,8 +2276,9 @@ apps:
     }
 
     #[test]
-    fn remote_install_matches_requires_matching_channel_and_version() {
+    fn remote_install_matches_requires_matching_app_channel_and_version() {
         let production = RemoteInstallState {
+            app_id: Some("demo".to_string()),
             version: "1.2.3".to_string(),
             active_executable_exists: true,
             channel: Some("production".to_string()),
@@ -2285,6 +2288,7 @@ apps:
             storage_endpoint: None,
         };
         let test = RemoteInstallState {
+            app_id: Some("demo".to_string()),
             version: "1.2.3".to_string(),
             active_executable_exists: true,
             channel: Some("test".to_string()),
@@ -2294,15 +2298,27 @@ apps:
             storage_endpoint: None,
         };
 
-        assert!(remote_install_matches(Some(&production), "1.2.3", "production"));
-        assert!(!remote_install_matches(Some(&production), "1.2.4", "production"));
-        assert!(!remote_install_matches(Some(&test), "1.2.3", "production"));
-        assert!(!remote_install_matches(None, "1.2.3", "production"));
+        assert!(remote_install_matches(Some(&production), "demo", "1.2.3", "production"));
+        assert!(!remote_install_matches(
+            Some(&production),
+            "other",
+            "1.2.3",
+            "production"
+        ));
+        assert!(!remote_install_matches(
+            Some(&production),
+            "demo",
+            "1.2.4",
+            "production"
+        ));
+        assert!(!remote_install_matches(Some(&test), "demo", "1.2.3", "production"));
+        assert!(!remote_install_matches(None, "demo", "1.2.3", "production"));
     }
 
     #[test]
     fn force_flag_bypasses_remote_install_skip() {
         let remote_state = RemoteInstallState {
+            app_id: Some("demo".to_string()),
             version: "1.2.3".to_string(),
             active_executable_exists: true,
             channel: Some("test".to_string()),
@@ -2312,7 +2328,7 @@ apps:
             storage_endpoint: None,
         };
 
-        let install_matches = remote_install_matches(Some(&remote_state), "1.2.3", "test");
+        let install_matches = remote_install_matches(Some(&remote_state), "demo", "1.2.3", "test");
 
         assert!(should_skip_remote_install(install_matches, false));
         assert!(!should_skip_remote_install(install_matches, true));
@@ -2400,6 +2416,39 @@ apps:
                 .reason
                 .as_deref()
                 .is_some_and(|reason| reason.contains("verify remote runtime convergence"))
+        );
+    }
+
+    #[test]
+    fn remote_convergence_plan_reinstalls_same_version_when_app_id_differs() {
+        let storage = storage_config("/srv/releases");
+        let target = release("1.2.0", "test", "linux-x64", "target-1.2.0-linux-x64-full.tar.zst");
+        let index = ReleaseIndex {
+            app_id: "target".to_string(),
+            releases: vec![target.clone()],
+            ..ReleaseIndex::default()
+        };
+        let mut state = remote_state("1.2.0", "test", &storage);
+        state.app_id = Some("previous".to_string());
+
+        let plan = plan_remote_convergence(
+            Some(&state),
+            &index,
+            "target",
+            "linux-x64",
+            &target,
+            "test",
+            &storage,
+            RemoteInstallerMode::Online,
+            true,
+        )
+        .expect("forced app swap plan should resolve");
+
+        assert_eq!(plan.action, RemoteConvergenceAction::Reinstall);
+        assert!(
+            plan.reason
+                .as_deref()
+                .is_some_and(|reason| reason.contains("installed app id 'previous' differs"))
         );
     }
 

--- a/crates/surge-cli/src/commands/install/remote/mod.rs
+++ b/crates/surge-cli/src/commands/install/remote/mod.rs
@@ -134,7 +134,7 @@ pub(super) async fn install_release_via_tailscale(
         return Ok(());
     }
 
-    let install_matches = remote_install_matches(remote_state.as_ref(), &release.version, channel);
+    let install_matches = remote_install_matches(remote_state.as_ref(), app_id, &release.version, channel);
     if install_matches && behavior.force {
         logline::info(&format!(
             "'{app_id}' v{} ({channel}) is already installed on '{file_target}'; reinstalling due to --force.",

--- a/crates/surge-cli/src/commands/install/remote/runtime.rs
+++ b/crates/surge-cli/src/commands/install/remote/runtime.rs
@@ -176,10 +176,13 @@ pub(crate) async fn verify_remote_runtime_after_install(
                 "Remote runtime verification failed on '{file_target}': no runtime metadata found"
             ))
         })?;
-    if state.version.trim() == release.version.trim() && state.metadata_matches(channel, storage_config) {
+    if state.app_identity_matches(app_id)
+        && state.version.trim() == release.version.trim()
+        && state.metadata_matches(channel, storage_config)
+    {
         logline::success(&format!(
-            "Verified remote runtime on '{file_target}': v{} ({channel}).",
-            release.version
+            "Verified remote runtime on '{file_target}': '{app_id}' v{} ({channel}).",
+            release.version,
         ));
         if verify_started_process {
             verify_remote_started_process(ssh_target, file_target, app_id, release).await?;
@@ -188,8 +191,8 @@ pub(crate) async fn verify_remote_runtime_after_install(
     }
 
     Err(SurgeError::Update(format!(
-        "Remote runtime verification failed on '{file_target}': found v{} channel {:?}, expected v{} channel '{}'.",
-        state.version, state.channel, release.version, channel
+        "Remote runtime verification failed on '{file_target}': found app id {:?} v{} channel {:?}, expected '{app_id}' v{} channel '{}'.",
+        state.app_id, state.version, state.channel, release.version, channel
     )))
 }
 

--- a/crates/surge-cli/src/commands/install/remote/state.rs
+++ b/crates/surge-cli/src/commands/install/remote/state.rs
@@ -78,6 +78,7 @@ manifest="$app_dir/.surge/runtime.yml";
 if [ ! -f "$manifest" ]; then
   exit 0
 fi
+id="$(sed -n 's/^id:[[:space:]]*//p' "$manifest" | head -n1)"
 version="$(sed -n 's/^version:[[:space:]]*//p' "$manifest" | head -n1)"
 channel="$(sed -n 's/^channel:[[:space:]]*//p' "$manifest" | head -n1)"
 provider="$(sed -n 's/^provider:[[:space:]]*//p' "$manifest" | head -n1)"
@@ -88,7 +89,7 @@ active_executable_exists=false
 if [ -n "$main_exe" ] && [ -f "$app_dir/$main_exe" ]; then
   active_executable_exists=true
 fi
-printf 'version=%s\nactive_executable_exists=%s\nchannel=%s\nprovider=%s\nbucket=%s\nregion=%s\nendpoint=%s\n' "$version" "$active_executable_exists" "$channel" "$provider" "$bucket" "$region" "$endpoint""#,
+printf 'id=%s\nversion=%s\nactive_executable_exists=%s\nchannel=%s\nprovider=%s\nbucket=%s\nregion=%s\nendpoint=%s\n' "$id" "$version" "$active_executable_exists" "$channel" "$provider" "$bucket" "$region" "$endpoint""#,
         install_dir.replace('\'', ""),
         main_exe.replace('\'', ""),
     );
@@ -104,6 +105,7 @@ printf 'version=%s\nactive_executable_exists=%s\nchannel=%s\nprovider=%s\nbucket
 }
 
 pub(crate) fn parse_remote_install_state(output: &str) -> Option<RemoteInstallState> {
+    let mut app_id = None;
     let mut version = None;
     let mut active_executable_exists = false;
     let mut channel = None;
@@ -113,6 +115,14 @@ pub(crate) fn parse_remote_install_state(output: &str) -> Option<RemoteInstallSt
     let mut storage_endpoint = None;
 
     for line in output.lines() {
+        if let Some(value) = line.strip_prefix("id=") {
+            let value = value.trim();
+            if !value.is_empty() {
+                app_id = Some(value.to_string());
+            }
+            continue;
+        }
+
         if let Some(value) = line.strip_prefix("version=") {
             let value = value.trim();
             if !value.is_empty() {
@@ -167,6 +177,7 @@ pub(crate) fn parse_remote_install_state(output: &str) -> Option<RemoteInstallSt
     }
 
     version.map(|version| RemoteInstallState {
+        app_id,
         version,
         active_executable_exists,
         channel,
@@ -193,6 +204,16 @@ pub(crate) fn plan_remote_convergence(
     };
 
     let installed_version = Some(remote_state.version.clone());
+    if !remote_state.app_identity_matches(app_id) {
+        return Ok(RemoteConvergencePlan {
+            action: RemoteConvergenceAction::Reinstall,
+            installed_version,
+            target_version: release.version.clone(),
+            update_info: None,
+            reason: Some(remote_state.app_identity_reinstall_reason(app_id)),
+        });
+    }
+
     let metadata_matches = remote_state.metadata_matches(channel, storage_config);
     match compare_versions(&remote_state.version, &release.version) {
         std::cmp::Ordering::Equal if metadata_matches && !remote_state.active_executable_exists => {
@@ -454,11 +475,13 @@ pub(crate) fn parse_remote_launch_environment(output: &str) -> RemoteLaunchEnvir
 
 pub(crate) fn remote_install_matches(
     remote_state: Option<&RemoteInstallState>,
+    expected_app_id: &str,
     expected_version: &str,
     expected_channel: &str,
 ) -> bool {
     remote_state.is_some_and(|state| {
-        state.version.trim() == expected_version
+        state.app_identity_matches(expected_app_id)
+            && state.version.trim() == expected_version
             && state
                 .channel
                 .as_deref()

--- a/crates/surge-cli/src/commands/install/remote/types.rs
+++ b/crates/surge-cli/src/commands/install/remote/types.rs
@@ -91,6 +91,7 @@ pub(crate) struct RemoteTailscaleTransferInputs {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct RemoteInstallState {
+    pub(crate) app_id: Option<String>,
     pub(crate) version: String,
     pub(crate) active_executable_exists: bool,
     pub(crate) channel: Option<String>,
@@ -101,6 +102,23 @@ pub(crate) struct RemoteInstallState {
 }
 
 impl RemoteInstallState {
+    pub(crate) fn app_identity_matches(&self, expected_app_id: &str) -> bool {
+        self.app_id
+            .as_deref()
+            .is_some_and(|value| value.trim() == expected_app_id.trim())
+    }
+
+    pub(crate) fn app_identity_reinstall_reason(&self, expected_app_id: &str) -> String {
+        match self.app_id.as_deref().map(str::trim).filter(|value| !value.is_empty()) {
+            Some(installed_app_id) => format!(
+                "installed app id '{installed_app_id}' differs from selected app id '{expected_app_id}'; full reinstall is required"
+            ),
+            None => format!(
+                "installed runtime metadata does not expose app id '{expected_app_id}'; full reinstall is required"
+            ),
+        }
+    }
+
     pub(crate) fn metadata_matches(&self, expected_channel: &str, storage_config: &StorageConfig) -> bool {
         self.channel
             .as_deref()


### PR DESCRIPTION
## Summary
- Read the installed runtime manifest app id during remote Tailscale install preflight.
- Force a full reinstall when the installed app id is missing or differs from the selected app id, including same-version `--force` installs.
- Require post-install remote runtime verification to match app id as well as version/channel/storage metadata.

## Behavior impact
- Same-version sibling app swaps no longer converge or restart the previous package family.
- Plan-only output now explains that app identity differs and a full reinstall is required.

## Tests
- ./scripts/sync-surge-core-vendor.sh --check
- ./scripts/check-version-sync.sh
- cargo fmt --all -- --check
- ./scripts/check-maintainability.sh
- cargo test -p surge-cli remote_
- RUSTFLAGS="-D warnings" cargo test --workspace
- cargo clippy --all-targets --all-features -- -D warnings
- cargo clippy --workspace --lib --bins --examples -- -D warnings -D clippy::unwrap_used -D clippy::expect_used
- cargo clippy --workspace --all-targets --all-features -- -D warnings -W clippy::pedantic
- dotnet format dotnet/Surge.slnx --verify-no-changes
- dotnet test dotnet/Surge.slnx --configuration Release