### PR TITLE
fix(core): bound update artifact cache during delta restore

### DIFF
--- a/crates/surge-cli/src/commands/install/releases.rs
+++ b/crates/surge-cli/src/commands/install/releases.rs
@@ -132,6 +132,7 @@ pub(super) async fn download_release_archive(
                 RestoreOptions {
                     cache_dir: destination.parent(),
                     progress: Some(&progress),
+                    ..RestoreOptions::default()
                 },
             )
             .await?;

--- a/crates/surge-cli/src/commands/pack.rs
+++ b/crates/surge-cli/src/commands/pack.rs
@@ -343,6 +343,7 @@ pub async fn execute_installers_only(
                 RestoreOptions {
                     cache_dir: Some(output_dir),
                     progress: None,
+                    ..RestoreOptions::default()
                 },
             )
             .await?;

--- a/crates/surge-cli/src/commands/restore.rs
+++ b/crates/surge-cli/src/commands/restore.rs
@@ -342,6 +342,7 @@ async fn restore_release_from_storage(
                 RestoreOptions {
                     cache_dir: Some(packages_dir),
                     progress: None,
+                    ..RestoreOptions::default()
                 },
             )
             .await?;

--- a/crates/surge-core/src/installer_package.rs
+++ b/crates/surge-core/src/installer_package.rs
@@ -125,6 +125,7 @@ pub async fn resolve_installer_package(
             RestoreOptions {
                 cache_dir: Some(&artifact_cache_dir),
                 progress: options.restore_progress,
+                ..RestoreOptions::default()
             },
         )
         .await?;

--- a/crates/surge-core/src/pack/builder.rs
+++ b/crates/surge-core/src/pack/builder.rs
@@ -1090,6 +1090,7 @@ apps:
             RestoreOptions {
                 cache_dir: Some(&cache_root),
                 progress: None,
+                ..RestoreOptions::default()
             },
         )
         .await

--- a/crates/surge-core/src/releases/restore.rs
+++ b/crates/surge-core/src/releases/restore.rs
@@ -30,6 +30,15 @@ pub struct RestoreProgress {
 pub struct RestoreOptions<'a> {
     pub cache_dir: Option<&'a Path>,
     pub progress: Option<&'a RestoreProgressCallback<'a>>,
+    pub rebuilt_full_cache_policy: RebuiltFullCachePolicy,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum RebuiltFullCachePolicy {
+    #[default]
+    All,
+    TargetOnly,
+    None,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -453,6 +462,7 @@ mod tests {
             RestoreOptions {
                 cache_dir: Some(&cache_root),
                 progress: None,
+                ..RestoreOptions::default()
             },
         )
         .await
@@ -470,6 +480,7 @@ mod tests {
             RestoreOptions {
                 cache_dir: Some(&cache_root),
                 progress: None,
+                ..RestoreOptions::default()
             },
         )
         .await
@@ -542,6 +553,7 @@ mod tests {
             RestoreOptions {
                 cache_dir: Some(&cache_root),
                 progress: None,
+                ..RestoreOptions::default()
             },
         )
         .await

--- a/crates/surge-core/src/releases/restore/recovery.rs
+++ b/crates/surge-core/src/releases/restore/recovery.rs
@@ -16,7 +16,7 @@ use futures_util::stream::{self, StreamExt};
 
 use super::candidate::select_restore_candidate;
 use super::planning::sorted_releases_for_rid;
-use super::{RestoreOptions, RestoreProgress, RestoreProgressCallback};
+use super::{RebuiltFullCachePolicy, RestoreOptions, RestoreProgress, RestoreProgressCallback};
 
 #[derive(Debug, Clone)]
 struct ArtifactPrefetchSpec {
@@ -139,12 +139,22 @@ pub async fn restore_full_archive_for_version_with_options(
             &restored,
             &format!("rebuilt full archive for {}", release.version),
         )?;
-        if let Some(cache_root) = options.cache_dir {
+        if let Some(cache_root) = options.cache_dir
+            && should_cache_rebuilt_full(options.rebuilt_full_cache_policy, release, version)
+        {
             cache_restored_full_archive(cache_root, release, &restored)?;
         }
     }
 
     Ok(restored)
+}
+
+fn should_cache_rebuilt_full(policy: RebuiltFullCachePolicy, release: &ReleaseEntry, target_version: &str) -> bool {
+    match policy {
+        RebuiltFullCachePolicy::All => true,
+        RebuiltFullCachePolicy::TargetOnly => release.version == target_version,
+        RebuiltFullCachePolicy::None => false,
+    }
 }
 
 fn cache_restored_full_archive(cache_root: &Path, release: &ReleaseEntry, restored: &[u8]) -> Result<()> {

--- a/crates/surge-core/src/update/manager.rs
+++ b/crates/surge-core/src/update/manager.rs
@@ -414,6 +414,7 @@ impl UpdateManager {
 mod tests {
     #![allow(clippy::cast_possible_wrap)]
 
+    use std::collections::BTreeSet;
     use std::path::{Path, PathBuf};
     use std::sync::Mutex;
     use std::time::Duration;
@@ -2354,6 +2355,113 @@ echo started > new-child-started
 
         let installed = std::fs::read_to_string(install_root.join("app").join("payload.txt")).unwrap();
         assert_eq!(installed, "v3 payload");
+    }
+
+    #[tokio::test]
+    async fn test_download_and_apply_delta_failure_does_not_cache_intermediate_restored_fulls() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store_root = tmp.path().join("store");
+        let install_root = tmp.path().join("install");
+        let app_id = "test-app";
+        std::fs::create_dir_all(&store_root).unwrap();
+        std::fs::create_dir_all(&install_root).unwrap();
+        let app_store = app_scoped_store_root(&store_root, app_id);
+
+        let rid = current_rid();
+        let os = current_os_label_for_tests();
+        let full_payloads: Vec<Vec<u8>> = (0..=5)
+            .map(|idx| format!("full payload for 1.{idx}.0").into_bytes())
+            .collect();
+        let mut full_names = Vec::new();
+        let mut delta_names = Vec::new();
+        let mut releases = Vec::new();
+
+        for idx in 0..=5 {
+            let version = format!("1.{idx}.0");
+            let full_name = format!("{app_id}-{version}-{rid}-full.tar.zst");
+            let mut release = make_entry(&version, "stable", &os, &rid);
+            release.is_genesis = idx == 0;
+            release.full_filename = full_name.clone();
+            release.full_size = full_payloads[idx].len() as i64;
+            release.full_sha256 = sha256_hex(&full_payloads[idx]);
+
+            if idx == 0 {
+                release.deltas = Vec::new();
+                release.preferred_delta_id = String::new();
+                std::fs::write(app_store.join(&full_name), &full_payloads[idx]).unwrap();
+            } else {
+                let from_version = format!("1.{}.0", idx - 1);
+                let delta_target = if idx == 5 {
+                    b"wrong latest payload".to_vec()
+                } else {
+                    full_payloads[idx].clone()
+                };
+                let patch = bsdiff_buffers(&full_payloads[idx - 1], &delta_target).unwrap();
+                let delta = zstd::encode_all(patch.as_slice(), 3).unwrap();
+                let delta_name = format!("{app_id}-{version}-{rid}-delta.tar.zst");
+                release.set_primary_delta(Some(DeltaArtifact::bsdiff_zstd(
+                    "primary",
+                    &from_version,
+                    &delta_name,
+                    delta.len() as i64,
+                    &sha256_hex(&delta),
+                )));
+                std::fs::write(app_store.join(&delta_name), &delta).unwrap();
+                delta_names.push(delta_name);
+            }
+
+            full_names.push(full_name);
+            releases.push(release);
+        }
+
+        let index = ReleaseIndex {
+            app_id: app_id.to_string(),
+            releases,
+            ..ReleaseIndex::default()
+        };
+        write_app_scoped_release_index(&store_root, app_id, &index);
+
+        let ctx = Arc::new(Context::new());
+        ctx.set_storage(
+            StorageProvider::Filesystem,
+            store_root.to_str().unwrap(),
+            "",
+            "",
+            "",
+            "",
+        );
+
+        let mut manager = UpdateManager::new(ctx, app_id, "1.4.0", "stable", install_root.to_str().unwrap()).unwrap();
+        let info = manager.check_for_updates().await.unwrap().unwrap();
+        assert_eq!(info.apply_strategy, ApplyStrategy::Delta);
+        assert_eq!(info.apply_releases.len(), 1);
+        assert_eq!(info.apply_releases[0].version, "1.5.0");
+
+        let err = manager
+            .download_and_apply(&info, None::<fn(ProgressInfo)>)
+            .await
+            .expect_err("bad latest delta and missing full fallback should fail before finalize");
+        assert!(
+            err.to_string().contains("full package fallback failed"),
+            "unexpected error: {err}"
+        );
+
+        let artifact_cache = install_root.join(".surge-cache").join("artifacts");
+        let cached_artifacts: BTreeSet<String> = std::fs::read_dir(&artifact_cache)
+            .unwrap()
+            .map(|entry| entry.unwrap().file_name().to_string_lossy().into_owned())
+            .filter(|name| !name.starts_with('.'))
+            .collect();
+
+        assert!(cached_artifacts.contains(&full_names[4]));
+        assert!(cached_artifacts.contains(delta_names.last().unwrap()));
+        assert!(!cached_artifacts.contains(&full_names[5]));
+        for intermediate_full in &full_names[1..4] {
+            assert!(
+                !cached_artifacts.contains(intermediate_full),
+                "intermediate rebuilt full should not remain cached: {intermediate_full}"
+            );
+        }
     }
 
     #[tokio::test]

--- a/crates/surge-core/src/update/manager/apply.rs
+++ b/crates/surge-core/src/update/manager/apply.rs
@@ -19,7 +19,7 @@ use crate::releases::delta::{
 };
 use crate::releases::manifest::{ReleaseEntry, decompress_release_index};
 use crate::releases::restore::{
-    RestoreOptions, find_release_for_version_rid, restore_full_archive_for_version_with_options,
+    RebuiltFullCachePolicy, RestoreOptions, find_release_for_version_rid, restore_full_archive_for_version_with_options,
 };
 use crate::supervisor::stub::find_latest_app_dir;
 
@@ -406,6 +406,7 @@ async fn restore_base_full_archive(manager: &UpdateManager, artifact_cache_dir: 
         RestoreOptions {
             cache_dir: Some(artifact_cache_dir),
             progress: None,
+            rebuilt_full_cache_policy: RebuiltFullCachePolicy::TargetOnly,
         },
     )
     .await


### PR DESCRIPTION
## Summary
- add a restore cache policy for rebuilt full archives, preserving the existing default behavior for restore callers
- use target-only rebuilt-full caching while update delta materialization restores the current base archive
- add a regression where a long delta-chain update fails before finalize and does not leave intermediate rebuilt full archives in the install artifact cache

Fixes #149

## Validation
- ./scripts/sync-surge-core-vendor.sh --check
- ./scripts/check-version-sync.sh
- cargo fmt --all -- --check
- cargo test -p surge-core test_download_and_apply_delta_failure_does_not_cache_intermediate_restored_fulls -- --nocapture
- cargo test -p surge-core restore_full_archive -- --nocapture
- cargo test -p surge-core test_download_and_apply_delta -- --nocapture
- RUSTFLAGS="-D warnings" cargo test --workspace
- cargo clippy --all-targets --all-features -- -D warnings
- cargo clippy --workspace --lib --bins --examples -- -D warnings -D clippy::unwrap_used -D clippy::expect_used
- cargo clippy --workspace --all-targets --all-features -- -D warnings -W clippy::pedantic
- dotnet format dotnet/Surge.slnx --verify-no-changes
- dotnet test dotnet/Surge.slnx --configuration Release