### PR TITLE
Fix update convergence and FFI diagnostics

### DIFF
--- a/crates/surge-cli/src/commands/install/mod.rs
+++ b/crates/surge-cli/src/commands/install/mod.rs
@@ -807,6 +807,10 @@ mod tests {
         assert!(script.contains("--surge-first-run \"$version\""));
         assert!(script.contains("kill_matching \"$install_root/$main_exe\""));
         assert!(script.contains("kill_matching \"$install_root/app-\""));
+        assert!(script.contains("stale_app_pids()"));
+        assert!(script.contains("terminate_stale_app_processes"));
+        assert!(script.contains("\"$install_root\"/app-*/\"$main_exe\""));
+        assert!(script.contains("\"$install_root\"/.surge-app-prev/\"$main_exe\""));
     }
 
     #[cfg(unix)]
@@ -1148,9 +1152,12 @@ mod tests {
         assert!(probe.contains("active_exe=\"$install_root/app/$main_exe\""));
         assert!(probe.contains("status_file=\"$install_root/.surge-update-status.json\""));
         assert!(probe.contains("status_converged=0"));
+        assert!(probe.contains("stale_retained_app_seen=0"));
         assert!(probe.contains("contains_target_first_run()"));
         assert!(probe.contains("contains_target_version_arg()"));
         assert!(probe.contains("process_exe_matches_active()"));
+        assert!(probe.contains("process_exe_path()"));
+        assert!(probe.contains("process_exe_is_retained_app()"));
         assert!(probe.contains("extract_watched_pid()"));
         assert!(probe.contains("*\" --surge-first-run $version \"*|*\" $version --surge-first-run \"*"));
         assert!(probe.contains("*'\"state\":\"converged\"'*"));
@@ -1163,6 +1170,7 @@ mod tests {
         assert!(probe.contains("app process for $active_exe was not found"));
         assert!(probe.contains("app process for $active_exe is running without target proof for $version"));
         assert!(probe.contains("stale app process for $active_exe is still running without target proof for $version"));
+        assert!(probe.contains("stale app process for $main_exe is still running from a superseded install directory"));
         assert!(probe.contains("supervisor process '$supervisor_id' is still waiting for the previous child"));
         assert!(probe.contains("supervisor process '$supervisor_id' is running with stale first-run proof"));
         assert!(probe.contains("supervisor process '$supervisor_id' was not found"));
@@ -2509,6 +2517,9 @@ apps:
         assert!(command.contains("export DISPLAY=':0'"));
         assert!(command.contains("kill_matching \"$active_exe\""));
         assert!(command.contains("kill_matching \"$install_root/app-\""));
+        assert!(command.contains("stale_app_pids()"));
+        assert!(command.contains("terminate_stale_app_processes"));
+        assert!(command.contains("\"$install_root\"/app-*/\"$main_exe\""));
         assert!(command.contains("kill_matching \"surge-supervisor.*--id $supervisor_id\""));
         assert!(command.contains("supervisor_bin=\"$active_app_dir/surge-supervisor\""));
         assert!(command.contains("nohup \"$supervisor_bin\" run --id \"$supervisor_id\""));

--- a/crates/surge-cli/src/commands/install/remote/activation.rs
+++ b/crates/surge-cli/src/commands/install/remote/activation.rs
@@ -155,9 +155,45 @@ kill_matching() {{\n\
   done\n\
 }}\n\
 \n\
+stale_app_pids() {{\n\
+  for exe_link in /proc/[0-9]*/exe; do\n\
+    [ -e \"$exe_link\" ] || continue\n\
+    pid=\"${{exe_link%/exe}}\"\n\
+    pid=\"${{pid##*/}}\"\n\
+    case \"$pid\" in \"$$\"|\"$PPID\") continue ;; esac\n\
+    actual=\"$(readlink \"$exe_link\" 2>/dev/null || true)\"\n\
+    case \"$actual\" in *\" (deleted)\") actual=\"${{actual% (deleted)}}\" ;; esac\n\
+    case \"$actual\" in \"$install_root\"/app-*/\"$main_exe\"|\"$install_root\"/.surge-app-prev/\"$main_exe\"|\"$install_root\"/\"$main_exe\") printf '%s ' \"$pid\" ;; esac\n\
+  done\n\
+}}\n\
+\n\
+terminate_stale_app_processes() {{\n\
+  pids=\"$(stale_app_pids)\"\n\
+  [ -n \"$pids\" ] || return 0\n\
+  kill $pids 2>/dev/null || true\n\
+  i=0\n\
+  while [ \"$i\" -lt 50 ]; do\n\
+    pids=\"$(stale_app_pids)\"\n\
+    [ -z \"$pids\" ] && return 0\n\
+    sleep 0.1\n\
+    i=$((i + 1))\n\
+  done\n\
+  kill -KILL $pids 2>/dev/null || true\n\
+  i=0\n\
+  while [ \"$i\" -lt 20 ]; do\n\
+    pids=\"$(stale_app_pids)\"\n\
+    [ -z \"$pids\" ] && return 0\n\
+    sleep 0.1\n\
+    i=$((i + 1))\n\
+  done\n\
+  echo \"stale app process for $main_exe is still running from a superseded install directory\" >&2\n\
+  return 1\n\
+}}\n\
+\n\
 kill_matching \"$install_root/$main_exe\"\n\
 kill_matching \"$install_root/app-\"\n\
 kill_matching \"$install_root/app/\"\n\
+terminate_stale_app_processes\n\
 rm -rf \"$next_app_dir\" \"$previous_app_dir\"\n\
 if [ ! -d \"$stage_dir/app\" ]; then\n\
   echo \"Remote install stage is missing app payload\" >&2\n\
@@ -168,6 +204,7 @@ if [ -d \"$active_app_dir\" ]; then\n\
   mv \"$active_app_dir\" \"$previous_app_dir\"\n\
 fi\n\
 mv \"$next_app_dir\" \"$active_app_dir\"\n\
+terminate_stale_app_processes\n\
 \n\
 if [ -n \"${{legacy_app_dir:-}}\" ] && [ -d \"$legacy_app_dir\" ] && [ ! -d \"$previous_app_dir\" ]; then\n\
   persistent_source_dir=\"$legacy_app_dir\"\n\

--- a/crates/surge-cli/src/commands/install/remote/runtime.rs
+++ b/crates/surge-cli/src/commands/install/remote/runtime.rs
@@ -111,9 +111,45 @@ kill_matching() {{\n\
     kill \"$pid\" 2>/dev/null || true\n\
   done\n\
 }}\n\
+\n\
+stale_app_pids() {{\n\
+  for exe_link in /proc/[0-9]*/exe; do\n\
+    [ -e \"$exe_link\" ] || continue\n\
+    pid=\"${{exe_link%/exe}}\"\n\
+    pid=\"${{pid##*/}}\"\n\
+    case \"$pid\" in \"$$\"|\"$PPID\") continue ;; esac\n\
+    actual=\"$(readlink \"$exe_link\" 2>/dev/null || true)\"\n\
+    case \"$actual\" in *\" (deleted)\") actual=\"${{actual% (deleted)}}\" ;; esac\n\
+    case \"$actual\" in \"$install_root\"/app-*/\"$main_exe\"|\"$install_root\"/.surge-app-prev/\"$main_exe\"|\"$install_root\"/\"$main_exe\") printf '%s ' \"$pid\" ;; esac\n\
+  done\n\
+}}\n\
+\n\
+terminate_stale_app_processes() {{\n\
+  pids=\"$(stale_app_pids)\"\n\
+  [ -n \"$pids\" ] || return 0\n\
+  kill $pids 2>/dev/null || true\n\
+  i=0\n\
+  while [ \"$i\" -lt 50 ]; do\n\
+    pids=\"$(stale_app_pids)\"\n\
+    [ -z \"$pids\" ] && return 0\n\
+    sleep 0.1\n\
+    i=$((i + 1))\n\
+  done\n\
+  kill -KILL $pids 2>/dev/null || true\n\
+  i=0\n\
+  while [ \"$i\" -lt 20 ]; do\n\
+    pids=\"$(stale_app_pids)\"\n\
+    [ -z \"$pids\" ] && return 0\n\
+    sleep 0.1\n\
+    i=$((i + 1))\n\
+  done\n\
+  echo \"stale app process for $main_exe is still running from a superseded install directory\" >&2\n\
+  return 1\n\
+}}\n\
 kill_matching \"$active_exe\"\n\
 kill_matching \"$install_root/app-\"\n\
 kill_matching \"$install_root/app/\"\n\
+terminate_stale_app_processes\n\
 cd \"$install_root\"\n\
 if [ -n \"$supervisor_id\" ]; then\n\
   kill_matching \"surge-supervisor.*--id $supervisor_id\"\n\
@@ -245,7 +281,7 @@ pub(crate) fn build_remote_process_verification_probe(
 ) -> String {
     format!(
         r#"install_root={}; main_exe={}; supervisor_id={}; version={};
-active_exe="$install_root/app/$main_exe"; status_file="$install_root/.surge-update-status.json"; app_seen=0; target_app_seen=0; stale_app_seen=0; supervisor_seen=0; stale_supervisor_seen=0; waiting_supervisor_seen=0; target_supervisor_seen=0; target_app_pids=""; watched_pids=""; status_converged=0;
+active_exe="$install_root/app/$main_exe"; status_file="$install_root/.surge-update-status.json"; app_seen=0; target_app_seen=0; stale_app_seen=0; stale_retained_app_seen=0; supervisor_seen=0; stale_supervisor_seen=0; waiting_supervisor_seen=0; target_supervisor_seen=0; target_app_pids=""; watched_pids=""; status_converged=0;
 if [ -r "$status_file" ]; then
   status_compact="$(tr -d '[:space:]' < "$status_file" 2>/dev/null || true)";
   status_has_state=0; status_has_installed=0; status_has_target=0;
@@ -257,13 +293,16 @@ fi;
 contains_target_first_run() {{ cmd_tokens=" $1 "; case "$cmd_tokens" in *" --surge-first-run $version "*|*" $version --surge-first-run "*) return 0 ;; esac; return 1; }}
 contains_target_version_arg() {{ cmd_tokens=" $1 "; case "$cmd_tokens" in *" $version "*) return 0 ;; esac; return 1; }}
 contains_target_proof() {{ contains_target_first_run "$1" || contains_target_version_arg "$1"; }}
-process_exe_matches_active() {{ actual="$(readlink "/proc/$1/exe" 2>/dev/null || true)"; [ "$actual" = "$active_exe" ]; }}
+process_exe_path() {{ actual="$(readlink "/proc/$1/exe" 2>/dev/null || true)"; case "$actual" in *" (deleted)") actual="${{actual% (deleted)}}" ;; esac; printf '%s\n' "$actual"; }}
+process_exe_matches_active() {{ actual="$(process_exe_path "$1")"; [ "$actual" = "$active_exe" ]; }}
+process_exe_is_retained_app() {{ actual="$(process_exe_path "$1")"; case "$actual" in "$install_root"/app-*/"$main_exe"|"$install_root"/.surge-app-prev/"$main_exe"|"$install_root"/"$main_exe") return 0 ;; esac; return 1; }}
 extract_watched_pid() {{ case "$1" in *" watch "*" --pid "*) rest="${{1#* --pid }}"; watched_pid="${{rest%% *}}"; case "$watched_pid" in ""|*[!0-9]*) return 1 ;; esac; printf '%s\n' "$watched_pid"; return 0 ;; esac; return 1; }}
 for cmdline in /proc/[0-9]*/cmdline; do
   [ -r "$cmdline" ] || continue;
   pid="${{cmdline%/cmdline}}"; pid="${{pid##*/}}";
   case "$pid" in "$$"|"$PPID") continue ;; esac;
   cmd="$(tr '\0' ' ' < "$cmdline" 2>/dev/null || true)";
+  if process_exe_is_retained_app "$pid"; then stale_retained_app_seen=1; fi;
   [ -n "$cmd" ] || continue;
   case "$cmd" in *"surge-supervisor"*) ;; *"$active_exe"*) app_seen=1; if contains_target_proof "$cmd" || {{ [ "$status_converged" -eq 1 ] && process_exe_matches_active "$pid"; }}; then target_app_seen=1; target_app_pids="${{target_app_pids}}${{pid}} "; else stale_app_seen=1; fi ;; esac;
   if [ -n "$supervisor_id" ]; then
@@ -282,6 +321,7 @@ if [ "$target_app_seen" -ne 1 ]; then
   exit 0;
 fi;
 if [ "$stale_app_seen" -eq 1 ]; then echo "stale app process for $active_exe is still running without target proof for $version"; exit 0; fi;
+if [ "$stale_retained_app_seen" -eq 1 ]; then echo "stale app process for $main_exe is still running from a superseded install directory"; exit 0; fi;
 if [ -n "$supervisor_id" ] && [ "$waiting_supervisor_seen" -eq 1 ]; then echo "supervisor process '$supervisor_id' is still waiting for the previous child"; exit 0; fi;
 if [ -n "$supervisor_id" ] && [ "$stale_supervisor_seen" -eq 1 ]; then echo "supervisor process '$supervisor_id' is running with stale first-run proof"; exit 0; fi;
 if [ -n "$supervisor_id" ] && [ "$supervisor_seen" -ne 1 ]; then echo "supervisor process '$supervisor_id' was not found"; exit 0; fi;

--- a/crates/surge-core/src/update/manager/finalize.rs
+++ b/crates/surge-core/src/update/manager/finalize.rs
@@ -271,6 +271,17 @@ where
     } else {
         SupervisorRestartOutcome::NotApplicable
     };
+    match lifecycle::terminate_superseded_app_processes(&manager.install_dir, &active_app_dir, &latest.main_exe) {
+        Ok(0) => {}
+        Ok(terminated) => {
+            debug!(
+                version = %latest.version,
+                terminated,
+                "Terminated stale app processes from superseded install directories"
+            );
+        }
+        Err(e) => return Err(e),
+    }
 
     emit_progress(
         progress_emitter.progress,

--- a/crates/surge-core/src/update/manager/lifecycle.rs
+++ b/crates/surge-core/src/update/manager/lifecycle.rs
@@ -1,4 +1,6 @@
 use std::path::Path;
+#[cfg(unix)]
+use std::path::PathBuf;
 use std::time::Duration;
 
 use tracing::{debug, info, warn};
@@ -244,6 +246,176 @@ pub(super) fn restart_supervisor_after_update_with_pid(
     }
 }
 
+pub(super) fn terminate_superseded_app_processes(
+    install_dir: &Path,
+    active_app_dir: &Path,
+    main_exe: &str,
+) -> Result<usize> {
+    terminate_superseded_app_processes_except(install_dir, active_app_dir, main_exe, current_pid())
+}
+
+#[cfg(unix)]
+fn terminate_superseded_app_processes_except(
+    install_dir: &Path,
+    active_app_dir: &Path,
+    main_exe: &str,
+    protected_pid: u32,
+) -> Result<usize> {
+    use nix::errno::Errno;
+    use nix::sys::signal::Signal;
+
+    let main_exe = main_exe.trim();
+    if main_exe.is_empty() {
+        return Ok(0);
+    }
+
+    let pids = superseded_app_process_pids(install_dir, active_app_dir, main_exe, protected_pid);
+    if pids.is_empty() {
+        return Ok(0);
+    }
+
+    for pid in &pids {
+        if let Err(e) = signal_pid(*pid, Signal::SIGTERM) {
+            warn!(pid, error = %e, "Failed to request stale app process termination");
+        }
+    }
+
+    if wait_until_superseded_processes_exit(
+        install_dir,
+        active_app_dir,
+        main_exe,
+        protected_pid,
+        Duration::from_secs(5),
+    ) {
+        info!(
+            count = pids.len(),
+            "Terminated stale app processes from superseded install directories"
+        );
+        return Ok(pids.len());
+    }
+
+    let remaining = superseded_app_process_pids(install_dir, active_app_dir, main_exe, protected_pid);
+    for pid in &remaining {
+        match signal_pid(*pid, Signal::SIGKILL) {
+            Ok(()) | Err(Errno::ESRCH) => {}
+            Err(e) => {
+                warn!(pid, error = %e, "Failed to force-kill stale app process");
+            }
+        }
+    }
+
+    if wait_until_superseded_processes_exit(
+        install_dir,
+        active_app_dir,
+        main_exe,
+        protected_pid,
+        Duration::from_secs(2),
+    ) {
+        info!(
+            count = pids.len(),
+            forced = remaining.len(),
+            "Force-killed stale app processes from superseded install directories"
+        );
+        return Ok(pids.len());
+    }
+
+    Err(SurgeError::Platform(format!(
+        "Timed out waiting for stale '{main_exe}' processes from superseded install directories to exit"
+    )))
+}
+
+#[cfg(unix)]
+fn signal_pid(pid: u32, signal: nix::sys::signal::Signal) -> std::result::Result<(), nix::errno::Errno> {
+    use nix::sys::signal::kill;
+    use nix::unistd::Pid;
+
+    let Ok(raw_pid) = i32::try_from(pid) else {
+        return Ok(());
+    };
+    kill(Pid::from_raw(raw_pid), signal)
+}
+
+#[cfg(not(unix))]
+fn terminate_superseded_app_processes_except(
+    _install_dir: &Path,
+    _active_app_dir: &Path,
+    _main_exe: &str,
+    _protected_pid: u32,
+) -> Result<usize> {
+    Ok(0)
+}
+
+#[cfg(unix)]
+fn wait_until_superseded_processes_exit(
+    install_dir: &Path,
+    active_app_dir: &Path,
+    main_exe: &str,
+    protected_pid: u32,
+    timeout: Duration,
+) -> bool {
+    let deadline = std::time::Instant::now() + timeout;
+    loop {
+        if superseded_app_process_pids(install_dir, active_app_dir, main_exe, protected_pid).is_empty() {
+            return true;
+        }
+        if std::time::Instant::now() >= deadline {
+            return false;
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+}
+
+#[cfg(unix)]
+fn superseded_app_process_pids(
+    install_dir: &Path,
+    active_app_dir: &Path,
+    main_exe: &str,
+    protected_pid: u32,
+) -> Vec<u32> {
+    let Ok(entries) = std::fs::read_dir("/proc") else {
+        return Vec::new();
+    };
+
+    entries
+        .filter_map(std::result::Result::ok)
+        .filter_map(|entry| entry.file_name().to_string_lossy().parse::<u32>().ok())
+        .filter(|pid| *pid != protected_pid)
+        .filter(|pid| {
+            std::fs::read_link(format!("/proc/{pid}/exe"))
+                .map(normalize_proc_exe_path)
+                .is_ok_and(|exe| is_superseded_app_exe(install_dir, active_app_dir, main_exe, &exe))
+        })
+        .collect()
+}
+
+#[cfg(unix)]
+fn normalize_proc_exe_path(path: PathBuf) -> PathBuf {
+    let normalized = {
+        let path_text = path.to_string_lossy();
+        path_text.strip_suffix(" (deleted)").map(PathBuf::from)
+    };
+    normalized.unwrap_or(path)
+}
+
+#[cfg(unix)]
+fn is_superseded_app_exe(install_dir: &Path, active_app_dir: &Path, main_exe: &str, exe: &Path) -> bool {
+    if exe == active_app_dir.join(main_exe) || exe.file_name().and_then(|name| name.to_str()) != Some(main_exe) {
+        return false;
+    }
+
+    let Ok(relative) = exe.strip_prefix(install_dir) else {
+        return false;
+    };
+
+    let mut components = relative.components();
+    let Some(std::path::Component::Normal(first)) = components.next() else {
+        return false;
+    };
+    let first = first.to_string_lossy();
+
+    first == ".surge-app-prev" || first.starts_with("app-") || components.next().is_none()
+}
+
 fn supervisor_watch_args(
     supervisor_id: &str,
     install_dir: &Path,
@@ -309,6 +481,59 @@ mod tests {
                 "--app-mode",
                 "service",
             ]
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn superseded_app_exe_detection_matches_retained_directories_only() {
+        let install_dir = Path::new("/opt/demo");
+        let active_app_dir = install_dir.join("app");
+
+        assert!(is_superseded_app_exe(
+            install_dir,
+            &active_app_dir,
+            "demo",
+            Path::new("/opt/demo/app-1.0.0/demo")
+        ));
+        assert!(is_superseded_app_exe(
+            install_dir,
+            &active_app_dir,
+            "demo",
+            Path::new("/opt/demo/.surge-app-prev/demo")
+        ));
+        assert!(is_superseded_app_exe(
+            install_dir,
+            &active_app_dir,
+            "demo",
+            Path::new("/opt/demo/demo")
+        ));
+        assert!(!is_superseded_app_exe(
+            install_dir,
+            &active_app_dir,
+            "demo",
+            Path::new("/opt/demo/app/demo")
+        ));
+        assert!(!is_superseded_app_exe(
+            install_dir,
+            &active_app_dir,
+            "demo",
+            Path::new("/opt/demo/app-1.0.0/other")
+        ));
+        assert!(!is_superseded_app_exe(
+            install_dir,
+            &active_app_dir,
+            "demo",
+            Path::new("/srv/other/app-1.0.0/demo")
+        ));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn proc_exe_deleted_suffix_is_ignored_for_matching() {
+        assert_eq!(
+            normalize_proc_exe_path(PathBuf::from("/opt/demo/app-1.0.0/demo (deleted)")),
+            PathBuf::from("/opt/demo/app-1.0.0/demo")
         );
     }
 }

--- a/crates/surge-ffi/src/context.rs
+++ b/crates/surge-ffi/src/context.rs
@@ -6,19 +6,28 @@ use surge_core::context::{Context, ResourceBudget, StorageProvider};
 
 use crate::SurgeResourceBudgetFfi;
 use crate::handles::SurgeContextHandle;
-use crate::shared::{SURGE_ERROR, SURGE_OK, catch_ffi, cstr_to_string, set_ctx_error};
+use crate::shared::{SURGE_ERROR, SURGE_OK, catch_ffi, cstr_to_string, ffi_trace, set_ctx_error};
 
 /// Create a new Surge context.
 ///
 /// Returns a new context handle, or null on allocation/runtime failure.
 #[unsafe(no_mangle)]
 pub extern "C" fn surge_context_create() -> *mut SurgeContextHandle {
+    ffi_trace("surge_context_create: enter");
     let result = std::panic::catch_unwind(|| {
+        ffi_trace("surge_context_create: creating tokio runtime");
         let runtime = match tokio::runtime::Runtime::new() {
-            Ok(rt) => Arc::new(rt),
-            Err(_) => return ptr::null_mut(),
+            Ok(rt) => {
+                ffi_trace("surge_context_create: tokio runtime ready");
+                Arc::new(rt)
+            }
+            Err(_) => {
+                ffi_trace("surge_context_create: tokio runtime failed");
+                return ptr::null_mut();
+            }
         };
 
+        ffi_trace("surge_context_create: creating context handle");
         let ctx = Arc::new(Context::new());
         let handle = Box::new(SurgeContextHandle {
             ctx,
@@ -27,10 +36,14 @@ pub extern "C" fn surge_context_create() -> *mut SurgeContextHandle {
             shared_last_error: Arc::new(std::sync::Mutex::new(None)),
         });
 
+        ffi_trace("surge_context_create: success");
         Box::into_raw(handle)
     });
 
-    result.unwrap_or(ptr::null_mut())
+    result.unwrap_or_else(|_| {
+        ffi_trace("surge_context_create: panic");
+        ptr::null_mut()
+    })
 }
 
 /// Destroy a Surge context and release all associated resources.

--- a/crates/surge-ffi/src/lib.rs
+++ b/crates/surge-ffi/src/lib.rs
@@ -44,8 +44,8 @@ pub use crate::releases::{
     surge_releases_count, surge_releases_destroy,
 };
 use crate::shared::{
-    SURGE_CANCELLED, SURGE_ERROR, SURGE_OK, SurgeEventCallback, catch_ffi, collect_argv, cstr_to_string, libc_malloc,
-    set_ctx_error,
+    SURGE_CANCELLED, SURGE_ERROR, SURGE_OK, SurgeEventCallback, catch_ffi, collect_argv, cstr_to_string, ffi_trace,
+    libc_malloc, set_ctx_error,
 };
 pub use crate::update::{
     surge_update_check, surge_update_download_and_apply, surge_update_manager_create, surge_update_manager_destroy,
@@ -213,8 +213,10 @@ pub unsafe extern "C" fn surge_supervisor_start(
     argc: c_int,
     argv: *const *const c_char,
 ) -> i32 {
+    ffi_trace("surge_supervisor_start: enter");
     catch_ffi(std::panic::AssertUnwindSafe(|| {
         if exe_path.is_null() || install_dir.is_null() || supervisor_id.is_null() {
+            ffi_trace("surge_supervisor_start: null input");
             return SURGE_ERROR;
         }
 
@@ -228,6 +230,7 @@ pub unsafe extern "C" fn surge_supervisor_start(
             )
         };
         if exe_s.trim().is_empty() || install_dir_s.trim().is_empty() || sup_id.trim().is_empty() {
+            ffi_trace("surge_supervisor_start: missing required input");
             return SURGE_ERROR;
         }
 
@@ -242,11 +245,14 @@ pub unsafe extern "C" fn surge_supervisor_start(
                 "supervisor_start failed: supervisor binary not found at {}",
                 supervisor_path.display()
             );
+            ffi_trace("surge_supervisor_start: supervisor binary missing");
             return SURGE_ERROR;
         }
 
+        ffi_trace("surge_supervisor_start: writing restart args");
         if let Err(e) = write_restart_args(install_dir, &sup_id, &args_owned) {
             tracing::error!("supervisor_start failed: {e}");
+            ffi_trace("surge_supervisor_start: restart args failed");
             return SURGE_ERROR;
         }
 
@@ -267,6 +273,7 @@ pub unsafe extern "C" fn surge_supervisor_start(
             args.extend(args_owned.iter().map(String::as_str));
         }
 
+        ffi_trace("surge_supervisor_start: spawning supervisor");
         match surge_core::platform::process::spawn_detached(
             &supervisor_path,
             &args,
@@ -274,11 +281,13 @@ pub unsafe extern "C" fn surge_supervisor_start(
             &BTreeMap::new(),
         ) {
             Ok(_) => {
+                ffi_trace("surge_supervisor_start: spawned supervisor");
                 mark_self_supervised_runtime_converged(install_dir, exe.parent().unwrap_or(install_dir));
                 SURGE_OK
             }
             Err(e) => {
                 tracing::error!("supervisor_start failed: {e}");
+                ffi_trace("surge_supervisor_start: spawn failed");
                 SURGE_ERROR
             }
         }
@@ -345,29 +354,36 @@ fn mark_self_supervised_runtime_converged(install_dir: &Path, active_app_dir: &P
 /// Stop a supervised process watcher.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn surge_supervisor_stop(install_dir: *const c_char, supervisor_id: *const c_char) -> i32 {
+    ffi_trace("surge_supervisor_stop: enter");
     catch_ffi(std::panic::AssertUnwindSafe(|| {
         if install_dir.is_null() || supervisor_id.is_null() {
+            ffi_trace("surge_supervisor_stop: null input");
             return SURGE_ERROR;
         }
 
         // SAFETY: pointer inputs satisfy this API's FFI contract.
         let (install_dir_s, sup_id) = unsafe { (cstr_to_string(install_dir), cstr_to_string(supervisor_id)) };
         if install_dir_s.trim().is_empty() || sup_id.trim().is_empty() {
+            ffi_trace("surge_supervisor_stop: missing required input");
             return SURGE_ERROR;
         }
 
         let install_dir = Path::new(&install_dir_s);
         let pid_file = supervisor_pid_file(install_dir, &sup_id);
         if !pid_file.is_file() {
+            ffi_trace("surge_supervisor_stop: pid file missing");
             return SURGE_ERROR;
         }
 
+        ffi_trace("surge_supervisor_stop: writing stop file");
         let stop_file = supervisor_stop_file(install_dir, &sup_id);
         if let Err(e) = std::fs::write(&stop_file, b"surge-stop") {
             tracing::error!("supervisor_stop failed: {e}");
+            ffi_trace("surge_supervisor_stop: stop file failed");
             return SURGE_ERROR;
         }
 
+        ffi_trace("surge_supervisor_stop: waiting for supervisor exit");
         let deadline = std::time::Instant::now() + std::time::Duration::from_secs(20);
         while pid_file.exists() {
             if std::time::Instant::now() >= deadline {
@@ -375,11 +391,13 @@ pub unsafe extern "C" fn surge_supervisor_stop(install_dir: *const c_char, super
                     "supervisor_stop failed: timed out waiting for supervisor '{}' to exit",
                     sup_id
                 );
+                ffi_trace("surge_supervisor_stop: timed out");
                 return SURGE_ERROR;
             }
             std::thread::sleep(std::time::Duration::from_millis(100));
         }
         let _ = std::fs::remove_file(&stop_file);
+        ffi_trace("surge_supervisor_stop: success");
         SURGE_OK
     }))
 }

--- a/crates/surge-ffi/src/shared.rs
+++ b/crates/surge-ffi/src/shared.rs
@@ -28,6 +28,8 @@ pub(crate) const SURGE_PHASE_FINALIZE: i32 = 5;
 pub(crate) type SurgeProgressCallback = Option<extern "C" fn(*const SurgeProgressFfi, *mut c_void)>;
 pub(crate) type SurgeEventCallback = Option<extern "C" fn(*const c_char, *mut c_void)>;
 
+const SURGE_FFI_TRACE_ENV: &str = "SURGE_FFI_TRACE";
+
 /// # Safety
 ///
 /// Only safe when the pointer is valid for the duration of the async call
@@ -90,6 +92,17 @@ pub(crate) fn catch_ffi<F: FnOnce() -> i32 + std::panic::UnwindSafe>(f: F) -> i3
         Ok(code) => code,
         Err(_) => SURGE_ERROR,
     }
+}
+
+pub(crate) fn ffi_trace(phase: &str) {
+    tracing::debug!(phase, "surge ffi phase");
+    if ffi_trace_enabled(std::env::var(SURGE_FFI_TRACE_ENV).ok().as_deref()) {
+        eprintln!("surge-ffi: {phase}");
+    }
+}
+
+fn ffi_trace_enabled(value: Option<&str>) -> bool {
+    value.is_some_and(|value| matches!(value.trim().to_ascii_lowercase().as_str(), "1" | "true" | "yes" | "on"))
 }
 
 pub(crate) fn set_ctx_error(handle: &SurgeContextHandle, e: &SurgeError) -> i32 {
@@ -193,7 +206,7 @@ mod tests {
     use std::ffi::CString;
     use std::ptr;
 
-    use super::{collect_argv, try_index, try_len};
+    use super::{collect_argv, ffi_trace_enabled, try_index, try_len};
     use std::ffi::c_int;
 
     #[test]
@@ -225,5 +238,16 @@ mod tests {
         // SAFETY: `argv` points to valid C strings for the duration of the call.
         let args = unsafe { collect_argv(argv.len() as c_int, argv.as_ptr()) };
         assert_eq!(args, vec!["--surge-first-run", "--surge-updated=1.2.3"]);
+    }
+
+    #[test]
+    fn ffi_trace_flag_accepts_common_truthy_values() {
+        assert!(ffi_trace_enabled(Some("1")));
+        assert!(ffi_trace_enabled(Some("true")));
+        assert!(ffi_trace_enabled(Some("YES")));
+        assert!(ffi_trace_enabled(Some(" on ")));
+        assert!(!ffi_trace_enabled(Some("0")));
+        assert!(!ffi_trace_enabled(Some("false")));
+        assert!(!ffi_trace_enabled(None));
     }
 }

--- a/crates/surge-ffi/src/update.rs
+++ b/crates/surge-ffi/src/update.rs
@@ -1,14 +1,19 @@
 use std::ffi::{c_char, c_int, c_void};
 use std::ptr;
+use std::time::Duration;
 
 use surge_core::config::manifest::{InstallArtifactCachePolicy, InstallArtifactCacheRetention};
+use surge_core::error::SurgeError;
 use surge_core::update::manager::{ProgressInfo, UpdateManager};
 
 use crate::handles::{ReleaseEntryFfi, SurgeReleasesInfoHandle, SurgeUpdateManagerHandle};
 use crate::shared::{
     ProgressBridge, SURGE_CANCELLED, SURGE_ERROR, SURGE_NOT_FOUND, SURGE_OK, SurgeProgressCallback, catch_ffi,
-    clear_shared_error, cstr_to_string, set_ctx_error, set_shared_error,
+    clear_shared_error, cstr_to_string, ffi_trace, set_ctx_error, set_shared_error,
 };
+
+const DEFAULT_UPDATE_CHECK_TIMEOUT: Duration = Duration::from_mins(1);
+const UPDATE_CHECK_TIMEOUT_ENV: &str = "SURGE_UPDATE_CHECK_TIMEOUT_SECONDS";
 /// Create an update manager bound to a specific application.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn surge_update_manager_create(
@@ -18,7 +23,9 @@ pub unsafe extern "C" fn surge_update_manager_create(
     channel: *const c_char,
     install_dir: *const c_char,
 ) -> *mut SurgeUpdateManagerHandle {
+    ffi_trace("surge_update_manager_create: enter");
     if ctx.is_null() {
+        ffi_trace("surge_update_manager_create: null context");
         return ptr::null_mut();
     }
 
@@ -43,9 +50,11 @@ pub unsafe extern "C" fn surge_update_manager_create(
             let e =
                 surge_core::error::SurgeError::Config("app_id, version, channel, and install_dir are required".into());
             set_ctx_error(handle, &e);
+            ffi_trace("surge_update_manager_create: missing required input");
             return ptr::null_mut();
         }
 
+        ffi_trace("surge_update_manager_create: creating handle");
         let mgr = Box::new(SurgeUpdateManagerHandle {
             ctx: handle.ctx.clone(),
             runtime: handle.runtime.clone(),
@@ -58,10 +67,14 @@ pub unsafe extern "C" fn surge_update_manager_create(
             install_dir: install_s,
         });
 
+        ffi_trace("surge_update_manager_create: success");
         Box::into_raw(mgr)
     }));
 
-    result.unwrap_or(ptr::null_mut())
+    result.unwrap_or_else(|_| {
+        ffi_trace("surge_update_manager_create: panic");
+        ptr::null_mut()
+    })
 }
 
 /// Destroy an update manager.
@@ -206,7 +219,9 @@ pub unsafe extern "C" fn surge_update_check(
     mgr: *mut SurgeUpdateManagerHandle,
     info: *mut *mut SurgeReleasesInfoHandle,
 ) -> i32 {
+    ffi_trace("surge_update_check: enter");
     if mgr.is_null() || info.is_null() {
+        ffi_trace("surge_update_check: null input");
         return SURGE_ERROR;
     }
 
@@ -220,9 +235,11 @@ pub unsafe extern "C" fn surge_update_check(
         clear_shared_error(&mgr_ref.ctx, &mgr_ref.last_error);
 
         if mgr_ref.ctx.is_cancelled() {
+            ffi_trace("surge_update_check: cancelled before check");
             return SURGE_CANCELLED;
         }
 
+        ffi_trace("surge_update_check: creating update manager");
         let mut update_mgr = match UpdateManager::new(
             mgr_ref.ctx.clone(),
             &mgr_ref.app_id,
@@ -238,10 +255,15 @@ pub unsafe extern "C" fn surge_update_check(
             return set_shared_error(&mgr_ref.ctx, &mgr_ref.last_error, &e);
         }
 
-        let result = mgr_ref.runtime.block_on(update_mgr.check_for_updates());
+        let timeout = update_check_timeout();
+        ffi_trace("surge_update_check: checking release index");
+        let result = mgr_ref
+            .runtime
+            .block_on(async { tokio::time::timeout(timeout, update_mgr.check_for_updates()).await });
 
         match result {
-            Ok(Some(update_info)) => {
+            Ok(Ok(Some(update_info))) => {
+                ffi_trace("surge_update_check: updates available");
                 let ffi_releases: Vec<ReleaseEntryFfi> = update_info
                     .available_releases
                     .iter()
@@ -264,7 +286,8 @@ pub unsafe extern "C" fn surge_update_check(
                 unsafe { *info = Box::into_raw(releases_handle) };
                 SURGE_OK
             }
-            Ok(None) => {
+            Ok(Ok(None)) => {
+                ffi_trace("surge_update_check: no updates available");
                 let releases_handle = Box::new(SurgeReleasesInfoHandle {
                     releases: Vec::new(),
                     cached_strings: Vec::new(),
@@ -274,9 +297,28 @@ pub unsafe extern "C" fn surge_update_check(
                 unsafe { *info = Box::into_raw(releases_handle) };
                 SURGE_NOT_FOUND
             }
-            Err(e) => set_shared_error(&mgr_ref.ctx, &mgr_ref.last_error, &e),
+            Ok(Err(e)) => {
+                ffi_trace("surge_update_check: failed");
+                set_shared_error(&mgr_ref.ctx, &mgr_ref.last_error, &e)
+            }
+            Err(_) => {
+                ffi_trace("surge_update_check: timed out");
+                let e = SurgeError::Update(format!("update check timed out after {} seconds", timeout.as_secs()));
+                set_shared_error(&mgr_ref.ctx, &mgr_ref.last_error, &e)
+            }
         }
     }))
+}
+
+fn update_check_timeout() -> Duration {
+    parse_update_check_timeout(std::env::var(UPDATE_CHECK_TIMEOUT_ENV).ok().as_deref())
+}
+
+fn parse_update_check_timeout(value: Option<&str>) -> Duration {
+    value
+        .and_then(|value| value.trim().parse::<u64>().ok())
+        .filter(|seconds| *seconds > 0)
+        .map_or(DEFAULT_UPDATE_CHECK_TIMEOUT, Duration::from_secs)
 }
 
 /// Download and apply an update described by `info`.
@@ -424,13 +466,15 @@ pub unsafe extern "C" fn surge_update_status_read_json(install_dir: *const c_cha
 #[cfg(test)]
 mod tests {
     use std::ffi::{CStr, CString};
+    use std::time::Duration;
 
     use crate::{surge_context_create, surge_context_destroy, surge_context_last_error};
 
     use super::{
-        SURGE_OK, SurgeReleasesInfoHandle, surge_update_check, surge_update_manager_create,
-        surge_update_manager_destroy, surge_update_manager_set_artifact_retention_policy,
-        surge_update_manager_set_channel, surge_update_manager_set_release_retention_limit,
+        DEFAULT_UPDATE_CHECK_TIMEOUT, SURGE_OK, SurgeReleasesInfoHandle, parse_update_check_timeout,
+        surge_update_check, surge_update_manager_create, surge_update_manager_destroy,
+        surge_update_manager_set_artifact_retention_policy, surge_update_manager_set_channel,
+        surge_update_manager_set_release_retention_limit,
     };
 
     #[test]
@@ -629,5 +673,18 @@ mod tests {
             surge_update_manager_destroy(mgr);
             surge_context_destroy(ctx);
         }
+    }
+
+    #[test]
+    fn update_check_timeout_uses_positive_seconds_or_default() {
+        assert_eq!(parse_update_check_timeout(Some("5")), Duration::from_secs(5));
+        assert_eq!(parse_update_check_timeout(Some(" 12 ")), Duration::from_secs(12));
+        assert_eq!(parse_update_check_timeout(Some("0")), DEFAULT_UPDATE_CHECK_TIMEOUT);
+        assert_eq!(parse_update_check_timeout(Some("-1")), DEFAULT_UPDATE_CHECK_TIMEOUT);
+        assert_eq!(
+            parse_update_check_timeout(Some("not-a-number")),
+            DEFAULT_UPDATE_CHECK_TIMEOUT
+        );
+        assert_eq!(parse_update_check_timeout(None), DEFAULT_UPDATE_CHECK_TIMEOUT);
     }
 }


### PR DESCRIPTION
## Summary
- terminate stale app processes from retained install directories during update convergence and remote install/restart flows
- make remote process verification report stale retained app processes explicitly
- add opt-in FFI phase breadcrumbs and bound update checks with SURGE_UPDATE_CHECK_TIMEOUT_SECONDS

Closes #159.
Closes #160.

## Validation
- ./scripts/sync-surge-core-vendor.sh --check
- ./scripts/check-version-sync.sh
- cargo fmt --all -- --check
- RUSTFLAGS="-D warnings" cargo test --workspace
- cargo clippy --all-targets --all-features -- -D warnings
- cargo clippy --workspace --lib --bins --examples -- -D warnings -D clippy::unwrap_used -D clippy::expect_used
- cargo clippy --workspace --all-targets --all-features -- -D warnings -W clippy::pedantic
- dotnet format dotnet/Surge.slnx --verify-no-changes
- dotnet test dotnet/Surge.slnx --configuration Release