### PR TITLE
Fix Unix executable modes in packages

### DIFF
--- a/crates/surge-core/src/archive/packer.rs
+++ b/crates/surge-core/src/archive/packer.rs
@@ -1,5 +1,6 @@
 //! Create tar + zstd archives.
 
+use std::collections::BTreeSet;
 use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
@@ -47,6 +48,25 @@ impl ArchivePacker {
         prefix: &str,
         progress: Option<&PackProgress<'_>>,
     ) -> Result<()> {
+        self.add_directory_with_progress_and_executables(source_dir, prefix, progress, None)
+    }
+
+    pub fn add_directory_with_executable_overrides(
+        &mut self,
+        source_dir: &Path,
+        prefix: &str,
+        executable_paths: &BTreeSet<String>,
+    ) -> Result<()> {
+        self.add_directory_with_progress_and_executables(source_dir, prefix, None, Some(executable_paths))
+    }
+
+    fn add_directory_with_progress_and_executables(
+        &mut self,
+        source_dir: &Path,
+        prefix: &str,
+        progress: Option<&PackProgress<'_>>,
+        executable_paths: Option<&BTreeSet<String>>,
+    ) -> Result<()> {
         let archive_prefix = Path::new(prefix);
         let totals = if progress.is_some() {
             count_directory_entries(source_dir, archive_prefix)?
@@ -59,7 +79,7 @@ impl ArchivePacker {
             items_done: 0,
             bytes_done: 0,
         };
-        self.add_directory_recursive(source_dir, archive_prefix, &mut progress_state)
+        self.add_directory_recursive(source_dir, archive_prefix, &mut progress_state, executable_paths)
     }
 
     pub fn add_buffer(&mut self, archive_path: &str, data: &[u8], mode: u32) -> Result<()> {
@@ -100,6 +120,7 @@ impl ArchivePacker {
         source_dir: &Path,
         archive_prefix: &Path,
         progress: &mut PackProgressState<'_>,
+        executable_paths: Option<&BTreeSet<String>>,
     ) -> Result<()> {
         if !archive_prefix.as_os_str().is_empty() {
             self.add_directory_entry(archive_prefix, source_dir)?;
@@ -120,12 +141,12 @@ impl ArchivePacker {
             let metadata = fs::symlink_metadata(&source_path)?;
 
             if metadata.is_dir() {
-                self.add_directory_recursive(&source_path, &archive_path, progress)?;
+                self.add_directory_recursive(&source_path, &archive_path, progress, executable_paths)?;
                 continue;
             }
 
             if metadata.is_file() {
-                self.add_file_entry(&source_path, &archive_path, &metadata)?;
+                self.add_file_entry(&source_path, &archive_path, &metadata, executable_paths)?;
                 progress.advance(metadata.len());
                 continue;
             }
@@ -159,11 +180,21 @@ impl ArchivePacker {
         Ok(())
     }
 
-    fn add_file_entry(&mut self, source_path: &Path, archive_path: &Path, metadata: &fs::Metadata) -> Result<()> {
+    fn add_file_entry(
+        &mut self,
+        source_path: &Path,
+        archive_path: &Path,
+        metadata: &fs::Metadata,
+        executable_paths: Option<&BTreeSet<String>>,
+    ) -> Result<()> {
         let mut header = tar::Header::new_gnu();
         header.set_entry_type(tar::EntryType::Regular);
         header.set_size(metadata.len());
-        header.set_mode(normalized_mode(metadata, false));
+        let mut mode = normalized_mode(metadata, false);
+        if executable_paths.is_some_and(|paths| paths.contains(&archive_path_to_string(archive_path))) {
+            mode |= 0o111;
+        }
+        header.set_mode(mode);
         set_normalized_header_metadata(&mut header);
         header.set_cksum();
 

--- a/crates/surge-core/src/install/activation.rs
+++ b/crates/surge-core/src/install/activation.rs
@@ -151,6 +151,8 @@ pub fn install_package_locally_at_root_with_progress(
             copy_persistent_assets(previous, &active_app_dir, profile.persistent_assets)?;
         }
 
+        ensure_main_executable_mode(profile, &active_app_dir)?;
+
         if !profile.shortcuts.is_empty() {
             emit_install_progress(
                 progress,
@@ -212,6 +214,26 @@ pub fn install_package_locally_at_root_with_progress(
         warn!(error = %err, "Failed to prune installed app version snapshots after install");
     }
 
+    Ok(())
+}
+
+#[cfg(unix)]
+fn ensure_main_executable_mode(profile: &InstallProfile<'_>, active_app_dir: &Path) -> Result<()> {
+    let main_exe = profile.main_exe.trim();
+    if main_exe.is_empty() {
+        return Ok(());
+    }
+
+    let exe_path = active_app_dir.join(main_exe);
+    if exe_path.is_file() {
+        crate::platform::fs::make_executable(&exe_path)?;
+    }
+
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn ensure_main_executable_mode(_profile: &InstallProfile<'_>, _active_app_dir: &Path) -> Result<()> {
     Ok(())
 }
 

--- a/crates/surge-core/src/install/mod.rs
+++ b/crates/surge-core/src/install/mod.rs
@@ -264,6 +264,48 @@ mod tests {
     }
 
     #[test]
+    #[cfg(unix)]
+    fn install_package_locally_repairs_main_executable_mode() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = tempfile::tempdir().expect("temp dir should exist");
+        let install_root = tmp.path().join("install-root");
+        let package_path = tmp.path().join("package.tar.zst");
+        let environment = BTreeMap::new();
+        let shortcuts: [ShortcutLocation; 0] = [];
+        let persistent_assets: [String; 0] = [];
+
+        let mut packer = ArchivePacker::new(3).expect("archive packer should be created");
+        packer
+            .add_buffer("demo", b"#!/bin/sh\necho demo\n", 0o644)
+            .expect("main executable should be added");
+        packer
+            .finalize_to_file(&package_path)
+            .expect("archive should be written");
+
+        let profile = InstallProfile::new(
+            "demo-app",
+            "Demo App",
+            "demo",
+            "demo-install",
+            "",
+            "",
+            &shortcuts,
+            &persistent_assets,
+            &environment,
+        );
+
+        install_package_locally_at_root(&profile, &package_path, &install_root).expect("install should succeed");
+
+        let mode = std::fs::metadata(install_root.join("app").join("demo"))
+            .expect("installed main executable should exist")
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(mode & 0o111, 0o111);
+    }
+
+    #[test]
     fn install_package_locally_restores_runtime_manifests_when_post_copy_work_fails() {
         let tmp = tempfile::tempdir().expect("temp dir should exist");
         let install_root = tmp.path().join("install-root");

--- a/crates/surge-core/src/pack/builder.rs
+++ b/crates/surge-core/src/pack/builder.rs
@@ -1227,6 +1227,85 @@ apps:
     }
 
     #[tokio::test]
+    #[cfg(unix)]
+    async fn test_build_full_package_repairs_main_executable_mode_in_archive() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = tempfile::tempdir().expect("tempdir should be created");
+        let store_root = tmp.path().join("store");
+        let artifacts_root = tmp.path().join("artifacts");
+        std::fs::create_dir_all(&store_root).expect("store dir should exist");
+        std::fs::create_dir_all(&artifacts_root).expect("artifacts dir should exist");
+
+        let app_id = "demo";
+        let rid = current_rid();
+        let manifest_path = tmp.path().join("surge.yml");
+        let manifest_yaml = format!(
+            r"schema: 1
+storage:
+  provider: filesystem
+  bucket: {bucket}
+apps:
+  - id: {app_id}
+    main: demoapp
+    target:
+      rid: {rid}
+",
+            bucket = store_root.display()
+        );
+        std::fs::write(&manifest_path, manifest_yaml).expect("manifest should be written");
+
+        let app_path = artifacts_root.join("demoapp");
+        std::fs::write(&app_path, b"#!/bin/sh\necho demo\n").expect("main executable should be written");
+        std::fs::set_permissions(&app_path, std::fs::Permissions::from_mode(0o644))
+            .expect("main executable mode should be set");
+        std::fs::write(artifacts_root.join("payload.txt"), b"payload").expect("payload should be written");
+
+        let ctx = Arc::new(Context::new());
+        ctx.set_storage(
+            StorageProvider::Filesystem,
+            store_root.to_str().expect("store root utf8"),
+            "",
+            "",
+            "",
+            "",
+        );
+
+        let mut builder = PackBuilder::new(
+            ctx,
+            manifest_path.to_str().expect("manifest path utf8"),
+            app_id,
+            &rid,
+            "1.0.0",
+            artifacts_root.to_str().expect("artifacts path utf8"),
+        )
+        .expect("builder should be created");
+
+        builder.build(None).await.expect("build should succeed");
+        let full = builder
+            .artifacts()
+            .iter()
+            .find(|artifact| !artifact.is_delta)
+            .expect("full artifact should be produced");
+
+        let extracted = tmp.path().join("extracted");
+        extract_to(full.bytes(), &extracted, None).expect("full archive should extract");
+        let archived_mode = std::fs::metadata(extracted.join("demoapp"))
+            .expect("archived main executable should exist")
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(archived_mode & 0o111, 0o111);
+
+        let source_mode = std::fs::metadata(&app_path)
+            .expect("source main executable should still exist")
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(source_mode, 0o644);
+    }
+
+    #[tokio::test]
     async fn test_checkpoint_threshold_keeps_direct_delta() {
         let tmp = tempfile::tempdir().expect("tempdir should be created");
         let store_root = tmp.path().join("store");

--- a/crates/surge-core/src/pack/builder/full.rs
+++ b/crates/surge-core/src/pack/builder/full.rs
@@ -1,3 +1,6 @@
+use std::collections::BTreeSet;
+use std::path::Path;
+
 use crate::archive::packer::ArchivePacker;
 use crate::crypto::sha256::sha256_hex;
 use crate::error::{Result, SurgeError};
@@ -40,7 +43,12 @@ impl PackBuilder {
 
         let compression_level = budget.zstd_compression_level;
         let mut packer = ArchivePacker::with_threads(compression_level, n_workers)?;
-        packer.add_directory(pack_root, "")?;
+        let executable_paths = self.executable_archive_paths();
+        if executable_paths.is_empty() {
+            packer.add_directory(pack_root, "")?;
+        } else {
+            packer.add_directory_with_executable_overrides(pack_root, "", &executable_paths)?;
+        }
 
         let archive_bytes = packer.finalize()?;
         let sha256 = sha256_hex(&archive_bytes);
@@ -59,4 +67,34 @@ impl PackBuilder {
             bytes: archive_bytes,
         })
     }
+
+    fn executable_archive_paths(&self) -> BTreeSet<String> {
+        if !rid_uses_unix_executable_bits(&self.rid) {
+            return BTreeSet::new();
+        }
+
+        let mut paths = BTreeSet::new();
+        let main_exe = self.main_exe.trim();
+        if !main_exe.is_empty() && self.artifacts_dir.join(main_exe).is_file() {
+            paths.insert(archive_path_string(main_exe));
+        }
+
+        if !self.supervisor_id.trim().is_empty() {
+            let supervisor_name = supervisor_binary_name_for_rid(&self.rid);
+            if self.artifacts_dir.join(supervisor_name).is_file() {
+                paths.insert(archive_path_string(supervisor_name));
+            }
+        }
+
+        paths
+    }
+}
+
+fn rid_uses_unix_executable_bits(rid: &str) -> bool {
+    let rid = rid.to_ascii_lowercase();
+    rid.starts_with("linux-") || rid.starts_with("osx-") || rid.starts_with("macos-")
+}
+
+fn archive_path_string(path: &str) -> String {
+    Path::new(path).to_string_lossy().replace('\\', "/")
 }


### PR DESCRIPTION
## Summary
- force Unix executable bits for configured main executables when building full packages
- repair extracted main executable permissions during local install activation
- add regressions for GitHub artifact-style permission loss and install repair

## Root cause
GitHub artifact download can restore apphost files as regular `0644` files. Surge then packaged that mode into the full archive, so fresh installs extracted a non-executable apphost and auto-start failed with `Permission denied`.

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p surge-core`