### PR TITLE
Extend remote process verification window

### DIFF
--- a/crates/surge-cli/src/commands/install/mod.rs
+++ b/crates/surge-cli/src/commands/install/mod.rs
@@ -496,8 +496,9 @@ mod tests {
     };
     use super::releases::{ArchiveAcquisition, download_release_archive, select_release};
     use super::remote::{
-        RemoteConvergenceAction, RemoteHostInstallerAvailability, RemoteInstallState, RemoteInstallerMode,
-        RemoteLaunchEnvironment, RemotePublishedInstallerPlan, RemoteTailscaleCachedState, RemoteTailscaleOperation,
+        REMOTE_PROCESS_VERIFICATION_POLL_INTERVAL, REMOTE_PROCESS_VERIFICATION_TIMEOUT, RemoteConvergenceAction,
+        RemoteHostInstallerAvailability, RemoteInstallState, RemoteInstallerMode, RemoteLaunchEnvironment,
+        RemotePublishedInstallerPlan, RemoteTailscaleCachedState, RemoteTailscaleOperation,
         RemoteTailscaleTransferInputs, RemoteTailscaleTransferStrategy, build_remote_app_copy_activation_script,
         build_remote_installer_manifest, build_remote_paths_exist_probe, build_remote_process_verification_probe,
         build_remote_runtime_start_command, build_remote_stage_cleanup_command,
@@ -1175,6 +1176,12 @@ mod tests {
         assert!(probe.contains("supervisor process '$supervisor_id' is running with stale first-run proof"));
         assert!(probe.contains("supervisor process '$supervisor_id' was not found"));
         assert!(probe.contains("supervisor process '$supervisor_id' is not watching target app process for $version"));
+    }
+
+    #[test]
+    fn remote_process_verification_waits_for_delayed_supervisor_proof() {
+        assert!(REMOTE_PROCESS_VERIFICATION_TIMEOUT >= std::time::Duration::from_secs(30));
+        assert!(REMOTE_PROCESS_VERIFICATION_POLL_INTERVAL <= std::time::Duration::from_millis(250));
     }
 
     #[cfg(unix)]

--- a/crates/surge-cli/src/commands/install/remote/mod.rs
+++ b/crates/surge-cli/src/commands/install/remote/mod.rs
@@ -53,7 +53,10 @@ pub(crate) use self::activation::build_remote_app_copy_activation_script;
 #[cfg(test)]
 pub(crate) use self::published_installer::{build_remote_installer_manifest, published_installer_public_url};
 #[cfg(test)]
-pub(crate) use self::runtime::{build_remote_process_verification_probe, build_remote_runtime_start_command};
+pub(crate) use self::runtime::{
+    REMOTE_PROCESS_VERIFICATION_POLL_INTERVAL, REMOTE_PROCESS_VERIFICATION_TIMEOUT,
+    build_remote_process_verification_probe, build_remote_runtime_start_command,
+};
 #[cfg(test)]
 pub(crate) use self::staging::{
     build_remote_paths_exist_probe, build_remote_stage_cleanup_command, build_remote_staged_installer_setup_command,

--- a/crates/surge-cli/src/commands/install/remote/runtime.rs
+++ b/crates/surge-cli/src/commands/install/remote/runtime.rs
@@ -6,6 +6,9 @@ use super::{
     run_tailscale_streaming, shell_single_quote, staging, types,
 };
 
+pub(crate) const REMOTE_PROCESS_VERIFICATION_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+pub(crate) const REMOTE_PROCESS_VERIFICATION_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(250);
+
 pub(crate) async fn converge_current_remote_runtime(
     ssh_target: &str,
     file_target: &str,
@@ -249,7 +252,7 @@ async fn verify_remote_started_process(
         build_remote_process_verification_probe(&install_root, main_exe, &release.supervisor_id, &release.version);
     let command = format!("sh -c {}", shell_single_quote(&probe));
     let mut last_result = String::new();
-    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+    let deadline = std::time::Instant::now() + REMOTE_PROCESS_VERIFICATION_TIMEOUT;
     loop {
         let output = execution::run_tailscale_capture(&["ssh", ssh_target, command.as_str()]).await?;
         let result = output.trim();
@@ -265,11 +268,12 @@ async fn verify_remote_started_process(
         if std::time::Instant::now() >= deadline {
             break;
         }
-        tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+        tokio::time::sleep(REMOTE_PROCESS_VERIFICATION_POLL_INTERVAL).await;
     }
 
     Err(SurgeError::Update(format!(
-        "Remote process verification failed on '{file_target}': {last_result}"
+        "Remote process verification did not converge within {}s on '{file_target}': {last_result}",
+        REMOTE_PROCESS_VERIFICATION_TIMEOUT.as_secs()
     )))
 }
 


### PR DESCRIPTION
## Summary

- extend remote process verification from 10 seconds to 30 seconds
- keep the existing 250 ms polling cadence while allowing delayed supervisor proof to appear
- make the final timeout error report the convergence window

## Root cause

Remote install verification could fail if target app proof appeared before supervisor process proof. The install could still be successful, but the CLI returned a hard process-verification error before the supervisor proof became visible.

## Validation

- `./scripts/sync-surge-core-vendor.sh --check`
- `./scripts/check-version-sync.sh`
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo test -p surge-cli remote_process_verification -- --nocapture`
- `RUSTFLAGS="-D warnings" cargo test --workspace` initially failed in sandbox on `commands::lock::tests::acquire_and_release_use_manifest_lock_server` with listener `PermissionDenied`; rerun outside sandbox passed
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo clippy --workspace --lib --bins --examples -- -D warnings -D clippy::unwrap_used -D clippy::expect_used`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings -W clippy::pedantic`
- `dotnet format dotnet/Surge.slnx --verify-no-changes` initially failed restore in sandbox; rerun outside sandbox passed
- `dotnet test dotnet/Surge.slnx --configuration Release`

Fixes #170
