### PR TITLE
Treat invalid supervisor pid files as stale

### DIFF
--- a/crates/surge-cli/src/commands/install/mod.rs
+++ b/crates/surge-cli/src/commands/install/mod.rs
@@ -1136,9 +1136,32 @@ mod tests {
         assert!(command.contains("install_root='/home/demo/apps/customer'\"'\"'s app'"));
         assert!(command.contains("supervisor_id='demo-supervisor'"));
         assert!(command.contains("pid_file=\"$install_root/.surge-supervisor-$supervisor_id.pid\""));
+        assert!(command.contains("case \"$pid\" in ''|*[!0-9]*) rm -f \"$pid_file\"; exit 0 ;; esac"));
         assert!(command.contains("clear_if_stale"));
         assert!(command.contains("rm -f \"$pid_file\""));
         assert!(command.contains("kill -KILL \"$pid\""));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn build_remote_stop_supervisor_command_is_valid_shell_syntax() {
+        use std::io::Write;
+
+        let command = build_remote_stop_supervisor_command(Path::new("/home/demo/apps/demo-app"), "demo-supervisor")
+            .expect("supervisor command should exist");
+        let mut child = std::process::Command::new("sh")
+            .arg("-n")
+            .stdin(std::process::Stdio::piped())
+            .spawn()
+            .expect("shell syntax checker should start");
+        child
+            .stdin
+            .as_mut()
+            .expect("stdin should be piped")
+            .write_all(command.as_bytes())
+            .expect("command should be written to shell");
+        let status = child.wait().expect("shell syntax checker should exit");
+        assert!(status.success(), "command failed shell syntax check with {status}");
     }
 
     #[test]

--- a/crates/surge-cli/src/commands/install/remote/staging.rs
+++ b/crates/surge-cli/src/commands/install/remote/staging.rs
@@ -462,7 +462,7 @@ pub(crate) fn build_remote_stop_supervisor_command(install_root: &Path, supervis
         "install_root={}; supervisor_id={}; pid_file=\"$install_root/.surge-supervisor-$supervisor_id.pid\"; \
 if [ ! -d \"$install_root\" ] || [ ! -f \"$pid_file\" ]; then exit 0; fi; \
 pid=\"$(tr -d '[:space:]' < \"$pid_file\")\"; \
-case \"$pid\" in ''|*[!0-9]*) echo \"Invalid PID in supervisor PID file: $pid_file\" >&2; exit 1 ;; esac; \
+case \"$pid\" in ''|*[!0-9]*) rm -f \"$pid_file\"; exit 0 ;; esac; \
 pid_stat() {{ if command -v ps >/dev/null 2>&1; then ps -o stat= -p \"$pid\" 2>/dev/null | tr -d '[:space:]' || true; elif kill -0 \"$pid\" 2>/dev/null; then printf R; fi; }}; \
 clear_if_stale() {{ stat=\"$(pid_stat)\"; if [ -z \"$stat\" ] || [ \"${{stat#Z}}\" != \"$stat\" ]; then rm -f \"$pid_file\"; exit 0; fi; }}; \
 clear_if_stale; \


### PR DESCRIPTION
## Summary

- treat empty and non-numeric supervisor pid files as stale state
- remove invalid pid files instead of failing remote repair/install
- add shell syntax coverage for the generated remote stop-supervisor command

## Root cause

The remote stop-supervisor script treated invalid pid-file contents as a hard error before it could prove any live supervisor process existed. That blocked otherwise valid repair/install flows on stale pid files.

## Validation

- `./scripts/sync-surge-core-vendor.sh --check`
- `./scripts/check-version-sync.sh`
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo test -p surge-cli build_remote_stop_supervisor_command -- --nocapture`
- `RUSTFLAGS="-D warnings" cargo test --workspace` outside sandbox because the lock-server listener test needs local listener permissions
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo clippy --workspace --lib --bins --examples -- -D warnings -D clippy::unwrap_used -D clippy::expect_used`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings -W clippy::pedantic`
- `dotnet format dotnet/Surge.slnx --verify-no-changes` outside sandbox because restore needs feed/network access
- `dotnet test dotnet/Surge.slnx --configuration Release`

Fixes #171
