### PR TITLE
Restore NuGet release publish secret

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -189,7 +189,7 @@ jobs:
       - name: Pack
         run: dotnet pack Surge.NET/Surge.NET.csproj --configuration Release -p:Version=${{ needs.validate-release.outputs.release_version }} --output ../nupkgs
       - name: Push to NuGet
-        run: dotnet nuget push ../nupkgs/*.nupkg --source nuget.org --api-key ${{ secrets.FINTER_NUGET_ORG_API_KEY }} --skip-duplicate
+        run: dotnet nuget push ../nupkgs/*.nupkg --source nuget.org --api-key ${{ secrets.PETERSUNDE_NUGET_ORG_API_KEY }} --skip-duplicate
 
   publish-cargo-crates-io:
     name: Publish Cargo (crates.io)


### PR DESCRIPTION
## Summary
- restore the previous NuGet.org publish secret reference after the beta publish failed at the NuGet push step with 403
- keep release packaging and upload behavior unchanged

## Validation
- git diff --check
- Copilot review completed; the secret-name concern is intentionally accepted for this unblocker because the org-scoped key currently fails NuGet authorization

## Release notes
- v1.0.0-beta.47 published release assets and crates.io packages, but Surge.NET was not accepted by NuGet. A replacement beta should be cut after this fix merges.