### PR TITLE
Publish Surge.NET package to GitHub Packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ env:
 
 permissions:
   contents: write
+  packages: write
 
 jobs:
   validate-release:
@@ -188,8 +189,8 @@ jobs:
           restore-keys: nuget-
       - name: Pack
         run: dotnet pack Surge.NET/Surge.NET.csproj --configuration Release -p:Version=${{ needs.validate-release.outputs.release_version }} --output ../nupkgs
-      - name: Push to NuGet
-        run: dotnet nuget push ../nupkgs/*.nupkg --source nuget.org --api-key ${{ secrets.PETERSUNDE_NUGET_ORG_API_KEY }} --skip-duplicate
+      - name: Push to GitHub Packages
+        run: dotnet nuget push ../nupkgs/*.nupkg --source https://nuget.pkg.github.com/fintermobilityas/index.json --api-key ${{ secrets.GITHUB_TOKEN }} --skip-duplicate
 
   publish-cargo-crates-io:
     name: Publish Cargo (crates.io)


### PR DESCRIPTION
## Purpose

Publish the `Surge.NET` NuGet package to the org GitHub Packages feed during releases.

## Why

The beta release pipeline can pack `Surge.NET`, but nuget.org now rejects both configured org API-key secret paths with `403`. The downstream app repos already use the org NuGet feed for private packages, so publishing the beta package there gives the release workflow a repository-managed credential path via `GITHUB_TOKEN`.

## Impact

- Grants the release workflow `packages: write`.
- Pushes the packed `.nupkg` to `https://nuget.pkg.github.com/fintermobilityas/index.json`.
- Leaves Rust crate publishing and GitHub release assets unchanged.

## Validation

- `git diff --check`
- `dotnet pack dotnet/Surge.NET/Surge.NET.csproj --configuration Release -p:Version=1.0.0-beta.49 --output /tmp/surge-pack-check`

## Migration Notes

Downstream app repos that use package source mapping need `Surge.NET` mapped to the `fintermobilityas` source before consuming the next beta.
