### PR TITLE
Enable AOT and trimming validation for .NET package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -243,3 +243,17 @@ jobs:
       - run: dotnet format --verify-no-changes --verbosity diagnostic
       - run: dotnet build --no-restore --configuration Release -p:Version=${{ needs.version-sync.outputs.version }}
       - run: dotnet test --no-build --configuration Release --verbosity normal
+      - name: Restore AOT/trim smoke app
+        run: dotnet restore Surge.NET.AotSmoke/Surge.NET.AotSmoke.csproj --runtime linux-x64
+      - name: Publish AOT/trim smoke app
+        run: >
+          dotnet publish Surge.NET.AotSmoke/Surge.NET.AotSmoke.csproj
+          --no-restore
+          --configuration Release
+          --runtime linux-x64
+          -p:PublishAot=true
+          -p:PublishTrimmed=true
+          -p:SelfContained=true
+          -p:InvariantGlobalization=true
+          -warnaserror
+          -m:1

--- a/dotnet/Directory.Build.targets
+++ b/dotnet/Directory.Build.targets
@@ -1,0 +1,9 @@
+<Project>
+  <PropertyGroup Condition="'$(IsPackable)' != 'false' and '$(TargetFramework)' == 'net10.0'">
+    <IsAotCompatible>true</IsAotCompatible>
+    <IsTrimmable>true</IsTrimmable>
+    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
+    <EnableAotAnalyzer>true</EnableAotAnalyzer>
+    <EnableSingleFileAnalyzer>true</EnableSingleFileAnalyzer>
+  </PropertyGroup>
+</Project>

--- a/dotnet/Directory.Solution.props
+++ b/dotnet/Directory.Solution.props
@@ -1,0 +1,7 @@
+<Project>
+  <PropertyGroup>
+    <!-- NuGet.targets consumes both knobs: the first serializes the solution graph walk, the second serializes package restore work. -->
+    <RestoreBuildInParallel>false</RestoreBuildInParallel>
+    <RestoreDisableParallel>true</RestoreDisableParallel>
+  </PropertyGroup>
+</Project>

--- a/dotnet/Surge.NET.AotSmoke/Program.cs
+++ b/dotnet/Surge.NET.AotSmoke/Program.cs
@@ -1,0 +1,32 @@
+using System;
+using Surge;
+
+var release = new SurgeRelease
+{
+    Version = "1.0.0",
+    Channel = "stable",
+    FullSize = 42,
+    IsGenesis = true
+};
+
+var budget = new SurgeResourceBudget { MaxThreads = 2 };
+var retention = SurgeArtifactRetentionPolicy.LatestFull(2);
+var lifecycleCallbackVersion = "";
+var lifecycleHandled = SurgeApp.ProcessEvents(
+    Array.Empty<string>(),
+    onFirstRun: version => lifecycleCallbackVersion = version,
+    onInstalled: version => lifecycleCallbackVersion = version,
+    onUpdated: version => lifecycleCallbackVersion = version);
+
+if (release.Version != "1.0.0"
+    || release.Channel != "stable"
+    || budget.MaxThreads != 2
+    || retention.Mode != SurgeArtifactRetentionMode.LatestFull
+    || lifecycleHandled
+    || lifecycleCallbackVersion.Length != 0)
+{
+    return 1;
+}
+
+Console.WriteLine($"{SurgeApp.Version}:{release.Version}:{retention.KeepFullCount}");
+return 0;

--- a/dotnet/Surge.NET.AotSmoke/Surge.NET.AotSmoke.csproj
+++ b/dotnet/Surge.NET.AotSmoke/Surge.NET.AotSmoke.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference
+      Include="../Surge.NET/Surge.NET.csproj"
+      GlobalPropertiesToRemove="PublishAot;PublishTrimmed;SelfContained;RuntimeIdentifier;RuntimeIdentifiers;InvariantGlobalization" />
+  </ItemGroup>
+</Project>

--- a/dotnet/Surge.NET/README.md
+++ b/dotnet/Surge.NET/README.md
@@ -7,7 +7,7 @@
 | Target | Binding | Compatibility |
 |---|---|---|
 | `netstandard2.0` | `[DllImport]` | .NET Framework 4.6.1+, .NET Core, Mono, Xamarin |
-| `net10.0` | `[LibraryImport]` | Full AOT and trimming support |
+| `net10.0` | `[LibraryImport]` | AOT/trim-compatible; CI publishes a Native AOT smoke app |
 
 ## Quick Start
 

--- a/dotnet/Surge.NET/Surge.NET.csproj
+++ b/dotnet/Surge.NET/Surge.NET.csproj
@@ -9,7 +9,6 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'net10.0'">
-    <IsAotCompatible>true</IsAotCompatible>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>

--- a/dotnet/Surge.slnx
+++ b/dotnet/Surge.slnx
@@ -1,4 +1,5 @@
 <Solution>
+  <Project Path="Surge.NET.AotSmoke/Surge.NET.AotSmoke.csproj" />
   <Project Path="Surge.NET.Tests/Surge.NET.Tests.csproj" />
   <Project Path="Surge.NET/Surge.NET.csproj" />
 </Solution>


### PR DESCRIPTION
## Summary
- centralize AOT/trimming analyzer flags for packable `net10.0` NuGet projects
- add a non-packable Native AOT smoke app that references the `Surge.NET` `net10.0` asset
- extend CI to restore and publish the smoke app with `PublishAot`, `PublishTrimmed`, and warnings as errors

## Impact
This keeps `Surge.NET` multi-targeted for `netstandard2.0` compatibility while enforcing the modern `net10.0` package asset as AOT/trim-compatible.

## Validation
- `dotnet restore`
- `dotnet format dotnet/Surge.slnx --verify-no-changes --verbosity diagnostic`
- `dotnet build dotnet/Surge.slnx --no-restore --configuration Release -p:Version=0.1.0`
- `dotnet test dotnet/Surge.slnx --no-build --configuration Release --verbosity normal`
- `dotnet restore dotnet/Surge.NET.AotSmoke/Surge.NET.AotSmoke.csproj --runtime linux-x64`
- `dotnet publish dotnet/Surge.NET.AotSmoke/Surge.NET.AotSmoke.csproj --no-restore --configuration Release --runtime linux-x64 -p:PublishAot=true -p:PublishTrimmed=true -p:SelfContained=true -p:InvariantGlobalization=true -warnaserror -m:1`