### PR TITLE
fix(supervisor): keep supervision alive across child exits and package swaps

### DIFF
--- a/crates/surge-cli/src/commands/install/remote/runtime.rs
+++ b/crates/surge-cli/src/commands/install/remote/runtime.rs
@@ -88,6 +88,13 @@ pub(crate) fn build_remote_runtime_start_command(
     let version = shell_single_quote(version.trim());
     let exports = activation::shell_export_lines(environment);
 
+    // Unlike the finalize/ffi spawn sites, this remote-install template keeps
+    // `--exe` on the supervisor argv. A newer CLI can install an older package
+    // whose bundled supervisor still requires `--exe`, so omitting it here would
+    // break that install. The supervisor keeps `--exe` as its first-choice exe
+    // source, so the app-path stays out of argv on later update/self-restart
+    // spawns (finalize/ffi) once the node runs a supervisor that reads the exe
+    // state file.
     format!(
         "set -eu\n\
 install_root={install_root}\n\

--- a/crates/surge-core/src/supervisor/state.rs
+++ b/crates/surge-core/src/supervisor/state.rs
@@ -28,6 +28,43 @@ pub fn supervisor_restart_args_file(install_dir: &Path, supervisor_id: &str) -> 
     supervisor_state_path(install_dir, supervisor_id, ".args.json")
 }
 
+#[must_use]
+pub fn supervisor_exe_file(install_dir: &Path, supervisor_id: &str) -> PathBuf {
+    supervisor_state_path(install_dir, supervisor_id, ".exe")
+}
+
+/// Persist the supervised executable path so the spawning side can omit it from
+/// the supervisor's argv. Keeping the app path out of argv stops an external
+/// `pkill -f <app-path>` from also matching the supervisor process.
+pub fn write_supervisor_exe_path(install_dir: &Path, supervisor_id: &str, exe_path: &Path) -> Result<()> {
+    let supervisor_id = normalized_supervisor_id(supervisor_id);
+    if supervisor_id.is_empty() {
+        return Ok(());
+    }
+
+    std::fs::write(
+        supervisor_exe_file(install_dir, supervisor_id),
+        exe_path.to_string_lossy().as_bytes(),
+    )?;
+    Ok(())
+}
+
+#[must_use]
+pub fn read_supervisor_exe_path(install_dir: &Path, supervisor_id: &str) -> Option<PathBuf> {
+    let supervisor_id = normalized_supervisor_id(supervisor_id);
+    if supervisor_id.is_empty() {
+        return None;
+    }
+
+    let exe_path = supervisor_exe_file(install_dir, supervisor_id);
+    let contents = std::fs::read_to_string(exe_path).ok()?;
+    let trimmed = contents.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    Some(PathBuf::from(trimmed))
+}
+
 pub fn write_restart_args(install_dir: &Path, supervisor_id: &str, args: &[String]) -> Result<()> {
     let supervisor_id = normalized_supervisor_id(supervisor_id);
     if supervisor_id.is_empty() {
@@ -76,5 +113,28 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let restored = read_restart_args(dir.path(), "demo-supervisor").unwrap();
         assert!(restored.is_empty());
+    }
+
+    #[test]
+    fn supervisor_exe_path_round_trip() {
+        let dir = tempfile::tempdir().unwrap();
+        let exe = dir.path().join("app").join("demo-app");
+
+        write_supervisor_exe_path(dir.path(), "demo-supervisor", &exe).unwrap();
+
+        assert_eq!(read_supervisor_exe_path(dir.path(), "demo-supervisor"), Some(exe));
+    }
+
+    #[test]
+    fn supervisor_exe_path_missing_file_returns_none() {
+        let dir = tempfile::tempdir().unwrap();
+        assert_eq!(read_supervisor_exe_path(dir.path(), "demo-supervisor"), None);
+    }
+
+    #[test]
+    fn supervisor_exe_path_blank_contents_returns_none() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(supervisor_exe_file(dir.path(), "demo-supervisor"), "   \n").unwrap();
+        assert_eq!(read_supervisor_exe_path(dir.path(), "demo-supervisor"), None);
     }
 }

--- a/crates/surge-core/src/update/manager.rs
+++ b/crates/surge-core/src/update/manager.rs
@@ -720,6 +720,9 @@ while [ "$#" -gt 0 ]; do
     *) shift ;;
   esac
 done
+if [ -z "$exe" ]; then
+  exe="$(cat "$dir/.surge-supervisor-$id.exe" 2>/dev/null || true)"
+fi
 echo $$ > "$dir/.surge-supervisor-$id.pid"
 while kill -0 "$pid" 2>/dev/null; do
   sleep 0.05
@@ -1800,6 +1803,101 @@ echo started > new-child-started
         let final_record = status::read_update_status(&install_root).unwrap().unwrap();
         assert_eq!(final_record.state, status::UpdateConvergenceState::Converged);
         assert!(final_record.current_phase.is_none());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_finalize_starts_supervisor_when_none_was_running() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let store_root = tmp.path().join("store");
+        let install_root = tmp.path().join("install");
+        let app_id = "test-app";
+        std::fs::create_dir_all(&store_root).unwrap();
+        std::fs::create_dir_all(&install_root).unwrap();
+        let app_store = app_scoped_store_root(&store_root, app_id);
+
+        let rid = current_rid();
+        let full_filename = format!("{app_id}-1.1.0-{rid}-full.tar.zst");
+        let full_path = app_store.join(&full_filename);
+
+        // Mock supervisor: parse --id/--dir, write the pid file so the restart is
+        // confirmed, then exit. It never watches, so nothing lingers after the test.
+        let supervisor_script = b"#!/bin/sh\nid=\"\"\ndir=\"\"\nwhile [ \"$#\" -gt 0 ]; do\n  case \"$1\" in\n    --id) id=\"$2\"; shift 2 ;;\n    --dir) dir=\"$2\"; shift 2 ;;\n    *) shift ;;\n  esac\ndone\necho $$ > \"$dir/.surge-supervisor-$id.pid\"\n";
+
+        let mut packer = ArchivePacker::new(3).unwrap();
+        packer.add_buffer(app_id, b"#!/bin/sh\nexit 0\n", 0o755).unwrap();
+        packer.add_buffer("surge-supervisor", supervisor_script, 0o755).unwrap();
+        packer.finalize_to_file(&full_path).unwrap();
+
+        let full_size = std::fs::metadata(&full_path).unwrap().len() as i64;
+        let full_sha256 = sha256_hex_file(&full_path).unwrap();
+
+        let index = ReleaseIndex {
+            app_id: app_id.to_string(),
+            releases: vec![ReleaseEntry {
+                version: "1.1.0".to_string(),
+                channels: vec!["stable".to_string()],
+                os: current_os_label_for_tests(),
+                rid: rid.clone(),
+                is_genesis: true,
+                full_filename: full_filename.clone(),
+                full_size,
+                full_sha256,
+                main_exe: app_id.to_string(),
+                install_directory: app_id.to_string(),
+                supervisor_id: "demo-supervisor".to_string(),
+                created_utc: chrono::Utc::now().to_rfc3339(),
+                ..ReleaseEntry::default()
+            }],
+            ..ReleaseIndex::default()
+        };
+        write_app_scoped_release_index(&store_root, app_id, &index);
+
+        let ctx = Arc::new(Context::new());
+        ctx.set_storage(
+            StorageProvider::Filesystem,
+            store_root.to_str().unwrap(),
+            "",
+            "",
+            "",
+            "",
+        );
+
+        let pid_file = crate::supervisor::state::supervisor_pid_file(&install_root, "demo-supervisor");
+        assert!(!pid_file.exists(), "no supervisor should be running before the update");
+
+        let mut manager = UpdateManager::new(ctx, app_id, "1.0.0", "stable", install_root.to_str().unwrap()).unwrap();
+        let info = manager.check_for_updates().await.unwrap().unwrap();
+        manager
+            .download_and_apply(&info, None::<fn(ProgressInfo)>)
+            .await
+            .unwrap();
+
+        // The finalize step must start a watch supervisor even though none was
+        // running before the update, leaving a pending restart handoff.
+        assert!(
+            pid_file.is_file(),
+            "finalize should start a watch supervisor and write its pid file"
+        );
+        let exe_state = crate::supervisor::state::read_supervisor_exe_path(&install_root, "demo-supervisor");
+        assert_eq!(exe_state, Some(install_root.join("app").join(app_id)));
+
+        let final_record = status::read_update_status(&install_root).unwrap().unwrap();
+        assert_eq!(final_record.state, status::UpdateConvergenceState::PendingRestart);
+        assert_eq!(
+            final_record.failure_phase.as_deref(),
+            Some(status::RESTART_HANDOFF_WAITING_FOR_OLD_CHILD_PHASE)
+        );
+
+        let _ = std::fs::remove_file(&pid_file);
+        let mode_probe = std::fs::metadata(install_root.join("app").join("surge-supervisor")).unwrap();
+        assert_ne!(
+            mode_probe.permissions().mode() & 0o111,
+            0,
+            "packed supervisor should remain executable"
+        );
     }
 
     #[tokio::test]

--- a/crates/surge-core/src/update/manager/finalize.rs
+++ b/crates/surge-core/src/update/manager/finalize.rs
@@ -151,8 +151,23 @@ where
     );
     write_runtime_manifest(&active_app_dir, &runtime_manifest_profile, &runtime_manifest_metadata)?;
 
+    // Start the replacement watch-supervisor as soon as the swapped app is
+    // usable (directory swapped, persistent assets carried over, runtime
+    // manifest written), before the best-effort shortcut/prune/hook steps that
+    // can block for many seconds. This shrinks the window in which no
+    // supervisor is watching the app. The start no longer depends on a
+    // supervisor having been running before the update: if the release
+    // configures supervision, a fresh watch supervisor is always started so a
+    // supervisor that died before the update is recovered here.
+    let restart_outcome = if latest.supervisor_id.trim().is_empty() {
+        SupervisorRestartOutcome::NotApplicable
+    } else {
+        progress_emitter.emit_substep(6, finalize_phase::RESTARTING_SUPERVISOR, 96);
+        lifecycle::restart_supervisor_after_update(&manager.install_dir, &active_app_dir, latest)
+    };
+
     if !latest.shortcuts.is_empty() {
-        progress_emitter.emit_substep(6, finalize_phase::INSTALLING_SHORTCUTS, 96);
+        progress_emitter.emit_substep(6, finalize_phase::INSTALLING_SHORTCUTS, 97);
         match install_shortcuts(
             &manager.app_id,
             latest.display_name(&manager.app_id),
@@ -176,7 +191,7 @@ where
         }
     }
 
-    progress_emitter.emit_substep(6, finalize_phase::PRUNING_OLD_VERSIONS, 97);
+    progress_emitter.emit_substep(6, finalize_phase::PRUNING_OLD_VERSIONS, 98);
     if previous_swap_dir.is_dir() {
         let previous_version_dir = manager.install_dir.join(format!("app-{}", manager.current_version));
         if !manager.current_version.trim().is_empty()
@@ -262,15 +277,9 @@ where
         }
     }
 
-    progress_emitter.emit_substep(6, finalize_phase::POST_UPDATE_HOOK, 98);
+    progress_emitter.emit_substep(6, finalize_phase::POST_UPDATE_HOOK, 99);
     lifecycle::invoke_post_update_hook(&manager.install_dir, &active_app_dir, latest);
 
-    let restart_outcome = if supervisor_was_running {
-        progress_emitter.emit_substep(6, finalize_phase::RESTARTING_SUPERVISOR, 99);
-        lifecycle::restart_supervisor_after_update(&manager.install_dir, &active_app_dir, latest)
-    } else {
-        SupervisorRestartOutcome::NotApplicable
-    };
     match lifecycle::terminate_superseded_app_processes(&manager.install_dir, &active_app_dir, &latest.main_exe) {
         Ok(0) => {}
         Ok(terminated) => {

--- a/crates/surge-core/src/update/manager/lifecycle.rs
+++ b/crates/surge-core/src/update/manager/lifecycle.rs
@@ -8,12 +8,16 @@ use tracing::{debug, info, warn};
 use crate::error::{Result, SurgeError};
 use crate::platform::process::{ProcessHandle, current_pid, spawn_detached, spawn_process, supervisor_binary_name};
 use crate::releases::manifest::ReleaseEntry;
-use crate::supervisor::state::{read_restart_args, supervisor_pid_file, supervisor_stop_file};
+use crate::supervisor::state::{
+    read_restart_args, supervisor_pid_file, supervisor_stop_file, write_supervisor_exe_path,
+};
 use crate::update::status::{
     RESTART_HANDOFF_FAILED_PHASE, RESTART_HANDOFF_WAITING_FOR_OLD_CHILD_PHASE, confirm_supervisor_restart,
 };
 
 const SUPERVISOR_RESTART_CONFIRM_TIMEOUT: Duration = Duration::from_secs(5);
+const SUPERVISOR_RESTART_MAX_ATTEMPTS: u32 = 2;
+const SUPERVISOR_RESTART_RETRY_DELAY: Duration = Duration::from_millis(500);
 
 #[derive(Debug, Clone)]
 pub(super) enum SupervisorRestartOutcome {
@@ -157,6 +161,26 @@ pub(super) fn restart_supervisor_after_update_with_pid(
     latest: &ReleaseEntry,
     watched_pid: u32,
 ) -> SupervisorRestartOutcome {
+    restart_supervisor_after_update_with_config(
+        install_dir,
+        active_app_dir,
+        latest,
+        watched_pid,
+        SUPERVISOR_RESTART_CONFIRM_TIMEOUT,
+        SUPERVISOR_RESTART_MAX_ATTEMPTS,
+        SUPERVISOR_RESTART_RETRY_DELAY,
+    )
+}
+
+fn restart_supervisor_after_update_with_config(
+    install_dir: &Path,
+    active_app_dir: &Path,
+    latest: &ReleaseEntry,
+    watched_pid: u32,
+    confirm_timeout: Duration,
+    max_attempts: u32,
+    retry_delay: Duration,
+) -> SupervisorRestartOutcome {
     let supervisor_id = latest.supervisor_id.trim();
     if supervisor_id.is_empty() {
         return SupervisorRestartOutcome::NotApplicable;
@@ -186,6 +210,18 @@ pub(super) fn restart_supervisor_after_update_with_pid(
         };
     }
 
+    if let Err(e) = write_supervisor_exe_path(install_dir, supervisor_id, &exe_path) {
+        warn!(
+            supervisor_id,
+            error = %e,
+            "Failed to persist supervisor exe state before restart"
+        );
+        return SupervisorRestartOutcome::PendingRestart {
+            reason: format!("failed to persist supervisor exe state: {e}"),
+            failure_phase: RESTART_HANDOFF_FAILED_PHASE,
+        };
+    }
+
     let restart_args = match read_restart_args(install_dir, supervisor_id) {
         Ok(args) => args,
         Err(e) => {
@@ -198,52 +234,60 @@ pub(super) fn restart_supervisor_after_update_with_pid(
         }
     };
 
-    let args = supervisor_watch_args(
-        supervisor_id,
-        install_dir,
-        watched_pid,
-        &latest.version,
-        &exe_path,
-        &restart_args,
-    );
+    let args = supervisor_watch_args(supervisor_id, install_dir, watched_pid, &latest.version, &restart_args);
     let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
 
-    match spawn_detached(&supervisor_path, &arg_refs, Some(install_dir), &latest.environment) {
-        Ok(handle) => {
-            info!(pid = handle.pid(), supervisor_id, "Restarted supervisor after update");
+    let mut last_failure: Option<(String, &'static str)> = None;
+    for attempt in 1..=max_attempts {
+        match spawn_detached(&supervisor_path, &arg_refs, Some(install_dir), &latest.environment) {
+            Ok(handle) => {
+                info!(
+                    pid = handle.pid(),
+                    supervisor_id, attempt, "Restarted supervisor after update"
+                );
+                if confirm_supervisor_restart(install_dir, supervisor_id, confirm_timeout) {
+                    return SupervisorRestartOutcome::PendingRestart {
+                        reason: format!(
+                            "supervisor handoff accepted; waiting for previous child pid {watched_pid} to exit and target version {} to start",
+                            latest.version
+                        ),
+                        failure_phase: RESTART_HANDOFF_WAITING_FOR_OLD_CHILD_PHASE,
+                    };
+                }
+                let timeout_ms = u64::try_from(confirm_timeout.as_millis()).unwrap_or(u64::MAX);
+                warn!(
+                    supervisor_id,
+                    timeout_ms, attempt, "Supervisor pid file did not appear after restart within timeout window"
+                );
+                last_failure = Some((
+                    format!("supervisor pid file did not appear within {timeout_ms}ms after restart"),
+                    RESTART_HANDOFF_FAILED_PHASE,
+                ));
+            }
+            Err(e) => {
+                warn!(
+                    supervisor_id,
+                    error = %e,
+                    attempt,
+                    "Failed to restart supervisor after update"
+                );
+                last_failure = Some((format!("spawn failed: {e}"), RESTART_HANDOFF_FAILED_PHASE));
+            }
         }
-        Err(e) => {
-            warn!(
-                supervisor_id,
-                error = %e,
-                "Failed to restart supervisor after update (continuing)"
-            );
-            return SupervisorRestartOutcome::PendingRestart {
-                reason: format!("spawn failed: {e}"),
-                failure_phase: RESTART_HANDOFF_FAILED_PHASE,
-            };
+
+        if attempt < max_attempts {
+            warn!(supervisor_id, attempt, "Retrying supervisor restart after short delay");
+            std::thread::sleep(retry_delay);
         }
     }
 
-    if confirm_supervisor_restart(install_dir, supervisor_id, SUPERVISOR_RESTART_CONFIRM_TIMEOUT) {
-        SupervisorRestartOutcome::PendingRestart {
-            reason: format!(
-                "supervisor handoff accepted; waiting for previous child pid {watched_pid} to exit and target version {} to start",
-                latest.version
-            ),
-            failure_phase: RESTART_HANDOFF_WAITING_FOR_OLD_CHILD_PHASE,
-        }
-    } else {
-        let timeout_ms = u64::try_from(SUPERVISOR_RESTART_CONFIRM_TIMEOUT.as_millis()).unwrap_or(u64::MAX);
-        warn!(
-            supervisor_id,
-            timeout_ms, "Supervisor pid file did not appear after restart within timeout window"
-        );
-        SupervisorRestartOutcome::PendingRestart {
-            reason: format!("supervisor pid file did not appear within {timeout_ms}ms after restart"),
-            failure_phase: RESTART_HANDOFF_FAILED_PHASE,
-        }
-    }
+    let (reason, failure_phase) = last_failure.unwrap_or_else(|| {
+        (
+            "supervisor restart did not complete".to_string(),
+            RESTART_HANDOFF_FAILED_PHASE,
+        )
+    });
+    SupervisorRestartOutcome::PendingRestart { reason, failure_phase }
 }
 
 pub(super) fn terminate_superseded_app_processes(
@@ -421,7 +465,6 @@ fn supervisor_watch_args(
     install_dir: &Path,
     watched_pid: u32,
     handoff_version: &str,
-    exe_path: &Path,
     restart_args: &[String],
 ) -> Vec<String> {
     let mut args = vec![
@@ -434,8 +477,6 @@ fn supervisor_watch_args(
         watched_pid.to_string(),
         "--handoff-version".to_string(),
         handoff_version.to_string(),
-        "--exe".to_string(),
-        exe_path.to_string_lossy().into_owned(),
     ];
     if !restart_args.is_empty() {
         args.push("--".to_string());
@@ -454,14 +495,7 @@ mod tests {
     fn supervisor_watch_args_include_handoff_version_before_child_args() {
         let restart_args = vec!["--app-mode".to_string(), "service".to_string()];
 
-        let args = supervisor_watch_args(
-            "demo-supervisor",
-            Path::new("/opt/demo"),
-            42,
-            "2.0.0",
-            Path::new("/opt/demo/app/demo"),
-            &restart_args,
-        );
+        let args = supervisor_watch_args("demo-supervisor", Path::new("/opt/demo"), 42, "2.0.0", &restart_args);
 
         assert_eq!(
             args,
@@ -475,12 +509,80 @@ mod tests {
                 "42",
                 "--handoff-version",
                 "2.0.0",
-                "--exe",
-                "/opt/demo/app/demo",
                 "--",
                 "--app-mode",
                 "service",
             ]
+        );
+        assert!(
+            !args.iter().any(|arg| arg == "--exe"),
+            "supervisor argv must not carry the app exe path so external pkill -f <app-path> cannot match it"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn restart_supervisor_retries_once_when_pid_file_never_appears() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let install_dir = tmp.path();
+        let active_app_dir = install_dir.join("app");
+        std::fs::create_dir_all(&active_app_dir).unwrap();
+
+        let attempts_log = install_dir.join("supervisor-attempts.log");
+        let supervisor_path = active_app_dir.join(crate::platform::process::supervisor_binary_name());
+        std::fs::write(
+            &supervisor_path,
+            format!("#!/bin/sh\necho attempt >> '{}'\nexit 0\n", attempts_log.display()),
+        )
+        .unwrap();
+        let mut permissions = std::fs::metadata(&supervisor_path).unwrap().permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&supervisor_path, permissions).unwrap();
+
+        let app_path = active_app_dir.join("demo-app");
+        std::fs::write(&app_path, "#!/bin/sh\nexit 0\n").unwrap();
+        let mut permissions = std::fs::metadata(&app_path).unwrap().permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&app_path, permissions).unwrap();
+
+        let latest = ReleaseEntry {
+            version: "2.0.0".to_string(),
+            main_exe: "demo-app".to_string(),
+            supervisor_id: "demo-supervisor".to_string(),
+            ..ReleaseEntry::default()
+        };
+
+        let outcome = restart_supervisor_after_update_with_config(
+            install_dir,
+            &active_app_dir,
+            &latest,
+            std::process::id(),
+            Duration::from_millis(200),
+            2,
+            Duration::from_millis(10),
+        );
+
+        match outcome {
+            SupervisorRestartOutcome::PendingRestart { failure_phase, .. } => {
+                assert_eq!(failure_phase, RESTART_HANDOFF_FAILED_PHASE);
+            }
+            SupervisorRestartOutcome::NotApplicable => panic!("expected PendingRestart failure, got NotApplicable"),
+        }
+
+        let deadline = std::time::Instant::now() + Duration::from_secs(2);
+        let mut attempts = 0;
+        while std::time::Instant::now() < deadline {
+            attempts = std::fs::read_to_string(&attempts_log).map_or(0, |contents| contents.lines().count());
+            if attempts >= 2 {
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(20));
+        }
+        assert_eq!(
+            attempts, 2,
+            "restart should spawn the supervisor exactly twice (one retry)"
         );
     }
 

--- a/crates/surge-ffi/src/lib.rs
+++ b/crates/surge-ffi/src/lib.rs
@@ -29,7 +29,9 @@ use std::path::Path;
 use std::ptr;
 
 use surge_core::lock::mutex::DistributedMutex;
-use surge_core::supervisor::state::{supervisor_pid_file, supervisor_stop_file, write_restart_args};
+use surge_core::supervisor::state::{
+    supervisor_pid_file, supervisor_stop_file, write_restart_args, write_supervisor_exe_path,
+};
 use surge_core::update::status::{UpdateConvergenceState, mark_restart_handoff_converged, read_update_status};
 
 pub use crate::context::{
@@ -256,18 +258,15 @@ pub unsafe extern "C" fn surge_supervisor_start(
             return SURGE_ERROR;
         }
 
+        ffi_trace("surge_supervisor_start: writing exe state");
+        if let Err(e) = write_supervisor_exe_path(install_dir, &sup_id, exe) {
+            tracing::error!("supervisor_start failed: {e}");
+            ffi_trace("surge_supervisor_start: exe state failed");
+            return SURGE_ERROR;
+        }
+
         let pid = surge_core::platform::process::current_pid().to_string();
-        let mut args: Vec<&str> = vec![
-            "watch",
-            "--id",
-            &sup_id,
-            "--dir",
-            &install_dir_s,
-            "--pid",
-            &pid,
-            "--exe",
-            &exe_s,
-        ];
+        let mut args: Vec<&str> = vec!["watch", "--id", &sup_id, "--dir", &install_dir_s, "--pid", &pid];
         if !args_owned.is_empty() {
             args.push("--");
             args.extend(args_owned.iter().map(String::as_str));

--- a/crates/surge-supervisor/src/child.rs
+++ b/crates/surge-supervisor/src/child.rs
@@ -1,0 +1,290 @@
+use std::path::Path;
+use std::process::{Child, Command, ExitStatus};
+
+#[cfg(windows)]
+use sysinfo::{Pid, ProcessesToUpdate, System};
+
+use crate::SupervisorError;
+use crate::handoff;
+use crate::ownership::supervisor_was_superseded;
+
+const RESTART_HANDOFF_STABILITY_WINDOW: std::time::Duration = std::time::Duration::from_secs(4);
+
+pub(crate) fn spawn_supervised_child(
+    exe_path: &Path,
+    install_dir: &Path,
+    child_args: &[String],
+) -> Result<Child, SupervisorError> {
+    tracing::info!("Starting child process: {}", exe_path.display());
+
+    let mut command = Command::new(exe_path);
+    command.current_dir(install_dir).args(child_args);
+
+    // Put the child in its own process group so a group-scoped signal or
+    // `pkill -g` aimed at the supervisor cannot also take down the child.
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        command.process_group(0);
+    }
+
+    let child = command.spawn()?;
+    tracing::info!("Child process started with PID {}", child.id());
+    Ok(child)
+}
+
+pub(crate) fn wait_for_supervised_child(
+    child: &mut Child,
+    shutdown: &std::sync::Arc<std::sync::atomic::AtomicBool>,
+    stop_file: &Path,
+    pid_file: &Path,
+    own_pid: u32,
+    install_dir: &Path,
+    pending_handoff_version: &mut Option<String>,
+) -> Result<Option<ExitStatus>, SupervisorError> {
+    let Some(version) = pending_handoff_version.clone() else {
+        return wait_for_child_exit_status(child, shutdown, stop_file, pid_file, own_pid);
+    };
+
+    match wait_for_child_startup_or_stop(
+        child,
+        shutdown,
+        stop_file,
+        pid_file,
+        own_pid,
+        RESTART_HANDOFF_STABILITY_WINDOW,
+    )? {
+        StartupOutcome::Running => {
+            handoff::record_restart_handoff_converged(install_dir, &version);
+            *pending_handoff_version = None;
+            wait_for_child_exit_status(child, shutdown, stop_file, pid_file, own_pid)
+        }
+        StartupOutcome::Exited(status) => {
+            handoff::record_restart_handoff_child_exited(install_dir, &version, status);
+            Ok(Some(status))
+        }
+        StartupOutcome::StopRequested => {
+            tracing::info!("Stop requested, exiting supervisor loop and leaving child running");
+            Ok(None)
+        }
+        StartupOutcome::ShutdownRequested => {
+            tracing::info!("Shutdown signal received, child terminated and supervisor loop is exiting");
+            Ok(None)
+        }
+        StartupOutcome::Superseded => Ok(None),
+    }
+}
+
+fn wait_for_child_exit_status(
+    child: &mut Child,
+    shutdown: &std::sync::Arc<std::sync::atomic::AtomicBool>,
+    stop_file: &Path,
+    pid_file: &Path,
+    own_pid: u32,
+) -> Result<Option<ExitStatus>, SupervisorError> {
+    match wait_for_child_or_stop(child, shutdown, stop_file, pid_file, own_pid)? {
+        WaitOutcome::Exited(status) => Ok(Some(status)),
+        WaitOutcome::ObservedProcessExited => unreachable!(),
+        WaitOutcome::StopRequested => {
+            tracing::info!("Stop requested, exiting supervisor loop and leaving child running");
+            Ok(None)
+        }
+        WaitOutcome::ShutdownRequested => {
+            tracing::info!("Shutdown signal received, child terminated and supervisor loop is exiting");
+            Ok(None)
+        }
+        WaitOutcome::Superseded => Ok(None),
+    }
+}
+
+pub(crate) enum WaitOutcome {
+    Exited(std::process::ExitStatus),
+    ObservedProcessExited,
+    StopRequested,
+    ShutdownRequested,
+    Superseded,
+}
+
+enum StartupOutcome {
+    Running,
+    Exited(std::process::ExitStatus),
+    StopRequested,
+    ShutdownRequested,
+    Superseded,
+}
+
+fn wait_for_child_startup_or_stop(
+    child: &mut Child,
+    shutdown: &std::sync::Arc<std::sync::atomic::AtomicBool>,
+    stop_file: &Path,
+    pid_file: &Path,
+    own_pid: u32,
+    stable_for: std::time::Duration,
+) -> Result<StartupOutcome, SupervisorError> {
+    let deadline = std::time::Instant::now() + stable_for;
+    loop {
+        if shutdown.load(std::sync::atomic::Ordering::Acquire) {
+            terminate_child_process(child)?;
+            return Ok(StartupOutcome::ShutdownRequested);
+        }
+
+        if supervisor_was_superseded(pid_file, own_pid) {
+            return Ok(StartupOutcome::Superseded);
+        }
+
+        if stop_file.exists() {
+            return Ok(StartupOutcome::StopRequested);
+        }
+
+        if let Some(status) = child.try_wait()? {
+            return Ok(StartupOutcome::Exited(status));
+        }
+
+        if std::time::Instant::now() >= deadline {
+            return Ok(StartupOutcome::Running);
+        }
+
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    }
+}
+
+pub(crate) fn wait_for_pid_or_stop(
+    pid: u32,
+    shutdown: &std::sync::Arc<std::sync::atomic::AtomicBool>,
+    stop_file: &Path,
+    pid_file: &Path,
+    own_pid: u32,
+) -> WaitOutcome {
+    loop {
+        if shutdown.load(std::sync::atomic::Ordering::Acquire) {
+            return WaitOutcome::ShutdownRequested;
+        }
+
+        if supervisor_was_superseded(pid_file, own_pid) {
+            return WaitOutcome::Superseded;
+        }
+
+        if stop_file.exists() {
+            return WaitOutcome::StopRequested;
+        }
+
+        if !is_process_running(pid) {
+            return WaitOutcome::ObservedProcessExited;
+        }
+
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    }
+}
+
+fn wait_for_child_or_stop(
+    child: &mut Child,
+    shutdown: &std::sync::Arc<std::sync::atomic::AtomicBool>,
+    stop_file: &Path,
+    pid_file: &Path,
+    own_pid: u32,
+) -> Result<WaitOutcome, SupervisorError> {
+    loop {
+        if shutdown.load(std::sync::atomic::Ordering::Acquire) {
+            terminate_child_process(child)?;
+            return Ok(WaitOutcome::ShutdownRequested);
+        }
+
+        if supervisor_was_superseded(pid_file, own_pid) {
+            return Ok(WaitOutcome::Superseded);
+        }
+
+        if stop_file.exists() {
+            return Ok(WaitOutcome::StopRequested);
+        }
+
+        if let Some(status) = child.try_wait()? {
+            return Ok(WaitOutcome::Exited(status));
+        }
+
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    }
+}
+
+pub(crate) fn wait_before_restart(
+    shutdown: &std::sync::Arc<std::sync::atomic::AtomicBool>,
+    stop_file: &Path,
+    pid_file: &Path,
+    own_pid: u32,
+    delay: std::time::Duration,
+) -> bool {
+    let deadline = std::time::Instant::now() + delay;
+    loop {
+        if shutdown.load(std::sync::atomic::Ordering::Acquire) {
+            tracing::info!("Shutdown signal received during restart delay, not restarting");
+            return false;
+        }
+
+        if supervisor_was_superseded(pid_file, own_pid) {
+            return false;
+        }
+
+        if stop_file.exists() {
+            tracing::info!("Stop requested during restart delay, not restarting");
+            return false;
+        }
+
+        if std::time::Instant::now() >= deadline {
+            return true;
+        }
+
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    }
+}
+
+fn terminate_child_process(child: &mut Child) -> Result<(), SupervisorError> {
+    if child.try_wait()?.is_some() {
+        return Ok(());
+    }
+
+    #[cfg(unix)]
+    {
+        use nix::sys::signal::{Signal, kill};
+        use nix::unistd::Pid;
+
+        let _ = kill(Pid::from_raw(child.id() as i32), Signal::SIGTERM);
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        while std::time::Instant::now() < deadline {
+            if child.try_wait()?.is_some() {
+                return Ok(());
+            }
+            std::thread::sleep(std::time::Duration::from_millis(50));
+        }
+    }
+
+    #[cfg(not(unix))]
+    {
+        if child.try_wait()?.is_some() {
+            return Ok(());
+        }
+    }
+
+    let _ = child.kill();
+    let _ = child.wait();
+    Ok(())
+}
+
+#[cfg(unix)]
+fn is_process_running(pid: u32) -> bool {
+    use nix::errno::Errno;
+    use nix::sys::signal::kill;
+    use nix::unistd::Pid;
+
+    let Ok(raw_pid) = i32::try_from(pid) else {
+        return false;
+    };
+
+    matches!(kill(Pid::from_raw(raw_pid), None), Ok(()) | Err(Errno::EPERM))
+}
+
+#[cfg(windows)]
+fn is_process_running(pid: u32) -> bool {
+    let watched_pid = Pid::from_u32(pid);
+    let mut system = System::new();
+    let _ = system.refresh_processes(ProcessesToUpdate::Some(&[watched_pid]), true);
+    system.process(watched_pid).is_some()
+}

--- a/crates/surge-supervisor/src/main.rs
+++ b/crates/surge-supervisor/src/main.rs
@@ -2,22 +2,22 @@
 #![allow(clippy::cast_possible_wrap)]
 
 use std::path::{Path, PathBuf};
-use std::process::{Child, Command, ExitCode, ExitStatus};
+use std::process::ExitCode;
 
 use clap::{Parser, Subcommand};
 use surge_core::supervisor::state::{read_supervisor_exe_path, supervisor_pid_file, supervisor_stop_file};
-#[cfg(windows)]
-use sysinfo::{Pid, ProcessesToUpdate, System};
 use thiserror::Error;
 
+mod child;
 mod handoff;
 mod ownership;
 
+use child::{
+    WaitOutcome, spawn_supervised_child, wait_before_restart, wait_for_pid_or_stop, wait_for_supervised_child,
+};
 #[cfg(all(test, unix))]
 use ownership::current_supervisor_owns_pid_file;
 use ownership::{remove_owned_supervisor_state, supervisor_was_superseded};
-
-const RESTART_HANDOFF_STABILITY_WINDOW: std::time::Duration = std::time::Duration::from_secs(4);
 
 /// Delay before relaunching a supervised child that has exited. Applied to both
 /// crash exits and clean (code 0) exits so a child that exits immediately cannot
@@ -324,289 +324,10 @@ fn run_supervisor(
     Ok(())
 }
 
-fn spawn_supervised_child(
-    exe_path: &Path,
-    install_dir: &Path,
-    child_args: &[String],
-) -> Result<Child, SupervisorError> {
-    tracing::info!("Starting child process: {}", exe_path.display());
-
-    let mut command = Command::new(exe_path);
-    command.current_dir(install_dir).args(child_args);
-
-    // Put the child in its own process group so a group-scoped signal or
-    // `pkill -g` aimed at the supervisor cannot also take down the child.
-    #[cfg(unix)]
-    {
-        use std::os::unix::process::CommandExt;
-        command.process_group(0);
-    }
-
-    let child = command.spawn()?;
-    tracing::info!("Child process started with PID {}", child.id());
-    Ok(child)
-}
-
-fn wait_for_supervised_child(
-    child: &mut Child,
-    shutdown: &std::sync::Arc<std::sync::atomic::AtomicBool>,
-    stop_file: &Path,
-    pid_file: &Path,
-    own_pid: u32,
-    install_dir: &Path,
-    pending_handoff_version: &mut Option<String>,
-) -> Result<Option<ExitStatus>, SupervisorError> {
-    let Some(version) = pending_handoff_version.clone() else {
-        return wait_for_child_exit_status(child, shutdown, stop_file, pid_file, own_pid);
-    };
-
-    match wait_for_child_startup_or_stop(
-        child,
-        shutdown,
-        stop_file,
-        pid_file,
-        own_pid,
-        RESTART_HANDOFF_STABILITY_WINDOW,
-    )? {
-        StartupOutcome::Running => {
-            handoff::record_restart_handoff_converged(install_dir, &version);
-            *pending_handoff_version = None;
-            wait_for_child_exit_status(child, shutdown, stop_file, pid_file, own_pid)
-        }
-        StartupOutcome::Exited(status) => {
-            handoff::record_restart_handoff_child_exited(install_dir, &version, status);
-            Ok(Some(status))
-        }
-        StartupOutcome::StopRequested => {
-            tracing::info!("Stop requested, exiting supervisor loop and leaving child running");
-            Ok(None)
-        }
-        StartupOutcome::ShutdownRequested => {
-            tracing::info!("Shutdown signal received, child terminated and supervisor loop is exiting");
-            Ok(None)
-        }
-        StartupOutcome::Superseded => Ok(None),
-    }
-}
-
-fn wait_for_child_exit_status(
-    child: &mut Child,
-    shutdown: &std::sync::Arc<std::sync::atomic::AtomicBool>,
-    stop_file: &Path,
-    pid_file: &Path,
-    own_pid: u32,
-) -> Result<Option<ExitStatus>, SupervisorError> {
-    match wait_for_child_or_stop(child, shutdown, stop_file, pid_file, own_pid)? {
-        WaitOutcome::Exited(status) => Ok(Some(status)),
-        WaitOutcome::ObservedProcessExited => unreachable!(),
-        WaitOutcome::StopRequested => {
-            tracing::info!("Stop requested, exiting supervisor loop and leaving child running");
-            Ok(None)
-        }
-        WaitOutcome::ShutdownRequested => {
-            tracing::info!("Shutdown signal received, child terminated and supervisor loop is exiting");
-            Ok(None)
-        }
-        WaitOutcome::Superseded => Ok(None),
-    }
-}
-
 fn write_pid_file(path: &Path, own_pid: u32) -> Result<(), SupervisorError> {
     std::fs::write(path, own_pid.to_string())?;
     tracing::debug!("Wrote PID file: {} (pid={})", path.display(), own_pid);
     Ok(())
-}
-
-enum WaitOutcome {
-    Exited(std::process::ExitStatus),
-    ObservedProcessExited,
-    StopRequested,
-    ShutdownRequested,
-    Superseded,
-}
-
-enum StartupOutcome {
-    Running,
-    Exited(std::process::ExitStatus),
-    StopRequested,
-    ShutdownRequested,
-    Superseded,
-}
-
-fn wait_for_child_startup_or_stop(
-    child: &mut Child,
-    shutdown: &std::sync::Arc<std::sync::atomic::AtomicBool>,
-    stop_file: &Path,
-    pid_file: &Path,
-    own_pid: u32,
-    stable_for: std::time::Duration,
-) -> Result<StartupOutcome, SupervisorError> {
-    let deadline = std::time::Instant::now() + stable_for;
-    loop {
-        if shutdown.load(std::sync::atomic::Ordering::Acquire) {
-            terminate_child_process(child)?;
-            return Ok(StartupOutcome::ShutdownRequested);
-        }
-
-        if supervisor_was_superseded(pid_file, own_pid) {
-            return Ok(StartupOutcome::Superseded);
-        }
-
-        if stop_file.exists() {
-            return Ok(StartupOutcome::StopRequested);
-        }
-
-        if let Some(status) = child.try_wait()? {
-            return Ok(StartupOutcome::Exited(status));
-        }
-
-        if std::time::Instant::now() >= deadline {
-            return Ok(StartupOutcome::Running);
-        }
-
-        std::thread::sleep(std::time::Duration::from_millis(100));
-    }
-}
-
-fn wait_for_pid_or_stop(
-    pid: u32,
-    shutdown: &std::sync::Arc<std::sync::atomic::AtomicBool>,
-    stop_file: &Path,
-    pid_file: &Path,
-    own_pid: u32,
-) -> WaitOutcome {
-    loop {
-        if shutdown.load(std::sync::atomic::Ordering::Acquire) {
-            return WaitOutcome::ShutdownRequested;
-        }
-
-        if supervisor_was_superseded(pid_file, own_pid) {
-            return WaitOutcome::Superseded;
-        }
-
-        if stop_file.exists() {
-            return WaitOutcome::StopRequested;
-        }
-
-        if !is_process_running(pid) {
-            return WaitOutcome::ObservedProcessExited;
-        }
-
-        std::thread::sleep(std::time::Duration::from_millis(100));
-    }
-}
-
-fn wait_for_child_or_stop(
-    child: &mut Child,
-    shutdown: &std::sync::Arc<std::sync::atomic::AtomicBool>,
-    stop_file: &Path,
-    pid_file: &Path,
-    own_pid: u32,
-) -> Result<WaitOutcome, SupervisorError> {
-    loop {
-        if shutdown.load(std::sync::atomic::Ordering::Acquire) {
-            terminate_child_process(child)?;
-            return Ok(WaitOutcome::ShutdownRequested);
-        }
-
-        if supervisor_was_superseded(pid_file, own_pid) {
-            return Ok(WaitOutcome::Superseded);
-        }
-
-        if stop_file.exists() {
-            return Ok(WaitOutcome::StopRequested);
-        }
-
-        if let Some(status) = child.try_wait()? {
-            return Ok(WaitOutcome::Exited(status));
-        }
-
-        std::thread::sleep(std::time::Duration::from_millis(100));
-    }
-}
-
-fn wait_before_restart(
-    shutdown: &std::sync::Arc<std::sync::atomic::AtomicBool>,
-    stop_file: &Path,
-    pid_file: &Path,
-    own_pid: u32,
-    delay: std::time::Duration,
-) -> bool {
-    let deadline = std::time::Instant::now() + delay;
-    loop {
-        if shutdown.load(std::sync::atomic::Ordering::Acquire) {
-            tracing::info!("Shutdown signal received during restart delay, not restarting");
-            return false;
-        }
-
-        if supervisor_was_superseded(pid_file, own_pid) {
-            return false;
-        }
-
-        if stop_file.exists() {
-            tracing::info!("Stop requested during restart delay, not restarting");
-            return false;
-        }
-
-        if std::time::Instant::now() >= deadline {
-            return true;
-        }
-
-        std::thread::sleep(std::time::Duration::from_millis(100));
-    }
-}
-
-fn terminate_child_process(child: &mut Child) -> Result<(), SupervisorError> {
-    if child.try_wait()?.is_some() {
-        return Ok(());
-    }
-
-    #[cfg(unix)]
-    {
-        use nix::sys::signal::{Signal, kill};
-        use nix::unistd::Pid;
-
-        let _ = kill(Pid::from_raw(child.id() as i32), Signal::SIGTERM);
-        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
-        while std::time::Instant::now() < deadline {
-            if child.try_wait()?.is_some() {
-                return Ok(());
-            }
-            std::thread::sleep(std::time::Duration::from_millis(50));
-        }
-    }
-
-    #[cfg(not(unix))]
-    {
-        if child.try_wait()?.is_some() {
-            return Ok(());
-        }
-    }
-
-    let _ = child.kill();
-    let _ = child.wait();
-    Ok(())
-}
-
-#[cfg(unix)]
-fn is_process_running(pid: u32) -> bool {
-    use nix::errno::Errno;
-    use nix::sys::signal::kill;
-    use nix::unistd::Pid;
-
-    let Ok(raw_pid) = i32::try_from(pid) else {
-        return false;
-    };
-
-    matches!(kill(Pid::from_raw(raw_pid), None), Ok(()) | Err(Errno::EPERM))
-}
-
-#[cfg(windows)]
-fn is_process_running(pid: u32) -> bool {
-    let watched_pid = Pid::from_u32(pid);
-    let mut system = System::new();
-    let _ = system.refresh_processes(ProcessesToUpdate::Some(&[watched_pid]), true);
-    system.process(watched_pid).is_some()
 }
 
 fn install_signal_handlers() -> std::sync::Arc<std::sync::atomic::AtomicBool> {
@@ -651,6 +372,8 @@ fn ctrlc_handler(shutdown: std::sync::Arc<std::sync::atomic::AtomicBool>) {
 mod tests {
     #[cfg(unix)]
     use std::path::{Path, PathBuf};
+    #[cfg(unix)]
+    use std::process::Command;
 
     use super::*;
 

--- a/crates/surge-supervisor/src/main.rs
+++ b/crates/surge-supervisor/src/main.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 use std::process::{Child, Command, ExitCode, ExitStatus};
 
 use clap::{Parser, Subcommand};
-use surge_core::supervisor::state::{supervisor_pid_file, supervisor_stop_file};
+use surge_core::supervisor::state::{read_supervisor_exe_path, supervisor_pid_file, supervisor_stop_file};
 #[cfg(windows)]
 use sysinfo::{Pid, ProcessesToUpdate, System};
 use thiserror::Error;
@@ -18,6 +18,11 @@ use ownership::current_supervisor_owns_pid_file;
 use ownership::{remove_owned_supervisor_state, supervisor_was_superseded};
 
 const RESTART_HANDOFF_STABILITY_WINDOW: std::time::Duration = std::time::Duration::from_secs(4);
+
+/// Delay before relaunching a supervised child that has exited. Applied to both
+/// crash exits and clean (code 0) exits so a child that exits immediately cannot
+/// spin the supervisor in a tight relaunch loop.
+const CHILD_RESTART_BACKOFF: std::time::Duration = std::time::Duration::from_secs(2);
 
 #[derive(Parser)]
 #[command(
@@ -42,9 +47,10 @@ enum Commands {
         #[arg(long)]
         dir: PathBuf,
 
-        /// Path to the application executable
+        /// Path to the application executable. Optional: when omitted it is
+        /// resolved from the supervisor exe state file written by the spawner.
         #[arg(long)]
-        exe: PathBuf,
+        exe: Option<PathBuf>,
 
         /// Arguments to pass to the child process
         #[arg(trailing_var_arg = true)]
@@ -73,9 +79,10 @@ enum Commands {
         #[arg(long)]
         handoff_version: Option<String>,
 
-        /// Path to the application executable
+        /// Path to the application executable. Optional: when omitted it is
+        /// resolved from the supervisor exe state file written by the spawner.
         #[arg(long)]
-        exe: PathBuf,
+        exe: Option<PathBuf>,
 
         /// Arguments to pass when launching the replacement child process
         #[arg(trailing_var_arg = true)]
@@ -99,8 +106,27 @@ enum SupervisorError {
     #[error("Executable not found: {0}")]
     ExecutableNotFound(String),
 
+    #[error("No executable path: pass --exe or write the supervisor exe state file for id '{0}' in {1}")]
+    MissingExecutablePath(String, String),
+
     #[error("I/O error: {0}")]
     Io(#[from] std::io::Error),
+}
+
+fn resolve_exe_path(
+    cli_exe: Option<&Path>,
+    install_dir: &Path,
+    supervisor_id: &str,
+) -> Result<PathBuf, SupervisorError> {
+    if let Some(exe) = cli_exe
+        && !exe.as_os_str().is_empty()
+    {
+        return Ok(exe.to_path_buf());
+    }
+
+    read_supervisor_exe_path(install_dir, supervisor_id).ok_or_else(|| {
+        SupervisorError::MissingExecutablePath(supervisor_id.to_string(), install_dir.display().to_string())
+    })
 }
 
 fn init_tracing(verbose: bool) {
@@ -126,7 +152,14 @@ fn main() -> ExitCode {
             verbose,
         } => {
             init_tracing(verbose);
-            if let Err(e) = run_supervisor(&id, &dir, &exe, &args, None, None) {
+            let exe_path = match resolve_exe_path(exe.as_deref(), &dir, &id) {
+                Ok(exe_path) => exe_path,
+                Err(e) => {
+                    tracing::error!("{e}");
+                    return ExitCode::FAILURE;
+                }
+            };
+            if let Err(e) = run_supervisor(&id, &dir, &exe_path, &args, None, None) {
                 tracing::error!("{e}");
                 return ExitCode::FAILURE;
             }
@@ -142,7 +175,14 @@ fn main() -> ExitCode {
             verbose,
         } => {
             init_tracing(verbose);
-            if let Err(e) = run_supervisor(&id, &dir, &exe, &args, Some(pid), handoff_version.as_deref()) {
+            let exe_path = match resolve_exe_path(exe.as_deref(), &dir, &id) {
+                Ok(exe_path) => exe_path,
+                Err(e) => {
+                    tracing::error!("{e}");
+                    return ExitCode::FAILURE;
+                }
+            };
+            if let Err(e) = run_supervisor(&id, &dir, &exe_path, &args, Some(pid), handoff_version.as_deref()) {
                 tracing::error!("{e}");
                 return ExitCode::FAILURE;
             }
@@ -237,15 +277,7 @@ fn run_supervisor(
         }
 
         let child_args = next_child_args.take().unwrap_or_else(|| restart_args.clone());
-
-        tracing::info!("Starting child process: {}", exe_path.display());
-
-        let mut child = Command::new(exe_path)
-            .current_dir(install_dir)
-            .args(&child_args)
-            .spawn()?;
-
-        tracing::info!("Child process started with PID {}", child.id());
+        let mut child = spawn_supervised_child(exe_path, install_dir, &child_args)?;
 
         let Some(status) = wait_for_supervised_child(
             &mut child,
@@ -270,18 +302,18 @@ fn run_supervisor(
         }
 
         if status.success() {
-            tracing::info!("Child exited successfully (code 0), not restarting");
-            break;
+            tracing::info!(
+                "Child exited successfully (code 0), restarting in {} seconds...",
+                CHILD_RESTART_BACKOFF.as_secs()
+            );
+        } else {
+            tracing::warn!(
+                "Child exited with {status}, restarting in {} seconds...",
+                CHILD_RESTART_BACKOFF.as_secs()
+            );
         }
 
-        tracing::warn!("Child exited with {status}, restarting in 2 seconds...");
-        if !wait_before_restart(
-            &shutdown,
-            &stop_file,
-            &pid_file,
-            own_pid,
-            std::time::Duration::from_secs(2),
-        ) {
+        if !wait_before_restart(&shutdown, &stop_file, &pid_file, own_pid, CHILD_RESTART_BACKOFF) {
             break;
         }
     }
@@ -290,6 +322,29 @@ fn run_supervisor(
 
     tracing::info!("Supervisor '{supervisor_id}' exiting");
     Ok(())
+}
+
+fn spawn_supervised_child(
+    exe_path: &Path,
+    install_dir: &Path,
+    child_args: &[String],
+) -> Result<Child, SupervisorError> {
+    tracing::info!("Starting child process: {}", exe_path.display());
+
+    let mut command = Command::new(exe_path);
+    command.current_dir(install_dir).args(child_args);
+
+    // Put the child in its own process group so a group-scoped signal or
+    // `pkill -g` aimed at the supervisor cannot also take down the child.
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        command.process_group(0);
+    }
+
+    let child = command.spawn()?;
+    tracing::info!("Child process started with PID {}", child.id());
+    Ok(child)
 }
 
 fn wait_for_supervised_child(
@@ -798,13 +853,18 @@ mod tests {
         let tmp = TestInstallDir::new("surge-supervisor-first-run-order");
         let install_dir = tmp.path();
         let args_path = install_dir.join("args.txt");
+        let first_run_marker = install_dir.join("first-run-done");
         let exe_path = install_dir.join("target-child");
         std::fs::write(
             &exe_path,
             format!(
                 "#!/bin/sh\n\
-                 printf '%s\\n' \"$@\" > '{}'\n",
-                args_path.display()
+                 if [ ! -f '{marker}' ]; then\n\
+                 printf '%s\\n' \"$@\" > '{args}'\n\
+                 touch '{marker}'\n\
+                 fi\n",
+                marker = first_run_marker.display(),
+                args = args_path.display()
             ),
         )
         .unwrap();
@@ -812,23 +872,39 @@ mod tests {
         permissions.set_mode(0o755);
         std::fs::set_permissions(&exe_path, permissions).unwrap();
 
-        run_supervisor(
-            "demo-supervisor",
-            install_dir,
-            &exe_path,
-            &[
-                "--app-mode".to_string(),
-                "service".to_string(),
-                "--surge-first-run".to_string(),
-                "2.0.0".to_string(),
-            ],
-            None,
-            None,
-        )
-        .unwrap();
+        let install_dir_for_thread = install_dir.to_path_buf();
+        let exe_path_for_thread = exe_path.clone();
+        let (tx, rx) = std::sync::mpsc::channel();
+        let supervisor = std::thread::spawn(move || {
+            let result = run_supervisor(
+                "demo-supervisor",
+                &install_dir_for_thread,
+                &exe_path_for_thread,
+                &[
+                    "--app-mode".to_string(),
+                    "service".to_string(),
+                    "--surge-first-run".to_string(),
+                    "2.0.0".to_string(),
+                ],
+                None,
+                None,
+            );
+            tx.send(result).unwrap();
+        });
 
-        let args = std::fs::read_to_string(args_path).unwrap();
-        assert_eq!(args, "--app-mode\nservice\n--surge-first-run\n2.0.0\n");
+        let stop_file = supervisor_stop_file(install_dir, "demo-supervisor");
+        let first_child_ran = wait_until(std::time::Duration::from_secs(5), || first_run_marker.exists());
+        let args = std::fs::read_to_string(&args_path);
+        std::fs::write(&stop_file, "stop").unwrap();
+
+        let supervisor_result = rx.recv_timeout(std::time::Duration::from_secs(5));
+        supervisor.join().unwrap();
+        supervisor_result
+            .expect("supervisor did not exit after stop file")
+            .unwrap();
+
+        assert!(first_child_ran, "first child should have recorded its argv");
+        assert_eq!(args.unwrap(), "--app-mode\nservice\n--surge-first-run\n2.0.0\n");
     }
 
     #[cfg(unix)]
@@ -869,16 +945,41 @@ mod tests {
         let mut watched_child = Command::new("sh").arg("-c").arg("sleep 0.1").spawn().unwrap();
         let watched_pid = watched_child.id();
         watched_child.wait().unwrap();
-        run_supervisor(
-            "demo-supervisor",
-            install_dir,
-            &exe_path,
-            &[],
-            Some(watched_pid),
-            Some("2.0.0"),
-        )
-        .unwrap();
 
+        let install_dir_for_thread = install_dir.to_path_buf();
+        let exe_path_for_thread = exe_path.clone();
+        let (tx, rx) = std::sync::mpsc::channel();
+        let supervisor = std::thread::spawn(move || {
+            let result = run_supervisor(
+                "demo-supervisor",
+                &install_dir_for_thread,
+                &exe_path_for_thread,
+                &[],
+                Some(watched_pid),
+                Some("2.0.0"),
+            );
+            tx.send(result).unwrap();
+        });
+
+        let stop_file = supervisor_stop_file(install_dir, "demo-supervisor");
+        let converged = wait_until(std::time::Duration::from_secs(15), || {
+            surge_core::update::status::read_update_status(install_dir)
+                .ok()
+                .flatten()
+                .is_some_and(|status| status.state == surge_core::update::status::UpdateConvergenceState::Converged)
+        });
+        std::fs::write(&stop_file, "stop").unwrap();
+
+        let supervisor_result = rx.recv_timeout(std::time::Duration::from_secs(10));
+        supervisor.join().unwrap();
+        supervisor_result
+            .expect("supervisor did not exit after stop file")
+            .unwrap();
+
+        assert!(
+            converged,
+            "restart handoff should converge once the target child survives the stability window"
+        );
         assert!(child_started.exists(), "replacement child should have started");
         let status = surge_core::update::status::read_update_status(install_dir)
             .unwrap()
@@ -892,5 +993,90 @@ mod tests {
         assert!(status.supervisor_restart_confirmed);
         assert_eq!(status.failure_phase, None);
         assert_eq!(status.reason, None);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn clean_child_exit_triggers_restart_in_steady_state() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = TestInstallDir::new("surge-supervisor-clean-exit-restart");
+        let install_dir = tmp.path();
+        let runs_path = install_dir.join("child-runs.log");
+        let exe_path = install_dir.join("target-child");
+        std::fs::write(
+            &exe_path,
+            format!("#!/bin/sh\necho run >> '{}'\nexit 0\n", runs_path.display()),
+        )
+        .unwrap();
+        let mut permissions = std::fs::metadata(&exe_path).unwrap().permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&exe_path, permissions).unwrap();
+
+        let install_dir_for_thread = install_dir.to_path_buf();
+        let exe_path_for_thread = exe_path.clone();
+        let (tx, rx) = std::sync::mpsc::channel();
+        let supervisor = std::thread::spawn(move || {
+            let result = run_supervisor(
+                "demo-supervisor",
+                &install_dir_for_thread,
+                &exe_path_for_thread,
+                &[],
+                None,
+                None,
+            );
+            tx.send(result).unwrap();
+        });
+
+        let restarted = wait_until(std::time::Duration::from_secs(10), || {
+            std::fs::read_to_string(&runs_path).is_ok_and(|contents| contents.lines().count() >= 2)
+        });
+
+        let stop_file = supervisor_stop_file(install_dir, "demo-supervisor");
+        std::fs::write(&stop_file, "stop").unwrap();
+        let supervisor_result = rx.recv_timeout(std::time::Duration::from_secs(10));
+        supervisor.join().unwrap();
+        supervisor_result
+            .expect("supervisor did not exit after stop file")
+            .unwrap();
+
+        assert!(
+            restarted,
+            "supervisor must relaunch a child that exits cleanly (code 0) instead of stopping supervision"
+        );
+    }
+
+    #[test]
+    fn resolve_exe_path_prefers_explicit_flag() {
+        let resolved = resolve_exe_path(
+            Some(Path::new("/opt/demo/app/demo")),
+            Path::new("/opt/demo"),
+            "demo-supervisor",
+        )
+        .unwrap();
+        assert_eq!(resolved, PathBuf::from("/opt/demo/app/demo"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn resolve_exe_path_reads_state_file_when_flag_absent() {
+        let tmp = TestInstallDir::new("surge-supervisor-exe-state");
+        let install_dir = tmp.path();
+        let exe = install_dir.join("app").join("demo-app");
+        surge_core::supervisor::state::write_supervisor_exe_path(install_dir, "demo-supervisor", &exe).unwrap();
+
+        let resolved = resolve_exe_path(None, install_dir, "demo-supervisor").unwrap();
+        assert_eq!(resolved, exe);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn resolve_exe_path_errors_when_flag_and_state_file_absent() {
+        let tmp = TestInstallDir::new("surge-supervisor-exe-missing");
+        let install_dir = tmp.path();
+
+        let err = resolve_exe_path(None, install_dir, "demo-supervisor").unwrap_err();
+
+        assert!(matches!(err, SupervisorError::MissingExecutablePath(..)));
     }
 }


### PR DESCRIPTION
## Purpose

A production node was found dead for ~34 hours after a package swap: the supervised app logged a clean shutdown during the apply, the supervisor treated exit code 0 as "done, not restarting", and the replacement watch supervisor never took over. The only respawn path left was the desktop autostart entry. A second variant: operators running `pkill -f <app-path>` killed the supervisor together with the child because the app path appeared in the supervisor's own `--exe` argument.

This PR hardens the supervisor lifecycle against that entire class:

1. **Restart on all child exits.** A clean (code 0) child exit no longer ends supervision; every exit relaunches after a shared 2s backoff. Supervision ends only via the stop file, supersession, or SIGTERM/SIGINT. Intentional app quits keep working through `surge_supervisor_stop` (stop file), which is honored both at loop head and after a child exit.
2. **Child in its own process group** (`CommandExt::process_group(0)`, unix). Group-scoped signals or `pkill -g` aimed at the supervisor can no longer take down both. Supervisor-initiated termination is pid-direct and unaffected.
3. **Finalize hardening.** The replacement watch supervisor now starts immediately after the app directory swap + persistent assets + runtime manifest, before the best-effort shortcuts/prune/hook steps — shrinking the unsupervised window. The start is no longer gated on a supervisor having been running before the update, so a supervisor that died earlier is recovered at the next update. The spawn is retried once (500ms delay) when the pid file does not appear within the confirm window; a slow first spawn plus a retry resolves safely via the existing supersession mechanism.
4. **App path out of supervisor argv.** The spawner persists the supervised executable path in a per-supervisor state file (`.surge-supervisor-<id>.exe`); `--exe` is now optional and kept as the first-choice override. The update/self-restart spawn sites (finalize lifecycle + FFI `surge_supervisor_start`) omit `--exe`, so `pkill -f <app-path>` no longer matches the supervisor on the steady-state respawn paths. The C ABI signature is unchanged.

## Behavior impact

- A child dying inside the 4s restart-handoff stability window now records the failed handoff and retries; convergence is re-evaluated on the respawn instead of abandoning the node.
- If a late finalize step fails (prune/hook), the supervisor is already running — the app ends up supervised on the new version while the update reports the failure. Intended consequence of shrinking the unsupervised window.
- Apps configured for supervision but launched without a running supervisor now gain a watch supervisor at their next update (that is the recovery behavior this PR exists for).

## Cross-version compatibility / migration notes

- New supervisors accept `--exe` (preferred when present) or the state file; old spawners passing `--exe` keep working unchanged.
- Spawn sites that may launch an **older** package's supervisor keep `--exe` on argv: the remote-install shell template, the initial local-install launch, and generated autostart shortcuts. Omitting it there would break installs of pre-change packages. Residual: a boot-spawned (autostart) supervisor still carries `--exe` until the node's first update/self-restart spawn; closing that requires a follow-up once fleet supervisors all understand the state file.
- The state file is written before every watch spawn (finalize + FFI), so it is always fresh for the version being handed off to.

## Test evidence

All mandatory pre-push gates green in this worktree:

- `./scripts/sync-surge-core-vendor.sh --check`, `./scripts/check-version-sync.sh`
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo test --workspace` — 493 passed, 0 failed
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo clippy --workspace --lib --bins --examples -- -D warnings -D clippy::unwrap_used -D clippy::expect_used`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings -W clippy::pedantic`
- `dotnet format dotnet/Surge.slnx --verify-no-changes`
- `dotnet test dotnet/Surge.slnx --configuration Release` — 39 passed

New regression tests:
- `clean_child_exit_triggers_restart_in_steady_state` — code-0 child is relaunched.
- `test_finalize_starts_supervisor_when_none_was_running` — full `download_and_apply` with supervision configured but no pre-existing supervisor: pid file appears, exe state written, status = PendingRestart(waiting).
- `restart_supervisor_retries_once_when_pid_file_never_appears` — spawn retried exactly once, FAILED outcome preserved.
- `resolve_exe_path_*` (flag precedence, state-file fallback, missing-both error) and `supervisor_exe_path_*` (round trip, missing, blank).
- Adapted: first-run argv-order and handoff-convergence tests now drive the supervisor on a thread and stop it via the stop file, since a clean child exit no longer ends the loop; handoff test asserts Converged as before.

https://claude.ai/code/session_01Wq6ioVxZenkzmCXHX146e4