### PR TITLE
fix(core): stop re-stamping completed_at_utc at handoff transitions and abandoned-attempt discovery

### DIFF
--- a/crates/surge-core/src/update/status.rs
+++ b/crates/surge-core/src/update/status.rs
@@ -85,6 +85,10 @@ pub struct UpdateStatusRecord {
     pub supervisor_restart_confirmed: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub attempted_at_utc: Option<String>,
+    /// When the update work (download, verify, apply, restart initiation)
+    /// finished. Deliberately not re-stamped when convergence is proven later:
+    /// `attempted_at_utc..completed_at_utc` must stay a truthful measure of the
+    /// update work even when the restart handoff takes hours to settle.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub completed_at_utc: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -355,6 +359,34 @@ impl UpdateStatusRecord {
         reason: &str,
         context: FailureContext,
     ) -> Self {
+        Self::failed_with_context_at(
+            app_id,
+            installed_version,
+            target_version,
+            channel,
+            attempted_at_utc,
+            now_utc_rfc3339(),
+            reason,
+            context,
+        )
+    }
+
+    /// Like [`Self::failed_with_context`], but with an explicit
+    /// `completed_at_utc` for failures classified after the fact (for example
+    /// an abandoned attempt discovered on the next update check), where "now"
+    /// would fold the idle gap into the recorded attempt duration.
+    #[must_use]
+    #[allow(clippy::too_many_arguments)]
+    pub fn failed_with_context_at(
+        app_id: &str,
+        installed_version: &str,
+        target_version: &str,
+        channel: &str,
+        attempted_at_utc: String,
+        completed_at_utc: String,
+        reason: &str,
+        context: FailureContext,
+    ) -> Self {
         Self {
             state: UpdateConvergenceState::Failed,
             installed_version: installed_version.to_string(),
@@ -363,7 +395,7 @@ impl UpdateStatusRecord {
             app_id: app_id.to_string(),
             supervisor_restart_confirmed: false,
             attempted_at_utc: Some(attempted_at_utc),
-            completed_at_utc: Some(now_utc_rfc3339()),
+            completed_at_utc: Some(completed_at_utc),
             reason: Some(reason.to_string()),
             last_progress_at_utc: context.last_progress_at_utc,
             current_phase: None,
@@ -482,12 +514,17 @@ fn fail_abandoned_in_progress_update_at(
         .or(record.failure_phase.as_deref())
         .unwrap_or("unknown");
     let attempted_at_utc = record.attempted_at_utc.clone().unwrap_or_else(now_utc_rfc3339);
-    let failed = UpdateStatusRecord::failed_with_context(
+    let last_activity_at_utc = record
+        .last_progress_at_utc
+        .clone()
+        .unwrap_or_else(|| attempted_at_utc.clone());
+    let failed = UpdateStatusRecord::failed_with_context_at(
         &record.app_id,
         &record.installed_version,
         &record.target_version,
         &record.channel,
         attempted_at_utc,
+        last_activity_at_utc,
         &format!(
             "previous update attempt abandoned after {}s without progress at phase '{phase}'",
             age.as_secs()
@@ -727,6 +764,8 @@ mod tests {
         assert_eq!(failed.target_version, "9999.0.0");
         assert_eq!(failed.failure_phase.as_deref(), Some("package apply started"));
         assert_eq!(failed.retry_safe, Some(true));
+        assert_eq!(failed.attempted_at_utc.as_deref(), Some("2026-05-15T20:00:00Z"));
+        assert_eq!(failed.completed_at_utc.as_deref(), Some("2026-05-15T20:01:00Z"));
         assert!(
             failed
                 .reason

--- a/crates/surge-core/src/update/status.rs
+++ b/crates/surge-core/src/update/status.rs
@@ -25,14 +25,15 @@ use crate::platform::fs::write_file_atomic;
 use crate::supervisor::state::supervisor_pid_file;
 
 mod handoff;
+mod worker;
 
 pub use handoff::{
     RESTART_HANDOFF_FAILED_PHASE, RESTART_HANDOFF_TARGET_CHILD_EXITED_PHASE,
     RESTART_HANDOFF_WAITING_FOR_OLD_CHILD_PHASE, mark_restart_handoff_converged, mark_restart_handoff_pending,
 };
+pub use worker::{UpdateWorkerGuard, fail_abandoned_in_progress_update};
 
 pub const UPDATE_STATUS_FILE_NAME: &str = ".surge-update-status.json";
-const UPDATE_WORKER_FILE_NAME: &str = ".surge-update-worker.json";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -112,56 +113,6 @@ pub struct UpdateStatusRecord {
     /// Whether retrying the same setup/update command is expected to be safe.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub retry_safe: Option<bool>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-struct UpdateWorkerRecord {
-    pid: u32,
-    app_id: String,
-    target_version: String,
-    started_at_utc: String,
-}
-
-pub struct UpdateWorkerGuard {
-    path: PathBuf,
-    pid: u32,
-    app_id: String,
-    target_version: String,
-}
-
-impl UpdateWorkerGuard {
-    pub fn record(install_dir: &Path, app_id: &str, target_version: &str) -> Result<Self> {
-        let record = UpdateWorkerRecord {
-            pid: std::process::id(),
-            app_id: app_id.to_string(),
-            target_version: target_version.to_string(),
-            started_at_utc: now_utc_rfc3339(),
-        };
-        let path = update_worker_path(install_dir);
-        let json = serde_json::to_vec_pretty(&record)
-            .map_err(|e| SurgeError::Config(format!("Failed to encode update worker marker: {e}")))?;
-        write_file_atomic(&path, &json)?;
-        Ok(Self {
-            path,
-            pid: record.pid,
-            app_id: record.app_id,
-            target_version: record.target_version,
-        })
-    }
-}
-
-impl Drop for UpdateWorkerGuard {
-    fn drop(&mut self) {
-        let Ok(raw) = std::fs::read(&self.path) else {
-            return;
-        };
-        let Ok(record) = serde_json::from_slice::<UpdateWorkerRecord>(&raw) else {
-            return;
-        };
-        if record.pid == self.pid && record.app_id == self.app_id && record.target_version == self.target_version {
-            let _ = std::fs::remove_file(&self.path);
-        }
-    }
 }
 
 impl UpdateStatusRecord {
@@ -437,11 +388,6 @@ pub fn update_status_path(install_dir: &Path) -> PathBuf {
     install_dir.join(UPDATE_STATUS_FILE_NAME)
 }
 
-#[must_use]
-fn update_worker_path(install_dir: &Path) -> PathBuf {
-    install_dir.join(UPDATE_WORKER_FILE_NAME)
-}
-
 /// Read the persisted update status record from `install_dir`, if any.
 ///
 /// Returns `Ok(None)` when no record has been written yet (clean install that
@@ -464,104 +410,6 @@ pub fn write_update_status(install_dir: &Path, record: &UpdateStatusRecord) -> R
         .map_err(|e| SurgeError::Config(format!("Failed to encode update status: {e}")))?;
     write_file_atomic(&path, &json)?;
     Ok(())
-}
-
-pub fn fail_abandoned_in_progress_update(
-    install_dir: &Path,
-    app_id: &str,
-    target_version: &str,
-    channel: &str,
-    stale_after: Duration,
-) -> Result<Option<UpdateStatusRecord>> {
-    fail_abandoned_in_progress_update_at(
-        install_dir,
-        app_id,
-        target_version,
-        channel,
-        stale_after,
-        chrono::Utc::now(),
-    )
-}
-
-fn fail_abandoned_in_progress_update_at(
-    install_dir: &Path,
-    app_id: &str,
-    target_version: &str,
-    channel: &str,
-    stale_after: Duration,
-    now: chrono::DateTime<chrono::Utc>,
-) -> Result<Option<UpdateStatusRecord>> {
-    let Some(record) = read_update_status(install_dir)? else {
-        return Ok(None);
-    };
-    if record.state != UpdateConvergenceState::InProgress
-        || record.app_id != app_id
-        || record.target_version != target_version
-        || record.channel != channel
-    {
-        return Ok(None);
-    }
-    let Some(age) = stale_progress_age(&record, now) else {
-        return Ok(None);
-    };
-    if age < stale_after || matching_worker_is_current(install_dir, &record) {
-        return Ok(None);
-    }
-
-    let phase = record
-        .current_phase
-        .as_deref()
-        .or(record.failure_phase.as_deref())
-        .unwrap_or("unknown");
-    let attempted_at_utc = record.attempted_at_utc.clone().unwrap_or_else(now_utc_rfc3339);
-    let last_activity_at_utc = record
-        .last_progress_at_utc
-        .clone()
-        .unwrap_or_else(|| attempted_at_utc.clone());
-    let failed = UpdateStatusRecord::failed_with_context_at(
-        &record.app_id,
-        &record.installed_version,
-        &record.target_version,
-        &record.channel,
-        attempted_at_utc,
-        last_activity_at_utc,
-        &format!(
-            "previous update attempt abandoned after {}s without progress at phase '{phase}'",
-            age.as_secs()
-        ),
-        FailureContext::from_record(Some(&record), true),
-    );
-    write_update_status(install_dir, &failed)?;
-    Ok(Some(failed))
-}
-
-fn stale_progress_age(record: &UpdateStatusRecord, now: chrono::DateTime<chrono::Utc>) -> Option<Duration> {
-    let timestamp = record
-        .last_progress_at_utc
-        .as_deref()
-        .or(record.attempted_at_utc.as_deref())?;
-    let parsed = chrono::DateTime::parse_from_rfc3339(timestamp).ok()?;
-    now.signed_duration_since(parsed.with_timezone(&chrono::Utc))
-        .to_std()
-        .ok()
-}
-
-fn matching_worker_is_current(install_dir: &Path, record: &UpdateStatusRecord) -> bool {
-    let Ok(Some(worker)) = read_update_worker(install_dir) else {
-        return false;
-    };
-    worker.pid == std::process::id() && worker.app_id == record.app_id && worker.target_version == record.target_version
-}
-
-fn read_update_worker(install_dir: &Path) -> Result<Option<UpdateWorkerRecord>> {
-    let path = update_worker_path(install_dir);
-    if !path.is_file() {
-        return Ok(None);
-    }
-    let raw = std::fs::read(&path)?;
-    serde_json::from_slice(&raw)
-        .map(Some)
-        .map_err(|e| SurgeError::Config(format!("Failed to decode {}: {e}", path.display())))
 }
 
 #[must_use]
@@ -730,86 +578,6 @@ mod tests {
 
         assert_eq!(loaded.state, UpdateConvergenceState::InProgress);
         assert_eq!(loaded.current_phase.as_deref(), Some("stopping supervisor"));
-    }
-
-    #[test]
-    fn stale_in_progress_package_apply_becomes_retry_safe_failed_when_abandoned() {
-        let dir = tempfile::tempdir().unwrap();
-        let record = UpdateStatusRecord::in_progress(
-            "demo-app",
-            "9998.0.0",
-            "9999.0.0",
-            "stable",
-            "2026-05-15T20:00:00Z".to_string(),
-        )
-        .with_current_phase_at("package apply started", "2026-05-15T20:01:00Z".to_string());
-        write_update_status(dir.path(), &record).unwrap();
-
-        let now = chrono::DateTime::parse_from_rfc3339("2026-05-15T20:10:00Z")
-            .unwrap()
-            .with_timezone(&chrono::Utc);
-        let failed = fail_abandoned_in_progress_update_at(
-            dir.path(),
-            "demo-app",
-            "9999.0.0",
-            "stable",
-            Duration::from_mins(1),
-            now,
-        )
-        .unwrap()
-        .expect("stale record should transition");
-
-        assert_eq!(failed.state, UpdateConvergenceState::Failed);
-        assert_eq!(failed.installed_version, "9998.0.0");
-        assert_eq!(failed.target_version, "9999.0.0");
-        assert_eq!(failed.failure_phase.as_deref(), Some("package apply started"));
-        assert_eq!(failed.retry_safe, Some(true));
-        assert_eq!(failed.attempted_at_utc.as_deref(), Some("2026-05-15T20:00:00Z"));
-        assert_eq!(failed.completed_at_utc.as_deref(), Some("2026-05-15T20:01:00Z"));
-        assert!(
-            failed
-                .reason
-                .as_deref()
-                .unwrap_or_default()
-                .contains("abandoned after 540s without progress")
-        );
-
-        let persisted = read_update_status(dir.path()).unwrap().unwrap();
-        assert_eq!(persisted.state, UpdateConvergenceState::Failed);
-        assert_eq!(persisted.failure_phase.as_deref(), Some("package apply started"));
-    }
-
-    #[test]
-    fn stale_in_progress_owned_by_current_worker_is_left_in_progress() {
-        let dir = tempfile::tempdir().unwrap();
-        let record = UpdateStatusRecord::in_progress(
-            "demo-app",
-            "9998.0.0",
-            "9999.0.0",
-            "stable",
-            "2026-05-15T20:00:00Z".to_string(),
-        )
-        .with_current_phase_at("package apply started", "2026-05-15T20:01:00Z".to_string());
-        write_update_status(dir.path(), &record).unwrap();
-        let _worker = UpdateWorkerGuard::record(dir.path(), "demo-app", "9999.0.0").unwrap();
-
-        let now = chrono::DateTime::parse_from_rfc3339("2026-05-15T20:10:00Z")
-            .unwrap()
-            .with_timezone(&chrono::Utc);
-        let result = fail_abandoned_in_progress_update_at(
-            dir.path(),
-            "demo-app",
-            "9999.0.0",
-            "stable",
-            Duration::from_mins(1),
-            now,
-        )
-        .unwrap();
-
-        assert!(result.is_none());
-        let persisted = read_update_status(dir.path()).unwrap().unwrap();
-        assert_eq!(persisted.state, UpdateConvergenceState::InProgress);
-        assert_eq!(persisted.current_phase.as_deref(), Some("package apply started"));
     }
 
     #[test]

--- a/crates/surge-core/src/update/status/handoff.rs
+++ b/crates/surge-core/src/update/status/handoff.rs
@@ -18,6 +18,7 @@ pub fn mark_restart_handoff_pending(
         return Ok(None);
     };
 
+    let completed_at_utc = update_work_completed_at(&existing);
     let attempted_at_utc = existing.attempted_at_utc.unwrap_or_else(now_utc_rfc3339);
     let record = UpdateStatusRecord::pending_restart_with_failure_phase(
         &existing.app_id,
@@ -25,7 +26,7 @@ pub fn mark_restart_handoff_pending(
         &existing.target_version,
         &existing.channel,
         attempted_at_utc,
-        now_utc_rfc3339(),
+        completed_at_utc,
         reason,
         failure_phase,
     );
@@ -38,16 +39,30 @@ pub fn mark_restart_handoff_converged(install_dir: &Path, target_version: &str) 
         return Ok(None);
     };
 
+    let completed_at_utc = update_work_completed_at(&existing);
     let record = UpdateStatusRecord::converged(
         &existing.app_id,
         &existing.target_version,
         &existing.channel,
         existing.attempted_at_utc,
-        now_utc_rfc3339(),
+        completed_at_utc,
         true,
     );
     write_update_status(install_dir, &record)?;
     Ok(Some(record))
+}
+
+/// `attempted_at_utc..completed_at_utc` measures the update work itself, not
+/// how long convergence took to prove. Handoff transitions can fire hours
+/// after the apply finished (wedged old child, power loss, crash-looping
+/// target child), so re-stamping `completed_at_utc` at transition time would
+/// fold that outage into the recorded update duration.
+fn update_work_completed_at(existing: &UpdateStatusRecord) -> String {
+    existing
+        .completed_at_utc
+        .clone()
+        .or_else(|| existing.last_progress_at_utc.clone())
+        .unwrap_or_else(now_utc_rfc3339)
 }
 
 fn read_matching_handoff_record(install_dir: &Path, target_version: &str) -> Result<Option<UpdateStatusRecord>> {
@@ -98,6 +113,7 @@ mod tests {
             child_exited.failure_phase.as_deref(),
             Some(RESTART_HANDOFF_TARGET_CHILD_EXITED_PHASE)
         );
+        assert_eq!(child_exited.completed_at_utc.as_deref(), Some("2026-05-11T14:05:00Z"));
 
         let converged = mark_restart_handoff_converged(dir.path(), "9999.0.0")
             .unwrap()
@@ -105,5 +121,46 @@ mod tests {
         assert_eq!(converged.state, UpdateConvergenceState::Converged);
         assert!(converged.supervisor_restart_confirmed);
         assert_eq!(converged.attempted_at_utc.as_deref(), Some("2026-05-11T14:00:00Z"));
+        assert_eq!(converged.completed_at_utc.as_deref(), Some("2026-05-11T14:05:00Z"));
+    }
+
+    #[test]
+    fn delayed_convergence_preserves_update_work_completed_at() {
+        let dir = tempfile::tempdir().unwrap();
+        let record = UpdateStatusRecord::pending_restart(
+            "demo-app",
+            "9999.0.0",
+            "9999.0.0",
+            "stable",
+            "2026-05-11T14:00:00Z".to_string(),
+            "2026-05-11T14:05:00Z".to_string(),
+            "waiting for previous child to exit",
+        );
+        write_update_status(dir.path(), &record).unwrap();
+
+        let converged = mark_restart_handoff_converged(dir.path(), "9999.0.0")
+            .unwrap()
+            .expect("matching record should converge");
+        assert_eq!(converged.completed_at_utc.as_deref(), Some("2026-05-11T14:05:00Z"));
+    }
+
+    #[test]
+    fn in_progress_convergence_falls_back_to_last_progress_timestamp() {
+        let dir = tempfile::tempdir().unwrap();
+        let record = UpdateStatusRecord::in_progress(
+            "demo-app",
+            "9998.0.0",
+            "9999.0.0",
+            "stable",
+            "2026-05-11T14:00:00Z".to_string(),
+        )
+        .with_completed_phase_at("finalize", "2026-05-11T14:04:00Z".to_string());
+        write_update_status(dir.path(), &record).unwrap();
+
+        let converged = mark_restart_handoff_converged(dir.path(), "9999.0.0")
+            .unwrap()
+            .expect("matching record should converge");
+        assert_eq!(converged.attempted_at_utc.as_deref(), Some("2026-05-11T14:00:00Z"));
+        assert_eq!(converged.completed_at_utc.as_deref(), Some("2026-05-11T14:04:00Z"));
     }
 }

--- a/crates/surge-core/src/update/status/handoff.rs
+++ b/crates/surge-core/src/update/status/handoff.rs
@@ -19,7 +19,7 @@ pub fn mark_restart_handoff_pending(
     };
 
     let completed_at_utc = update_work_completed_at(&existing);
-    let attempted_at_utc = existing.attempted_at_utc.unwrap_or_else(now_utc_rfc3339);
+    let attempted_at_utc = existing.attempted_at_utc.unwrap_or_else(|| completed_at_utc.clone());
     let record = UpdateStatusRecord::pending_restart_with_failure_phase(
         &existing.app_id,
         &existing.target_version,

--- a/crates/surge-core/src/update/status/worker.rs
+++ b/crates/surge-core/src/update/status/worker.rs
@@ -1,0 +1,259 @@
+//! Update-worker ownership marker and abandoned-attempt classification.
+//!
+//! A live update attempt records its worker (pid, app, target version) next
+//! to the status file. When a later attempt finds an `InProgress` record
+//! whose worker is gone and whose progress heartbeat is stale, it classifies
+//! that attempt as abandoned before starting its own.
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::{Result, SurgeError};
+use crate::platform::fs::write_file_atomic;
+
+use super::{
+    FailureContext, UpdateConvergenceState, UpdateStatusRecord, now_utc_rfc3339, read_update_status,
+    write_update_status,
+};
+
+const UPDATE_WORKER_FILE_NAME: &str = ".surge-update-worker.json";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct UpdateWorkerRecord {
+    pid: u32,
+    app_id: String,
+    target_version: String,
+    started_at_utc: String,
+}
+
+pub struct UpdateWorkerGuard {
+    path: PathBuf,
+    pid: u32,
+    app_id: String,
+    target_version: String,
+}
+
+impl UpdateWorkerGuard {
+    pub fn record(install_dir: &Path, app_id: &str, target_version: &str) -> Result<Self> {
+        let record = UpdateWorkerRecord {
+            pid: std::process::id(),
+            app_id: app_id.to_string(),
+            target_version: target_version.to_string(),
+            started_at_utc: now_utc_rfc3339(),
+        };
+        let path = update_worker_path(install_dir);
+        let json = serde_json::to_vec_pretty(&record)
+            .map_err(|e| SurgeError::Config(format!("Failed to encode update worker marker: {e}")))?;
+        write_file_atomic(&path, &json)?;
+        Ok(Self {
+            path,
+            pid: record.pid,
+            app_id: record.app_id,
+            target_version: record.target_version,
+        })
+    }
+}
+
+impl Drop for UpdateWorkerGuard {
+    fn drop(&mut self) {
+        let Ok(raw) = std::fs::read(&self.path) else {
+            return;
+        };
+        let Ok(record) = serde_json::from_slice::<UpdateWorkerRecord>(&raw) else {
+            return;
+        };
+        if record.pid == self.pid && record.app_id == self.app_id && record.target_version == self.target_version {
+            let _ = std::fs::remove_file(&self.path);
+        }
+    }
+}
+
+pub fn fail_abandoned_in_progress_update(
+    install_dir: &Path,
+    app_id: &str,
+    target_version: &str,
+    channel: &str,
+    stale_after: Duration,
+) -> Result<Option<UpdateStatusRecord>> {
+    fail_abandoned_in_progress_update_at(
+        install_dir,
+        app_id,
+        target_version,
+        channel,
+        stale_after,
+        chrono::Utc::now(),
+    )
+}
+
+fn fail_abandoned_in_progress_update_at(
+    install_dir: &Path,
+    app_id: &str,
+    target_version: &str,
+    channel: &str,
+    stale_after: Duration,
+    now: chrono::DateTime<chrono::Utc>,
+) -> Result<Option<UpdateStatusRecord>> {
+    let Some(record) = read_update_status(install_dir)? else {
+        return Ok(None);
+    };
+    if record.state != UpdateConvergenceState::InProgress
+        || record.app_id != app_id
+        || record.target_version != target_version
+        || record.channel != channel
+    {
+        return Ok(None);
+    }
+    let Some(age) = stale_progress_age(&record, now) else {
+        return Ok(None);
+    };
+    if age < stale_after || matching_worker_is_current(install_dir, &record) {
+        return Ok(None);
+    }
+
+    let phase = record
+        .current_phase
+        .as_deref()
+        .or(record.failure_phase.as_deref())
+        .unwrap_or("unknown");
+    let attempted_at_utc = record.attempted_at_utc.clone().unwrap_or_else(now_utc_rfc3339);
+    let last_activity_at_utc = record
+        .last_progress_at_utc
+        .clone()
+        .unwrap_or_else(|| attempted_at_utc.clone());
+    let failed = UpdateStatusRecord::failed_with_context_at(
+        &record.app_id,
+        &record.installed_version,
+        &record.target_version,
+        &record.channel,
+        attempted_at_utc,
+        last_activity_at_utc,
+        &format!(
+            "previous update attempt abandoned after {}s without progress at phase '{phase}'",
+            age.as_secs()
+        ),
+        FailureContext::from_record(Some(&record), true),
+    );
+    write_update_status(install_dir, &failed)?;
+    Ok(Some(failed))
+}
+
+fn stale_progress_age(record: &UpdateStatusRecord, now: chrono::DateTime<chrono::Utc>) -> Option<Duration> {
+    let timestamp = record
+        .last_progress_at_utc
+        .as_deref()
+        .or(record.attempted_at_utc.as_deref())?;
+    let parsed = chrono::DateTime::parse_from_rfc3339(timestamp).ok()?;
+    now.signed_duration_since(parsed.with_timezone(&chrono::Utc))
+        .to_std()
+        .ok()
+}
+
+fn matching_worker_is_current(install_dir: &Path, record: &UpdateStatusRecord) -> bool {
+    let Ok(Some(worker)) = read_update_worker(install_dir) else {
+        return false;
+    };
+    worker.pid == std::process::id() && worker.app_id == record.app_id && worker.target_version == record.target_version
+}
+
+fn read_update_worker(install_dir: &Path) -> Result<Option<UpdateWorkerRecord>> {
+    let path = update_worker_path(install_dir);
+    if !path.is_file() {
+        return Ok(None);
+    }
+    let raw = std::fs::read(&path)?;
+    serde_json::from_slice(&raw)
+        .map(Some)
+        .map_err(|e| SurgeError::Config(format!("Failed to decode {}: {e}", path.display())))
+}
+
+#[must_use]
+fn update_worker_path(install_dir: &Path) -> PathBuf {
+    install_dir.join(UPDATE_WORKER_FILE_NAME)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stale_in_progress_package_apply_becomes_retry_safe_failed_when_abandoned() {
+        let dir = tempfile::tempdir().unwrap();
+        let record = UpdateStatusRecord::in_progress(
+            "demo-app",
+            "9998.0.0",
+            "9999.0.0",
+            "stable",
+            "2026-05-15T20:00:00Z".to_string(),
+        )
+        .with_current_phase_at("package apply started", "2026-05-15T20:01:00Z".to_string());
+        write_update_status(dir.path(), &record).unwrap();
+
+        let now = chrono::DateTime::parse_from_rfc3339("2026-05-15T20:10:00Z")
+            .unwrap()
+            .with_timezone(&chrono::Utc);
+        let failed = fail_abandoned_in_progress_update_at(
+            dir.path(),
+            "demo-app",
+            "9999.0.0",
+            "stable",
+            Duration::from_mins(1),
+            now,
+        )
+        .unwrap()
+        .expect("stale record should transition");
+
+        assert_eq!(failed.state, UpdateConvergenceState::Failed);
+        assert_eq!(failed.installed_version, "9998.0.0");
+        assert_eq!(failed.target_version, "9999.0.0");
+        assert_eq!(failed.failure_phase.as_deref(), Some("package apply started"));
+        assert_eq!(failed.retry_safe, Some(true));
+        assert_eq!(failed.attempted_at_utc.as_deref(), Some("2026-05-15T20:00:00Z"));
+        assert_eq!(failed.completed_at_utc.as_deref(), Some("2026-05-15T20:01:00Z"));
+        assert!(
+            failed
+                .reason
+                .as_deref()
+                .unwrap_or_default()
+                .contains("abandoned after 540s without progress")
+        );
+
+        let persisted = read_update_status(dir.path()).unwrap().unwrap();
+        assert_eq!(persisted.state, UpdateConvergenceState::Failed);
+        assert_eq!(persisted.failure_phase.as_deref(), Some("package apply started"));
+    }
+
+    #[test]
+    fn stale_in_progress_owned_by_current_worker_is_left_in_progress() {
+        let dir = tempfile::tempdir().unwrap();
+        let record = UpdateStatusRecord::in_progress(
+            "demo-app",
+            "9998.0.0",
+            "9999.0.0",
+            "stable",
+            "2026-05-15T20:00:00Z".to_string(),
+        )
+        .with_current_phase_at("package apply started", "2026-05-15T20:01:00Z".to_string());
+        write_update_status(dir.path(), &record).unwrap();
+        let _worker = UpdateWorkerGuard::record(dir.path(), "demo-app", "9999.0.0").unwrap();
+
+        let now = chrono::DateTime::parse_from_rfc3339("2026-05-15T20:10:00Z")
+            .unwrap()
+            .with_timezone(&chrono::Utc);
+        let result = fail_abandoned_in_progress_update_at(
+            dir.path(),
+            "demo-app",
+            "9999.0.0",
+            "stable",
+            Duration::from_mins(1),
+            now,
+        )
+        .unwrap();
+
+        assert!(result.is_none());
+        let persisted = read_update_status(dir.path()).unwrap().unwrap();
+        assert_eq!(persisted.state, UpdateConvergenceState::InProgress);
+        assert_eq!(persisted.current_phase.as_deref(), Some("package apply started"));
+    }
+}

--- a/crates/surge-core/src/update/status/worker.rs
+++ b/crates/surge-core/src/update/status/worker.rs
@@ -117,7 +117,11 @@ fn fail_abandoned_in_progress_update_at(
         .as_deref()
         .or(record.failure_phase.as_deref())
         .unwrap_or("unknown");
-    let attempted_at_utc = record.attempted_at_utc.clone().unwrap_or_else(now_utc_rfc3339);
+    let attempted_at_utc = record
+        .attempted_at_utc
+        .clone()
+        .or_else(|| record.last_progress_at_utc.clone())
+        .unwrap_or_else(now_utc_rfc3339);
     let last_activity_at_utc = record
         .last_progress_at_utc
         .clone()


### PR DESCRIPTION
## Purpose

Fixes #200. `attempted_at_utc..completed_at_utc` in `.surge-update-status.json` is consumed downstream as the update's duration. Three lifecycle transitions re-stamped `completed_at_utc = now()` long after the update work ended, folding restart-wedge / power-loss / crash-loop windows into the recorded duration and producing hours-long `converged` samples (with zero failures) for updates whose work took minutes.

## Changes

- `mark_restart_handoff_converged` / `mark_restart_handoff_pending`: preserve the existing record's `completed_at_utc` (stamped by `download_and_apply` when apply finished), falling back to `last_progress_at_utc`, then `now()` only when neither exists. Convergence proof stays visible via `state` + `supervisor_restart_confirmed`; it no longer rewrites the work window.
- `fail_abandoned_in_progress_update_at`: abandoned attempts now record `completed_at_utc` = last observed activity (`last_progress_at_utc`, else `attempted_at_utc`) instead of discovery time, via a new `failed_with_context_at` constructor. Real-time failure paths keep `now()` semantics through the unchanged `failed_with_context`.
- Documented the field contract on `UpdateStatusRecord::completed_at_utc`.

## Behavior impact

- Normal updates: unchanged (values differ by the sub-second gap between apply completion and handoff confirmation).
- Wedged/interrupted handoffs: `converged` records now carry the truthful work window; the settling delay remains observable as the gap between `completed_at_utc` and when the state transitioned.
- Abandoned attempts: failed records no longer claim the idle gap as attempt time.

## Test evidence

- `./scripts/sync-surge-core-vendor.sh --check`, `./scripts/check-version-sync.sh`, `cargo fmt --all -- --check` — pass
- `RUSTFLAGS="-D warnings" cargo test --workspace` — pass (495 tests)
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` and `--lib --bins --examples -- -D warnings -D clippy::unwrap_used -D clippy::expect_used` — pass
- `dotnet format dotnet/Surge.slnx --verify-no-changes` and `dotnet test dotnet/Surge.slnx --configuration Release` — pass
- New/extended tests: handoff preserves `completed_at_utc` through child-exit re-marks and delayed convergence; `InProgress`→`Converged` falls back to `last_progress_at_utc`; abandoned-attempt failure asserts last-activity `completed_at_utc`.

## Follow-up in this PR

The new constructor pushed `status.rs` over the repo's 600-production-line maintainability target, so the update-worker ownership marker and abandoned-attempt classification moved to a focused `status/worker.rs` leaf module (pure move, public API re-exported unchanged: `UpdateWorkerGuard`, `fail_abandoned_in_progress_update`).
