### PR TITLE
Update .NET 10 security servicing to 10.0.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,7 +233,7 @@ jobs:
           submodules: true
       - uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: '10.0.301'
+          dotnet-version: '10.0.302'
       - uses: actions/cache@v6
         with:
           path: ~/.nuget/packages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -181,7 +181,7 @@ jobs:
           submodules: true
       - uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: '10.0.301'
+          dotnet-version: '10.0.302'
       - uses: actions/cache@v6
         with:
           path: ~/.nuget/packages

--- a/dotnet/Directory.Packages.props
+++ b/dotnet/Directory.Packages.props
@@ -1,6 +1,6 @@
 <Project>
   <ItemGroup>
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="coverlet.collector" Version="10.0.1" />


### PR DESCRIPTION
## Purpose

Align Surge's .NET build and test tooling with the July 2026 .NET 10 security-servicing release.

## Behavior

No runtime behavior changes are expected. CI and release jobs now use .NET SDK 10.0.302, and the existing Microsoft.NET.Test.Sdk entry is updated from 18.7.0 to 18.8.1. No PackageVersion, PackageReference, or transitive pin was added.

## Validation

- `./scripts/check-version-sync.sh`
- `cargo fmt --all -- --check`
- `./scripts/sync-surge-core-vendor.sh --check`
- `RUSTFLAGS="-D warnings" cargo test --workspace` (492 passed)
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo clippy --workspace --lib --bins --examples -- -D warnings -D clippy::unwrap_used -D clippy::expect_used`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings -W clippy::pedantic`
- `dotnet format dotnet/Surge.slnx --verify-no-changes`
- `dotnet build dotnet/Surge.slnx --configuration Release --no-restore` (0 warnings, 0 errors)
- `dotnet test dotnet/Surge.slnx --configuration Release --no-build --no-restore` (39 passed)
- Linux x64 self-contained, trimmed native-AOT smoke publish with warnings as errors
- `dotnet list dotnet/Surge.slnx package --vulnerable --include-transitive` (no vulnerable packages)
- Resolved asset files contain no remaining `10.0.9` package version

## Migration

No migration or configuration change is required.

## Release Note

Surge er oppdatert til siste sikkerhetsvedlikehold for .NET 10 og tilhørende testverktøy.
