### PR TITLE
Harden beta release contracts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,23 @@ jobs:
       - name: Verify surge-core vendor snapshot
         run: ./scripts/sync-surge-core-vendor.sh --check
 
+  msrv:
+    name: Rust 1.95 MSRV
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: true
+      - name: Install Rust 1.95
+        run: rustup toolchain install 1.95.0 --profile minimal
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-bin: false
+          key: msrv-1.95
+          prefix-key: v1-rust-no-bin
+      - name: Check the full workspace on the declared MSRV
+        run: cargo +1.95.0 check --workspace --all-targets --all-features --locked
+
   fmt:
     name: rustfmt
     runs-on: ubuntu-latest
@@ -117,9 +134,14 @@ jobs:
           - os: windows-latest
             name: Windows x64
             cache_key: windows-test
-          - os: macos-latest
-            name: macOS
-            cache_key: macos-test
+          - os: macos-15-intel
+            name: macOS Intel
+            cache_key: macos-intel-test
+            macos_arch: x86_64
+          - os: macos-15
+            name: macOS Apple Silicon
+            cache_key: macos-arm64-test
+            macos_arch: arm64
     steps:
       - uses: actions/checkout@v7
         with:
@@ -129,6 +151,9 @@ jobs:
           cache-bin: false
           key: ${{ matrix.cache_key }}
           prefix-key: v1-rust-no-bin
+      - name: Validate macOS runner and Rust host
+        if: startsWith(matrix.os, 'macos-')
+        run: bash ./scripts/check-macos-architecture.sh --arch "${{ matrix.macos_arch }}" --runner-only
       - run: cargo test --release
 
   rust-artifacts:
@@ -169,11 +194,24 @@ jobs:
               target/release/surge-installer.exe
               target/release/surge-installer-ui.exe
               target/release/surge-supervisor.exe
-          - os: macos-latest
-            name: macOS
-            cache_key: macos-artifacts
+          - os: macos-15-intel
+            name: macOS Intel
+            cache_key: macos-intel-artifacts
             artifact_name: osx-x64
             build_strategy: host
+            macos_arch: x86_64
+            artifact_path: |
+              target/release/libsurge.dylib
+              target/release/surge
+              target/release/surge-installer
+              target/release/surge-installer-ui
+              target/release/surge-supervisor
+          - os: macos-15
+            name: macOS Apple Silicon
+            cache_key: macos-arm64-artifacts
+            artifact_name: osx-arm64
+            build_strategy: host
+            macos_arch: arm64
             artifact_path: |
               target/release/libsurge.dylib
               target/release/surge
@@ -214,6 +252,15 @@ jobs:
             artifacts/linux-arm64/surge-installer \
             artifacts/linux-arm64/surge-installer-ui \
             artifacts/linux-arm64/libsurge.so
+      - name: Validate macOS architecture
+        if: startsWith(matrix.os, 'macos-')
+        run: |
+          bash ./scripts/check-macos-architecture.sh --arch "${{ matrix.macos_arch }}" \
+            target/release/libsurge.dylib \
+            target/release/surge \
+            target/release/surge-installer \
+            target/release/surge-installer-ui \
+            target/release/surge-supervisor
       - name: Upload artifacts
         uses: actions/upload-artifact@v7
         with:
@@ -244,16 +291,78 @@ jobs:
       - run: dotnet build --no-restore --configuration Release -p:Version=${{ needs.version-sync.outputs.version }}
       - run: dotnet test --no-build --configuration Release --verbosity normal
       - name: Restore AOT/trim smoke app
-        run: dotnet restore Surge.NET.AotSmoke/Surge.NET.AotSmoke.csproj --runtime linux-x64
+        run: >
+          dotnet restore Surge.NET.AotSmoke/Surge.NET.AotSmoke.csproj
+          --runtime linux-x64
+          -p:TargetFramework=net10.0
+          -p:PublishAot=true
+          -p:PublishTrimmed=true
+          -p:SelfContained=true
+          -p:InvariantGlobalization=true
       - name: Publish AOT/trim smoke app
         run: >
           dotnet publish Surge.NET.AotSmoke/Surge.NET.AotSmoke.csproj
           --no-restore
           --configuration Release
           --runtime linux-x64
+          -p:TargetFramework=net10.0
           -p:PublishAot=true
           -p:PublishTrimmed=true
           -p:SelfContained=true
           -p:InvariantGlobalization=true
           -warnaserror
           -m:1
+
+  dotnet-prerelease:
+    name: .NET synthetic prerelease
+    runs-on: ubuntu-latest
+    env:
+      SYNTHETIC_VERSION: 1.0.0-beta.999
+    defaults:
+      run:
+        working-directory: dotnet
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: true
+      - uses: actions/setup-dotnet@v6
+        with:
+          dotnet-version: '10.0.302'
+      - uses: actions/cache@v6
+        with:
+          path: ~/.nuget/packages
+          key: nuget-${{ hashFiles('dotnet/Directory.Packages.props') }}
+          restore-keys: nuget-
+      - run: dotnet restore
+      - name: Test synthetic prerelease version
+        run: dotnet test --configuration Release -p:Version="${SYNTHETIC_VERSION}" --verbosity normal
+      - name: Restore prerelease AOT/trim smoke app
+        run: >
+          dotnet restore Surge.NET.AotSmoke/Surge.NET.AotSmoke.csproj
+          --runtime linux-x64
+          -p:TargetFramework=net10.0
+          -p:PublishAot=true
+          -p:PublishTrimmed=true
+          -p:SelfContained=true
+          -p:InvariantGlobalization=true
+      - name: Publish prerelease AOT/trim smoke app
+        run: >
+          dotnet publish Surge.NET.AotSmoke/Surge.NET.AotSmoke.csproj
+          --no-restore
+          --configuration Release
+          --runtime linux-x64
+          -p:TargetFramework=net10.0
+          -p:Version=${SYNTHETIC_VERSION}
+          -p:PublishAot=true
+          -p:PublishTrimmed=true
+          -p:SelfContained=true
+          -p:InvariantGlobalization=true
+          -warnaserror
+          -m:1
+      - name: Verify prerelease version survives AOT and trimming
+        run: |
+          output="$(Surge.NET.AotSmoke/bin/Release/net10.0/linux-x64/publish/Surge.NET.AotSmoke)"
+          if [[ "${output}" != "${SYNTHETIC_VERSION}:"* ]]; then
+            echo "::error::Unexpected AOT smoke output: ${output}"
+            exit 1
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,18 +3,23 @@ name: Release
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: Existing published release tag to recover
+        required: true
+        type: string
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.release.tag_name }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event.release.tag_name || inputs.tag_name }}
+  cancel-in-progress: false
 
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: -D warnings
 
 permissions:
-  contents: write
-  packages: write
+  contents: read
 
 jobs:
   validate-release:
@@ -23,23 +28,85 @@ jobs:
     outputs:
       release_version: ${{ steps.validate.outputs.release_version }}
       is_prerelease: ${{ steps.validate.outputs.is_prerelease }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
+      tag_commit: ${{ steps.release.outputs.tag_commit }}
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.release.tag_name }}
+          ref: ${{ github.event.release.tag_name || inputs.tag_name }}
           fetch-depth: 0
           submodules: true
+
+      - id: release
+        name: Resolve and guard published release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REQUESTED_TAG: ${{ github.event.release.tag_name || inputs.tag_name }}
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_RELEASE_ID: ${{ github.event.release.id }}
+        run: |
+          if [ -z "${REQUESTED_TAG}" ]; then
+            echo "::error::A release tag is required."
+            exit 1
+          fi
+          if [[ ! "${REQUESTED_TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta)\.[0-9]+)?$ ]]; then
+            echo "::error::Unsupported release tag: ${REQUESTED_TAG}"
+            exit 1
+          fi
+
+          if ! release_json="$(gh api \
+            "/repos/${{ github.repository }}/releases/tags/${REQUESTED_TAG}")"; then
+            echo "::error::No GitHub Release exists for ${REQUESTED_TAG}."
+            exit 1
+          fi
+
+          actual_tag="$(jq -r '.tag_name' <<< "${release_json}")"
+          release_id="$(jq -r '.id' <<< "${release_json}")"
+          draft="$(jq -r '.draft' <<< "${release_json}")"
+          prerelease="$(jq -r '.prerelease' <<< "${release_json}")"
+          published_at="$(jq -r '.published_at // empty' <<< "${release_json}")"
+
+          if [ "${actual_tag}" != "${REQUESTED_TAG}" ]; then
+            echo "::error::Requested tag ${REQUESTED_TAG} resolved to release tag ${actual_tag}."
+            exit 1
+          fi
+          if [ "${draft}" != "false" ] || [ -z "${published_at}" ]; then
+            echo "::error::Release ${REQUESTED_TAG} must already be published and non-draft."
+            exit 1
+          fi
+          if [ "${EVENT_NAME}" = "release" ] && [ "${release_id}" != "${EVENT_RELEASE_ID}" ]; then
+            echo "::error::Release event ID does not match the release resolved from ${REQUESTED_TAG}."
+            exit 1
+          fi
+          if ! git rev-parse --verify --quiet "refs/tags/${REQUESTED_TAG}^{commit}" >/dev/null; then
+            echo "::error::Release tag ${REQUESTED_TAG} does not resolve to a commit."
+            exit 1
+          fi
+
+          tag_commit="$(git rev-parse "refs/tags/${REQUESTED_TAG}^{commit}")"
+          checkout_commit="$(git rev-parse HEAD)"
+          if [ "${checkout_commit}" != "${tag_commit}" ]; then
+            echo "::error::Checked-out commit ${checkout_commit} does not match release tag commit ${tag_commit}."
+            exit 1
+          fi
+
+          echo "tag_name=${REQUESTED_TAG}" >> "$GITHUB_OUTPUT"
+          echo "tag_commit=${tag_commit}" >> "$GITHUB_OUTPUT"
+          echo "release_prerelease=${prerelease}" >> "$GITHUB_OUTPUT"
 
       - name: Verify workspace versions are aligned
         run: ./scripts/check-version-sync.sh
 
       - id: validate
         name: Validate tag and release metadata
+        env:
+          TAG_NAME: ${{ steps.release.outputs.tag_name }}
+          RELEASE_PRERELEASE: ${{ steps.release.outputs.release_prerelease }}
         run: |
           source ./scripts/version-lib.sh
 
-          tag_name="${{ github.event.release.tag_name }}"
-          release_prerelease="${{ github.event.release.prerelease }}"
+          tag_name="${TAG_NAME}"
+          release_prerelease="${RELEASE_PRERELEASE}"
 
           if [[ "$tag_name" =~ ^v([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
             release_version="${BASH_REMATCH[1]}"
@@ -112,11 +179,24 @@ jobs:
               target/release/surge-installer.exe
               target/release/surge-installer-ui.exe
               target/release/surge-supervisor.exe
-          - os: macos-latest
-            name: macOS
-            cache_key: macos-release-artifacts
+          - os: macos-15-intel
+            name: macOS Intel
+            cache_key: macos-intel-release-artifacts
             artifact_name: osx-x64
             build_strategy: host
+            macos_arch: x86_64
+            artifact_path: |
+              target/release/libsurge.dylib
+              target/release/surge
+              target/release/surge-installer
+              target/release/surge-installer-ui
+              target/release/surge-supervisor
+          - os: macos-15
+            name: macOS Apple Silicon
+            cache_key: macos-arm64-release-artifacts
+            artifact_name: osx-arm64
+            build_strategy: host
+            macos_arch: arm64
             artifact_path: |
               target/release/libsurge.dylib
               target/release/surge
@@ -126,7 +206,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.release.tag_name }}
+          ref: ${{ needs.validate-release.outputs.tag_commit }}
           submodules: true
       - name: Set release version
         shell: bash
@@ -161,24 +241,34 @@ jobs:
             artifacts/linux-arm64/surge-installer \
             artifacts/linux-arm64/surge-installer-ui \
             artifacts/linux-arm64/libsurge.so
+      - name: Validate macOS architecture
+        if: startsWith(matrix.os, 'macos-')
+        run: |
+          bash ./scripts/check-macos-architecture.sh --arch "${{ matrix.macos_arch }}" \
+            target/release/libsurge.dylib \
+            target/release/surge \
+            target/release/surge-installer \
+            target/release/surge-installer-ui \
+            target/release/surge-supervisor
       - name: Upload artifacts
         uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.artifact_name }}
           path: ${{ matrix.artifact_path }}
 
-  publish-nuget:
-    name: Publish NuGet
+  package-nuget:
+    name: Package NuGet
     needs: [validate-release, build-artifacts]
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: dotnet
+    permissions:
+      contents: write
+    outputs:
+      package_name: ${{ steps.package.outputs.package_name }}
+      package_sha256: ${{ steps.package.outputs.package_sha256 }}
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.release.tag_name }}
-          submodules: true
+          ref: ${{ needs.validate-release.outputs.tag_commit }}
       - uses: actions/setup-dotnet@v6
         with:
           dotnet-version: '10.0.302'
@@ -187,10 +277,194 @@ jobs:
           path: ~/.nuget/packages
           key: nuget-${{ hashFiles('dotnet/Directory.Packages.props') }}
           restore-keys: nuget-
-      - name: Pack
-        run: dotnet pack Surge.NET/Surge.NET.csproj --configuration Release -p:Version=${{ needs.validate-release.outputs.release_version }} --output ../nupkgs
+      - id: package
+        name: Reuse or create the immutable NuGet package
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ needs.validate-release.outputs.tag_name }}
+          RELEASE_VERSION: ${{ needs.validate-release.outputs.release_version }}
+          TAG_COMMIT: ${{ needs.validate-release.outputs.tag_commit }}
+          EXPECTED_REPOSITORY_URL: ${{ github.server_url }}/${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          package_name="Surge.NET.${RELEASE_VERSION}.nupkg"
+          package_path="nupkgs/${package_name}"
+          mkdir -p nupkgs
+
+          release_json="$(gh api "/repos/${{ github.repository }}/releases/tags/${RELEASE_TAG}")"
+          asset_count="$(jq --arg name "${package_name}" \
+            '[.assets[] | select(.name == $name)] | length' <<< "${release_json}")"
+
+          case "${asset_count}" in
+            0)
+              dotnet pack dotnet/Surge.NET/Surge.NET.csproj \
+                --configuration Release \
+                -p:Version="${RELEASE_VERSION}" \
+                --output nupkgs
+              ;;
+            1)
+              asset_size="$(jq --arg name "${package_name}" -r \
+                '.assets[] | select(.name == $name) | .size' <<< "${release_json}")"
+              gh release download "${RELEASE_TAG}" \
+                --pattern "${package_name}" \
+                --dir nupkgs \
+                --repo "${{ github.repository }}"
+              downloaded_size="$(stat -c '%s' "${package_path}")"
+              if [ "${downloaded_size}" != "${asset_size}" ]; then
+                echo "::error::Downloaded ${package_name} has size ${downloaded_size}; release metadata says ${asset_size}."
+                exit 1
+              fi
+              echo "Reusing ${package_name} from the published GitHub Release."
+              ;;
+            *)
+              echo "::error::Expected at most one ${package_name} release asset, found ${asset_count}."
+              exit 1
+              ;;
+          esac
+
+          shopt -s nullglob
+          packages=(nupkgs/*.nupkg)
+          if [ "${#packages[@]}" -ne 1 ] || [ "${packages[0]}" != "${package_path}" ]; then
+            echo "::error::Expected exactly one NuGet package named ${package_name}."
+            exit 1
+          fi
+
+          python3 - "${package_path}" "${RELEASE_VERSION}" "${TAG_COMMIT}" "${EXPECTED_REPOSITORY_URL}" <<'PY'
+          import sys
+          import xml.etree.ElementTree as ET
+          import zipfile
+
+          package_path, expected_version, expected_commit, expected_repository_url = sys.argv[1:]
+          with zipfile.ZipFile(package_path) as package:
+              nuspecs = [name for name in package.namelist() if name.endswith(".nuspec")]
+              if len(nuspecs) != 1:
+                  raise SystemExit(
+                      f"expected exactly one nuspec in {package_path}, found {len(nuspecs)}"
+                  )
+              root = ET.fromstring(package.read(nuspecs[0]))
+
+          metadata = next(
+              (element for element in root.iter() if element.tag.rsplit("}", 1)[-1] == "metadata"),
+              None,
+          )
+          if metadata is None:
+              raise SystemExit(f"missing package metadata in {package_path}")
+
+          fields = {
+              child.tag.rsplit("}", 1)[-1]: (child.text or "")
+              for child in metadata
+          }
+          if fields.get("id") != "Surge.NET":
+              raise SystemExit(f"unexpected package id: {fields.get('id')!r}")
+          if fields.get("version") != expected_version:
+              raise SystemExit(
+                  f"unexpected package version: {fields.get('version')!r}; "
+                  f"expected {expected_version!r}"
+              )
+
+          repositories = [
+              child
+              for child in metadata
+              if child.tag.rsplit("}", 1)[-1] == "repository"
+          ]
+          if len(repositories) != 1:
+              raise SystemExit(
+                  f"expected exactly one repository element, found {len(repositories)}"
+              )
+          repository = repositories[0]
+          if repository.attrib.get("type") != "git":
+              raise SystemExit(
+                  f"unexpected repository type: {repository.attrib.get('type')!r}"
+              )
+          if repository.attrib.get("url") != expected_repository_url:
+              raise SystemExit(
+                  f"unexpected repository URL: {repository.attrib.get('url')!r}; "
+                  f"expected {expected_repository_url!r}"
+              )
+          if repository.attrib.get("commit") != expected_commit:
+              raise SystemExit(
+                  f"unexpected repository commit: {repository.attrib.get('commit')!r}; "
+                  f"expected {expected_commit!r}"
+              )
+          PY
+
+          if [ "${asset_count}" = "0" ]; then
+            gh release upload "${RELEASE_TAG}" "${package_path}" \
+              --repo "${{ github.repository }}"
+
+            release_json="$(gh api "/repos/${{ github.repository }}/releases/tags/${RELEASE_TAG}")"
+            attached_count="$(jq --arg name "${package_name}" \
+              '[.assets[] | select(.name == $name)] | length' <<< "${release_json}")"
+            attached_size="$(jq --arg name "${package_name}" -r \
+              '.assets[] | select(.name == $name) | .size' <<< "${release_json}")"
+            local_size="$(stat -c '%s' "${package_path}")"
+            if [ "${attached_count}" != "1" ] || [ "${attached_size}" != "${local_size}" ]; then
+              echo "::error::The attached ${package_name} asset does not match the packaged file."
+              exit 1
+            fi
+            echo "Attached immutable ${package_name} to ${RELEASE_TAG}."
+          fi
+
+          package_sha256="$(sha256sum "${package_path}" | cut -d ' ' -f 1)"
+          echo "package_name=${package_name}" >> "$GITHUB_OUTPUT"
+          echo "package_sha256=${package_sha256}" >> "$GITHUB_OUTPUT"
+      - name: Upload immutable NuGet package for publishing
+        uses: actions/upload-artifact@v7
+        with:
+          name: surge-net-nuget
+          path: nupkgs/${{ steps.package.outputs.package_name }}
+          if-no-files-found: error
+
+  publish-nuget:
+    name: Publish NuGet
+    needs: [validate-release, package-nuget]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      packages: write
+    steps:
+      - uses: actions/setup-dotnet@v6
+        with:
+          dotnet-version: '10.0.302'
+      - name: Download immutable NuGet package
+        uses: actions/download-artifact@v8
+        with:
+          name: surge-net-nuget
+          path: nupkgs
+      - name: Verify immutable package handoff
+        env:
+          EXPECTED_PACKAGE_NAME: ${{ needs.package-nuget.outputs.package_name }}
+          EXPECTED_PACKAGE_SHA256: ${{ needs.package-nuget.outputs.package_sha256 }}
+          RELEASE_VERSION: ${{ needs.validate-release.outputs.release_version }}
+        run: |
+          set -euo pipefail
+          expected_path="nupkgs/${EXPECTED_PACKAGE_NAME}"
+          if [ "${EXPECTED_PACKAGE_NAME}" != "Surge.NET.${RELEASE_VERSION}.nupkg" ]; then
+            echo "::error::Unexpected package name: ${EXPECTED_PACKAGE_NAME}"
+            exit 1
+          fi
+          shopt -s nullglob
+          packages=(nupkgs/*.nupkg)
+          if [ "${#packages[@]}" -ne 1 ] || [ "${packages[0]}" != "${expected_path}" ]; then
+            echo "::error::Expected exactly one package at ${expected_path}."
+            exit 1
+          fi
+          actual_sha256="$(sha256sum "${expected_path}" | cut -d ' ' -f 1)"
+          if [ "${actual_sha256}" != "${EXPECTED_PACKAGE_SHA256}" ]; then
+            echo "::error::Downloaded workflow artifact does not match the immutable NuGet package."
+            exit 1
+          fi
+      - name: Authenticate to NuGet.org with Trusted Publishing
+        id: nuget-login
+        uses: NuGet/login@v1
+        with:
+          user: petersunde
+      - name: Push to NuGet.org
+        run: dotnet nuget push "nupkgs/${{ needs.package-nuget.outputs.package_name }}" --source https://api.nuget.org/v3/index.json --api-key "${{ steps.nuget-login.outputs.NUGET_API_KEY }}" --skip-duplicate
       - name: Push to GitHub Packages
-        run: dotnet nuget push ../nupkgs/*.nupkg --source https://nuget.pkg.github.com/fintermobilityas/index.json --api-key ${{ secrets.GITHUB_TOKEN }} --skip-duplicate
+        run: dotnet nuget push "nupkgs/${{ needs.package-nuget.outputs.package_name }}" --source https://nuget.pkg.github.com/fintermobilityas/index.json --api-key ${{ secrets.GITHUB_TOKEN }} --skip-duplicate
 
   publish-cargo-crates-io:
     name: Publish Cargo (crates.io)
@@ -201,7 +475,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.release.tag_name }}
+          ref: ${{ needs.validate-release.outputs.tag_commit }}
           submodules: true
       - uses: Swatinem/rust-cache@v2
         with:
@@ -215,29 +489,19 @@ jobs:
           fi
       - name: Set release version
         run: ./scripts/set-release-version.sh "${{ needs.validate-release.outputs.release_version }}"
-      - name: Publish surge-core to crates.io
-        run: cargo publish -p surge-core --allow-dirty
-      - name: Publish surge-cli to crates.io
-        run: |
-          for attempt in $(seq 1 10); do
-            if cargo publish -p surge-cli --allow-dirty; then
-              exit 0
-            fi
-            if [ "${attempt}" -eq 10 ]; then
-              echo "Failed to publish surge-cli after waiting for surge-core to sync on crates.io."
-              exit 1
-            fi
-            sleep $((attempt * 5))
-          done
+      - name: Publish crates idempotently
+        run: bash ./scripts/publish-cargo-release.sh "${{ needs.validate-release.outputs.release_version }}"
 
   upload-release-assets:
     name: Upload Release Assets
-    needs: [validate-release, build-artifacts]
+    needs: [validate-release, build-artifacts, package-nuget]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.release.tag_name }}
+          ref: ${{ needs.validate-release.outputs.tag_commit }}
 
       - name: Download all artifacts
         uses: actions/download-artifact@v8
@@ -246,9 +510,16 @@ jobs:
 
       - name: Collect and verify release assets
         run: |
+          set -euo pipefail
           mkdir -p release-assets
 
-          required_dirs=(linux-x64 linux-arm64 win-x64 osx-x64)
+          source_date_epoch="$(git show -s --format=%ct "${{ needs.validate-release.outputs.tag_commit }}")"
+          if [[ ! "${source_date_epoch}" =~ ^[0-9]+$ ]]; then
+            echo "::error::Could not determine the release commit timestamp."
+            exit 1
+          fi
+
+          required_dirs=(linux-x64 linux-arm64 win-x64 osx-x64 osx-arm64)
           for dir in "${required_dirs[@]}"; do
             if [ ! -d "artifacts/$dir" ]; then
               echo "::error::Missing required artifact directory: $dir"
@@ -256,23 +527,209 @@ jobs:
             fi
           done
 
-          cd artifacts
-          tar czf ../release-assets/surge-linux-x64.tar.gz -C linux-x64 .
-          tar czf ../release-assets/surge-linux-arm64.tar.gz -C linux-arm64 .
-          tar czf ../release-assets/surge-osx-x64.tar.gz -C osx-x64 .
-          cd win-x64 && zip -r ../../release-assets/surge-win-x64.zip . && cd ..
+          normalize_unix_artifact() {
+            local dir="$1"
+            local library="$2"
+            local expected_entries actual_entries entry mode
+            local executables=(surge surge-installer surge-installer-ui surge-supervisor)
+            local expected=("${library}" "${executables[@]}")
 
-      - name: Generate checksums
+            expected_entries="$(printf '%s\n' "${expected[@]}" | LC_ALL=C sort)"
+            actual_entries="$(find "${dir}" -mindepth 1 -maxdepth 1 -printf '%f\n' | LC_ALL=C sort)"
+            if [ "${actual_entries}" != "${expected_entries}" ]; then
+              echo "::error::${dir} does not contain exactly the five expected Unix release files."
+              printf 'Expected:\n%s\nActual:\n%s\n' "${expected_entries}" "${actual_entries}" >&2
+              exit 1
+            fi
+
+            for entry in "${expected[@]}"; do
+              if [ ! -f "${dir}/${entry}" ] || [ -L "${dir}/${entry}" ]; then
+                echo "::error::${dir}/${entry} must be a regular, non-symlink file."
+                exit 1
+              fi
+            done
+
+            chmod 0644 "${dir}/${library}"
+            chmod 0755 "${executables[@]/#/${dir}/}"
+
+            mode="$(stat -c '%a' "${dir}/${library}")"
+            if [ "${mode}" != "644" ]; then
+              echo "::error::${dir}/${library} has mode ${mode}, expected 644."
+              exit 1
+            fi
+            for entry in "${executables[@]}"; do
+              mode="$(stat -c '%a' "${dir}/${entry}")"
+              if [ "${mode}" != "755" ]; then
+                echo "::error::${dir}/${entry} has mode ${mode}, expected 755."
+                exit 1
+              fi
+            done
+          }
+
+          normalize_unix_artifact artifacts/linux-x64 libsurge.so
+          normalize_unix_artifact artifacts/linux-arm64 libsurge.so
+          normalize_unix_artifact artifacts/osx-x64 libsurge.dylib
+          normalize_unix_artifact artifacts/osx-arm64 libsurge.dylib
+
+          create_reproducible_tarball() {
+            local dir="$1"
+            local library="$2"
+            local output="$3"
+            tar \
+              --sort=name \
+              --format=gnu \
+              --owner=0 \
+              --group=0 \
+              --numeric-owner \
+              --mtime="@${source_date_epoch}" \
+              --no-recursion \
+              -cf - \
+              -C "${dir}" \
+              "${library}" \
+              surge \
+              surge-installer \
+              surge-installer-ui \
+              surge-supervisor \
+              | gzip -n -9 > "${output}"
+          }
+
+          create_reproducible_tarball \
+            artifacts/linux-x64 libsurge.so release-assets/surge-linux-x64.tar.gz
+          create_reproducible_tarball \
+            artifacts/linux-arm64 libsurge.so release-assets/surge-linux-arm64.tar.gz
+          create_reproducible_tarball \
+            artifacts/osx-x64 libsurge.dylib release-assets/surge-osx-x64.tar.gz
+          create_reproducible_tarball \
+            artifacts/osx-arm64 libsurge.dylib release-assets/surge-osx-arm64.tar.gz
+
+          windows_files=(
+            surge.dll
+            surge.dll.lib
+            surge.exe
+            surge-installer.exe
+            surge-installer-ui.exe
+            surge-supervisor.exe
+          )
+          expected_windows="$(printf '%s\n' "${windows_files[@]}" | LC_ALL=C sort)"
+          actual_windows="$(find artifacts/win-x64 -mindepth 1 -maxdepth 1 -printf '%f\n' | LC_ALL=C sort)"
+          if [ "${actual_windows}" != "${expected_windows}" ]; then
+            echo "::error::artifacts/win-x64 does not contain exactly the expected release files."
+            printf 'Expected:\n%s\nActual:\n%s\n' "${expected_windows}" "${actual_windows}" >&2
+            exit 1
+          fi
+          for entry in "${windows_files[@]}"; do
+            path="artifacts/win-x64/${entry}"
+            if [ ! -f "${path}" ] || [ -L "${path}" ]; then
+              echo "::error::${path} must be a regular, non-symlink file."
+              exit 1
+            fi
+            chmod 0644 "${path}"
+            touch --date="@${source_date_epoch}" "${path}"
+          done
+          (
+            cd artifacts/win-x64
+            printf '%s\n' "${windows_files[@]}" \
+              | LC_ALL=C sort \
+              | TZ=UTC zip -X -9 ../../release-assets/surge-win-x64.zip -@
+          )
+
+          cp include/surge/surge_api.h release-assets/surge_api.h
+
+          nuget_package_name="${{ needs.package-nuget.outputs.package_name }}"
+          nuget_artifact_dir="artifacts/surge-net-nuget"
+          if [ "${nuget_package_name}" != "Surge.NET.${{ needs.validate-release.outputs.release_version }}.nupkg" ]; then
+            echo "::error::Unexpected NuGet package name: ${nuget_package_name}"
+            exit 1
+          fi
+          shopt -s nullglob
+          nuget_packages=("${nuget_artifact_dir}"/*.nupkg)
+          if [ "${#nuget_packages[@]}" -ne 1 ] || [ "$(basename "${nuget_packages[0]}")" != "${nuget_package_name}" ]; then
+            echo "::error::Expected exactly one NuGet workflow artifact named ${nuget_package_name}."
+            exit 1
+          fi
+          cp "${nuget_packages[0]}" "release-assets/${nuget_package_name}"
+
+      - name: Generate and verify checksums
         run: |
           cd release-assets
-          sha256sum *.tar.gz *.zip | tee SHA256SUMS.txt
+          expected_assets=(
+            "${{ needs.package-nuget.outputs.package_name }}"
+            surge-linux-arm64.tar.gz
+            surge-linux-x64.tar.gz
+            surge-osx-arm64.tar.gz
+            surge-osx-x64.tar.gz
+            surge-win-x64.zip
+            surge_api.h
+          )
+          for asset in "${expected_assets[@]}"; do
+            if [ ! -f "${asset}" ]; then
+              echo "::error::Missing release asset: ${asset}"
+              exit 1
+            fi
+          done
+          sha256sum "${expected_assets[@]}" > SHA256SUMS.txt
+          sha256sum --check --strict SHA256SUMS.txt
 
       - name: Upload assets to GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ needs.validate-release.outputs.tag_name }}
         run: |
-          gh release upload "${{ github.event.release.tag_name }}" \
-            release-assets/* \
-            include/surge/surge_api.h \
-            --repo "${{ github.repository }}" \
-            --clobber
+          set -euo pipefail
+          comparison_dir="$(mktemp -d)"
+          trap 'rm -rf "${comparison_dir}"' EXIT
+
+          publish_immutable_asset() {
+            local path="$1"
+            local name release_json asset_count local_digest remote_digest was_missing
+            name="$(basename "${path}")"
+            release_json="$(gh api "/repos/${{ github.repository }}/releases/tags/${RELEASE_TAG}")"
+            asset_count="$(jq --arg name "${name}" \
+              '[.assets[] | select(.name == $name)] | length' <<< "${release_json}")"
+
+            case "${asset_count}" in
+              0)
+                gh release upload "${RELEASE_TAG}" "${path}" \
+                  --repo "${{ github.repository }}"
+                was_missing="true"
+                ;;
+              1)
+                was_missing="false"
+                ;;
+              *)
+                echo "::error::Expected at most one release asset named ${name}, found ${asset_count}."
+                exit 1
+                ;;
+            esac
+
+            gh release download "${RELEASE_TAG}" \
+              --pattern "${name}" \
+              --dir "${comparison_dir}" \
+              --repo "${{ github.repository }}"
+            local_digest="$(sha256sum "${path}" | cut -d ' ' -f 1)"
+            remote_digest="$(sha256sum "${comparison_dir}/${name}" | cut -d ' ' -f 1)"
+            if [ "${local_digest}" != "${remote_digest}" ]; then
+              echo "::error::Published release asset ${name} differs from the exact-tag rebuild."
+              echo "::error::Published SHA-256: ${remote_digest}; rebuilt SHA-256: ${local_digest}."
+              exit 1
+            fi
+            if [ "${was_missing}" = "true" ]; then
+              echo "Uploaded and verified immutable release asset ${name}."
+            else
+              echo "Release asset ${name} already matches exactly; skipping upload."
+            fi
+          }
+
+          immutable_assets=(
+            "release-assets/${{ needs.package-nuget.outputs.package_name }}"
+            release-assets/surge-linux-arm64.tar.gz
+            release-assets/surge-linux-x64.tar.gz
+            release-assets/surge-osx-arm64.tar.gz
+            release-assets/surge-osx-x64.tar.gz
+            release-assets/surge-win-x64.zip
+            release-assets/surge_api.h
+            release-assets/SHA256SUMS.txt
+          )
+          for asset in "${immutable_assets[@]}"; do
+            publish_immutable_asset "${asset}"
+          done

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ resolver = "3"
 [workspace.package]
 version = "1.0.0"
 edition = "2024"
+rust-version = "1.95"
 license = "MIT"
 repository = "https://github.com/fintermobilityas/surge"
 

--- a/README.md
+++ b/README.md
@@ -250,8 +250,12 @@ if let Some(info) = mgr.check_for_updates().await? {
 ```c
 surge_update_manager* mgr = surge_update_manager_create(ctx, "my-app", "1.0.0", "stable", dir);
 surge_releases_info* info = NULL;
-if (surge_update_check(mgr, &info) == SURGE_OK)
+if (surge_update_check(mgr, &info) == SURGE_OK) {
     surge_update_download_and_apply(mgr, info, progress_cb, NULL);
+    surge_releases_destroy(info);
+}
+surge_update_manager_destroy(mgr);
+surge_context_destroy(ctx);
 ```
 
 ## CI/CD Integration
@@ -533,13 +537,16 @@ The [`Surge.NET`](dotnet/Surge.NET/) NuGet package provides the full API:
 
 - **netstandard2.0** &mdash; `[DllImport]` for .NET Framework 4.6.1+, .NET Core, Mono, Xamarin
 - **net10.0** &mdash; `[LibraryImport]` with full AOT and trimming support
-- Zero external dependencies
+- Zero external managed dependencies; ship the matching native Surge library
+  from the same version and runtime identifier with the application
 - `SurgeUpdateManager.UpdateToLatestReleaseAsync()` &mdash; one call that checks, downloads, verifies, extracts, and applies
 - Per-phase progress callbacks, cancellation tokens, pre/post-update hooks
 
 ### C / C++
 
-Include [`surge_api.h`](include/surge/surge_api.h) and link against the shared library. 31 functions, all following the same pattern: opaque handles, `surge_result` return codes, thread-safe cancellation.
+Include [`surge_api.h`](include/surge/surge_api.h) and link against the shared
+library. The API uses opaque handles, `surge_result` return codes, explicit
+ownership rules, and thread-safe cancellation.
 
 ### Rust
 
@@ -595,14 +602,14 @@ surge restore -i \
 |---|---|
 | Lifecycle | `surge_context_create`, `surge_context_destroy`, `surge_context_last_error` |
 | Configuration | `surge_config_set_storage`, `surge_config_set_lock_server`, `surge_config_set_resource_budget` |
-| Update Manager | `surge_update_manager_create`, `surge_update_manager_destroy`, `surge_update_manager_set_channel`, `surge_update_manager_set_current_version`, `surge_update_check`, `surge_update_download_and_apply` |
+| Update Manager | `surge_update_manager_create`, `surge_update_manager_destroy`, `surge_update_manager_set_channel`, `surge_update_manager_set_current_version`, `surge_update_manager_set_release_retention_limit`, `surge_update_manager_set_artifact_retention_policy`, `surge_update_check`, `surge_update_download_and_apply`, `surge_update_status_read_json`, `surge_free_cstring` |
 | Release Info | `surge_releases_count`, `surge_releases_destroy`, `surge_release_version`, `surge_release_channel`, `surge_release_full_size`, `surge_release_is_genesis` |
 | Binary Diff | `surge_bsdiff`, `surge_bspatch`, `surge_bsdiff_free`, `surge_bspatch_free` |
 | Pack Builder | `surge_pack_create`, `surge_pack_build`, `surge_pack_push`, `surge_pack_destroy` |
 | Distributed Lock | `surge_lock_acquire`, `surge_lock_release` |
-| Supervisor | `surge_supervisor_start` |
+| Supervisor | `surge_supervisor_start`, `surge_supervisor_stop` |
 | Events | `surge_process_events` |
-| Cancellation | `surge_cancel` |
+| Cancellation | `surge_cancel`, `surge_reset_cancel` |
 
 ### Manifest reference
 
@@ -672,7 +679,7 @@ Use `surge compact` after rollout convergence, or for deliberate recovery/cleanu
                           │  P/Invoke or C calls
 ┌─────────────────────────▼────────────────────────────────┐
 │                 surge-ffi  (cdylib)                       │
-│          31 exported functions · surge_api.h              │
+│                  C ABI · surge_api.h                       │
 └─────────────────────────┬────────────────────────────────┘
                           │
 ┌─────────────────────────▼────────────────────────────────┐
@@ -685,7 +692,7 @@ Use `surge compact` after rollout convergence, or for deliberate recovery/cleanu
 | Crate | Description |
 |---|---|
 | `surge-core` | Core library &mdash; config, crypto, storage backends, archive (tar+zstd), bsdiff, release index, update manager, pack builder, supervisor, platform detection |
-| `surge-ffi` | C API shared library exporting 31 functions through `surge_api.h` |
+| `surge-ffi` | C API shared library exporting the interface declared in `surge_api.h` |
 | `surge-cli` | Command-line tool for packing, pushing, and managing releases |
 | `surge-supervisor` | Standalone process supervisor binary |
 
@@ -704,7 +711,7 @@ git submodule update --init
 
 ### Requirements
 
-- **Rust 1.85+** (Edition 2024) &mdash; install via [rustup](https://rustup.rs/)
+- **Rust 1.95+** (Edition 2024) &mdash; install via [rustup](https://rustup.rs/)
 - **.NET 10 SDK** (optional, for the .NET wrapper and demo app)
 
 ### Build and test
@@ -721,6 +728,14 @@ cd dotnet
 dotnet build --configuration Release
 dotnet test --configuration Release
 ```
+
+### Release artifact trust
+
+Official archives are covered by `SHA256SUMS.txt`, including the public C
+header. The Windows and macOS binaries are currently unsigned, and the macOS
+binaries are not notarized. Verify the published checksums before use and apply
+the signing/notarization required by your product distribution before shipping
+to end users.
 
 ## License
 

--- a/crates/surge-bench/Cargo.toml
+++ b/crates/surge-bench/Cargo.toml
@@ -2,6 +2,7 @@
 name = "surge-bench"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Benchmark tool for the Surge update framework"

--- a/crates/surge-cli/Cargo.toml
+++ b/crates/surge-cli/Cargo.toml
@@ -2,6 +2,7 @@
 name = "surge-cli"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "CLI tool for the Surge update framework"

--- a/crates/surge-core/Cargo.toml
+++ b/crates/surge-core/Cargo.toml
@@ -2,6 +2,7 @@
 name = "surge-core"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Core library for the Surge update framework"

--- a/crates/surge-core/src/config/constants.rs
+++ b/crates/surge-core/src/config/constants.rs
@@ -1,5 +1,5 @@
 /// Current version of the Surge framework.
-pub const VERSION: &str = "0.1.0";
+pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 /// Default Surge working directory name.
 pub const SURGE_DIR: &str = ".surge";
@@ -45,3 +45,13 @@ pub const SHA256_HEX_LEN: usize = 64;
 
 /// Chunk size for streaming file operations (64 KB).
 pub const IO_CHUNK_SIZE: usize = 64 * 1024;
+
+#[cfg(test)]
+mod tests {
+    use super::VERSION;
+
+    #[test]
+    fn framework_version_matches_package_version() {
+        assert_eq!(VERSION, env!("CARGO_PKG_VERSION"));
+    }
+}

--- a/crates/surge-ffi/Cargo.toml
+++ b/crates/surge-ffi/Cargo.toml
@@ -2,6 +2,7 @@
 name = "surge-ffi"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 description = "C API (cdylib) for the Surge update framework"
 

--- a/crates/surge-ffi/src/lib.rs
+++ b/crates/surge-ffi/src/lib.rs
@@ -111,7 +111,8 @@ pub struct SurgeBspatchCtxFfi {
 /// Acquire a named distributed lock.
 ///
 /// On success, `*challenge_out` receives a C string that must be passed to
-/// `surge_lock_release`. The caller must free it with `free()`.
+/// `surge_lock_release`. The caller must then free it exactly once with
+/// `surge_free_cstring`.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn surge_lock_acquire(
     ctx: *mut SurgeContextHandle,
@@ -119,17 +120,21 @@ pub unsafe extern "C" fn surge_lock_acquire(
     timeout_seconds: i32,
     challenge_out: *mut *mut c_char,
 ) -> i32 {
-    if ctx.is_null() || name.is_null() || challenge_out.is_null() {
+    if challenge_out.is_null() {
+        return SURGE_ERROR;
+    }
+    // SAFETY: `challenge_out` is checked non-null above. Clear it before
+    // validating any other input so every failure has a deterministic output.
+    unsafe { *challenge_out = ptr::null_mut() };
+
+    if ctx.is_null() || name.is_null() {
         return SURGE_ERROR;
     }
 
     catch_ffi(std::panic::AssertUnwindSafe(|| {
-        // SAFETY: `ctx`/`challenge_out` are checked non-null above. The out
-        // pointer is cleared immediately to avoid stale outputs on failure.
-        let handle = unsafe {
-            *challenge_out = ptr::null_mut();
-            &*ctx
-        };
+        // SAFETY: `ctx` is checked non-null above and remains valid for this
+        // call. The out pointer was already cleared.
+        let handle = unsafe { &*ctx };
         handle.clear_last_error();
 
         if handle.ctx.is_cancelled() {
@@ -482,7 +487,7 @@ pub unsafe extern "C" fn surge_process_events(
 }
 
 // =========================================================================
-//  10. Cancellation (1 function)
+//  10. Cancellation (2 functions)
 // =========================================================================
 
 /// Request cancellation of any in-progress operation on `ctx`.
@@ -495,8 +500,27 @@ pub unsafe extern "C" fn surge_cancel(ctx: *mut SurgeContextHandle) -> i32 {
     }
 
     catch_ffi(std::panic::AssertUnwindSafe(|| {
+        // SAFETY: `ctx` is checked non-null above and remains valid for this call.
         let handle = unsafe { &*ctx };
         handle.ctx.cancel();
+        SURGE_OK
+    }))
+}
+
+/// Clear a previous cancellation so the context can start another operation.
+///
+/// The caller must ensure that no operation using this context or a child
+/// handle created from it is still running while cancellation is reset.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn surge_reset_cancel(ctx: *mut SurgeContextHandle) -> i32 {
+    if ctx.is_null() {
+        return SURGE_ERROR;
+    }
+
+    catch_ffi(std::panic::AssertUnwindSafe(|| {
+        // SAFETY: `ctx` is checked non-null above and remains valid for this call.
+        let handle = unsafe { &*ctx };
+        handle.ctx.reset_cancel();
         SURGE_OK
     }))
 }
@@ -505,19 +529,23 @@ pub unsafe extern "C" fn surge_cancel(ctx: *mut SurgeContextHandle) -> i32 {
 //  11. Allocator (1 function)
 // =========================================================================
 
-/// Free a NUL-terminated C string that was returned by a Surge FFI call which
-/// documents its output as `free()`-owned (for example
-/// `surge_update_status_read_json`). Safe to call with NULL.
+/// Free a Surge-owned NUL-terminated C string returned through a `char**`
+/// output. Each non-null output must be passed here exactly once and must never
+/// be freed by the host allocator. Safe to call with null.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn surge_free_cstring(ptr: *mut c_char) {
-    // SAFETY: caller guarantees `ptr` was returned by a Surge FFI function
-    // documented as `free()`-owned, or is null.
+    // SAFETY: caller guarantees `ptr` is a Surge-owned string returned through
+    // a `char**` output, or is null.
     unsafe { crate::shared::libc_free(ptr.cast::<c_void>()) };
 }
 
 #[cfg(test)]
 mod tests {
+    use std::ffi::CString;
     use std::path::{Path, PathBuf};
+    use std::ptr;
+
+    use crate::shared::{SURGE_ERROR, SURGE_OK};
 
     struct TestInstallDir {
         path: PathBuf,
@@ -557,6 +585,60 @@ mod tests {
             format!("id: demo-app\nversion: {version}\nchannel: test\n"),
         )
         .unwrap();
+    }
+
+    #[test]
+    fn lock_acquire_clears_challenge_before_other_input_validation() {
+        let stale = CString::new("stale").unwrap().into_raw();
+        let mut challenge = stale;
+        let rc = unsafe {
+            // SAFETY: the out pointer is valid; null inputs exercise the API's
+            // guarded failure path and are not dereferenced.
+            super::surge_lock_acquire(ptr::null_mut(), ptr::null(), 0, &mut challenge)
+        };
+        assert_eq!(rc, SURGE_ERROR);
+        assert!(challenge.is_null());
+        // SAFETY: `stale` came from `CString::into_raw`, and the failing API
+        // call cleared the out pointer without taking ownership of it.
+        drop(unsafe { CString::from_raw(stale) });
+
+        let ctx = super::surge_context_create();
+        assert!(!ctx.is_null());
+        let stale = CString::new("stale").unwrap().into_raw();
+        let mut challenge = stale;
+        let rc = unsafe {
+            // SAFETY: `ctx` and the out pointer are valid; the null name
+            // deliberately exercises the guarded failure path.
+            super::surge_lock_acquire(ctx, ptr::null(), 0, &mut challenge)
+        };
+        assert_eq!(rc, SURGE_ERROR);
+        assert!(challenge.is_null());
+        // SAFETY: `stale` came from `CString::into_raw`, and the failing API
+        // call cleared the out pointer without taking ownership of it.
+        drop(unsafe { CString::from_raw(stale) });
+        unsafe {
+            // SAFETY: `ctx` is a live handle created above and is destroyed once.
+            super::surge_context_destroy(ctx);
+        }
+    }
+
+    #[test]
+    fn cancellation_state_can_be_reset_between_operations() {
+        let ctx = super::surge_context_create();
+        assert!(!ctx.is_null());
+
+        unsafe {
+            // SAFETY: `ctx` is a live handle, no operation is running, and it
+            // is destroyed exactly once after inspecting its state.
+            assert_eq!(super::surge_cancel(ctx), SURGE_OK);
+            assert!((*ctx).ctx.is_cancelled());
+            assert_eq!(super::surge_reset_cancel(ctx), SURGE_OK);
+            assert!(!(*ctx).ctx.is_cancelled());
+            super::surge_context_destroy(ctx);
+
+            // SAFETY: null is an explicitly guarded invalid input.
+            assert_eq!(super::surge_reset_cancel(ptr::null_mut()), SURGE_ERROR);
+        }
     }
 
     #[test]

--- a/crates/surge-ffi/src/pack.rs
+++ b/crates/surge-ffi/src/pack.rs
@@ -12,6 +12,9 @@ use crate::shared::{
 use crate::utils::lock_recover;
 
 /// Create a new pack context for building release packages.
+///
+/// The returned pack context clones the shared state it needs and may outlive
+/// the context used during this call.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn surge_pack_create(
     ctx: *mut SurgeContextHandle,

--- a/crates/surge-ffi/src/releases.rs
+++ b/crates/surge-ffi/src/releases.rs
@@ -110,3 +110,97 @@ pub unsafe extern "C" fn surge_release_is_genesis(info: *const SurgeReleasesInfo
 
     result.unwrap_or(0)
 }
+
+#[cfg(test)]
+mod tests {
+    use std::ffi::CStr;
+    use std::ptr;
+
+    use crate::handles::{ReleaseEntryFfi, SurgeReleasesInfoHandle};
+
+    use super::{
+        surge_release_channel, surge_release_full_size, surge_release_is_genesis, surge_release_version,
+        surge_releases_count, surge_releases_destroy,
+    };
+
+    fn releases_handle() -> *mut SurgeReleasesInfoHandle {
+        let mut info = Box::new(SurgeReleasesInfoHandle {
+            releases: vec![ReleaseEntryFfi {
+                version: "1.2.3".to_string(),
+                channel: "beta".to_string(),
+                full_size: 42,
+                is_genesis: true,
+            }],
+            cached_strings: Vec::new(),
+            update_info: None,
+        });
+        info.cache_strings();
+        Box::into_raw(info)
+    }
+
+    #[test]
+    fn release_string_accessors_are_borrowed_for_handle_lifetime() {
+        let info = releases_handle();
+
+        let (version, channel) = unsafe {
+            // SAFETY: `info` is a live test-owned handle and index zero exists.
+            (surge_release_version(info, 0), surge_release_channel(info, 0))
+        };
+        assert!(!version.is_null());
+        assert!(!channel.is_null());
+        unsafe {
+            // SAFETY: both non-null strings are cached in the still-live
+            // `info` handle and remain NUL-terminated for its lifetime.
+            assert_eq!(CStr::from_ptr(version).to_bytes(), b"1.2.3");
+            assert_eq!(CStr::from_ptr(channel).to_bytes(), b"beta");
+            assert_eq!(surge_releases_count(info), 1);
+            assert_eq!(surge_release_full_size(info, 0), 42);
+            assert_eq!(surge_release_is_genesis(info, 0), 1);
+        }
+
+        // Other accessors do not invalidate the borrowed string storage.
+        unsafe {
+            // SAFETY: the borrowed strings remain valid until `info` is
+            // destroyed below.
+            assert_eq!(CStr::from_ptr(version).to_bytes(), b"1.2.3");
+            assert_eq!(CStr::from_ptr(channel).to_bytes(), b"beta");
+        }
+
+        unsafe {
+            // SAFETY: `info` is a live owned handle and is destroyed once.
+            surge_releases_destroy(info);
+        }
+    }
+
+    #[test]
+    fn release_accessors_reject_null_and_invalid_indices() {
+        unsafe {
+            // SAFETY: these accessors explicitly accept null handles and
+            // return neutral values without dereferencing them.
+            assert_eq!(surge_releases_count(ptr::null()), 0);
+            assert!(surge_release_version(ptr::null(), 0).is_null());
+            assert!(surge_release_channel(ptr::null(), 0).is_null());
+            assert_eq!(surge_release_full_size(ptr::null(), 0), 0);
+            assert_eq!(surge_release_is_genesis(ptr::null(), 0), 0);
+        }
+
+        let info = releases_handle();
+        for index in [-1, 1, i32::MAX] {
+            unsafe {
+                // SAFETY: `info` is live; each invalid index is intentionally
+                // passed to accessors that validate it before indexing.
+                assert!(surge_release_version(info, index).is_null());
+                assert!(surge_release_channel(info, index).is_null());
+                assert_eq!(surge_release_full_size(info, index), 0);
+                assert_eq!(surge_release_is_genesis(info, index), 0);
+            }
+        }
+
+        unsafe {
+            // SAFETY: `info` is destroyed exactly once; null destruction is an
+            // explicitly supported no-op.
+            surge_releases_destroy(info);
+            surge_releases_destroy(ptr::null_mut());
+        }
+    }
+}

--- a/crates/surge-ffi/src/shared.rs
+++ b/crates/surge-ffi/src/shared.rs
@@ -228,8 +228,9 @@ pub(crate) unsafe fn collect_argv(argc: c_int, argv: *const *const c_char) -> Ve
     args
 }
 
-/// Thin wrapper around platform `malloc` for allocating buffers that C callers
-/// will free with `free()`.
+/// Thin wrapper around platform `malloc` for allocating Surge-owned buffers.
+/// Public callers release these only through `surge_free_cstring` so allocation
+/// and deallocation always cross the same library boundary.
 ///
 /// Returns a pointer to `size` bytes of uninitialized memory, or null on failure.
 pub(crate) fn libc_malloc(size: usize) -> *mut u8 {
@@ -241,8 +242,7 @@ pub(crate) fn libc_malloc(size: usize) -> *mut u8 {
     unsafe { malloc(size).cast::<u8>() }
 }
 
-/// Counterpart to [`libc_malloc`]: frees a pointer returned by any Surge FFI
-/// function that documents its output as `free()`-owned.
+/// Internal counterpart to [`libc_malloc`] used by `surge_free_cstring`.
 ///
 /// # Safety
 /// `ptr` must have been returned by a Surge FFI call that allocated via

--- a/crates/surge-ffi/src/update.rs
+++ b/crates/surge-ffi/src/update.rs
@@ -15,6 +15,9 @@ use crate::shared::{
 const DEFAULT_UPDATE_CHECK_TIMEOUT: Duration = Duration::from_mins(1);
 const UPDATE_CHECK_TIMEOUT_ENV: &str = "SURGE_UPDATE_CHECK_TIMEOUT_SECONDS";
 /// Create an update manager bound to a specific application.
+///
+/// The returned manager clones the shared state it needs and may outlive the
+/// context used during this call.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn surge_update_manager_create(
     ctx: *mut crate::handles::SurgeContextHandle,
@@ -214,24 +217,31 @@ pub unsafe extern "C" fn surge_update_manager_set_artifact_retention_policy(
 /// Check for available updates.
 ///
 /// Returns `SURGE_OK` if updates are available, `SURGE_NOT_FOUND` if up-to-date.
+/// `*info` is non-null only on `SURGE_OK` and must then be destroyed exactly
+/// once with `surge_releases_destroy`.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn surge_update_check(
     mgr: *mut SurgeUpdateManagerHandle,
     info: *mut *mut SurgeReleasesInfoHandle,
 ) -> i32 {
     ffi_trace("surge_update_check: enter");
-    if mgr.is_null() || info.is_null() {
+    if info.is_null() {
+        ffi_trace("surge_update_check: null input");
+        return SURGE_ERROR;
+    }
+    // SAFETY: `info` is checked non-null above. Clear it before validating any
+    // other input so every non-success path has a deterministic null output.
+    unsafe { *info = ptr::null_mut() };
+
+    if mgr.is_null() {
         ffi_trace("surge_update_check: null input");
         return SURGE_ERROR;
     }
 
     catch_ffi(std::panic::AssertUnwindSafe(|| {
-        // SAFETY: `mgr`/`info` are checked non-null above. The out pointer is
-        // cleared first to avoid leaking stale values on early exits.
-        let mgr_ref = unsafe {
-            *info = ptr::null_mut();
-            &*mgr
-        };
+        // SAFETY: `mgr` is checked non-null above and remains valid for the
+        // duration of this call. The out pointer was already cleared.
+        let mgr_ref = unsafe { &*mgr };
         clear_shared_error(&mgr_ref.ctx, &mgr_ref.last_error);
 
         if mgr_ref.ctx.is_cancelled() {
@@ -288,13 +298,6 @@ pub unsafe extern "C" fn surge_update_check(
             }
             Ok(Ok(None)) => {
                 ffi_trace("surge_update_check: no updates available");
-                let releases_handle = Box::new(SurgeReleasesInfoHandle {
-                    releases: Vec::new(),
-                    cached_strings: Vec::new(),
-                    update_info: None,
-                });
-                // SAFETY: `info` is a valid out pointer checked above.
-                unsafe { *info = Box::into_raw(releases_handle) };
                 SURGE_NOT_FOUND
             }
             Ok(Err(e)) => {
@@ -398,8 +401,9 @@ pub unsafe extern "C" fn surge_update_download_and_apply(
 
 /// Read the persisted update convergence record from `install_dir` as JSON.
 ///
-/// On `SURGE_OK`, `*json_out` is set to a `malloc()`-allocated, NUL-terminated
-/// UTF-8 JSON string that the caller must free with `free()`. On
+/// On `SURGE_OK`, `*json_out` is set to a Surge-owned, NUL-terminated UTF-8
+/// JSON string that the caller must free exactly once with
+/// `surge_free_cstring`. On
 /// `SURGE_NOT_FOUND` no status record has been written for this install yet
 /// (clean install, or no update has been attempted) and `*json_out` is set to
 /// NULL. On `SURGE_ERROR` reading or decoding failed; `*json_out` is NULL.
@@ -466,16 +470,96 @@ pub unsafe extern "C" fn surge_update_status_read_json(install_dir: *const c_cha
 #[cfg(test)]
 mod tests {
     use std::ffi::{CStr, CString};
+    use std::path::{Path, PathBuf};
+    use std::ptr;
     use std::time::Duration;
 
-    use crate::{surge_context_create, surge_context_destroy, surge_context_last_error};
+    use surge_core::config::constants::{DEFAULT_ZSTD_LEVEL, RELEASES_FILE_COMPRESSED};
+    use surge_core::releases::manifest::{ReleaseIndex, compress_release_index};
+    use surge_core::update::status::{UpdateStatusRecord, write_update_status};
+
+    use crate::{
+        surge_cancel, surge_config_set_storage, surge_context_create, surge_context_destroy, surge_context_last_error,
+        surge_free_cstring, surge_reset_cancel,
+    };
 
     use super::{
-        DEFAULT_UPDATE_CHECK_TIMEOUT, SURGE_OK, SurgeReleasesInfoHandle, parse_update_check_timeout,
-        surge_update_check, surge_update_manager_create, surge_update_manager_destroy,
+        DEFAULT_UPDATE_CHECK_TIMEOUT, SURGE_CANCELLED, SURGE_ERROR, SURGE_NOT_FOUND, SURGE_OK, SurgeReleasesInfoHandle,
+        parse_update_check_timeout, surge_update_check, surge_update_manager_create, surge_update_manager_destroy,
         surge_update_manager_set_artifact_retention_policy, surge_update_manager_set_channel,
-        surge_update_manager_set_release_retention_limit,
+        surge_update_manager_set_release_retention_limit, surge_update_status_read_json,
     };
+
+    struct TestDir(PathBuf);
+
+    impl TestDir {
+        fn new(name: &str) -> Self {
+            let unique = format!(
+                "{name}-{}-{}",
+                std::process::id(),
+                std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap()
+                    .as_nanos()
+            );
+            let path = std::env::temp_dir().join(unique);
+            std::fs::create_dir_all(&path).unwrap();
+            Self(path)
+        }
+
+        fn path(&self) -> &Path {
+            &self.0
+        }
+
+        fn as_cstring(&self) -> CString {
+            CString::new(self.0.to_string_lossy().as_bytes()).unwrap()
+        }
+    }
+
+    impl Drop for TestDir {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    fn configure_filesystem_storage(ctx: *mut crate::handles::SurgeContextHandle, root: &TestDir) {
+        let bucket = root.as_cstring();
+        let rc = unsafe {
+            // SAFETY: `ctx` is live, `bucket` remains valid for the call, and
+            // null optional string arguments are supported by the API.
+            surge_config_set_storage(
+                ctx,
+                3,
+                bucket.as_ptr(),
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+            )
+        };
+        assert_eq!(rc, SURGE_OK);
+    }
+
+    fn create_manager(
+        ctx: *mut crate::handles::SurgeContextHandle,
+        install_dir: &Path,
+    ) -> *mut crate::handles::SurgeUpdateManagerHandle {
+        let app_id = CString::new("demo").unwrap();
+        let version = CString::new("1.0.0").unwrap();
+        let channel = CString::new("stable").unwrap();
+        let install_dir = CString::new(install_dir.to_string_lossy().as_bytes()).unwrap();
+        unsafe {
+            // SAFETY: `ctx` is live and all C strings remain valid for the
+            // duration of this call.
+            surge_update_manager_create(
+                ctx,
+                app_id.as_ptr(),
+                version.as_ptr(),
+                channel.as_ptr(),
+                install_dir.as_ptr(),
+            )
+        }
+    }
 
     #[test]
     fn manager_set_channel_updates_context_last_error() {
@@ -637,41 +721,137 @@ mod tests {
     }
 
     #[test]
-    fn update_check_clears_output_pointer_on_failure() {
+    fn update_check_clears_output_pointer_before_manager_validation() {
+        let stale = Box::new(SurgeReleasesInfoHandle {
+            releases: Vec::new(),
+            cached_strings: Vec::new(),
+            update_info: None,
+        });
+        let stale_ptr = Box::into_raw(stale);
+        let mut info_ptr = stale_ptr;
+        assert!(!info_ptr.is_null());
+
+        let rc = unsafe {
+            // SAFETY: the out pointer is valid; the null manager deliberately
+            // exercises the API's guarded failure path.
+            surge_update_check(ptr::null_mut(), &mut info_ptr)
+        };
+        assert_eq!(rc, SURGE_ERROR);
+        assert!(info_ptr.is_null());
+
+        // The out parameter does not own a pre-existing sentinel value.
+        // SAFETY: `stale_ptr` came from `Box::into_raw`, and the failing API
+        // call cleared the out pointer without taking ownership of it.
+        drop(unsafe { Box::from_raw(stale_ptr) });
+    }
+
+    #[test]
+    fn update_check_can_retry_after_cancellation_reset() {
+        let storage = TestDir::new("surge-ffi-no-update-storage");
+        let install = TestDir::new("surge-ffi-no-update-install");
+        let app_storage = storage.path().join("demo");
+        std::fs::create_dir_all(&app_storage).unwrap();
+        let index = ReleaseIndex {
+            app_id: "demo".to_string(),
+            ..ReleaseIndex::default()
+        };
+        let compressed = compress_release_index(&index, DEFAULT_ZSTD_LEVEL).unwrap();
+        std::fs::write(app_storage.join(RELEASES_FILE_COMPRESSED), compressed).unwrap();
+
         let ctx = surge_context_create();
         assert!(!ctx.is_null());
-
-        let app_id = CString::new("demo").unwrap();
-        let version = CString::new("1.0.0").unwrap();
-        let channel = CString::new("stable").unwrap();
-        let install_dir = CString::new("/tmp/demo").unwrap();
-
-        let mgr = unsafe {
-            surge_update_manager_create(
-                ctx,
-                app_id.as_ptr(),
-                version.as_ptr(),
-                channel.as_ptr(),
-                install_dir.as_ptr(),
-            )
-        };
+        configure_filesystem_storage(ctx, &storage);
+        let mgr = create_manager(ctx, install.path());
         assert!(!mgr.is_null());
+
+        let mut cancelled_info = ptr::null_mut();
+        unsafe {
+            // SAFETY: both handles are live, and no other operation uses this
+            // context while cancellation is requested and then reset.
+            assert_eq!(surge_cancel(ctx), SURGE_OK);
+            assert_eq!(surge_update_check(mgr, &mut cancelled_info), SURGE_CANCELLED);
+            assert!(cancelled_info.is_null());
+            assert_eq!(surge_reset_cancel(ctx), SURGE_OK);
+        }
 
         let stale = Box::new(SurgeReleasesInfoHandle {
             releases: Vec::new(),
             cached_strings: Vec::new(),
             update_info: None,
         });
-        let mut info_ptr = Box::into_raw(stale);
-        assert!(!info_ptr.is_null());
-
-        let rc = unsafe { surge_update_check(mgr, &mut info_ptr) };
-        assert_ne!(rc, SURGE_OK);
+        let stale_ptr = Box::into_raw(stale);
+        let mut info_ptr = stale_ptr;
+        let rc = unsafe {
+            // SAFETY: `mgr` and the out pointer are live for this call.
+            surge_update_check(mgr, &mut info_ptr)
+        };
+        assert_eq!(rc, SURGE_NOT_FOUND);
         assert!(info_ptr.is_null());
 
+        // SAFETY: the no-update result did not take ownership of the sentinel
+        // allocated with `Box::into_raw`.
+        drop(unsafe { Box::from_raw(stale_ptr) });
         unsafe {
+            // SAFETY: both handles are live and each is destroyed once.
             surge_update_manager_destroy(mgr);
             surge_context_destroy(ctx);
+        }
+    }
+
+    #[test]
+    fn update_status_read_json_clears_outputs_on_invalid_and_missing_inputs() {
+        let stale = CString::new("stale").unwrap().into_raw();
+        let mut json = stale;
+        let rc = unsafe {
+            // SAFETY: the out pointer is valid; the null path deliberately
+            // exercises the API's guarded failure path.
+            surge_update_status_read_json(ptr::null(), &mut json)
+        };
+        assert_eq!(rc, SURGE_ERROR);
+        assert!(json.is_null());
+        // SAFETY: `stale` came from `CString::into_raw`, and the failing API
+        // call cleared the out pointer without taking ownership of it.
+        drop(unsafe { CString::from_raw(stale) });
+
+        let install = TestDir::new("surge-ffi-status-missing");
+        let install_c = install.as_cstring();
+        let stale = CString::new("stale").unwrap().into_raw();
+        let mut json = stale;
+        let rc = unsafe {
+            // SAFETY: the install path and out pointer remain valid for this call.
+            surge_update_status_read_json(install_c.as_ptr(), &mut json)
+        };
+        assert_eq!(rc, SURGE_NOT_FOUND);
+        assert!(json.is_null());
+        // SAFETY: `stale` came from `CString::into_raw`, and the no-status API
+        // call cleared the out pointer without taking ownership of it.
+        drop(unsafe { CString::from_raw(stale) });
+    }
+
+    #[test]
+    fn update_status_json_is_released_through_surge_allocator() {
+        let install = TestDir::new("surge-ffi-status-owned-string");
+        let record = UpdateStatusRecord::idle("demo", "1.0.0", "stable");
+        write_update_status(install.path(), &record).unwrap();
+        let install_c = install.as_cstring();
+        let mut json = ptr::null_mut();
+
+        let rc = unsafe {
+            // SAFETY: the install path and out pointer remain valid for this call.
+            surge_update_status_read_json(install_c.as_ptr(), &mut json)
+        };
+        assert_eq!(rc, SURGE_OK);
+        assert!(!json.is_null());
+        // SAFETY: a successful call returns a non-null, NUL-terminated Surge
+        // string that remains live until it is freed below.
+        let text = unsafe { CStr::from_ptr(json) }.to_str().unwrap();
+        assert!(text.contains("\"app_id\":\"demo\""));
+
+        unsafe {
+            // SAFETY: `json` is a live Surge-owned string freed exactly once;
+            // freeing null is an explicitly supported no-op.
+            surge_free_cstring(json);
+            surge_free_cstring(ptr::null_mut());
         }
     }
 

--- a/crates/surge-installer-ui/Cargo.toml
+++ b/crates/surge-installer-ui/Cargo.toml
@@ -2,6 +2,7 @@
 name = "surge-installer-ui"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 description = "Graphical installer for Surge applications"
 

--- a/crates/surge-installer/Cargo.toml
+++ b/crates/surge-installer/Cargo.toml
@@ -2,6 +2,7 @@
 name = "surge-installer"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 description = "Embedded installer launcher for Surge"
 

--- a/crates/surge-supervisor/Cargo.toml
+++ b/crates/surge-supervisor/Cargo.toml
@@ -2,6 +2,7 @@
 name = "surge-supervisor"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 description = "Process supervisor for the Surge update framework"
 

--- a/docs/integrating-surge.md
+++ b/docs/integrating-surge.md
@@ -41,6 +41,12 @@ If you choose this path, the app repo must treat Surge as both:
 
 Do not mix these two shapes accidentally.
 
+For C ABI and `.NET` runtime integrations, ship the native Surge library from
+the same release version and runtime identifier as the wrapper or header. The
+`Surge.NET` package contains the managed wrapper only; obtain the matching
+native binary from the official release archive or the app's pinned Surge
+toolchain bundle.
+
 ## 2. What Every App Repo Should Contain
 
 Every app repo that integrates Surge should carry these pieces explicitly.
@@ -78,6 +84,10 @@ Use the latest released Surge tag by default.
 - for publishing/toolchain work in CI, prefer the Surge release bundle or a staged toolchain artifact built from a released tag
 
 Do not point normal app development at an open Surge PR unless you are explicitly validating an unreleased Surge fix.
+
+Official Surge archives are checksum-covered but currently unsigned; macOS
+archives are also not notarized. Verify `SHA256SUMS.txt`, then apply any signing
+or notarization required by the app's distribution process.
 
 ### Fix Surge upstream first
 

--- a/dotnet/Directory.Build.props
+++ b/dotnet/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>0.1.0</Version>
+    <Version>1.0.0</Version>
     <Authors>Finter As</Authors>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/fintermobilityas/surge</PackageProjectUrl>

--- a/dotnet/Surge.NET.AotSmoke/Program.cs
+++ b/dotnet/Surge.NET.AotSmoke/Program.cs
@@ -1,5 +1,14 @@
 using System;
+using System.Reflection;
 using Surge;
+
+var informationalVersion = Assembly.GetExecutingAssembly()
+    .GetCustomAttribute<AssemblyInformationalVersionAttribute>()!
+    .InformationalVersion;
+var metadataSeparator = informationalVersion.IndexOf('+');
+var expectedSurgeVersion = metadataSeparator < 0
+    ? informationalVersion
+    : informationalVersion.Substring(0, metadataSeparator);
 
 var release = new SurgeRelease
 {
@@ -12,13 +21,23 @@ var release = new SurgeRelease
 var budget = new SurgeResourceBudget { MaxThreads = 2 };
 var retention = SurgeArtifactRetentionPolicy.LatestFull(2);
 var lifecycleCallbackVersion = "";
-var lifecycleHandled = SurgeApp.ProcessEvents(
-    Array.Empty<string>(),
-    onFirstRun: version => lifecycleCallbackVersion = version,
-    onInstalled: version => lifecycleCallbackVersion = version,
-    onUpdated: version => lifecycleCallbackVersion = version);
+var lifecycleHandled = false;
+try
+{
+    lifecycleHandled = SurgeApp.ProcessEvents(
+        Array.Empty<string>(),
+        onFirstRun: version => lifecycleCallbackVersion = version,
+        onInstalled: version => lifecycleCallbackVersion = version,
+        onUpdated: version => lifecycleCallbackVersion = version);
+}
+catch (DllNotFoundException)
+{
+    // This smoke roots the P/Invoke surface without bundling a native runtime.
+}
 
-if (release.Version != "1.0.0"
+if (SurgeApp.Version != expectedSurgeVersion
+    || SurgeApp.Version.Contains('+')
+    || release.Version != "1.0.0"
     || release.Channel != "stable"
     || budget.MaxThreads != 2
     || retention.Mode != SurgeArtifactRetentionMode.LatestFull

--- a/dotnet/Surge.NET.AotSmoke/Surge.NET.AotSmoke.csproj
+++ b/dotnet/Surge.NET.AotSmoke/Surge.NET.AotSmoke.csproj
@@ -4,6 +4,11 @@
     <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
+  <PropertyGroup>
+    <PublishAot>true</PublishAot>
+    <PublishTrimmed>true</PublishTrimmed>
+    <SelfContained>true</SelfContained>
+  </PropertyGroup>
   <ItemGroup>
     <ProjectReference
       Include="../Surge.NET/Surge.NET.csproj"

--- a/dotnet/Surge.NET.Tests/SurgeTests.cs
+++ b/dotnet/Surge.NET.Tests/SurgeTests.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Reflection;
+using System.Threading;
 using Xunit;
 
 namespace Surge.Tests
@@ -10,7 +12,25 @@ namespace Surge.Tests
         [Fact]
         public void Version_ReturnsExpectedVersion()
         {
-            Assert.Equal("0.1.0", SurgeApp.Version);
+            var informationalVersion = typeof(SurgeApp).Assembly
+                .GetCustomAttribute<AssemblyInformationalVersionAttribute>()!
+                .InformationalVersion;
+
+            Assert.Equal(
+                SurgeApp.NormalizeInformationalVersion(informationalVersion),
+                SurgeApp.Version);
+            Assert.DoesNotContain("+", SurgeApp.Version, StringComparison.Ordinal);
+        }
+
+        [Theory]
+        [InlineData("1.0.0", "1.0.0")]
+        [InlineData("1.0.0-beta.53", "1.0.0-beta.53")]
+        [InlineData("1.0.0-beta.53+0123456789abcdef", "1.0.0-beta.53")]
+        public void NormalizeInformationalVersion_RemovesBuildMetadata(
+            string informationalVersion,
+            string expected)
+        {
+            Assert.Equal(expected, SurgeApp.NormalizeInformationalVersion(informationalVersion));
         }
 
         [Fact]
@@ -159,6 +179,31 @@ namespace Surge.Tests
 
             Assert.Throws<ArgumentOutOfRangeException>(() => SurgeArtifactRetentionPolicy.LatestFull(0));
             Assert.Throws<ArgumentOutOfRangeException>(() => new SurgeArtifactRetentionPolicy((SurgeArtifactRetentionMode)99));
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(-1)]
+        [InlineData(-3)]
+        public void HandleNativeCancellation_IgnoresOtherResults(int result)
+        {
+            Assert.False(SurgeUpdateManager.HandleNativeCancellation(result, CancellationToken.None));
+        }
+
+        [Fact]
+        public void HandleNativeCancellation_ReturnsTrueWithoutCancelledToken()
+        {
+            Assert.True(SurgeUpdateManager.HandleNativeCancellation(-2, CancellationToken.None));
+        }
+
+        [Fact]
+        public void HandleNativeCancellation_ThrowsForCancelledToken()
+        {
+            using var source = new CancellationTokenSource();
+            source.Cancel();
+
+            Assert.Throws<OperationCanceledException>(
+                () => SurgeUpdateManager.HandleNativeCancellation(-2, source.Token));
         }
     }
 

--- a/dotnet/Surge.NET/NativeMethods.cs
+++ b/dotnet/Surge.NET/NativeMethods.cs
@@ -226,6 +226,9 @@ namespace Surge
 
         [LibraryImport(LibName, EntryPoint = "surge_cancel")]
         internal static partial int Cancel(IntPtr ctx);
+
+        [LibraryImport(LibName, EntryPoint = "surge_reset_cancel")]
+        internal static partial int ResetCancel(IntPtr ctx);
 #else
         // netstandard2.0: CharSet.Ansi maps to UTF-8 on Linux/.NET Core.
         // CA2101 is suppressed because there is no StringMarshalling.Utf8 in netstandard2.0.
@@ -397,6 +400,9 @@ namespace Surge
 
         [DllImport(LibName, EntryPoint = "surge_cancel", CallingConvention = CallingConvention.Cdecl)]
         internal static extern int Cancel(IntPtr ctx);
+
+        [DllImport(LibName, EntryPoint = "surge_reset_cancel", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern int ResetCancel(IntPtr ctx);
 #pragma warning restore CA2101
 #endif
     }

--- a/dotnet/Surge.NET/README.md
+++ b/dotnet/Surge.NET/README.md
@@ -25,12 +25,18 @@ One call that checks for updates, downloads the smallest available patch, verifi
 
 ## Key Features
 
-- **Zero dependencies** — no external NuGet packages required
+- **Zero managed dependencies** — no external NuGet packages are required
 - **Delta patches** — binary diffs (bsdiff + zstd) mean users download only what changed, typically 5–20% of the full package
 - **Release channels** — ship to `beta` first, then promote the exact same build to `stable`
 - **Persistent assets** — config files, databases, and user content survive across updates
 - **Cross-platform** — Linux, Windows, and macOS with native shortcuts and platform-correct install directories
 - **Progress & cancellation** — per-phase progress callbacks and `CancellationToken` support
+
+`Surge.NET` is a managed wrapper around the native Surge shared library. The
+matching `libsurge.so`, `surge.dll`, or `libsurge.dylib` from the same Surge
+version and runtime identifier must be shipped with the application. Official
+release archives provide those native binaries; the NuGet package does not
+embed them.
 
 ## Storage Backends
 

--- a/dotnet/Surge.NET/Surge.NET.csproj
+++ b/dotnet/Surge.NET/Surge.NET.csproj
@@ -7,6 +7,7 @@
     <PackageId>Surge.NET</PackageId>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageReadmeFile>README.md</PackageReadmeFile>
+    <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'net10.0'">
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/dotnet/Surge.NET/SurgeApp.cs
+++ b/dotnet/Surge.NET/SurgeApp.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Reflection;
 using System.Runtime.InteropServices;
 
 namespace Surge
@@ -22,6 +23,7 @@ namespace Surge
 
         private static SurgeAppInfo? _current;
         private static readonly object _lock = new object();
+        private static readonly string _version = GetLibraryVersion();
 
         /// <summary>
         /// Information about the currently installed application, or null if not
@@ -71,9 +73,30 @@ namespace Surge
         }
 
         /// <summary>
-        /// The Surge library version.
+        /// The exact Surge package version, including any prerelease suffix.
         /// </summary>
-        public static string Version => "0.1.0";
+        public static string Version => _version;
+
+        internal static string NormalizeInformationalVersion(string informationalVersion)
+        {
+            int metadataSeparator = informationalVersion.IndexOf('+');
+            return metadataSeparator < 0
+                ? informationalVersion
+                : informationalVersion.Substring(0, metadataSeparator);
+        }
+
+        private static string GetLibraryVersion()
+        {
+            var assembly = typeof(SurgeApp).Assembly;
+            var informationalVersion = assembly
+                .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?
+                .InformationalVersion;
+
+            if (informationalVersion != null && informationalVersion.Length != 0)
+                return NormalizeInformationalVersion(informationalVersion);
+
+            return assembly.GetName().Version?.ToString(3) ?? "0.0.0";
+        }
 
         /// <summary>
         /// Process application lifecycle events. Should be called early in the

--- a/dotnet/Surge.NET/SurgeUpdateManager.cs
+++ b/dotnet/Surge.NET/SurgeUpdateManager.cs
@@ -60,6 +60,7 @@ namespace Surge
         private string _currentVersion = "0.0.0";
         private int _releaseRetentionLimit = 1;
         private SurgeArtifactRetentionPolicy _artifactRetentionPolicy = SurgeArtifactRetentionPolicy.ReleaseGraph;
+        private int _updateOperationActive;
 
         /// <summary>
         /// Maximum number of old installed versions to retain on disk after updating.
@@ -238,8 +239,15 @@ namespace Surge
         /// <param name="cancellationToken">Token to cancel the operation.</param>
         /// <returns>
         /// The <see cref="SurgeAppInfo"/> for the newly installed version,
-        /// or null if no updates were available or the operation was cancelled.
+        /// or null if no updates were available or native cancellation occurred
+        /// without the supplied token being cancelled.
         /// </returns>
+        /// <exception cref="OperationCanceledException">
+        /// The supplied cancellation token was cancelled.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">
+        /// Another update operation is already running on this manager.
+        /// </exception>
         public Task<SurgeAppInfo?> UpdateToLatestReleaseAsync(
             ISurgeProgressSource? progressSource = null,
             Action<ISurgeChannelReleases>? onUpdatesAvailable = null,
@@ -252,36 +260,44 @@ namespace Surge
 
             return Task.Run(() =>
             {
+                if (Interlocked.CompareExchange(ref _updateOperationActive, 1, 0) != 0)
+                    throw new InvalidOperationException("Only one update operation can run on a manager at a time.");
+
                 // Register cancellation
                 CancellationTokenRegistration registration = default;
                 IntPtr ctx = _nativeCtx;
-                if (cancellationToken.CanBeCanceled)
-                {
-                    registration = cancellationToken.Register(() =>
-                    {
-                        if (ctx != IntPtr.Zero)
-                            _ = NativeMethods.Cancel(ctx);
-                    });
-                }
 
                 try
                 {
+                    ResetNativeCancellation();
+
+                    if (cancellationToken.CanBeCanceled)
+                    {
+                        registration = cancellationToken.Register(() =>
+                        {
+                            if (ctx != IntPtr.Zero)
+                                _ = NativeMethods.Cancel(ctx);
+                        });
+                    }
+
                     cancellationToken.ThrowIfCancellationRequested();
 
                     // Check for updates
                     int checkResult = NativeMethods.UpdateCheck(_nativeMgr, out IntPtr releasesInfoPtr);
-
-                    if (checkResult == -3) // SURGE_NOT_FOUND
-                        return null;
-
-                    if (checkResult != 0)
-                    {
-                        var errorMsg = GetLastError();
-                        throw new SurgeException(checkResult, errorMsg ?? "Update check failed.");
-                    }
-
                     try
                     {
+                        if (checkResult == -3) // SURGE_NOT_FOUND
+                            return null;
+
+                        if (HandleNativeCancellation(checkResult, cancellationToken))
+                            return null;
+
+                        if (checkResult != 0)
+                        {
+                            var errorMsg = GetLastError();
+                            throw new SurgeException(checkResult, errorMsg ?? "Update check failed.");
+                        }
+
                         cancellationToken.ThrowIfCancellationRequested();
                         ApplyRetentionSettings();
 
@@ -356,11 +372,8 @@ namespace Surge
                                 nativeProgressCb,
                                 IntPtr.Zero);
 
-                            if (applyResult == -2) // SURGE_CANCELLED
-                            {
-                                cancellationToken.ThrowIfCancellationRequested();
+                            if (HandleNativeCancellation(applyResult, cancellationToken))
                                 return null;
-                            }
 
                             if (applyResult != 0)
                             {
@@ -398,14 +411,32 @@ namespace Surge
                     }
                     finally
                     {
-                        NativeMethods.ReleasesDestroy(releasesInfoPtr);
+                        if (releasesInfoPtr != IntPtr.Zero)
+                            NativeMethods.ReleasesDestroy(releasesInfoPtr);
                     }
                 }
                 finally
                 {
-                    registration.Dispose();
+                    try
+                    {
+                        // Wait for any in-flight callback before clearing its
+                        // native cancellation request.
+                        registration.Dispose();
+                    }
+                    finally
+                    {
+                        try
+                        {
+                            if (ctx != IntPtr.Zero)
+                                _ = NativeMethods.ResetCancel(ctx);
+                        }
+                        finally
+                        {
+                            Volatile.Write(ref _updateOperationActive, 0);
+                        }
+                    }
                 }
-            }, cancellationToken);
+            }, CancellationToken.None);
         }
 
         private static int ParseStorageProvider(string provider)
@@ -436,6 +467,25 @@ namespace Surge
         private static string? NullIfEmpty(string value)
         {
             return string.IsNullOrWhiteSpace(value) ? null : value;
+        }
+
+        internal static bool HandleNativeCancellation(int result, CancellationToken cancellationToken)
+        {
+            if (result != -2) // SURGE_CANCELLED
+                return false;
+
+            cancellationToken.ThrowIfCancellationRequested();
+            return true;
+        }
+
+        private void ResetNativeCancellation()
+        {
+            int result = NativeMethods.ResetCancel(_nativeCtx);
+            if (result != 0)
+            {
+                var errorMsg = GetLastError();
+                throw new SurgeException(result, errorMsg ?? "Failed to reset native cancellation state.");
+            }
         }
 
         private void SetCurrentVersionInternal(string version)

--- a/include/surge/surge_api.h
+++ b/include/surge/surge_api.h
@@ -41,6 +41,28 @@ typedef struct surge_releases_info surge_releases_info;
 typedef struct surge_pack_context surge_pack_context;
 
 /* -------------------------------------------------------------------------- */
+/*  Ownership and lifetime rules                                              */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Unless a function says otherwise, input pointers are borrowed only for the
+ * duration of the call.
+ *
+ * Opaque handles returned by Surge are owned by the caller and must be passed
+ * exactly once to their matching destroy function. Destroy functions accept
+ * NULL. Child handles such as surge_update_manager and surge_pack_context own
+ * the shared state they need and may outlive the surge_context used to create
+ * them.
+ *
+ * A `const char*` returned by an accessor or supplied to a callback is borrowed
+ * and must not be freed. Accessor lifetimes are documented by that API;
+ * callback arguments remain valid only for the callback invocation. A `char*`
+ * returned through an output parameter is Surge-owned: on success the caller
+ * must pass it exactly once to surge_free_cstring(), never to the host C
+ * runtime's free(). String output parameters are set to NULL on failure.
+ */
+
+/* -------------------------------------------------------------------------- */
 /*  Enumerations                                                              */
 /* -------------------------------------------------------------------------- */
 
@@ -207,7 +229,9 @@ SURGE_API surge_result SURGE_CALL surge_config_set_resource_budget(surge_context
 
 /**
  * Create an update manager bound to a specific application.
- * @param ctx             Context handle (must outlive the manager).
+ * @param ctx             Context handle used during creation. The returned
+ *                        manager owns the shared state it needs and may outlive
+ *                        this context.
  * @param app_id          Application identifier.
  * @param current_version Current installed version string (semver).
  * @param channel         Release channel (e.g. "stable", "beta").
@@ -263,8 +287,9 @@ SURGE_API surge_result SURGE_CALL surge_update_manager_set_artifact_retention_po
 /**
  * Check for available updates.
  * @param mgr  Manager handle.
- * @param info [out] Receives a pointer to release information.
- *             Must be freed with surge_releases_destroy().
+ * @param info [out] Receives a pointer to release information on SURGE_OK.
+ *             Must be freed exactly once with surge_releases_destroy(). Set to
+ *             NULL on SURGE_NOT_FOUND, SURGE_ERROR, or SURGE_CANCELLED.
  * @return SURGE_OK if updates are available, SURGE_NOT_FOUND if up-to-date.
  */
 SURGE_API surge_result SURGE_CALL surge_update_check(surge_update_manager* mgr, surge_releases_info** info);
@@ -290,19 +315,20 @@ SURGE_API surge_result SURGE_CALL surge_update_download_and_apply(surge_update_m
  *
  * @param install_dir Root install directory containing
  *                    `.surge-update-status.json`.
- * @param json_out    [out] Receives a malloc()-allocated NUL-terminated JSON
+ * @param json_out    [out] Receives a Surge-owned NUL-terminated JSON
  *                    string on SURGE_OK, or NULL on SURGE_NOT_FOUND /
- *                    SURGE_ERROR. Caller must free with free().
+ *                    SURGE_ERROR. Caller must free it exactly once with
+ *                    surge_free_cstring(), never with the host's free().
  * @return SURGE_OK when a record exists; SURGE_NOT_FOUND when no record has
  *         been written yet; SURGE_ERROR on read/decode failure.
  */
 SURGE_API surge_result SURGE_CALL surge_update_status_read_json(const char* install_dir, char** json_out);
 
 /**
- * Free a NUL-terminated string returned by a Surge FFI call that documents its
- * output as `free()`-owned (for example surge_update_status_read_json). Safe
- * to call with NULL. Use this rather than the host's free() to ensure the
- * matching allocator is used across libraries.
+ * Free a Surge-owned NUL-terminated string returned through a `char**` output
+ * (for example surge_update_status_read_json or surge_lock_acquire). Each
+ * non-NULL output must be passed to this function exactly once and must never
+ * be passed to the host's free(). Safe to call with NULL.
  */
 SURGE_API void SURGE_CALL surge_free_cstring(char* ptr);
 
@@ -316,10 +342,18 @@ SURGE_API int32_t SURGE_CALL surge_releases_count(const surge_releases_info* inf
 /** Free a releases-info structure returned by surge_update_check(). */
 SURGE_API void SURGE_CALL surge_releases_destroy(surge_releases_info* info);
 
-/** Return the version string for release at @p index. */
+/**
+ * Return the version string for release at @p index, or NULL for an invalid
+ * handle/index. The returned pointer is borrowed, remains valid until @p info
+ * is destroyed, and must not be freed.
+ */
 SURGE_API const char* SURGE_CALL surge_release_version(const surge_releases_info* info, int32_t index);
 
-/** Return the channel string for release at @p index. */
+/**
+ * Return the channel string for release at @p index, or NULL for an invalid
+ * handle/index. The returned pointer is borrowed, remains valid until @p info
+ * is destroyed, and must not be freed.
+ */
 SURGE_API const char* SURGE_CALL surge_release_channel(const surge_releases_info* info, int32_t index);
 
 /** Return the full-package size in bytes for release at @p index. */
@@ -348,10 +382,10 @@ SURGE_API surge_result SURGE_CALL surge_bsdiff(surge_bsdiff_ctx* ctx);
  */
 SURGE_API surge_result SURGE_CALL surge_bspatch(surge_bspatch_ctx* ctx);
 
-/** Free memory allocated by surge_bsdiff(). */
+/** Free memory allocated by surge_bsdiff() and reset patch/patch_size. */
 SURGE_API void SURGE_CALL surge_bsdiff_free(surge_bsdiff_ctx* ctx);
 
-/** Free memory allocated by surge_bspatch(). */
+/** Free memory allocated by surge_bspatch() and reset newer/newer_size. */
 SURGE_API void SURGE_CALL surge_bspatch_free(surge_bspatch_ctx* ctx);
 
 /* -------------------------------------------------------------------------- */
@@ -360,7 +394,9 @@ SURGE_API void SURGE_CALL surge_bspatch_free(surge_bspatch_ctx* ctx);
 
 /**
  * Create a new pack context for building release packages.
- * @param ctx           Surge context.
+ * @param ctx           Surge context used during creation. The returned pack
+ *                      context owns the shared state it needs and may outlive
+ *                      this context.
  * @param manifest_path Path to the surge.yml manifest file.
  * @param app_id        Application identifier.
  * @param rid           Runtime identifier (e.g. "linux-x64").
@@ -405,8 +441,10 @@ SURGE_API void SURGE_CALL surge_pack_destroy(surge_pack_context* pack_ctx);
  * @param ctx             Surge context (must have lock server configured).
  * @param name            Lock name.
  * @param timeout_seconds Maximum time to wait for the lock.
- * @param challenge_out   [out] Receives an opaque challenge string required
- *                        to release the lock. Caller must free with free().
+ * @param challenge_out   [out] Receives an opaque Surge-owned challenge string
+ *                        required to release the lock, or NULL on failure.
+ *                        After release, free it exactly once with
+ *                        surge_free_cstring(), never with the host's free().
  * @return SURGE_OK on success.
  */
 SURGE_API surge_result SURGE_CALL surge_lock_acquire(surge_context* ctx, const char* name, int32_t timeout_seconds,
@@ -476,6 +514,15 @@ SURGE_API surge_result SURGE_CALL surge_process_events(int argc, const char** ar
  * @return SURGE_OK on success.
  */
 SURGE_API surge_result SURGE_CALL surge_cancel(surge_context* ctx);
+
+/**
+ * Clear a previous cancellation so @p ctx can start another operation.
+ * The caller must ensure that no operation using this context or a child
+ * handle created from it is still running while cancellation is reset.
+ * @param ctx Context handle.
+ * @return SURGE_OK on success.
+ */
+SURGE_API surge_result SURGE_CALL surge_reset_cancel(surge_context* ctx);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/scripts/check-macos-architecture.sh
+++ b/scripts/check-macos-architecture.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Validate the macOS runner, Rust host, and Mach-O architecture of release files.
+
+Usage:
+  check-macos-architecture.sh --arch <x86_64|arm64> [--runner-only] [<file> ...]
+EOF
+}
+
+expected_arch=""
+runner_only="false"
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --arch)
+      expected_arch="${2:-}"
+      shift 2
+      ;;
+    --runner-only)
+      runner_only="true"
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      break
+      ;;
+    -*)
+      printf 'Unknown argument: %s\n\n' "$1" >&2
+      usage >&2
+      exit 1
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
+
+case "${expected_arch}" in
+  x86_64)
+    expected_rust_host="x86_64-apple-darwin"
+    ;;
+  arm64)
+    expected_rust_host="aarch64-apple-darwin"
+    ;;
+  *)
+    usage >&2
+    exit 1
+    ;;
+esac
+
+if [ "${runner_only}" = "false" ] && [ "$#" -eq 0 ]; then
+  usage >&2
+  exit 1
+fi
+
+runner_arch="$(uname -m)"
+if [ "${runner_arch}" != "${expected_arch}" ]; then
+  printf 'Unexpected macOS runner architecture: found %s, expected %s\n' \
+    "${runner_arch}" "${expected_arch}" >&2
+  exit 1
+fi
+
+rust_host="$(rustc -vV | sed -n 's/^host: //p')"
+if [ "${rust_host}" != "${expected_rust_host}" ]; then
+  printf 'Unexpected Rust host: found %s, expected %s\n' \
+    "${rust_host}" "${expected_rust_host}" >&2
+  exit 1
+fi
+
+printf 'macOS runner and Rust host OK: %s / %s\n' "${runner_arch}" "${rust_host}"
+
+if [ "${runner_only}" = "true" ]; then
+  if [ "$#" -ne 0 ]; then
+    printf '%s\n' '--runner-only does not accept file arguments.' >&2
+    exit 1
+  fi
+  exit 0
+fi
+
+for path in "$@"; do
+  if [ ! -f "${path}" ]; then
+    printf 'Missing Mach-O file: %s\n' "${path}" >&2
+    exit 1
+  fi
+
+  if ! actual_archs="$(lipo -archs "${path}")"; then
+    printf 'Could not read Mach-O architectures from %s\n' "${path}" >&2
+    exit 1
+  fi
+
+  if [ "${actual_archs}" != "${expected_arch}" ]; then
+    printf 'Mach-O architecture mismatch in %s: found %s, expected only %s\n' \
+      "${path}" "${actual_archs}" "${expected_arch}" >&2
+    exit 1
+  fi
+
+  printf 'Mach-O architecture OK in %s: %s\n' "${path}" "${expected_arch}"
+done

--- a/scripts/check-version-sync.sh
+++ b/scripts/check-version-sync.sh
@@ -6,13 +6,24 @@ source "$repo_root/scripts/version-lib.sh"
 
 workspace_version="$(workspace_base_version)"
 surge_core_version="$(workspace_surge_core_version)"
+dotnet_version="$(dotnet_package_version)"
 
-if [[ -z "$workspace_version" || -z "$surge_core_version" ]]; then
-  echo "Failed to parse version values from Cargo.toml." >&2
+if [[ -z "$workspace_version" || -z "$surge_core_version" || -z "$dotnet_version" ]]; then
+  echo "Failed to parse version values from Cargo.toml and dotnet/Directory.Build.props." >&2
   exit 1
 fi
 
 failed=0
+
+if [[ "$workspace_version" != "$dotnet_version" ]]; then
+  cat <<EOF >&2
+Version mismatch:
+  Cargo.toml [workspace.package].version: $workspace_version
+  dotnet/Directory.Build.props Version:   $dotnet_version
+Update the managed package version so it matches the Cargo workspace version.
+EOF
+  failed=1
+fi
 
 if [[ "$workspace_version" != "$surge_core_version" ]]; then
   cat <<EOF >&2
@@ -27,7 +38,7 @@ fi
 # Check Cargo.lock is in sync
 lock_file="$repo_root/Cargo.lock"
 if [[ -f "$lock_file" ]]; then
-  for crate in surge-core surge-cli surge-ffi surge-supervisor surge-installer surge-installer-ui; do
+  for crate in surge-core surge-cli surge-ffi surge-supervisor surge-bench surge-installer surge-installer-ui; do
     lock_version=$(awk -v pkg="$crate" '
       /^\[\[package\]\]/ { in_pkg = 0 }
       $0 == "name = \"" pkg "\"" { in_pkg = 1; next }

--- a/scripts/publish-cargo-release.sh
+++ b/scripts/publish-cargo-release.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Publish the Surge crates for an exact version, safely supporting workflow reruns.
+
+Usage:
+  publish-cargo-release.sh <version>
+EOF
+}
+
+if [ "$#" -ne 1 ] || [[ ! "$1" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta)\.[0-9]+)?$ ]]; then
+  usage >&2
+  exit 1
+fi
+
+version="$1"
+api_body="$(mktemp)"
+trap 'rm -f "${api_body}"' EXIT
+
+crate_visibility() {
+  local crate="$1"
+  local status
+
+  if ! status="$(curl \
+    --silent \
+    --show-error \
+    --output "${api_body}" \
+    --write-out '%{http_code}' \
+    --user-agent "surge-release-workflow/1.0 (${GITHUB_SERVER_URL:-https://github.com}/${GITHUB_REPOSITORY:-fintermobilityas/surge})" \
+    "https://crates.io/api/v1/crates/${crate}/${version}")"; then
+    printf 'Failed to query crates.io for %s %s\n' "${crate}" "${version}" >&2
+    exit 1
+  fi
+
+  case "${status}" in
+    200)
+      printf 'present\n'
+      ;;
+    404)
+      printf 'absent\n'
+      ;;
+    *)
+      printf 'Unexpected crates.io response for %s %s: HTTP %s\n' \
+        "${crate}" "${version}" "${status}" >&2
+      sed -n '1,20p' "${api_body}" >&2
+      exit 1
+      ;;
+  esac
+}
+
+publish_with_retries() {
+  local crate="$1"
+  local max_attempts="$2"
+  local attempt
+  local visibility
+
+  visibility="$(crate_visibility "${crate}")"
+  if [ "${visibility}" = "present" ]; then
+    printf '%s %s is already visible on crates.io; skipping publish.\n' \
+      "${crate}" "${version}"
+    return
+  fi
+
+  for attempt in $(seq 1 "${max_attempts}"); do
+    printf 'Publishing %s %s to crates.io (attempt %s/%s).\n' \
+      "${crate}" "${version}" "${attempt}" "${max_attempts}"
+    if cargo publish -p "${crate}" --allow-dirty; then
+      return
+    fi
+
+    visibility="$(crate_visibility "${crate}")"
+    if [ "${visibility}" = "present" ]; then
+      printf '%s %s became visible after cargo publish returned an error; continuing.\n' \
+        "${crate}" "${version}"
+      return
+    fi
+
+    if [ "${attempt}" -lt "${max_attempts}" ]; then
+      printf 'Publish failed while %s %s is still absent; waiting for registry/index propagation.\n' \
+        "${crate}" "${version}"
+      sleep $((attempt * 5))
+    fi
+  done
+
+  printf 'cargo publish failed after %s attempts and %s %s is still absent from crates.io.\n' \
+    "${max_attempts}" "${crate}" "${version}" >&2
+  return 1
+}
+
+wait_until_visible() {
+  local crate="$1"
+  local attempt
+  local visibility
+
+  for attempt in $(seq 1 30); do
+    visibility="$(crate_visibility "${crate}")"
+    if [ "${visibility}" = "present" ]; then
+      printf '%s %s is visible on crates.io.\n' "${crate}" "${version}"
+      return
+    fi
+
+    if [ "${attempt}" -lt 30 ]; then
+      printf 'Waiting for %s %s to become visible on crates.io (%s/30).\n' \
+        "${crate}" "${version}" "${attempt}"
+      sleep 10
+    fi
+  done
+
+  printf '%s %s did not become visible on crates.io within five minutes.\n' \
+    "${crate}" "${version}" >&2
+  exit 1
+}
+
+publish_with_retries surge-core 3
+wait_until_visible surge-core
+publish_with_retries surge-cli 10
+wait_until_visible surge-cli

--- a/scripts/version-lib.sh
+++ b/scripts/version-lib.sh
@@ -40,6 +40,47 @@ workspace_surge_core_version() {
   ' "$cargo_file"
 }
 
+dotnet_package_version() {
+  local props_file
+  props_file="$(version_repo_root)/dotnet/Directory.Build.props"
+
+  awk '
+    match($0, /<Version>[^<]+<\/Version>/) {
+      value = substr($0, RSTART, RLENGTH)
+      sub(/^<Version>/, "", value)
+      sub(/<\/Version>$/, "", value)
+      print value
+      exit
+    }
+  ' "$props_file"
+}
+
+rewrite_dotnet_version() {
+  local version="$1"
+  local repo_root props_file temp_file
+
+  repo_root="$(version_repo_root)"
+  props_file="$repo_root/dotnet/Directory.Build.props"
+  temp_file="$(mktemp)"
+
+  awk -v version="$version" '
+    !updated && /<Version>[^<]+<\/Version>/ {
+      sub(/<Version>[^<]+<\/Version>/, "<Version>" version "</Version>")
+      updated = 1
+    }
+    {
+      print
+    }
+    END {
+      if (!updated) {
+        exit 1
+      }
+    }
+  ' "$props_file" > "$temp_file"
+
+  mv "$temp_file" "$props_file"
+}
+
 rewrite_workspace_versions() {
   local version="$1"
   local repo_root cargo_file temp_file
@@ -79,4 +120,5 @@ rewrite_workspace_versions() {
   ' "$cargo_file" > "$temp_file"
 
   mv "$temp_file" "$cargo_file"
+  rewrite_dotnet_version "$version"
 }


### PR DESCRIPTION
## Purpose

Prepare the next 1.0.0 beta by fixing correctness and publishing gaps before any new tag is cut.

## Behavior impact

- Aligns Rust and managed version identity and declares Rust 1.95 as the workspace MSRV.
- Makes the NativeAOT prerelease smoke test execute a real native binary.
- Tightens C ABI ownership, null-output, child-handle lifetime, and allocator contracts.
- Makes managed cancellation reusable: concurrent update calls are rejected, in-flight callbacks are drained, and native cancellation state is reset before retry.
- Builds and validates separate Intel and Apple Silicon macOS artifacts.
- Makes release recovery immutable and idempotent:
  - exact tag-SHA checkouts
  - reproducible archives with restored Unix executable modes
  - one canonical NuGet package reused across both feeds
  - exact NuGet repository URL/tag-commit provenance
  - checksum coverage for archives, header, and NuGet package
  - exact-version Cargo publication with propagation retries
- Documents that Windows/macOS artifacts are unsigned and macOS artifacts are not notarized.

## Test evidence

- `./scripts/sync-surge-core-vendor.sh --check`
- `./scripts/check-version-sync.sh`
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo test --workspace`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo clippy --workspace --lib --bins --examples -- -D warnings -D clippy::unwrap_used -D clippy::expect_used`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings -W clippy::pedantic`
- `cargo +1.95.0 check --workspace --all-targets --all-features --locked`
- `RUSTFLAGS="-D warnings" cargo build --release`
- `dotnet format dotnet/Surge.slnx --verify-no-changes`
- `dotnet test dotnet/Surge.slnx --configuration Release` (47 passed)
- synthetic `1.0.0-beta.999` managed tests (47 passed)
- synthetic NativeAOT publish and execution: `1.0.0-beta.999:1.0.0:2`
- `surge-ffi` cancel-then-retry regression (29 passed)
- actionlint, workflow Bash syntax, YAML parsing, and immutable archive/package fixture checks

## Release and migration notes

- Intended next prerelease: `v1.0.0-beta.53`; this PR does not create or publish a release.
- Configure the NuGet.org Trusted Publishing policy for user `petersunde`, owner `fintermobilityas`, repository `surge`, workflow `release.yml`, with no environment restriction, before publishing the beta.
- Managed consumers must ship the native library from the same Surge version and runtime identifier.
- C consumers must release Surge-owned string outputs with `surge_free_cstring` and call `surge_reset_cancel` only when no operation using the context or its child handles is running.
- Verify `SHA256SUMS.txt`; apply product signing/notarization before end-user distribution where required.