### PR TITLE
Update .NET SDK workflow pins to 10.0.400

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -280,7 +280,7 @@ jobs:
           submodules: true
       - uses: actions/setup-dotnet@v6
         with:
-          dotnet-version: '10.0.302'
+          dotnet-version: '10.0.400'
       - uses: actions/cache@v6
         with:
           path: ~/.nuget/packages
@@ -327,7 +327,7 @@ jobs:
           submodules: true
       - uses: actions/setup-dotnet@v6
         with:
-          dotnet-version: '10.0.302'
+          dotnet-version: '10.0.400'
       - uses: actions/cache@v6
         with:
           path: ~/.nuget/packages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -271,7 +271,7 @@ jobs:
           ref: ${{ needs.validate-release.outputs.tag_commit }}
       - uses: actions/setup-dotnet@v6
         with:
-          dotnet-version: '10.0.302'
+          dotnet-version: '10.0.400'
       - uses: actions/cache@v6
         with:
           path: ~/.nuget/packages
@@ -427,7 +427,7 @@ jobs:
     steps:
       - uses: actions/setup-dotnet@v6
         with:
-          dotnet-version: '10.0.302'
+          dotnet-version: '10.0.400'
       - name: Download immutable NuGet package
         uses: actions/download-artifact@v8
         with:


### PR DESCRIPTION
## Summary

- update all four .NET SDK workflow pins from 10.0.302 to 10.0.400
- keep release behavior and package versions unchanged

## Validation

- `./scripts/sync-surge-core-vendor.sh --check`
- `./scripts/check-version-sync.sh`
- `cargo fmt --all -- --check`
- `cargo test --workspace`
- all repository-prescribed clippy gates
- `RUSTFLAGS="-D warnings" cargo test --workspace`
- `RUSTFLAGS="-D warnings" cargo build --release`
- `dotnet format dotnet/Surge.slnx --verify-no-changes`
- `dotnet test dotnet/Surge.slnx -c Release` (47/47 passed)

