### PR TITLE
Restore NuGet API-key publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -422,7 +422,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      id-token: write
       packages: write
     steps:
       - uses: actions/setup-dotnet@v6
@@ -456,13 +455,18 @@ jobs:
             echo "::error::Downloaded workflow artifact does not match the immutable NuGet package."
             exit 1
           fi
-      - name: Authenticate to NuGet.org with Trusted Publishing
-        id: nuget-login
-        uses: NuGet/login@v1
-        with:
-          user: petersunde
       - name: Push to NuGet.org
-        run: dotnet nuget push "nupkgs/${{ needs.package-nuget.outputs.package_name }}" --source https://api.nuget.org/v3/index.json --api-key "${{ steps.nuget-login.outputs.NUGET_API_KEY }}" --skip-duplicate
+        env:
+          NUGET_API_KEY: ${{ secrets.PETERSUNDE_NUGET_ORG_API_KEY }}
+        run: |
+          if [ -z "${NUGET_API_KEY}" ]; then
+            echo "::error::PETERSUNDE_NUGET_ORG_API_KEY is not available to this workflow."
+            exit 1
+          fi
+          dotnet nuget push "nupkgs/${{ needs.package-nuget.outputs.package_name }}" \
+            --source https://api.nuget.org/v3/index.json \
+            --api-key "${NUGET_API_KEY}" \
+            --skip-duplicate
       - name: Push to GitHub Packages
         run: dotnet nuget push "nupkgs/${{ needs.package-nuget.outputs.package_name }}" --source https://nuget.pkg.github.com/fintermobilityas/index.json --api-key ${{ secrets.GITHUB_TOKEN }} --skip-duplicate
 


### PR DESCRIPTION
## Summary

- restore NuGet.org publishing through the existing organization API-key secret
- keep the credential scoped to the single NuGet.org push step and fail explicitly when it is unavailable
- preserve immutable package verification, duplicate-safe recovery, and the separate GitHub Packages push

## Root cause

The beta release recovery switched NuGet.org authentication to Trusted Publishing, but token exchange returned HTTP 401 because no matching trust policy existed for the configured policy creator. The previous API-key path has proven successful publication history in this repository and another organization repository.

## Impact

New releases and existing-tag recovery dispatches can publish the already-verified package to NuGet.org without changing the tagged source or release assets. GitHub Packages continues to use the workflow token.

## Validation

- `./scripts/sync-surge-core-vendor.sh --check`
- `./scripts/check-version-sync.sh`
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo test --workspace`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo clippy --workspace --lib --bins --examples -- -D warnings -D clippy::unwrap_used -D clippy::expect_used`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings -W clippy::pedantic`
- `dotnet format dotnet/Surge.slnx --verify-no-changes`
- `dotnet test dotnet/Surge.slnx --configuration Release`
- actionlint 1.7.12
- YAML parse and changed shell-block syntax checks

## Migration notes

The existing organization API-key secret must remain available to this repository.