### PR TITLE
Add NuGet-only release recovery

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,14 @@ on:
         description: Existing published release tag to recover
         required: true
         type: string
+      recovery_mode:
+        description: Work to run for an existing release
+        required: true
+        default: full
+        type: choice
+        options:
+          - full
+          - nuget
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.release.tag_name || inputs.tag_name }}
@@ -142,6 +150,7 @@ jobs:
 
   build-artifacts:
     name: Artifacts (${{ matrix.name }})
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.recovery_mode == 'full' }}
     needs: validate-release
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
@@ -258,6 +267,7 @@ jobs:
 
   package-nuget:
     name: Package NuGet
+    if: ${{ !cancelled() && needs.validate-release.result == 'success' && (needs.build-artifacts.result == 'success' || (github.event_name == 'workflow_dispatch' && inputs.recovery_mode == 'nuget')) }}
     needs: [validate-release, build-artifacts]
     runs-on: ubuntu-latest
     permissions:
@@ -432,7 +442,8 @@ jobs:
         with:
           name: surge-net-nuget
           path: nupkgs
-      - name: Verify immutable package handoff
+      - id: verify_package
+        name: Verify immutable package handoff
         env:
           EXPECTED_PACKAGE_NAME: ${{ needs.package-nuget.outputs.package_name }}
           EXPECTED_PACKAGE_SHA256: ${{ needs.package-nuget.outputs.package_sha256 }}
@@ -468,10 +479,12 @@ jobs:
             --api-key "${NUGET_API_KEY}" \
             --skip-duplicate
       - name: Push to GitHub Packages
+        if: ${{ !cancelled() && steps.verify_package.outcome == 'success' }}
         run: dotnet nuget push "nupkgs/${{ needs.package-nuget.outputs.package_name }}" --source https://nuget.pkg.github.com/fintermobilityas/index.json --api-key ${{ secrets.GITHUB_TOKEN }} --skip-duplicate
 
   publish-cargo-crates-io:
     name: Publish Cargo (crates.io)
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.recovery_mode == 'full' }}
     needs: [validate-release, build-artifacts]
     runs-on: ubuntu-latest
     env:
@@ -498,6 +511,7 @@ jobs:
 
   upload-release-assets:
     name: Upload Release Assets
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.recovery_mode == 'full' }}
     needs: [validate-release, build-artifacts, package-nuget]
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Purpose

- add an explicit NuGet-only mode for recovering an existing published release
- reuse the release's immutable package without rebuilding platform artifacts
- allow GitHub Packages publication to proceed when NuGet.org rejects its credential

## Behavior impact

Normal release events and `full` recovery dispatches still require the complete platform artifact matrix before package publication. An explicit `nuget` recovery dispatch validates the published release and immutable tag, reuses the exact attached package, and publishes only the NuGet feeds. Cargo publication and release-asset collection are skipped in that mode.

The package job respects cancellation, and both feeds retain duplicate-safe publication for idempotent recovery.

## Validation

- `./scripts/sync-surge-core-vendor.sh --check`
- `./scripts/check-version-sync.sh`
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo test --workspace`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo clippy --workspace --lib --bins --examples -- -D warnings -D clippy::unwrap_used -D clippy::expect_used`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings -W clippy::pedantic`
- `dotnet format dotnet/Surge.slnx --verify-no-changes`
- `dotnet test dotnet/Surge.slnx --configuration Release`
- `actionlint .github/workflows/release.yml`
- YAML parse and release dependency assertions

## Migration

No application migration is required. Existing manual recovery calls default to `full`; select `nuget` only when retrying the package feeds for an already published release.