### PR TITLE
Ensure NuGet recovery publishes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -428,6 +428,7 @@ jobs:
 
   publish-nuget:
     name: Publish NuGet
+    if: ${{ !cancelled() && needs.validate-release.result == 'success' && needs.package-nuget.result == 'success' }}
     needs: [validate-release, package-nuget]
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Purpose

Ensure NuGet-only release recovery reaches the publish job after intentionally skipping platform artifact builds.

## Root cause

GitHub Actions applies an implicit `success()` condition to jobs without a status-check function. In NuGet recovery mode, the artifact matrix is intentionally skipped. The package job overrides that skip propagation and succeeds, but the downstream publish job inherited the skipped ancestor and was reported as skipped, leaving the workflow falsely green without publishing either feed.

## Change

Add an explicit job condition that:

- does not run after cancellation;
- requires release validation to succeed;
- requires the verified NuGet package handoff to succeed.

Full releases remain transitively gated on successful platform builds through the package job.

## Behavior impact

A `workflow_dispatch` run with `recovery_mode=nuget` now executes NuGet.org and GitHub Packages publication after reusing and verifying the immutable release package. Normal full releases retain their existing build and publication gates.

## Validation

- `./scripts/sync-surge-core-vendor.sh --check`
- `./scripts/check-version-sync.sh`
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo test --workspace`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo clippy --workspace --lib --bins --examples -- -D warnings -D clippy::unwrap_used -D clippy::expect_used`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings -W clippy::pedantic`
- `dotnet format dotnet/Surge.slnx --verify-no-changes`
- `dotnet test dotnet/Surge.slnx --configuration Release`
- `actionlint .github/workflows/release.yml`
- YAML structural recovery-gate assertion
- `git diff --check`

## Migration

No migration is required.