### PR TITLE
Make cancellation reset compatible with older runtimes

### DIFF
--- a/dotnet/Surge.NET.Tests/ResetCancelCompatTests.cs
+++ b/dotnet/Surge.NET.Tests/ResetCancelCompatTests.cs
@@ -1,0 +1,128 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Surge.Tests
+{
+    [CollectionDefinition(Name, DisableParallelization = true)]
+    public sealed class ResetCancelCompatibilityGroup
+    {
+        public const string Name = "Reset cancel compatibility";
+    }
+
+    [Collection(ResetCancelCompatibilityGroup.Name)]
+    public sealed class ResetCancelCompatTests : IDisposable
+    {
+        public ResetCancelCompatTests() => NativeMethods.ResetResetCancelProbeForTesting();
+
+        public void Dispose() => NativeMethods.ResetResetCancelProbeForTesting();
+
+        [Fact]
+        public void TryResetCancel_NullContext_DoesNotInvokeNativeMethod()
+        {
+            var calls = 0;
+
+            var supported = NativeMethods.TryResetCancelCore(
+                IntPtr.Zero,
+                _ =>
+                {
+                    calls++;
+                    return 0;
+                },
+                out var result);
+
+            Assert.False(supported);
+            Assert.Equal(0, result);
+            Assert.Equal(0, calls);
+        }
+
+        [Fact]
+        public void TryResetCancel_MissingSymbol_IsCached()
+        {
+            var calls = 0;
+            int MissingSymbol(IntPtr _)
+            {
+                calls++;
+                throw new EntryPointNotFoundException("surge_reset_cancel");
+            }
+
+            Assert.False(NativeMethods.TryResetCancelCore(new IntPtr(1), MissingSymbol, out var firstResult));
+            Assert.False(NativeMethods.TryResetCancelCore(new IntPtr(1), MissingSymbol, out var secondResult));
+
+            Assert.Equal(0, firstResult);
+            Assert.Equal(0, secondResult);
+            Assert.Equal(1, calls);
+        }
+
+        [Fact]
+        public void TryResetCancel_AvailableSymbol_ReturnsEveryNativeResult()
+        {
+            var nextResult = 0;
+            int Invoke(IntPtr _) => nextResult--;
+
+            Assert.True(NativeMethods.TryResetCancelCore(new IntPtr(1), Invoke, out var firstResult));
+            Assert.True(NativeMethods.TryResetCancelCore(new IntPtr(1), Invoke, out var secondResult));
+
+            Assert.Equal(0, firstResult);
+            Assert.Equal(-1, secondResult);
+        }
+
+        [Fact]
+        public void TryResetCancel_DllNotFoundException_IsNotHidden()
+        {
+            Assert.Throws<DllNotFoundException>(() =>
+                NativeMethods.TryResetCancelCore(
+                    new IntPtr(1),
+                    _ => throw new DllNotFoundException("surge"),
+                    out _));
+        }
+
+        [Fact]
+        public void TryResetCancel_OtherTypeLoadException_IsNotHidden()
+        {
+            Assert.Throws<TypeLoadException>(() =>
+                NativeMethods.TryResetCancelCore(
+                    new IntPtr(1),
+                    _ => throw new TypeLoadException("unexpected"),
+                    out _));
+        }
+
+        [Fact]
+        public async Task TryResetCancel_ConcurrentMissingSymbol_IsProbedOnce()
+        {
+            const int taskCount = 8;
+            var calls = 0;
+            using var entered = new ManualResetEventSlim();
+            using var release = new ManualResetEventSlim();
+
+            int MissingSymbol(IntPtr _)
+            {
+                Interlocked.Increment(ref calls);
+                entered.Set();
+                release.Wait();
+                throw new EntryPointNotFoundException("surge_reset_cancel");
+            }
+
+            var tasks = new Task<bool>[taskCount];
+            for (var i = 0; i < tasks.Length; i++)
+            {
+                tasks[i] = Task.Run(() =>
+                    NativeMethods.TryResetCancelCore(new IntPtr(1), MissingSymbol, out _));
+            }
+
+            try
+            {
+                Assert.True(entered.Wait(TimeSpan.FromSeconds(5)));
+            }
+            finally
+            {
+                release.Set();
+            }
+
+            var results = await Task.WhenAll(tasks);
+            Assert.All(results, Assert.False);
+            Assert.Equal(1, calls);
+        }
+    }
+}

--- a/dotnet/Surge.NET/NativeMethods.cs
+++ b/dotnet/Surge.NET/NativeMethods.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Runtime.InteropServices;
+using System.Threading;
 
 namespace Surge
 {
@@ -405,5 +406,67 @@ namespace Surge
         internal static extern int ResetCancel(IntPtr ctx);
 #pragma warning restore CA2101
 #endif
+
+        private const int ResetCancelUnknown = 0;
+        private const int ResetCancelAvailable = 1;
+        private const int ResetCancelUnavailable = 2;
+        private static readonly object ResetCancelProbeLock = new object();
+        private static int resetCancelState = ResetCancelUnknown;
+
+        internal static bool TryResetCancel(IntPtr ctx, out int result) =>
+            TryResetCancelCore(ctx, ResetCancel, out result);
+
+        internal static bool TryResetCancelCore(
+            IntPtr ctx,
+            Func<IntPtr, int> invoke,
+            out int result)
+        {
+            result = 0;
+            if (ctx == IntPtr.Zero)
+                return false;
+
+            var state = Volatile.Read(ref resetCancelState);
+            if (state == ResetCancelUnavailable)
+                return false;
+
+            if (state == ResetCancelAvailable)
+            {
+                result = invoke(ctx);
+                return true;
+            }
+
+            lock (ResetCancelProbeLock)
+            {
+                state = Volatile.Read(ref resetCancelState);
+                if (state == ResetCancelUnavailable)
+                    return false;
+
+                if (state == ResetCancelUnknown)
+                {
+                    try
+                    {
+                        result = invoke(ctx);
+                        Volatile.Write(ref resetCancelState, ResetCancelAvailable);
+                        return true;
+                    }
+                    catch (EntryPointNotFoundException)
+                    {
+                        Volatile.Write(ref resetCancelState, ResetCancelUnavailable);
+                        return false;
+                    }
+                }
+            }
+
+            result = invoke(ctx);
+            return true;
+        }
+
+        internal static void ResetResetCancelProbeForTesting()
+        {
+            lock (ResetCancelProbeLock)
+            {
+                Volatile.Write(ref resetCancelState, ResetCancelUnknown);
+            }
+        }
     }
 }

--- a/dotnet/Surge.NET/SurgeUpdateManager.cs
+++ b/dotnet/Surge.NET/SurgeUpdateManager.cs
@@ -428,7 +428,7 @@ namespace Surge
                         try
                         {
                             if (ctx != IntPtr.Zero)
-                                _ = NativeMethods.ResetCancel(ctx);
+                                _ = NativeMethods.TryResetCancel(ctx, out _);
                         }
                         finally
                         {
@@ -480,7 +480,9 @@ namespace Surge
 
         private void ResetNativeCancellation()
         {
-            int result = NativeMethods.ResetCancel(_nativeCtx);
+            if (!NativeMethods.TryResetCancel(_nativeCtx, out int result))
+                return;
+
             if (result != 0)
             {
                 var errorMsg = GetLastError();


### PR DESCRIPTION
## Summary

- Treat `surge_reset_cancel` as an optional capability when an installed native runtime predates the export.
- Cache only the missing-entry-point result, while preserving loader failures and native return-code handling.
- Add regression coverage for missing, available, concurrent, and unexpected-error paths.

## Why

`Surge.NET` beta.53 calls `surge_reset_cancel`, but existing nodes can still have an older separately installed `libsurge.so`. That version skew currently throws before an update check can run. The fallback restores beta.52 behavior on old runtimes without requiring a runtime reinstall.

Fixes #232.

## Validation

- `./scripts/sync-surge-core-vendor.sh --check`
- `./scripts/check-version-sync.sh`
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo test --workspace`
- Standard, strict, and pedantic Clippy gates
- `dotnet format dotnet/Surge.slnx --verify-no-changes`
- `dotnet test dotnet/Surge.slnx --configuration Release` — 53 passed
- E2E update check with the exact beta.52 Linux x64 native asset (`246ad10a287ef62698071574cce8346898c381e29828f6ad4167f3cc095d5654`), verified to lack `surge_reset_cancel`
- E2E update check with the beta.53 Linux x64 native asset, verified to export `surge_reset_cancel`
