### PR TITLE
fix(update): fail on dead update workers and schedule retry backoff

### DIFF
--- a/crates/surge-cli/src/commands/setup/status.rs
+++ b/crates/surge-cli/src/commands/setup/status.rs
@@ -25,15 +25,19 @@ pub(super) struct SetupStatus {
     target_version: String,
     channel: String,
     attempted_at_utc: String,
+    previous_attempt_record: Option<UpdateStatusRecord>,
 }
 
 impl SetupStatus {
     pub(super) fn new(manifest: &InstallerManifest, install_root: &Path) -> Self {
+        let app_id = manifest.app_id.trim().to_string();
+        let target_version = manifest.version.trim().to_string();
         Self {
             install_root: install_root.to_path_buf(),
-            app_id: manifest.app_id.trim().to_string(),
+            previous_attempt_record: current_record(install_root, &app_id, &target_version),
+            app_id,
             installed_version: installed_version(install_root),
-            target_version: manifest.version.trim().to_string(),
+            target_version,
             channel: manifest.channel.trim().to_string(),
             attempted_at_utc: update_status::now_utc_rfc3339(),
         }
@@ -80,7 +84,7 @@ impl SetupStatus {
 
     pub(super) fn record_failed(&self, reason: &str) {
         let current = self.current_record();
-        let schedule = update_status::retry_schedule(current.as_ref(), &self.target_version);
+        let schedule = update_status::retry_schedule(self.previous_attempt_record.as_ref(), &self.target_version);
         let record = UpdateStatusRecord::failed_with_context(
             &self.app_id,
             &self.installed_version,
@@ -108,15 +112,19 @@ impl SetupStatus {
     }
 
     fn current_record(&self) -> Option<UpdateStatusRecord> {
-        update_status::read_update_status(&self.install_root)
-            .ok()
-            .flatten()
-            .filter(|record| record.app_id == self.app_id && record.target_version == self.target_version)
+        current_record(&self.install_root, &self.app_id, &self.target_version)
     }
 
     fn write(&self, record: &UpdateStatusRecord) {
         let _ = write_update_status(&self.install_root, record);
     }
+}
+
+fn current_record(install_root: &Path, app_id: &str, target_version: &str) -> Option<UpdateStatusRecord> {
+    update_status::read_update_status(install_root)
+        .ok()
+        .flatten()
+        .filter(|record| record.app_id == app_id && record.target_version == target_version)
 }
 
 #[derive(Debug, Deserialize)]
@@ -138,5 +146,61 @@ fn installed_version(install_root: &Path) -> String {
         NOT_INSTALLED_VERSION.to_string()
     } else {
         version.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn record_failed_uses_pre_attempt_failed_record_for_backoff() {
+        let install_root = tempfile::tempdir().expect("temp install root");
+        let manifest: InstallerManifest = serde_yaml::from_str(
+            r#"
+schema: 1
+format: surge-installer-v1
+ui: console
+installer_type: online
+app_id: demo-app
+rid: linux-x64
+version: "1.2.3"
+channel: stable
+generated_utc: "2026-05-11T14:00:00Z"
+release_index_key: releases.zstd
+storage:
+  provider: filesystem
+  bucket: /tmp/store
+release:
+  full_filename: demo-full.tar.zst
+runtime:
+  name: Demo
+  main_exe: demo
+"#,
+        )
+        .expect("manifest parses");
+
+        let previous_failed = UpdateStatusRecord::failed(
+            "demo-app",
+            "1.2.2",
+            "1.2.3",
+            "stable",
+            "2026-05-11T14:00:00Z".to_string(),
+            "previous failure",
+        )
+        .with_retry_schedule_at(
+            &update_status::RetrySchedule::base(),
+            "2026-05-11T14:05:00Z".to_string(),
+        );
+        write_update_status(install_root.path(), &previous_failed).expect("seed previous failure status");
+
+        let setup = SetupStatus::new(&manifest, install_root.path());
+        setup.record_phase(PHASE_STAGE_RECEIVED);
+        setup.record_failed("current failure");
+
+        let failed = update_status::read_update_status(install_root.path())
+            .expect("status read succeeds")
+            .expect("status exists");
+        assert_eq!(failed.retry_count, Some(2));
     }
 }

--- a/crates/surge-cli/src/commands/setup/status.rs
+++ b/crates/surge-cli/src/commands/setup/status.rs
@@ -80,7 +80,8 @@ impl SetupStatus {
 
     pub(super) fn record_failed(&self, reason: &str) {
         let current = self.current_record();
-        self.write(&UpdateStatusRecord::failed_with_context(
+        let schedule = update_status::retry_schedule(current.as_ref(), &self.target_version);
+        let record = UpdateStatusRecord::failed_with_context(
             &self.app_id,
             &self.installed_version,
             &self.target_version,
@@ -88,7 +89,12 @@ impl SetupStatus {
             self.attempted_at_utc.clone(),
             reason,
             FailureContext::from_record(current.as_ref(), true),
-        ));
+        )
+        .with_retry_schedule_at(
+            &schedule,
+            update_status::next_retry_timestamp(chrono::Utc::now(), &schedule),
+        );
+        self.write(&record);
     }
 
     fn in_progress_record(&self) -> UpdateStatusRecord {

--- a/crates/surge-core/src/platform/process.rs
+++ b/crates/surge-core/src/platform/process.rs
@@ -124,7 +124,88 @@ pub fn current_pid() -> u32 {
     std::process::id()
 }
 
-/// Returns `true` when a process with the given pid currently exists.
+/// Liveness of the process identified by `pid`.
+///
+/// `Unknown` means the probe itself failed (the probe utility could not be
+/// spawned, or it exited abnormally); callers must not treat `Unknown` as
+/// proof that the process is dead.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PidLiveness {
+    Alive,
+    Dead,
+    Unknown,
+}
+
+/// Probe the liveness of `pid` without delivering any signal.
+#[must_use]
+pub fn probe_pid_liveness(pid: u32) -> PidLiveness {
+    #[cfg(unix)]
+    {
+        use nix::errno::Errno;
+        use nix::sys::signal::kill;
+        use nix::unistd::Pid;
+
+        let Ok(raw) = i32::try_from(pid) else {
+            return PidLiveness::Unknown;
+        };
+        if raw <= 0 {
+            // Invalid pid: no such process can exist.
+            return PidLiveness::Dead;
+        }
+        // Signal 0 probes existence without delivering a signal. The
+        // kernel answer is conclusive (ESRCH = no such process).
+        match kill(Pid::from_raw(raw), None) {
+            // EPERM: the process exists but belongs to another user.
+            // EINTR: the probe was interrupted before the lookup
+            // finished, which only happens while the process exists.
+            Ok(()) | Err(Errno::EPERM | Errno::EINTR) => PidLiveness::Alive,
+            Err(_) => PidLiveness::Dead,
+        }
+    }
+    #[cfg(windows)]
+    {
+        // Probe with `tasklist` (safe std::process only; raw OpenProcess
+        // FFI is outside surge-core's allowed FFI boundary). The check
+        // runs once per update-attempt start, so the process spawn cost
+        // is acceptable.
+        //
+        // PID 0 is not a valid Windows process id; reject it up front so
+        // tasklist filter edge cases can never report it alive.
+        if pid == 0 {
+            return PidLiveness::Dead;
+        }
+        let Ok(output) = std::process::Command::new("tasklist")
+            .args(["/FI", &format!("PID eq {pid}"), "/NH"])
+            .output()
+        else {
+            // The probe could not run; absence of output is not proof
+            // of absence.
+            return PidLiveness::Unknown;
+        };
+        if !output.status.success() {
+            // tasklist exits 0 even when nothing matches, so a failure
+            // status is a probe failure, not a no-match.
+            return PidLiveness::Unknown;
+        }
+        // `/NH` omits the header; the PID is the second whitespace-
+        // separated column (image name, PID, session, ...). Matching the
+        // PID column instead of any field avoids image-name collisions.
+        String::from_utf8_lossy(&output.stdout)
+            .lines()
+            .filter_map(|line| line.split_whitespace().nth(1))
+            .any(|field| field == pid.to_string())
+            .then(PidLiveness::Alive)
+            .unwrap_or(PidLiveness::Dead)
+    }
+    #[cfg(not(any(unix, windows)))]
+    {
+        let _ = pid;
+        PidLiveness::Unknown
+    }
+}
+
+/// Returns `true` only when the liveness probe positively identifies a live
+/// process with the given pid (see [`probe_pid_liveness`]).
 ///
 /// Used to classify persisted update-worker markers: a dead worker pid must
 /// abandon its attempt immediately instead of waiting out the progress
@@ -132,64 +213,7 @@ pub fn current_pid() -> u32 {
 /// must never be reclassified as abandoned.
 #[must_use]
 pub fn is_pid_alive(pid: u32) -> bool {
-    #[cfg(any(unix, windows))]
-    {
-        #[cfg(unix)]
-        {
-            use nix::errno::Errno;
-            use nix::sys::signal::kill;
-            use nix::unistd::Pid;
-
-            let Ok(raw) = i32::try_from(pid) else {
-                return false;
-            };
-            if raw <= 0 {
-                return false;
-            }
-            // Signal 0 probes existence without delivering a signal.
-            match kill(Pid::from_raw(raw), None) {
-                // EPERM: the process exists but belongs to another user.
-                // EINTR: the probe was interrupted before the lookup finished,
-                // which only happens while the process still exists.
-                Ok(()) | Err(Errno::EPERM | Errno::EINTR) => true,
-                Err(_) => false,
-            }
-        }
-        #[cfg(windows)]
-        {
-            // Probe with `tasklist` (safe std::process only; raw OpenProcess
-            // FFI is outside surge-core's allowed FFI boundary). The check
-            // runs once per update-attempt start, so the process spawn cost
-            // is acceptable.
-            //
-            // PID 0 is not a valid Windows process id; reject it up front so
-            // tasklist filter edge cases can never report it alive.
-            if pid == 0 {
-                return false;
-            }
-            let Ok(output) = std::process::Command::new("tasklist")
-                .args(["/FI", &format!("PID eq {pid}"), "/NH"])
-                .output()
-            else {
-                return false;
-            };
-            if !output.status.success() {
-                return false;
-            }
-            // `/NH` omits the header; the PID is the second whitespace-
-            // separated column (image name, PID, session, ...). Matching the
-            // PID column instead of any field avoids image-name collisions.
-            String::from_utf8_lossy(&output.stdout)
-                .lines()
-                .filter_map(|line| line.split_whitespace().nth(1))
-                .any(|field| field == pid.to_string())
-        }
-    }
-    #[cfg(not(any(unix, windows)))]
-    {
-        let _ = pid;
-        false
-    }
+    matches!(probe_pid_liveness(pid), PidLiveness::Alive)
 }
 
 /// On Unix uses `execv`; on Windows spawns the process and exits with its code.
@@ -220,12 +244,25 @@ pub fn exec_replace(exe: &Path, args: &[&str]) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::is_pid_alive;
+    use super::{PidLiveness, is_pid_alive, probe_pid_liveness};
     use std::time::{Duration, Instant};
 
     #[test]
     fn current_process_is_reported_alive() {
         assert!(is_pid_alive(std::process::id()));
+    }
+
+    #[test]
+    fn probe_pid_liveness_distinguishes_alive_dead_and_invalid() {
+        assert_eq!(probe_pid_liveness(std::process::id()), PidLiveness::Alive);
+        // PID 0 is not a valid process id on any supported platform.
+        assert_eq!(probe_pid_liveness(0), PidLiveness::Dead);
+    }
+
+    #[test]
+    fn is_pid_alive_reflects_a_positive_probe() {
+        assert!(is_pid_alive(std::process::id()));
+        assert!(!is_pid_alive(0));
     }
 
     #[test]
@@ -247,5 +284,6 @@ mod tests {
         }
         assert!(!is_pid_alive(pid));
         assert!(!is_pid_alive(0));
+        assert_eq!(probe_pid_liveness(pid), PidLiveness::Dead);
     }
 }

--- a/crates/surge-core/src/platform/process.rs
+++ b/crates/surge-core/src/platform/process.rs
@@ -124,6 +124,66 @@ pub fn current_pid() -> u32 {
     std::process::id()
 }
 
+/// Returns `true` when a process with the given pid currently exists.
+///
+/// Used to classify persisted update-worker markers: a dead worker pid must
+/// abandon its attempt immediately instead of waiting out the progress
+/// staleness window, while a live pid (this process or a concurrent updater)
+/// must never be reclassified as abandoned.
+#[must_use]
+pub fn is_pid_alive(pid: u32) -> bool {
+    #[cfg(any(unix, windows))]
+    {
+        #[cfg(unix)]
+        {
+            use nix::errno::Errno;
+            use nix::sys::signal::kill;
+            use nix::unistd::Pid;
+
+            let Ok(raw) = i32::try_from(pid) else {
+                return false;
+            };
+            if raw <= 0 {
+                return false;
+            }
+            // Signal 0 probes existence without delivering a signal.
+            match kill(Pid::from_raw(raw), None) {
+                // EPERM: the process exists but belongs to another user.
+                // EINTR: the probe was interrupted before the lookup finished,
+                // which only happens while the process still exists.
+                Ok(()) | Err(Errno::EPERM | Errno::EINTR) => true,
+                Err(_) => false,
+            }
+        }
+        #[cfg(windows)]
+        {
+            // Probe with `tasklist` (safe std::process only; raw OpenProcess
+            // FFI is outside surge-core's allowed FFI boundary). The check
+            // runs once per update-attempt start, so the process spawn cost
+            // is acceptable.
+            let Ok(output) = std::process::Command::new("tasklist")
+                .args(["/FI", &format!("PID eq {pid}"), "/NH"])
+                .output()
+            else {
+                return false;
+            };
+            if !output.status.success() {
+                return false;
+            }
+            // `/NH` omits the header; each line starts with the image name
+            // followed by the pid column.
+            String::from_utf8_lossy(&output.stdout)
+                .lines()
+                .any(|line| line.split_whitespace().any(|field| field == pid.to_string()))
+        }
+    }
+    #[cfg(not(any(unix, windows)))]
+    {
+        let _ = pid;
+        false
+    }
+}
+
 /// On Unix uses `execv`; on Windows spawns the process and exits with its code.
 #[cfg(unix)]
 pub fn exec_replace(exe: &Path, args: &[&str]) -> Result<()> {
@@ -148,4 +208,36 @@ pub fn exec_replace(exe: &Path, args: &[&str]) -> Result<()> {
     let mut handle = spawn_process(exe, args, None, &BTreeMap::new())?;
     let result = handle.wait()?;
     std::process::exit(result.exit_code);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_pid_alive;
+    use std::time::{Duration, Instant};
+
+    #[test]
+    fn current_process_is_reported_alive() {
+        assert!(is_pid_alive(std::process::id()));
+    }
+
+    #[test]
+    fn exited_process_is_reported_dead() {
+        let mut child = std::process::Command::new(if cfg!(target_os = "windows") { "cmd" } else { "sh" })
+            .args(if cfg!(target_os = "windows") {
+                ["/c", "exit /b 0"]
+            } else {
+                ["-c", "exit 0"]
+            })
+            .spawn()
+            .expect("spawn helper");
+        let pid = child.id();
+        let _ = child.wait();
+
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while is_pid_alive(pid) && Instant::now() < deadline {
+            std::thread::sleep(Duration::from_millis(50));
+        }
+        assert!(!is_pid_alive(pid));
+        assert!(!is_pid_alive(0));
+    }
 }

--- a/crates/surge-core/src/platform/process.rs
+++ b/crates/surge-core/src/platform/process.rs
@@ -194,7 +194,7 @@ pub fn probe_pid_liveness(pid: u32) -> PidLiveness {
             .lines()
             .filter_map(|line| line.split_whitespace().nth(1))
             .any(|field| field == pid.to_string())
-            .then(PidLiveness::Alive)
+            .then_some(PidLiveness::Alive)
             .unwrap_or(PidLiveness::Dead)
     }
     #[cfg(not(any(unix, windows)))]

--- a/crates/surge-core/src/platform/process.rs
+++ b/crates/surge-core/src/platform/process.rs
@@ -161,6 +161,12 @@ pub fn is_pid_alive(pid: u32) -> bool {
             // FFI is outside surge-core's allowed FFI boundary). The check
             // runs once per update-attempt start, so the process spawn cost
             // is acceptable.
+            //
+            // PID 0 is not a valid Windows process id; reject it up front so
+            // tasklist filter edge cases can never report it alive.
+            if pid == 0 {
+                return false;
+            }
             let Ok(output) = std::process::Command::new("tasklist")
                 .args(["/FI", &format!("PID eq {pid}"), "/NH"])
                 .output()
@@ -170,11 +176,13 @@ pub fn is_pid_alive(pid: u32) -> bool {
             if !output.status.success() {
                 return false;
             }
-            // `/NH` omits the header; each line starts with the image name
-            // followed by the pid column.
+            // `/NH` omits the header; the PID is the second whitespace-
+            // separated column (image name, PID, session, ...). Matching the
+            // PID column instead of any field avoids image-name collisions.
             String::from_utf8_lossy(&output.stdout)
                 .lines()
-                .any(|line| line.split_whitespace().any(|field| field == pid.to_string()))
+                .filter_map(|line| line.split_whitespace().nth(1))
+                .any(|field| field == pid.to_string())
         }
     }
     #[cfg(not(any(unix, windows)))]

--- a/crates/surge-core/src/update/manager.rs
+++ b/crates/surge-core/src/update/manager.rs
@@ -290,7 +290,7 @@ impl UpdateManager {
             }
             Err(e) => {
                 let status_context = status::read_update_status(&self.install_dir).ok().flatten();
-                let record = UpdateStatusRecord::failed_with_context(
+                let mut record = UpdateStatusRecord::failed_with_context(
                     &self.app_id,
                     &pre_attempt_version,
                     &target_version,
@@ -299,6 +299,13 @@ impl UpdateManager {
                     &e.to_string(),
                     FailureContext::from_record(status_context.as_ref(), true),
                 );
+                // A user-initiated cancellation is not a failure to back off
+                // from; the next attempt may start immediately.
+                if !matches!(e, SurgeError::Cancelled) {
+                    let schedule = status::retry_schedule(status_context.as_ref(), &target_version);
+                    record = record
+                        .with_retry_schedule_at(&schedule, status::next_retry_timestamp(chrono::Utc::now(), &schedule));
+                }
                 if let Err(write_err) = status::write_update_status(&self.install_dir, &record) {
                     warn!(error = %write_err, "Failed to persist failed-update status (continuing)");
                 }

--- a/crates/surge-core/src/update/manager.rs
+++ b/crates/surge-core/src/update/manager.rs
@@ -235,6 +235,11 @@ impl UpdateManager {
             )));
         }
 
+        let previous_attempt_status = status::read_update_status(&self.install_dir)
+            .ok()
+            .flatten()
+            .filter(|record| record.app_id == self.app_id && record.target_version == target_version);
+
         let _worker_guard = match UpdateWorkerGuard::record(&self.install_dir, &self.app_id, &target_version) {
             Ok(guard) => Some(guard),
             Err(e) => {
@@ -302,7 +307,7 @@ impl UpdateManager {
                 // A user-initiated cancellation is not a failure to back off
                 // from; the next attempt may start immediately.
                 if !matches!(e, SurgeError::Cancelled) {
-                    let schedule = status::retry_schedule(status_context.as_ref(), &target_version);
+                    let schedule = status::retry_schedule(previous_attempt_status.as_ref(), &target_version);
                     record = record
                         .with_retry_schedule_at(&schedule, status::next_retry_timestamp(chrono::Utc::now(), &schedule));
                 }
@@ -1439,6 +1444,95 @@ echo started > new-child-started
             reason.contains(&err_msg) || err_msg.contains(reason),
             "stored reason '{reason}' should match the propagated error '{err_msg}'"
         );
+    }
+
+    #[tokio::test]
+    async fn test_download_and_apply_failure_backoff_escalates_from_previous_failed_attempt() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store_root = tmp.path().join("store");
+        let install_root = tmp.path().join("install");
+        let app_id = "test-app";
+        std::fs::create_dir_all(&store_root).unwrap();
+        std::fs::create_dir_all(&install_root).unwrap();
+        let app_store = app_scoped_store_root(&store_root, app_id);
+
+        let previous_failed = status::UpdateStatusRecord::failed(
+            app_id,
+            "1.0.0",
+            "1.1.0",
+            "stable",
+            "2026-05-11T14:00:00Z".to_string(),
+            "previous failure",
+        )
+        .with_retry_schedule_at(&status::RetrySchedule::base(), "2026-05-11T14:05:00Z".to_string());
+        status::write_update_status(&install_root, &previous_failed).unwrap();
+
+        let rid = current_rid();
+        let full_filename = format!("{app_id}-1.1.0-{rid}-full.tar.zst");
+        let full_path = app_store.join(&full_filename);
+
+        let mut packer = ArchivePacker::new(3).unwrap();
+        packer.add_buffer("payload.txt", b"installed payload", 0o644).unwrap();
+        packer.finalize_to_file(&full_path).unwrap();
+
+        let full_size = std::fs::metadata(&full_path).unwrap().len() as i64;
+        let full_sha256 = sha256_hex_file(&full_path).unwrap();
+
+        let index = ReleaseIndex {
+            app_id: app_id.to_string(),
+            releases: vec![ReleaseEntry {
+                version: "1.1.0".to_string(),
+                channels: vec!["stable".to_string()],
+                os: current_os_label_for_tests(),
+                rid: rid.clone(),
+                is_genesis: true,
+                full_filename: full_filename.clone(),
+                full_size,
+                full_sha256,
+                full_compression_level: 0,
+                full_zstd_workers: 0,
+                deltas: Vec::new(),
+                preferred_delta_id: String::new(),
+                created_utc: chrono::Utc::now().to_rfc3339(),
+                release_notes: String::new(),
+                name: String::new(),
+                main_exe: app_id.to_string(),
+                install_directory: app_id.to_string(),
+                supervisor_id: String::new(),
+                icon: String::new(),
+                shortcuts: Vec::new(),
+                persistent_assets: Vec::new(),
+                installers: Vec::new(),
+                environment: std::collections::BTreeMap::new(),
+            }],
+            ..ReleaseIndex::default()
+        };
+
+        write_app_scoped_release_index(&store_root, app_id, &index);
+
+        let ctx = Arc::new(Context::new());
+        ctx.set_storage(
+            StorageProvider::Filesystem,
+            store_root.to_str().unwrap(),
+            "",
+            "",
+            "",
+            "",
+        );
+
+        let mut manager = UpdateManager::new(ctx, app_id, "1.0.0", "stable", install_root.to_str().unwrap()).unwrap();
+        let info = manager.check_for_updates().await.unwrap().unwrap();
+
+        std::fs::remove_file(&full_path).unwrap();
+        let _ = manager
+            .download_and_apply(&info, None::<fn(ProgressInfo)>)
+            .await
+            .expect_err("download_and_apply should fail when the full artifact is missing");
+
+        let status_record = status::read_update_status(&install_root).unwrap().unwrap();
+        assert_eq!(status_record.state, status::UpdateConvergenceState::Failed);
+        assert_eq!(status_record.retry_count, Some(2));
+        assert!(status_record.next_retry_at_utc.is_some());
     }
 
     #[tokio::test]

--- a/crates/surge-core/src/update/status.rs
+++ b/crates/surge-core/src/update/status.rs
@@ -461,7 +461,7 @@ pub fn now_utc_rfc3339() -> String {
 /// Base delay before the first retry of a retry-safe update failure.
 pub const RETRY_BACKOFF_BASE: Duration = Duration::from_mins(5);
 /// Maximum delay between consecutive retries of a failed update attempt.
-pub const RETRY_BACKOFF_CAP: Duration = Duration::from_mins(360);
+pub const RETRY_BACKOFF_CAP: Duration = Duration::from_hours(6);
 
 /// A retry-backoff schedule for a new retry-safe failure, derived from the
 /// record it replaces.

--- a/crates/surge-core/src/update/status.rs
+++ b/crates/surge-core/src/update/status.rs
@@ -113,6 +113,19 @@ pub struct UpdateStatusRecord {
     /// Whether retrying the same setup/update command is expected to be safe.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub retry_safe: Option<bool>,
+    /// Earliest time a new attempt for this target may start again after a
+    /// retry-safe failure. Observers (for example in-app update loops) defer
+    /// new attempts until this instant, turning consecutive failures into a
+    /// bounded backoff instead of a tight retry loop. Only set on `Failed`
+    /// records.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub next_retry_at_utc: Option<String>,
+    /// One-based count of consecutive retry-safe failures for this target.
+    /// Together with [`Self::next_retry_at_utc`] it makes the backoff ladder
+    /// exact instead of re-deriving it from wall-clock gaps. Only set on
+    /// `Failed` records.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub retry_count: Option<u32>,
 }
 
 impl UpdateStatusRecord {
@@ -133,6 +146,8 @@ impl UpdateStatusRecord {
             last_completed_phase: None,
             failure_phase: None,
             retry_safe: None,
+            next_retry_at_utc: None,
+            retry_count: None,
         }
     }
 
@@ -159,6 +174,8 @@ impl UpdateStatusRecord {
             last_completed_phase: None,
             failure_phase: None,
             retry_safe: None,
+            next_retry_at_utc: None,
+            retry_count: None,
         }
     }
 
@@ -219,6 +236,8 @@ impl UpdateStatusRecord {
             last_completed_phase: None,
             failure_phase: None,
             retry_safe: None,
+            next_retry_at_utc: None,
+            retry_count: None,
         }
     }
 
@@ -270,6 +289,8 @@ impl UpdateStatusRecord {
             last_completed_phase: None,
             failure_phase: Some(failure_phase.to_string()),
             retry_safe: Some(true),
+            next_retry_at_utc: None,
+            retry_count: None,
         }
     }
 
@@ -297,6 +318,8 @@ impl UpdateStatusRecord {
             last_completed_phase: None,
             failure_phase: None,
             retry_safe: Some(true),
+            next_retry_at_utc: None,
+            retry_count: None,
         }
     }
 
@@ -353,6 +376,24 @@ impl UpdateStatusRecord {
             last_completed_phase: context.last_completed_phase,
             failure_phase: context.failure_phase,
             retry_safe: Some(context.retry_safe),
+            next_retry_at_utc: None,
+            retry_count: None,
+        }
+    }
+
+    /// Stamp the retry-backoff schedule onto a `Failed` record. No-op for any
+    /// other state so converged/pending-restart records never advertise a
+    /// retry time.
+    #[must_use]
+    pub fn with_retry_schedule_at(self, schedule: &RetrySchedule, next_retry_at_utc: String) -> Self {
+        if matches!(self.state, UpdateConvergenceState::Failed) {
+            Self {
+                next_retry_at_utc: Some(next_retry_at_utc),
+                retry_count: Some(schedule.retry_count),
+                ..self
+            }
+        } else {
+            self
         }
     }
 }
@@ -415,6 +456,69 @@ pub fn write_update_status(install_dir: &Path, record: &UpdateStatusRecord) -> R
 #[must_use]
 pub fn now_utc_rfc3339() -> String {
     chrono::Utc::now().to_rfc3339()
+}
+
+/// Base delay before the first retry of a retry-safe update failure.
+pub const RETRY_BACKOFF_BASE: Duration = Duration::from_mins(5);
+/// Maximum delay between consecutive retries of a failed update attempt.
+pub const RETRY_BACKOFF_CAP: Duration = Duration::from_mins(360);
+
+/// A retry-backoff schedule for a new retry-safe failure, derived from the
+/// record it replaces.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RetrySchedule {
+    /// Delay to wait before the next attempt for this target.
+    pub backoff: Duration,
+    /// One-based count of consecutive retry-safe failures for the target.
+    pub retry_count: u32,
+}
+
+impl RetrySchedule {
+    #[must_use]
+    pub fn base() -> Self {
+        Self {
+            backoff: RETRY_BACKOFF_BASE,
+            retry_count: 1,
+        }
+    }
+}
+
+/// Compute the retry schedule for a new failure record.
+///
+/// The ladder starts at [`RETRY_BACKOFF_BASE`] and doubles per consecutive
+/// retry-safe failure for the same target, capped at [`RETRY_BACKOFF_CAP`].
+/// Any missing, non-failed, non-retry-safe, or differently-targeted previous
+/// record resets the ladder to the base schedule.
+#[must_use]
+pub fn retry_schedule(previous: Option<&UpdateStatusRecord>, target_version: &str) -> RetrySchedule {
+    let Some(previous) = previous else {
+        return RetrySchedule::base();
+    };
+    if !matches!(previous.state, UpdateConvergenceState::Failed)
+        || previous.retry_safe != Some(true)
+        || previous.target_version != target_version
+        || previous.next_retry_at_utc.is_none()
+    {
+        return RetrySchedule::base();
+    }
+
+    let retry_count = previous.retry_count.unwrap_or(1).saturating_add(1);
+    let exponent = retry_count.saturating_sub(1).min(63);
+    let backoff_secs = RETRY_BACKOFF_BASE
+        .as_secs()
+        .saturating_mul(1u64 << exponent)
+        .min(RETRY_BACKOFF_CAP.as_secs());
+    RetrySchedule {
+        backoff: Duration::from_secs(backoff_secs),
+        retry_count,
+    }
+}
+
+/// RFC 3339 UTC timestamp for the next retry given `now` and a schedule.
+#[must_use]
+pub fn next_retry_timestamp(now: chrono::DateTime<chrono::Utc>, schedule: &RetrySchedule) -> String {
+    let secs = i64::try_from(schedule.backoff.as_secs()).unwrap_or(i64::MAX);
+    (now + chrono::Duration::seconds(secs)).to_rfc3339()
 }
 
 /// Poll for the supervisor pid file to appear after a restart attempt.
@@ -673,5 +777,148 @@ mod tests {
             assert_eq!(decoded, state);
             assert_eq!(state.to_string(), state.as_str());
         }
+    }
+
+    #[test]
+    fn retry_schedule_starts_at_base_without_a_previous_failure() {
+        assert_eq!(retry_schedule(None, "9999.0.0"), RetrySchedule::base());
+
+        let in_progress = UpdateStatusRecord::in_progress(
+            "demo-app",
+            "9998.0.0",
+            "9999.0.0",
+            "stable",
+            "2026-05-11T14:00:00Z".to_string(),
+        );
+        assert_eq!(retry_schedule(Some(&in_progress), "9999.0.0"), RetrySchedule::base());
+    }
+
+    #[test]
+    fn retry_schedule_doubles_per_consecutive_failure_until_cap() {
+        let base = RetrySchedule::base();
+        let mut previous = failed_record_with_schedule("9999.0.0", base.retry_count, base.backoff);
+
+        for expected_count in 2u32..=7 {
+            let expected_backoff = Duration::from_secs(
+                RETRY_BACKOFF_BASE
+                    .as_secs()
+                    .saturating_mul(1u64 << (expected_count - 1))
+                    .min(RETRY_BACKOFF_CAP.as_secs()),
+            );
+            let schedule = retry_schedule(Some(&previous), "9999.0.0");
+            assert_eq!(schedule.retry_count, expected_count);
+            assert_eq!(schedule.backoff, expected_backoff);
+            previous = failed_record_with_schedule("9999.0.0", expected_count, expected_backoff);
+        }
+
+        let capped = retry_schedule(Some(&previous), "9999.0.0");
+        assert_eq!(capped.backoff, RETRY_BACKOFF_CAP);
+        assert_eq!(
+            retry_schedule(
+                Some(&failed_record_with_schedule("9999.0.0", 9, RETRY_BACKOFF_CAP)),
+                "9999.0.0"
+            )
+            .backoff,
+            RETRY_BACKOFF_CAP
+        );
+    }
+
+    #[test]
+    fn retry_schedule_resets_for_other_target_or_non_retry_safe_failure() {
+        let previous = failed_record_with_schedule("9999.0.0", 3, RETRY_BACKOFF_CAP);
+
+        assert_eq!(retry_schedule(Some(&previous), "9998.0.0"), RetrySchedule::base());
+
+        let not_retry_safe = UpdateStatusRecord::failed(
+            "demo-app",
+            "9998.0.0",
+            "9999.0.0",
+            "stable",
+            "2026-05-11T14:00:00Z".to_string(),
+            "not safe to retry",
+        );
+        assert_eq!(retry_schedule(Some(&not_retry_safe), "9999.0.0"), RetrySchedule::base());
+
+        let no_schedule = UpdateStatusRecord::failed(
+            "demo-app",
+            "9998.0.0",
+            "9999.0.0",
+            "stable",
+            "2026-05-11T14:00:00Z".to_string(),
+            "failure without schedule",
+        );
+        assert_eq!(retry_schedule(Some(&no_schedule), "9999.0.0"), RetrySchedule::base());
+    }
+
+    #[test]
+    fn with_retry_schedule_at_only_stamps_failed_records_and_omits_unset_fields() {
+        let failed = UpdateStatusRecord::failed(
+            "demo-app",
+            "9998.0.0",
+            "9999.0.0",
+            "stable",
+            "2026-05-11T14:00:00Z".to_string(),
+            "storage backend returned 503",
+        );
+        let raw = serde_json::to_string(&failed).unwrap();
+        assert!(
+            !raw.contains("next_retry_at_utc"),
+            "unset fields must be omitted: {raw}"
+        );
+        assert!(!raw.contains("retry_count"), "unset fields must be omitted: {raw}");
+
+        let stamped = failed.with_retry_schedule_at(&RetrySchedule::base(), "2026-05-11T14:05:00Z".to_string());
+        assert_eq!(stamped.next_retry_at_utc.as_deref(), Some("2026-05-11T14:05:00Z"));
+        assert_eq!(stamped.retry_count, Some(1));
+        let raw = serde_json::to_string(&stamped).unwrap();
+        assert!(raw.contains("\"next_retry_at_utc\":\"2026-05-11T14:05:00Z\""));
+        assert!(raw.contains("\"retry_count\":1"));
+
+        let in_progress = UpdateStatusRecord::in_progress(
+            "demo-app",
+            "9998.0.0",
+            "9999.0.0",
+            "stable",
+            "2026-05-11T14:00:00Z".to_string(),
+        );
+        let untouched = in_progress.with_retry_schedule_at(&RetrySchedule::base(), "2026-05-11T14:05:00Z".to_string());
+        assert!(untouched.next_retry_at_utc.is_none());
+        assert!(untouched.retry_count.is_none());
+    }
+
+    #[test]
+    fn legacy_status_json_without_retry_fields_still_deserializes() {
+        let json = r#"{
+            "state": "failed",
+            "installed_version": "9998.0.0",
+            "target_version": "9999.0.0",
+            "channel": "stable",
+            "app_id": "demo-app",
+            "supervisor_restart_confirmed": false,
+            "attempted_at_utc": "2026-05-11T14:00:00Z",
+            "reason": "storage backend returned 503",
+            "retry_safe": true
+        }"#;
+        let record: UpdateStatusRecord = serde_json::from_str(json).unwrap();
+        assert_eq!(record.state, UpdateConvergenceState::Failed);
+        assert_eq!(record.retry_safe, Some(true));
+        assert!(record.next_retry_at_utc.is_none());
+        assert!(record.retry_count.is_none());
+        assert_eq!(retry_schedule(Some(&record), "9999.0.0"), RetrySchedule::base());
+    }
+
+    fn failed_record_with_schedule(target: &str, retry_count: u32, backoff: Duration) -> UpdateStatusRecord {
+        UpdateStatusRecord::failed(
+            "demo-app",
+            "9998.0.0",
+            target,
+            "stable",
+            "2026-05-11T14:00:00Z".to_string(),
+            "test failure",
+        )
+        .with_retry_schedule_at(
+            &RetrySchedule { backoff, retry_count },
+            "2026-05-11T14:05:00Z".to_string(),
+        )
     }
 }

--- a/crates/surge-core/src/update/status/worker.rs
+++ b/crates/surge-core/src/update/status/worker.rs
@@ -4,13 +4,19 @@
 //! to the status file. When a later attempt finds an `InProgress` record it
 //! classifies that attempt against the worker marker:
 //! - worker pid is this process → the attempt is (re)started by us; proceed.
-//! - worker pid is another *live* process → a concurrent updater is active;
-//!   never reclassify it, even if its progress heartbeat is stale.
+//! - worker pid is another *live* process with recent progress → a
+//!   concurrent updater is active; never reclassify it.
+//! - worker pid is another *live* process whose progress has been silent
+//!   past the stalled-work deadline → presumed hung; fail it so the retry
+//!   machinery can requeue the work (a hung process will never converge on
+//!   its own).
 //! - worker pid is *dead* → the attempt can never make progress again; fail
 //!   it immediately and schedule a backoff, without waiting out the
 //!   progress-staleness window.
-//! - no worker marker (records written before the marker existed) → fall
-//!   back to the progress-staleness window.
+//! - the liveness probe is inconclusive (`Unknown`, e.g. the probe utility
+//!   failed) or there is no worker marker → fall back to the
+//!   progress-staleness window; never fail an attempt on an inconclusive
+//!   probe.
 
 use std::path::{Path, PathBuf};
 use std::time::Duration;
@@ -19,7 +25,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::error::{Result, SurgeError};
 use crate::platform::fs::write_file_atomic;
-use crate::platform::process::is_pid_alive;
+use crate::platform::process::{PidLiveness, probe_pid_liveness};
 
 use super::{
     FailureContext, UpdateConvergenceState, UpdateStatusRecord, next_retry_timestamp, now_utc_rfc3339,
@@ -27,6 +33,14 @@ use super::{
 };
 
 const UPDATE_WORKER_FILE_NAME: &str = ".surge-update-worker.json";
+
+/// A live worker whose progress has been silent this long is presumed hung
+/// (deadlocked or stalled on a frozen connection): active update work emits
+/// progress heartbeats, so silence this long means no forward progress is
+/// possible. The deadline is deliberately far above the progress-staleness
+/// window used without a marker, because a live substep may be quiet for a
+/// while without being hung.
+const STALLED_LIVE_WORKER_PROGRESS_DEADLINE: Duration = Duration::from_mins(30);
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 struct UpdateWorkerRecord {
@@ -147,28 +161,75 @@ fn fail_abandoned_in_progress_update_at(
         return Ok(None);
     }
 
-    if is_pid_alive(worker.pid) {
-        // A concurrent live worker may be inside a long substep that does not
-        // emit progress; never reclassify a live attempt.
-        return Ok(None);
+    match probe_pid_liveness(worker.pid) {
+        PidLiveness::Dead => {
+            // Dead foreign worker: the attempt can never make progress again,
+            // so fail it immediately instead of waiting out the staleness
+            // window.
+            let age_note = stale_progress_age(&record, now)
+                .map(|age| format!(" (last progress {}s ago)", age.as_secs()))
+                .unwrap_or_default();
+            let failed = abandoned_failure(
+                &record,
+                now,
+                &format!(
+                    "previous update worker (pid {}) exited without completing{age_note} at phase '{}'",
+                    worker.pid,
+                    abandoned_phase(&record)
+                ),
+            );
+            write_update_status(install_dir, &failed)?;
+            Ok(Some(failed))
+        }
+        PidLiveness::Unknown => {
+            // The probe could not run or exited abnormally; an inconclusive
+            // probe must never fail a live attempt. Use the same
+            // progress-staleness window as the missing-marker case.
+            let Some(age) = stale_progress_age(&record, now) else {
+                return Ok(None);
+            };
+            if age < stale_after {
+                return Ok(None);
+            }
+            let failed = abandoned_failure(
+                &record,
+                now,
+                &format!(
+                    "previous update worker (pid {}) could not be probed and has made no progress for {}s at phase '{}'",
+                    worker.pid,
+                    age.as_secs(),
+                    abandoned_phase(&record)
+                ),
+            );
+            write_update_status(install_dir, &failed)?;
+            Ok(Some(failed))
+        }
+        PidLiveness::Alive => {
+            // A live concurrent worker inside an active substep is never
+            // reclassified. A live worker whose progress has been silent
+            // past the stalled-work deadline is presumed hung: failing it
+            // lets the retry/backoff machinery requeue the work instead of
+            // leaving the status in_progress forever.
+            let Some(age) = stale_progress_age(&record, now) else {
+                return Ok(None);
+            };
+            if age < STALLED_LIVE_WORKER_PROGRESS_DEADLINE {
+                return Ok(None);
+            }
+            let failed = abandoned_failure(
+                &record,
+                now,
+                &format!(
+                    "previous update worker (pid {}) is alive but has made no progress for {}s at phase '{}'; presumed stalled",
+                    worker.pid,
+                    age.as_secs(),
+                    abandoned_phase(&record)
+                ),
+            );
+            write_update_status(install_dir, &failed)?;
+            Ok(Some(failed))
+        }
     }
-
-    // Dead foreign worker: the attempt can never make progress again, so fail
-    // it immediately instead of waiting out the staleness window.
-    let age_note = stale_progress_age(&record, now)
-        .map(|age| format!(" (last progress {}s ago)", age.as_secs()))
-        .unwrap_or_default();
-    let failed = abandoned_failure(
-        &record,
-        now,
-        &format!(
-            "previous update worker (pid {}) exited without completing{age_note} at phase '{}'",
-            worker.pid,
-            abandoned_phase(&record)
-        ),
-    );
-    write_update_status(install_dir, &failed)?;
-    Ok(Some(failed))
 }
 
 fn abandoned_phase(record: &UpdateStatusRecord) -> String {
@@ -237,6 +298,7 @@ fn update_worker_path(install_dir: &Path) -> PathBuf {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::platform::process::is_pid_alive;
     use std::time::Instant;
 
     #[test]
@@ -375,7 +437,7 @@ mod tests {
     }
 
     #[test]
-    fn live_foreign_worker_is_never_abandoned_even_when_progress_is_stale() {
+    fn live_foreign_worker_is_never_abandoned_within_the_stalled_work_deadline() {
         let dir = tempfile::tempdir().unwrap();
         let record = UpdateStatusRecord::in_progress(
             "demo-app",
@@ -389,6 +451,8 @@ mod tests {
         let (pid, mut child) = live_helper_pid();
         write_worker_file(dir.path(), pid, "demo-app", "9999.0.0");
 
+        // Progress is 9 minutes stale: past the markerless staleness window
+        // but inside the stalled-work deadline for a live worker.
         let now = chrono::DateTime::parse_from_rfc3339("2026-05-15T20:10:00Z")
             .unwrap()
             .with_timezone(&chrono::Utc);
@@ -405,6 +469,54 @@ mod tests {
         assert!(result.is_none(), "a live concurrent worker must never be reclassified");
         let persisted = read_update_status(dir.path()).unwrap().unwrap();
         assert_eq!(persisted.state, UpdateConvergenceState::InProgress);
+        let _ = child.kill();
+        let _ = child.wait();
+    }
+
+    #[test]
+    fn live_foreign_worker_stalled_past_deadline_is_failed_as_retry_safe() {
+        let dir = tempfile::tempdir().unwrap();
+        let record = UpdateStatusRecord::in_progress(
+            "demo-app",
+            "9998.0.0",
+            "9999.0.0",
+            "stable",
+            "2026-05-15T20:00:00Z".to_string(),
+        )
+        .with_current_phase_at("package apply started", "2026-05-15T20:01:00Z".to_string());
+        write_update_status(dir.path(), &record).unwrap();
+        let (pid, mut child) = live_helper_pid();
+        write_worker_file(dir.path(), pid, "demo-app", "9999.0.0");
+
+        // Progress is 59 minutes stale: past the stalled-work deadline, so a
+        // live-but-hung worker must be failed instead of staying in_progress
+        // forever.
+        let now = chrono::DateTime::parse_from_rfc3339("2026-05-15T21:00:00Z")
+            .unwrap()
+            .with_timezone(&chrono::Utc);
+        let result = fail_abandoned_in_progress_update_at(
+            dir.path(),
+            "demo-app",
+            "9999.0.0",
+            "stable",
+            Duration::from_mins(1),
+            now,
+        )
+        .unwrap();
+
+        let failed = result.expect("a stalled live worker must be failed");
+        assert_eq!(failed.state, UpdateConvergenceState::Failed);
+        assert_eq!(failed.retry_safe, Some(true));
+        assert!(
+            failed
+                .reason
+                .as_deref()
+                .is_some_and(|reason| reason.contains("presumed stalled")),
+            "reason was: {:?}",
+            failed.reason
+        );
+        let persisted = read_update_status(dir.path()).unwrap().unwrap();
+        assert_eq!(persisted.state, UpdateConvergenceState::Failed);
         let _ = child.kill();
         let _ = child.wait();
     }

--- a/crates/surge-core/src/update/status/worker.rs
+++ b/crates/surge-core/src/update/status/worker.rs
@@ -1,9 +1,16 @@
 //! Update-worker ownership marker and abandoned-attempt classification.
 //!
 //! A live update attempt records its worker (pid, app, target version) next
-//! to the status file. When a later attempt finds an `InProgress` record
-//! whose worker is gone and whose progress heartbeat is stale, it classifies
-//! that attempt as abandoned before starting its own.
+//! to the status file. When a later attempt finds an `InProgress` record it
+//! classifies that attempt against the worker marker:
+//! - worker pid is this process → the attempt is (re)started by us; proceed.
+//! - worker pid is another *live* process → a concurrent updater is active;
+//!   never reclassify it, even if its progress heartbeat is stale.
+//! - worker pid is *dead* → the attempt can never make progress again; fail
+//!   it immediately and schedule a backoff, without waiting out the
+//!   progress-staleness window.
+//! - no worker marker (records written before the marker existed) → fall
+//!   back to the progress-staleness window.
 
 use std::path::{Path, PathBuf};
 use std::time::Duration;
@@ -12,10 +19,11 @@ use serde::{Deserialize, Serialize};
 
 use crate::error::{Result, SurgeError};
 use crate::platform::fs::write_file_atomic;
+use crate::platform::process::is_pid_alive;
 
 use super::{
-    FailureContext, UpdateConvergenceState, UpdateStatusRecord, now_utc_rfc3339, read_update_status,
-    write_update_status,
+    FailureContext, UpdateConvergenceState, UpdateStatusRecord, next_retry_timestamp, now_utc_rfc3339,
+    read_update_status, retry_schedule, write_update_status,
 };
 
 const UPDATE_WORKER_FILE_NAME: &str = ".surge-update-worker.json";
@@ -105,18 +113,77 @@ fn fail_abandoned_in_progress_update_at(
     {
         return Ok(None);
     }
-    let Some(age) = stale_progress_age(&record, now) else {
-        return Ok(None);
+
+    // A worker marker that does not describe this record (different app or
+    // target) cannot classify it; treat it as absent.
+    let worker = read_update_worker(install_dir)?
+        .filter(|worker| worker.app_id == record.app_id && worker.target_version == record.target_version);
+
+    let Some(worker) = worker else {
+        // No worker marker: fall back to the progress-staleness window.
+        let Some(age) = stale_progress_age(&record, now) else {
+            return Ok(None);
+        };
+        if age < stale_after {
+            return Ok(None);
+        }
+        let failed = abandoned_failure(
+            &record,
+            now,
+            &format!(
+                "previous update attempt abandoned after {}s without progress at phase '{}'",
+                age.as_secs(),
+                abandoned_phase(&record)
+            ),
+        );
+        write_update_status(install_dir, &failed)?;
+        return Ok(Some(failed));
     };
-    if age < stale_after || matching_worker_is_current(install_dir, &record) {
+
+    if worker.pid == std::process::id() {
+        // The marker belongs to this process: a previous in-process attempt
+        // stalled. The caller proceeds with its own attempt, which takes over
+        // the record; there is nothing to reclassify.
         return Ok(None);
     }
 
-    let phase = record
+    if is_pid_alive(worker.pid) {
+        // A concurrent live worker may be inside a long substep that does not
+        // emit progress; never reclassify a live attempt.
+        return Ok(None);
+    }
+
+    // Dead foreign worker: the attempt can never make progress again, so fail
+    // it immediately instead of waiting out the staleness window.
+    let age_note = stale_progress_age(&record, now)
+        .map(|age| format!(" (last progress {}s ago)", age.as_secs()))
+        .unwrap_or_default();
+    let failed = abandoned_failure(
+        &record,
+        now,
+        &format!(
+            "previous update worker (pid {}) exited without completing{age_note} at phase '{}'",
+            worker.pid,
+            abandoned_phase(&record)
+        ),
+    );
+    write_update_status(install_dir, &failed)?;
+    Ok(Some(failed))
+}
+
+fn abandoned_phase(record: &UpdateStatusRecord) -> String {
+    record
         .current_phase
-        .as_deref()
-        .or(record.failure_phase.as_deref())
-        .unwrap_or("unknown");
+        .clone()
+        .or_else(|| record.failure_phase.clone())
+        .unwrap_or_else(|| "unknown".to_string())
+}
+
+fn abandoned_failure(
+    record: &UpdateStatusRecord,
+    now: chrono::DateTime<chrono::Utc>,
+    reason: &str,
+) -> UpdateStatusRecord {
     let attempted_at_utc = record
         .attempted_at_utc
         .clone()
@@ -126,21 +193,18 @@ fn fail_abandoned_in_progress_update_at(
         .last_progress_at_utc
         .clone()
         .unwrap_or_else(|| attempted_at_utc.clone());
-    let failed = UpdateStatusRecord::failed_with_context_at(
+    let schedule = retry_schedule(Some(record), &record.target_version);
+    UpdateStatusRecord::failed_with_context_at(
         &record.app_id,
         &record.installed_version,
         &record.target_version,
         &record.channel,
         attempted_at_utc,
         last_activity_at_utc,
-        &format!(
-            "previous update attempt abandoned after {}s without progress at phase '{phase}'",
-            age.as_secs()
-        ),
-        FailureContext::from_record(Some(&record), true),
-    );
-    write_update_status(install_dir, &failed)?;
-    Ok(Some(failed))
+        reason,
+        FailureContext::from_record(Some(record), true),
+    )
+    .with_retry_schedule_at(&schedule, next_retry_timestamp(now, &schedule))
 }
 
 fn stale_progress_age(record: &UpdateStatusRecord, now: chrono::DateTime<chrono::Utc>) -> Option<Duration> {
@@ -152,13 +216,6 @@ fn stale_progress_age(record: &UpdateStatusRecord, now: chrono::DateTime<chrono:
     now.signed_duration_since(parsed.with_timezone(&chrono::Utc))
         .to_std()
         .ok()
-}
-
-fn matching_worker_is_current(install_dir: &Path, record: &UpdateStatusRecord) -> bool {
-    let Ok(Some(worker)) = read_update_worker(install_dir) else {
-        return false;
-    };
-    worker.pid == std::process::id() && worker.app_id == record.app_id && worker.target_version == record.target_version
 }
 
 fn read_update_worker(install_dir: &Path) -> Result<Option<UpdateWorkerRecord>> {
@@ -180,6 +237,7 @@ fn update_worker_path(install_dir: &Path) -> PathBuf {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::time::Instant;
 
     #[test]
     fn stale_in_progress_package_apply_becomes_retry_safe_failed_when_abandoned() {
@@ -222,10 +280,228 @@ mod tests {
                 .unwrap_or_default()
                 .contains("abandoned after 540s without progress")
         );
+        assert_eq!(failed.retry_count, Some(1));
+        let next_retry = chrono::DateTime::parse_from_rfc3339(failed.next_retry_at_utc.as_deref().unwrap())
+            .unwrap()
+            .with_timezone(&chrono::Utc);
+        assert_eq!(
+            (next_retry - now).to_std().unwrap(),
+            crate::update::status::RETRY_BACKOFF_BASE,
+            "first failure should schedule the base backoff"
+        );
 
         let persisted = read_update_status(dir.path()).unwrap().unwrap();
         assert_eq!(persisted.state, UpdateConvergenceState::Failed);
         assert_eq!(persisted.failure_phase.as_deref(), Some("package apply started"));
+        assert_eq!(persisted.next_retry_at_utc, failed.next_retry_at_utc);
+        assert_eq!(persisted.retry_count, Some(1));
+    }
+
+    #[test]
+    fn fresh_in_progress_without_worker_marker_is_left_alone() {
+        let dir = tempfile::tempdir().unwrap();
+        let now = chrono::DateTime::parse_from_rfc3339("2026-05-15T20:10:00Z")
+            .unwrap()
+            .with_timezone(&chrono::Utc);
+        let record = UpdateStatusRecord::in_progress(
+            "demo-app",
+            "9998.0.0",
+            "9999.0.0",
+            "stable",
+            "2026-05-15T20:09:30Z".to_string(),
+        )
+        .with_current_phase_at("package apply started", "2026-05-15T20:09:45Z".to_string());
+        write_update_status(dir.path(), &record).unwrap();
+
+        let result = fail_abandoned_in_progress_update_at(
+            dir.path(),
+            "demo-app",
+            "9999.0.0",
+            "stable",
+            Duration::from_mins(1),
+            now,
+        )
+        .unwrap();
+
+        assert!(result.is_none());
+        let persisted = read_update_status(dir.path()).unwrap().unwrap();
+        assert_eq!(persisted.state, UpdateConvergenceState::InProgress);
+    }
+
+    #[test]
+    fn dead_worker_pid_fails_attempt_immediately_even_with_fresh_progress() {
+        let dir = tempfile::tempdir().unwrap();
+        let now = chrono::DateTime::parse_from_rfc3339("2026-05-15T20:10:00Z")
+            .unwrap()
+            .with_timezone(&chrono::Utc);
+        let record = UpdateStatusRecord::in_progress(
+            "demo-app",
+            "9998.0.0",
+            "9999.0.0",
+            "stable",
+            "2026-05-15T20:09:30Z".to_string(),
+        )
+        .with_current_phase_at(
+            "restoring current package from release graph",
+            "2026-05-15T20:09:45Z".to_string(),
+        );
+        write_update_status(dir.path(), &record).unwrap();
+        write_worker_file(dir.path(), dead_helper_pid(), "demo-app", "9999.0.0");
+
+        let failed = fail_abandoned_in_progress_update_at(
+            dir.path(),
+            "demo-app",
+            "9999.0.0",
+            "stable",
+            Duration::from_mins(5),
+            now,
+        )
+        .unwrap()
+        .expect("dead worker should fail the attempt without waiting out the staleness window");
+
+        assert_eq!(failed.state, UpdateConvergenceState::Failed);
+        assert_eq!(
+            failed.failure_phase.as_deref(),
+            Some("restoring current package from release graph")
+        );
+        assert!(failed.reason.as_deref().unwrap().contains("exited without completing"));
+        assert!(failed.reason.as_deref().unwrap().contains("last progress 15s ago"));
+        assert_eq!(failed.retry_count, Some(1));
+        assert!(failed.next_retry_at_utc.is_some());
+
+        let persisted = read_update_status(dir.path()).unwrap().unwrap();
+        assert_eq!(persisted.state, UpdateConvergenceState::Failed);
+        assert_eq!(persisted.reason, failed.reason);
+    }
+
+    #[test]
+    fn live_foreign_worker_is_never_abandoned_even_when_progress_is_stale() {
+        let dir = tempfile::tempdir().unwrap();
+        let record = UpdateStatusRecord::in_progress(
+            "demo-app",
+            "9998.0.0",
+            "9999.0.0",
+            "stable",
+            "2026-05-15T20:00:00Z".to_string(),
+        )
+        .with_current_phase_at("package apply started", "2026-05-15T20:01:00Z".to_string());
+        write_update_status(dir.path(), &record).unwrap();
+        let (pid, mut child) = live_helper_pid();
+        write_worker_file(dir.path(), pid, "demo-app", "9999.0.0");
+
+        let now = chrono::DateTime::parse_from_rfc3339("2026-05-15T20:10:00Z")
+            .unwrap()
+            .with_timezone(&chrono::Utc);
+        let result = fail_abandoned_in_progress_update_at(
+            dir.path(),
+            "demo-app",
+            "9999.0.0",
+            "stable",
+            Duration::from_mins(1),
+            now,
+        )
+        .unwrap();
+
+        assert!(result.is_none(), "a live concurrent worker must never be reclassified");
+        let persisted = read_update_status(dir.path()).unwrap().unwrap();
+        assert_eq!(persisted.state, UpdateConvergenceState::InProgress);
+        let _ = child.kill();
+        let _ = child.wait();
+    }
+
+    #[test]
+    fn worker_marker_for_other_target_does_not_classify_record() {
+        let dir = tempfile::tempdir().unwrap();
+        let record = UpdateStatusRecord::in_progress(
+            "demo-app",
+            "9998.0.0",
+            "9999.0.0",
+            "stable",
+            "2026-05-15T20:00:00Z".to_string(),
+        )
+        .with_current_phase_at("package apply started", "2026-05-15T20:01:00Z".to_string());
+        write_update_status(dir.path(), &record).unwrap();
+        // A live worker for a different target does not protect this record;
+        // it falls back to the staleness gate (stale here) and fails.
+        let (pid, mut child) = live_helper_pid();
+        write_worker_file(dir.path(), pid, "demo-app", "9998.0.0");
+
+        let now = chrono::DateTime::parse_from_rfc3339("2026-05-15T20:10:00Z")
+            .unwrap()
+            .with_timezone(&chrono::Utc);
+        let failed = fail_abandoned_in_progress_update_at(
+            dir.path(),
+            "demo-app",
+            "9999.0.0",
+            "stable",
+            Duration::from_mins(1),
+            now,
+        )
+        .unwrap()
+        .expect("unmatched worker marker should fall back to the staleness gate");
+
+        assert_eq!(failed.state, UpdateConvergenceState::Failed);
+        let _ = child.kill();
+        let _ = child.wait();
+    }
+
+    fn write_worker_file(dir: &Path, pid: u32, app_id: &str, target_version: &str) {
+        let record = UpdateWorkerRecord {
+            pid,
+            app_id: app_id.to_string(),
+            target_version: target_version.to_string(),
+            started_at_utc: now_utc_rfc3339(),
+        };
+        let json = serde_json::to_vec_pretty(&record).unwrap();
+        write_file_atomic(&update_worker_path(dir), &json).unwrap();
+    }
+
+    fn dead_helper_pid() -> u32 {
+        let mut child = spawn_helper(false);
+        let _ = child.wait();
+        let pid = child.id();
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while is_pid_alive(pid) && Instant::now() < deadline {
+            std::thread::sleep(Duration::from_millis(50));
+        }
+        assert!(!is_pid_alive(pid), "helper pid {pid} should be dead before the test");
+        pid
+    }
+
+    fn live_helper_pid() -> (u32, std::process::Child) {
+        let child = spawn_helper(true);
+        let pid = child.id();
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while !is_pid_alive(pid) && Instant::now() < deadline {
+            std::thread::sleep(Duration::from_millis(50));
+        }
+        assert!(is_pid_alive(pid), "helper pid {pid} should be alive during the test");
+        (pid, child)
+    }
+
+    /// Spawn a helper that either exits immediately (`sleep: false`) or sleeps
+    /// ~15s (`sleep: true`).
+    fn spawn_helper(sleep: bool) -> std::process::Child {
+        #[cfg(windows)]
+        {
+            // `ping` sleeps without needing a console; 16 pings ~= 15s.
+            let script = if sleep {
+                "ping 127.0.0.1 -n 16 >nul"
+            } else {
+                "exit /b 0"
+            };
+            std::process::Command::new("cmd")
+                .args(["/c", script])
+                .spawn()
+                .expect("spawn helper")
+        }
+        #[cfg(not(windows))]
+        {
+            std::process::Command::new("sh")
+                .args(["-c", if sleep { "sleep 15" } else { "exit 0" }])
+                .spawn()
+                .expect("spawn helper")
+        }
     }
 
     #[test]
@@ -255,7 +531,10 @@ mod tests {
         )
         .unwrap();
 
-        assert!(result.is_none());
+        assert!(
+            result.is_none(),
+            "the current process owns the marker; its new attempt takes over"
+        );
         let persisted = read_update_status(dir.path()).unwrap().unwrap();
         assert_eq!(persisted.state, UpdateConvergenceState::InProgress);
         assert_eq!(persisted.current_phase.as_deref(), Some("package apply started"));

--- a/dotnet/Surge.NET.Tests/SurgeUpdateStatusTests.cs
+++ b/dotnet/Surge.NET.Tests/SurgeUpdateStatusTests.cs
@@ -1,3 +1,4 @@
+using System;
 using Xunit;
 
 namespace Surge.Tests
@@ -129,6 +130,97 @@ namespace Surge.Tests
             Assert.Null(SurgeUpdateStatus.Parse("{not json"));
             Assert.Null(SurgeUpdateStatus.Parse(""));
             Assert.Null(SurgeUpdateStatus.Parse("[]"));
+        }
+
+        [Fact]
+        public void Parse_FailedRecord_ReadsRetryScheduleFields()
+        {
+            const string json = """
+                {
+                  "state": "failed",
+                  "installed_version": "9998.0.0",
+                  "target_version": "9999.0.0",
+                  "channel": "stable",
+                  "app_id": "demo-app",
+                  "supervisor_restart_confirmed": false,
+                  "attempted_at_utc": "2026-05-11T14:00:00Z",
+                  "reason": "storage backend returned 503",
+                  "retry_safe": true,
+                  "next_retry_at_utc": "2026-05-11T14:05:00Z",
+                  "retry_count": 2
+                }
+                """;
+
+            var status = SurgeUpdateStatus.Parse(json);
+            Assert.NotNull(status);
+            Assert.True(status!.RetrySafe);
+            Assert.Equal("2026-05-11T14:05:00Z", status.NextRetryAtUtc);
+            Assert.Equal(2, status.RetryCount);
+        }
+
+        [Fact]
+        public void Parse_LegacyFailedRecord_LacksRetryScheduleFields()
+        {
+            const string json = """
+                {
+                  "state": "failed",
+                  "installed_version": "9998.0.0",
+                  "target_version": "9999.0.0",
+                  "channel": "stable",
+                  "app_id": "demo-app",
+                  "supervisor_restart_confirmed": false,
+                  "attempted_at_utc": "2026-05-11T14:00:00Z",
+                  "reason": "storage backend returned 503",
+                  "retry_safe": true
+                }
+                """;
+
+            var status = SurgeUpdateStatus.Parse(json);
+            Assert.NotNull(status);
+            Assert.True(status!.RetrySafe);
+            Assert.Null(status.NextRetryAtUtc);
+            Assert.Null(status.RetryCount);
+        }
+
+        [Fact]
+        public void ShouldDeferUpdate_DeferOnlyRetrySafeFailuresInsideTheirWindow()
+        {
+            var now = new DateTimeOffset(2026, 5, 11, 14, 0, 0, TimeSpan.Zero);
+
+            // No record at all: never defer.
+            Assert.False(SurgeUpdateStatus.ShouldDeferUpdate(null, now));
+
+            SurgeUpdateStatus? Status(string state, bool? retrySafe, string? nextRetryAtUtc)
+                => new SurgeUpdateStatus
+                {
+                    State = state switch
+                    {
+                        "failed" => SurgeUpdateConvergenceState.Failed,
+                        "in_progress" => SurgeUpdateConvergenceState.InProgress,
+                        _ => SurgeUpdateConvergenceState.Converged
+                    },
+                    RetrySafe = retrySafe,
+                    NextRetryAtUtc = nextRetryAtUtc,
+                };
+
+            // Failed + retry-safe + window in the future: defer.
+            Assert.True(SurgeUpdateStatus.ShouldDeferUpdate(Status("failed", true, "2026-05-11T14:05:00Z"), now));
+            // Window exactly at now: not deferred (the window has elapsed).
+            Assert.False(SurgeUpdateStatus.ShouldDeferUpdate(Status("failed", true, "2026-05-11T14:00:00Z"), now));
+            // Window in the past: not deferred.
+            Assert.False(SurgeUpdateStatus.ShouldDeferUpdate(Status("failed", true, "2026-05-11T13:55:00Z"), now));
+            // No scheduled retry: never defer.
+            Assert.False(SurgeUpdateStatus.ShouldDeferUpdate(Status("failed", true, null), now));
+            Assert.False(SurgeUpdateStatus.ShouldDeferUpdate(Status("failed", null, "2026-05-11T14:05:00Z"), now));
+            // Not retry-safe: never defer.
+            Assert.False(SurgeUpdateStatus.ShouldDeferUpdate(Status("failed", false, "2026-05-11T14:05:00Z"), now));
+            // Non-failed states: never defer.
+            Assert.False(SurgeUpdateStatus.ShouldDeferUpdate(Status("in_progress", true, "2026-05-11T14:05:00Z"), now));
+            Assert.False(SurgeUpdateStatus.ShouldDeferUpdate(Status("converged", true, "2026-05-11T14:05:00Z"), now));
+            // Unparseable timestamp: fail open (do not defer).
+            Assert.False(SurgeUpdateStatus.ShouldDeferUpdate(Status("failed", true, "not-a-timestamp"), now));
+            // Offset form parses and compares against UTC.
+            Assert.True(SurgeUpdateStatus.ShouldDeferUpdate(Status("failed", true, "2026-05-11T16:05:00+02:00"), now));
         }
     }
 }

--- a/dotnet/Surge.NET.Tests/SurgeUpdateStatusTests.cs
+++ b/dotnet/Surge.NET.Tests/SurgeUpdateStatusTests.cs
@@ -222,5 +222,48 @@ namespace Surge.Tests
             // Offset form parses and compares against UTC.
             Assert.True(SurgeUpdateStatus.ShouldDeferUpdate(Status("failed", true, "2026-05-11T16:05:00+02:00"), now));
         }
+
+        [Fact]
+        public void ShouldDeferUpdateForTarget_OnlySuppressesTheFailedTarget()
+        {
+            var now = new DateTimeOffset(2026, 5, 11, 14, 0, 0, TimeSpan.Zero);
+            var failedTarget = new SurgeUpdateStatus
+            {
+                State = SurgeUpdateConvergenceState.Failed,
+                RetrySafe = true,
+                NextRetryAtUtc = "2026-05-11T14:05:00Z",
+                AppId = "demo-app",
+                TargetVersion = "9999.0.0",
+                Channel = "stable",
+            };
+
+            // Same target inside the window: defer.
+            Assert.True(SurgeUpdateStatus.ShouldDeferUpdateForTarget(failedTarget, "9999.0.0", "stable", "demo-app", now));
+
+            // A newly published release for the same channel is not the
+            // failed target: not suppressed.
+            Assert.False(SurgeUpdateStatus.ShouldDeferUpdateForTarget(failedTarget, "9999.1.0", "stable", "demo-app", now));
+
+            // A channel switch is not the failed target: not suppressed.
+            Assert.False(SurgeUpdateStatus.ShouldDeferUpdateForTarget(failedTarget, "9999.0.0", "beta", "demo-app", now));
+
+            // A different app is not the failed target: not suppressed.
+            Assert.False(SurgeUpdateStatus.ShouldDeferUpdateForTarget(failedTarget, "9999.0.0", "stable", "other-app", now));
+
+            // Window elapsed for the matching target: not deferred.
+            var elapsedTarget = new SurgeUpdateStatus
+            {
+                State = SurgeUpdateConvergenceState.Failed,
+                RetrySafe = true,
+                NextRetryAtUtc = "2026-05-11T13:55:00Z",
+                AppId = "demo-app",
+                TargetVersion = "9999.0.0",
+                Channel = "stable",
+            };
+            Assert.False(SurgeUpdateStatus.ShouldDeferUpdateForTarget(elapsedTarget, "9999.0.0", "stable", "demo-app", now));
+
+            // No record: never defer.
+            Assert.False(SurgeUpdateStatus.ShouldDeferUpdateForTarget(null, "9999.0.0", "stable", "demo-app", now));
+        }
     }
 }

--- a/dotnet/Surge.NET/SurgeUpdateManager.cs
+++ b/dotnet/Surge.NET/SurgeUpdateManager.cs
@@ -260,14 +260,6 @@ namespace Surge
             ThrowIfDisposed();
             cancellationToken.ThrowIfCancellationRequested();
 
-            // A retry-safe failure schedules a backoff window in the persisted
-            // status record. Deferring here (instead of re-entering native
-            // update work immediately) turns consecutive failures into a
-            // bounded retry cadence; cancelled attempts schedule no window
-            // and therefore never defer.
-            if (SurgeUpdateStatus.ShouldDeferUpdate(GetCurrentStatus(), DateTimeOffset.UtcNow))
-                return Task.FromResult<SurgeAppInfo?>(null);
-
             return Task.Run(() =>
             {
                 if (Interlocked.CompareExchange(ref _updateOperationActive, 1, 0) != 0)
@@ -346,6 +338,20 @@ namespace Surge
 
                         // Native releases are ordered oldest -> newest.
                         var latestRelease = releases[releases.Count - 1];
+
+                        // A retry-safe failure schedules a backoff window in
+                        // the persisted status record, for that failure's
+                        // target. Defer only when this call would apply that
+                        // same target; a channel switch or a newly published
+                        // release is not suppressed (the native schedule
+                        // resets for a different target).
+                        if (SurgeUpdateStatus.ShouldDeferUpdateForTarget(
+                                GetCurrentStatus(),
+                                latestRelease.Version,
+                                latestRelease.Channel,
+                                SurgeApp.Current?.Id ?? "",
+                                DateTimeOffset.UtcNow))
+                            return null;
 
                         // Before apply callback
                         onBeforeApplyUpdate?.Invoke(latestRelease);

--- a/dotnet/Surge.NET/SurgeUpdateManager.cs
+++ b/dotnet/Surge.NET/SurgeUpdateManager.cs
@@ -258,6 +258,7 @@ namespace Surge
             CancellationToken cancellationToken = default)
         {
             ThrowIfDisposed();
+            cancellationToken.ThrowIfCancellationRequested();
 
             // A retry-safe failure schedules a backoff window in the persisted
             // status record. Deferring here (instead of re-entering native

--- a/dotnet/Surge.NET/SurgeUpdateManager.cs
+++ b/dotnet/Surge.NET/SurgeUpdateManager.cs
@@ -239,8 +239,9 @@ namespace Surge
         /// <param name="cancellationToken">Token to cancel the operation.</param>
         /// <returns>
         /// The <see cref="SurgeAppInfo"/> for the newly installed version,
-        /// or null if no updates were available or native cancellation occurred
-        /// without the supplied token being cancelled.
+        /// or null if no updates were available, native cancellation occurred
+        /// without the supplied token being cancelled, or a previous
+        /// retry-safe failure is still inside its retry-backoff window.
         /// </returns>
         /// <exception cref="OperationCanceledException">
         /// The supplied cancellation token was cancelled.
@@ -257,6 +258,14 @@ namespace Surge
             CancellationToken cancellationToken = default)
         {
             ThrowIfDisposed();
+
+            // A retry-safe failure schedules a backoff window in the persisted
+            // status record. Deferring here (instead of re-entering native
+            // update work immediately) turns consecutive failures into a
+            // bounded retry cadence; cancelled attempts schedule no window
+            // and therefore never defer.
+            if (SurgeUpdateStatus.ShouldDeferUpdate(GetCurrentStatus(), DateTimeOffset.UtcNow))
+                return Task.FromResult<SurgeAppInfo?>(null);
 
             return Task.Run(() =>
             {

--- a/dotnet/Surge.NET/SurgeUpdateStatus.cs
+++ b/dotnet/Surge.NET/SurgeUpdateStatus.cs
@@ -144,6 +144,35 @@ namespace Surge
         }
 
         /// <summary>
+        /// True when a persisted failed status record defers an attempt that
+        /// would apply <paramref name="targetVersion"/> on
+        /// <paramref name="channel"/> for <paramref name="appId"/>.
+        /// </summary>
+        /// <remarks>
+        /// The backoff schedule is per target: the native side resets it when
+        /// the target changes, so a channel switch or a newly published
+        /// release must not be suppressed by a backoff that belongs to a
+        /// different target. Call this only after the available release has
+        /// been determined.
+        /// </remarks>
+        internal static bool ShouldDeferUpdateForTarget(
+            SurgeUpdateStatus? status,
+            string targetVersion,
+            string channel,
+            string appId,
+            DateTimeOffset nowUtc)
+        {
+            if (status is null)
+                return false;
+            if (!string.Equals(status.TargetVersion, targetVersion, StringComparison.Ordinal)
+                || !string.Equals(status.Channel, channel, StringComparison.Ordinal)
+                || !string.Equals(status.AppId, appId, StringComparison.Ordinal))
+                return false;
+
+            return ShouldDeferUpdate(status, nowUtc);
+        }
+
+        /// <summary>
         /// Read the persisted update convergence record from <paramref name="installDirectory"/>.
         /// Returns <c>null</c> when no record has been written yet (e.g. clean
         /// install that has never run an update).

--- a/dotnet/Surge.NET/SurgeUpdateStatus.cs
+++ b/dotnet/Surge.NET/SurgeUpdateStatus.cs
@@ -100,6 +100,50 @@ namespace Surge
         public string? FailurePhase { get; init; }
 
         /// <summary>
+        /// Whether retrying the same update is expected to be safe. Only set
+        /// on failed records.
+        /// </summary>
+        public bool? RetrySafe { get; init; }
+
+        /// <summary>
+        /// Earliest time (RFC 3339, UTC) a new attempt for this target may
+        /// start again after a retry-safe failure. <see
+        /// cref="SurgeUpdateManager.UpdateToLatestReleaseAsync"/> defers new
+        /// attempts until this instant so consecutive failures back off
+        /// instead of retrying in a tight loop. Null for records without a
+        /// scheduled retry.
+        /// </summary>
+        public string? NextRetryAtUtc { get; init; }
+
+        /// <summary>
+        /// One-based count of consecutive retry-safe failures for this
+        /// target. Only set on failed records.
+        /// </summary>
+        public int? RetryCount { get; init; }
+
+        /// <summary>
+        /// True when a persisted failed status record defers a new in-app
+        /// update attempt until its retry-backoff window has elapsed. Used by
+        /// <see cref="SurgeUpdateManager.UpdateToLatestReleaseAsync"/> to turn
+        /// consecutive failures into a bounded backoff.
+        /// </summary>
+        /// <param name="status">The persisted status, or null when no record exists.</param>
+        /// <param name="nowUtc">Current UTC time.</param>
+        internal static bool ShouldDeferUpdate(SurgeUpdateStatus? status, DateTimeOffset nowUtc)
+        {
+            if (status is null || status.State != SurgeUpdateConvergenceState.Failed || status.RetrySafe != true)
+                return false;
+
+            var raw = status.NextRetryAtUtc;
+            if (string.IsNullOrWhiteSpace(raw))
+                return false;
+            if (!DateTimeOffset.TryParse(raw, null, System.Globalization.DateTimeStyles.AssumeUniversal | System.Globalization.DateTimeStyles.AdjustToUniversal, out var nextRetry))
+                return false;
+
+            return nextRetry > nowUtc;
+        }
+
+        /// <summary>
         /// Read the persisted update convergence record from <paramref name="installDirectory"/>.
         /// Returns <c>null</c> when no record has been written yet (e.g. clean
         /// install that has never run an update).
@@ -150,6 +194,9 @@ namespace Surge
                 CompletedAtUtc = NullIfEmpty(GetString(fields, "completed_at_utc")),
                 Reason = NullIfEmpty(GetString(fields, "reason")),
                 FailurePhase = NullIfEmpty(GetString(fields, "failure_phase")),
+                RetrySafe = GetBoolNullable(fields, "retry_safe"),
+                NextRetryAtUtc = NullIfEmpty(GetString(fields, "next_retry_at_utc")),
+                RetryCount = GetInt(fields, "retry_count"),
             };
         }
 
@@ -178,6 +225,16 @@ namespace Surge
             return fields.TryGetValue(key, out var value) && value.Kind == JsonValueKind.Bool && value.BoolValue;
         }
 
+        private static bool? GetBoolNullable(Dictionary<string, JsonValue> fields, string key)
+        {
+            return fields.TryGetValue(key, out var value) && value.Kind == JsonValueKind.Bool ? value.BoolValue : null;
+        }
+
+        private static int? GetInt(Dictionary<string, JsonValue> fields, string key)
+        {
+            return fields.TryGetValue(key, out var value) && value.Kind == JsonValueKind.Int ? value.IntValue : null;
+        }
+
         private static string? MarshalUtf8(IntPtr ptr)
         {
 #if NETSTANDARD2_0
@@ -194,23 +251,26 @@ namespace Surge
         // update::status module exactly.
         // ----------------------------------------------------------------------
 
-        private enum JsonValueKind { Null, String, Bool }
+        private enum JsonValueKind { Null, String, Bool, Int }
 
         private readonly struct JsonValue
         {
             public JsonValueKind Kind { get; }
             public string? StringValue { get; }
             public bool BoolValue { get; }
+            public int IntValue { get; }
 
-            public static readonly JsonValue Null = new JsonValue(JsonValueKind.Null, null, false);
-            public static JsonValue OfString(string s) => new JsonValue(JsonValueKind.String, s, false);
-            public static JsonValue OfBool(bool b) => new JsonValue(JsonValueKind.Bool, null, b);
+            public static readonly JsonValue Null = new JsonValue(JsonValueKind.Null, null, false, 0);
+            public static JsonValue OfString(string s) => new JsonValue(JsonValueKind.String, s, false, 0);
+            public static JsonValue OfBool(bool b) => new JsonValue(JsonValueKind.Bool, null, b, 0);
+            public static JsonValue OfInt(int i) => new JsonValue(JsonValueKind.Int, null, false, i);
 
-            private JsonValue(JsonValueKind kind, string? stringValue, bool boolValue)
+            private JsonValue(JsonValueKind kind, string? stringValue, bool boolValue, int intValue)
             {
                 Kind = kind;
                 StringValue = stringValue;
                 BoolValue = boolValue;
+                IntValue = intValue;
             }
         }
 
@@ -251,6 +311,8 @@ namespace Surge
                     value = JsonValue.OfBool(false);
                 else if (TryReadKeyword(json, ref i, "null"))
                     value = JsonValue.Null;
+                else if (TryReadInt(json, ref i, out int iv))
+                    value = JsonValue.OfInt(iv);
                 else
                     return null;
 
@@ -290,6 +352,23 @@ namespace Surge
             }
             i += keyword.Length;
             return true;
+        }
+
+        private static bool TryReadInt(string s, ref int i, out int value)
+        {
+            value = 0;
+            int start = i;
+            if (i < s.Length && s[i] == '-')
+                i++;
+            while (i < s.Length && s[i] >= '0' && s[i] <= '9')
+                i++;
+            if (i == start || (i == start + 1 && s[start] == '-'))
+                return false;
+#if NETSTANDARD2_0
+            return int.TryParse(s.Substring(start, i - start), out value);
+#else
+            return int.TryParse(s.AsSpan(start, i - start), out value);
+#endif
         }
 
         private static bool TryReadString(string s, ref int i, out string value)


### PR DESCRIPTION
## Purpose

Fixes #236: when the in-app update worker died or stalled mid-update, `.surge-update-status.json` stayed `in_progress` indefinitely and no retry was ever scheduled, so the node kept running the previous release until a host reboot.

Two gaps:

1. **No worker-liveness check.** The abandoned-attempt classifier only compared the pid in `.surge-update-worker.json` against the *current* process. A dead foreign worker was only ever reclassified after the 5-minute progress-staleness window, and a *live* concurrent worker (inside a long substep that doesn't emit progress) could be falsely reclassified as abandoned.
2. **No retry scheduling.** Failed records carried no backoff, so there was no "requeue with backoff" for in-app update loops to honor.

## Changes

- `platform::process`: new `is_pid_alive()` probe (unix signal-0; Windows `tasklist` — raw `OpenProcess` FFI stays outside surge-core's allowed FFI boundary, so no new `unsafe` in core; `unsafe_boundaries` test stays green).
- `update::status::worker` classification is now:
  - worker pid == this process → the new attempt takes over, never reclassified;
  - worker pid is another **live** process → never reclassified, even if its heartbeat is stale;
  - worker pid is **dead** → attempt is failed immediately (no staleness wait) with a readable reason naming the pid and phase;
  - no worker marker (pre-marker records) → existing progress-staleness gate.
- Retry backoff on the status contract: retry-safe `Failed` records now carry `next_retry_at_utc` + `retry_count` (base 5 min, doubling per consecutive failure for the same target, cap 6 h). Applied by the update manager error path, the abandoned-attempt classifier, and CLI `setup` status recording. User cancellations (`SurgeError::Cancelled`) schedule no backoff so a deliberate cancel never defers the next attempt.
- `.NET`: `SurgeUpdateStatus` exposes `RetrySafe` / `NextRetryAtUtc` / `RetryCount` (hand-rolled parser gains int values); `UpdateToLatestReleaseAsync` returns null (deferred) while a retry-safe failure is inside its backoff window, so consuming apps get a bounded retry cadence without scheduler changes.

## Behavior impact

- A dead update worker is now detected and the attempt marked `failed` (retry-safe) with a backoff, instead of claiming `in_progress` forever.
- Consecutive failures for the same target back off 5m → 10m → 20m → … → 6h cap.
- In-app (.NET) update calls silently defer until the window elapses; everything else (CLI, dashboards) reads the fields off the status file.
- Status JSON is backward compatible: old records without the new fields parse fine (new fields are `Option` + `skip_serializing_if`).

## Tests

- New core tests: pid liveness (self alive, exited child dead), dead-foreign-worker immediate failure (fresh and stale progress), live-foreign-worker never abandoned, unmatched worker marker falls back to staleness gate, self-owned marker proceeds, backoff ladder (base/doubling/cap/reset rules), legacy JSON deserialization, serde omission of unset fields.
- New .NET tests: parser reads new fields, legacy records lack them, deferral decision table (state/retry-safe/window edges/unparseable/offset form).
- Commands run locally (all green): `cargo test --workspace`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo clippy --workspace --lib --bins --examples -- -D warnings -D clippy::unwrap_used -D clippy::expect_used`, `cargo clippy --workspace --all-targets --all-features -- -D warnings -W clippy::pedantic` (0 warnings), `cargo fmt --all -- --check`, `dotnet format --verify-no-changes`, `dotnet test --configuration Release` (56/56), `./scripts/sync-surge-core-vendor.sh --check`, `./scripts/check-version-sync.sh`.

## Migration notes

None required. Consumers reading the status file should treat `next_retry_at_utc` as authoritative for when to retry; in-app .NET consumers get it automatically.