### PR TITLE
fix(update): bound the delta materialization ladder with a verification-failure budget

### DIFF
--- a/crates/surge-cli/src/commands/install/remote/detached.rs
+++ b/crates/surge-cli/src/commands/install/remote/detached.rs
@@ -1,0 +1,401 @@
+use std::time::{Duration, Instant};
+
+use super::execution::{REMOTE_INSTALLER_FINAL_PATH, run_tailscale_capture};
+use super::watchdog::read_remote_update_status_file;
+use super::{Path, Result, SurgeError, logline, shell_single_quote};
+
+pub(crate) const REMOTE_INSTALLER_LOG_PATH: &str = "/tmp/.surge-installer.log";
+pub(crate) const REMOTE_INSTALLER_PID_PATH: &str = "/tmp/.surge-installer.pid";
+
+/// A full package download on a slow tailnet link can take hours; the
+/// detached monitor must outlive the interactive 30-minute stream timeout.
+pub(crate) const DETACHED_INSTALL_MONITOR_TIMEOUT: Duration = Duration::from_mins(360);
+pub(crate) const DETACHED_INSTALL_POLL_INTERVAL: Duration = Duration::from_secs(2);
+/// The status file is the authoritative liveness signal; allow more slack
+/// than the interactive watchdog because every check is a fresh SSH round
+/// trip and slow links slow both down.
+pub(crate) const DETACHED_INSTALL_STALE_PROGRESS_TIMEOUT: Duration = Duration::from_mins(5);
+const DETACHED_INSTALL_LOG_TAIL_CAP: u64 = 256 * 1024;
+
+pub(crate) struct RemoteDetachedInstallProbe {
+    pub pid: Option<String>,
+    pub alive: bool,
+    pub log_size: u64,
+}
+
+pub(crate) fn build_remote_detached_install_probe_command() -> String {
+    format!(
+        "set -eu; \
+pidfile={REMOTE_INSTALLER_PID_PATH}; \
+log={REMOTE_INSTALLER_LOG_PATH}; \
+pid=''; \
+if [ -f \"$pidfile\" ]; then pid=\"$(tr -d '[:space:]' < \"$pidfile\")\"; fi; \
+alive=no; \
+if [ -n \"$pid\" ]; then \
+  case \"$pid\" in \
+    ''|*[!0-9]*) : ;; \
+    *) if kill -0 \"$pid\" 2>/dev/null; then alive=yes; fi ;; \
+  esac; \
+fi; \
+logsize=0; \
+if [ -f \"$log\" ]; then logsize=\"$(wc -c < \"$log\" | tr -d '[:space:]')\"; fi; \
+printf 'pid=%s\\nalive=%s\\nlogsize=%s\\n' \"$pid\" \"$alive\" \"$logsize\""
+    )
+}
+
+pub(crate) fn parse_remote_detached_install_probe(output: &str) -> Result<RemoteDetachedInstallProbe> {
+    let mut pid: Option<String> = None;
+    let mut alive = false;
+    let mut log_size = 0_u64;
+    for line in output.lines() {
+        let line = line.trim();
+        if let Some(value) = line.strip_prefix("pid=") {
+            pid = if value.is_empty() {
+                None
+            } else {
+                Some(value.to_string())
+            };
+        } else if let Some(value) = line.strip_prefix("alive=") {
+            alive = value == "yes";
+        } else if let Some(value) = line.strip_prefix("logsize=") {
+            log_size = value.trim().parse::<u64>().map_err(|e| {
+                SurgeError::Platform(format!("Remote detached install probe returned invalid log size: {e}"))
+            })?;
+        }
+    }
+    Ok(RemoteDetachedInstallProbe { pid, alive, log_size })
+}
+
+/// Build the command that launches the staged installer as a detached
+/// node-local process (new session, SIGHUP-immune, stdout/stderr to the
+/// install log) and reports the installer PID.
+///
+/// `flags` must contain only the fixed CLI flag tokens (`--no-start`,
+/// `--stage`, `--reinstall`); it is interpolated unquoted into the inner
+/// command on purpose.
+pub(crate) fn build_remote_detached_install_launch_command(flags: &str) -> String {
+    let flags = flags.trim();
+    let inner = if flags.is_empty() {
+        format!("echo $$ > {REMOTE_INSTALLER_PID_PATH}; exec {REMOTE_INSTALLER_FINAL_PATH}")
+    } else {
+        format!("echo $$ > {REMOTE_INSTALLER_PID_PATH}; exec {REMOTE_INSTALLER_FINAL_PATH} {flags}")
+    };
+    format!(
+        "set -eu; \
+if [ ! -x {REMOTE_INSTALLER_FINAL_PATH} ]; then echo 'remote installer binary is missing or not executable' >&2; exit 1; fi; \
+: > {REMOTE_INSTALLER_LOG_PATH}; \
+inner='{inner}'; \
+if command -v setsid >/dev/null 2>&1; then \
+  setsid sh -c \"$inner\" >> {REMOTE_INSTALLER_LOG_PATH} 2>&1 < /dev/null & \
+else \
+  nohup sh -c \"$inner\" >> {REMOTE_INSTALLER_LOG_PATH} 2>&1 < /dev/null & \
+fi; \
+sleep 0.3; \
+if [ -f {REMOTE_INSTALLER_PID_PATH} ]; then \
+  echo \"launched $(tr -d '[:space:]' < {REMOTE_INSTALLER_PID_PATH})\"; \
+else \
+  echo launched; \
+fi"
+    )
+}
+
+pub(crate) fn build_remote_detached_install_log_tail_command(offset: u64) -> String {
+    format!(
+        "if [ -f {REMOTE_INSTALLER_LOG_PATH} ]; then tail -c +$(({offset} + 1)) {REMOTE_INSTALLER_LOG_PATH} | head -c {DETACHED_INSTALL_LOG_TAIL_CAP}; fi"
+    )
+}
+
+pub(crate) fn build_remote_detached_install_stop_command() -> String {
+    format!(
+        "pidfile={REMOTE_INSTALLER_PID_PATH}; \
+pid=\"$(tr -d '[:space:]' < \"$pidfile\" 2>/dev/null || true)\"; \
+case \"$pid\" in \
+  ''|*[!0-9]*) rm -f \"$pidfile\"; echo none ;; \
+  *) kill \"$pid\" 2>/dev/null || true; \
+    i=0; \
+    while kill -0 \"$pid\" 2>/dev/null && [ \"$i\" -lt 50 ]; do sleep 0.1; i=$((i + 1)); done; \
+    kill -KILL \"$pid\" 2>/dev/null || true; \
+    rm -f \"$pidfile\"; echo stopped ;; \
+esac"
+    )
+}
+
+pub(crate) fn build_remote_detached_install_cleanup_command() -> String {
+    format!(
+        "rm -f {REMOTE_INSTALLER_FINAL_PATH} {REMOTE_INSTALLER_PID_PATH} {REMOTE_INSTALLER_FINAL_PATH}.partial {REMOTE_INSTALLER_FINAL_PATH}.partial.meta"
+    )
+}
+
+async fn run_remote_detached_install_script(ssh_target: &str, script: &str) -> Result<String> {
+    let command = format!("sh -c {}", shell_single_quote(script));
+    run_tailscale_capture(&["ssh", ssh_target, command.as_str()]).await
+}
+
+pub(crate) async fn probe_remote_detached_install(ssh_target: &str) -> Result<RemoteDetachedInstallProbe> {
+    let raw = run_remote_detached_install_script(ssh_target, &build_remote_detached_install_probe_command()).await?;
+    parse_remote_detached_install_probe(raw.trim())
+}
+
+pub(crate) async fn stop_remote_detached_install(ssh_target: &str) -> Result<()> {
+    run_remote_detached_install_script(ssh_target, &build_remote_detached_install_stop_command()).await?;
+    Ok(())
+}
+
+pub(crate) async fn cleanup_remote_detached_install(ssh_target: &str) -> Result<()> {
+    run_remote_detached_install_script(ssh_target, &build_remote_detached_install_cleanup_command()).await?;
+    Ok(())
+}
+
+pub(crate) async fn read_remote_detached_install_tail(ssh_target: &str) -> Option<String> {
+    read_remote_detached_install_log_tail(ssh_target).await
+}
+
+async fn read_remote_detached_install_log_tail(ssh_target: &str) -> Option<String> {
+    let command = format!("if [ -f {REMOTE_INSTALLER_LOG_PATH} ]; then tail -n 12 {REMOTE_INSTALLER_LOG_PATH}; fi");
+    let raw = run_tailscale_capture(&["ssh", ssh_target, &format!("sh -c {}", shell_single_quote(&command))])
+        .await
+        .ok()?;
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+enum WatchOutcome {
+    Converged,
+    InProgress,
+}
+
+async fn poll_remote_detached_install_once(
+    ssh_target: &str,
+    file_target: &str,
+    install_root: &Path,
+    log_offset: &mut u64,
+) -> Result<WatchOutcome> {
+    // Relay any new installer output first so the local console mirrors the
+    // node even when the status file is quiet.
+    let tail_raw =
+        run_remote_detached_install_script(ssh_target, &build_remote_detached_install_log_tail_command(*log_offset))
+            .await?;
+    let had_log_output = !tail_raw.is_empty();
+    if had_log_output {
+        *log_offset = log_offset.saturating_add(tail_raw.len() as u64);
+        for line in tail_raw.lines() {
+            let trimmed = line.trim();
+            if !trimmed.is_empty() {
+                logline::subtle(&format!("remote: {trimmed}"));
+            }
+        }
+    }
+
+    let probe = probe_remote_detached_install(ssh_target).await?;
+    let status = read_remote_update_status_file(ssh_target, install_root).await?;
+
+    if let Some(status) = &status {
+        if status.state == "failed" {
+            return Err(SurgeError::Platform(format!(
+                "Remote setup failed on '{file_target}'{}",
+                status.format_context()
+            )));
+        }
+        if status.is_terminal_success() {
+            return Ok(WatchOutcome::Converged);
+        }
+        if status.has_recent_progress(DETACHED_INSTALL_STALE_PROGRESS_TIMEOUT) {
+            return Ok(WatchOutcome::InProgress);
+        }
+    }
+
+    if !probe.alive {
+        // The installer can exit right before the final status write; give
+        // the status file one grace re-read before declaring failure.
+        tokio::time::sleep(DETACHED_INSTALL_POLL_INTERVAL).await;
+        if let Some(status) = read_remote_update_status_file(ssh_target, install_root).await? {
+            if status.state == "failed" {
+                return Err(SurgeError::Platform(format!(
+                    "Remote setup failed on '{file_target}'{}",
+                    status.format_context()
+                )));
+            }
+            if status.is_terminal_success() {
+                return Ok(WatchOutcome::Converged);
+            }
+            // Restart handoff in progress: the new process owns the status
+            // file from here on.
+            if status.state == "pending_restart" {
+                return Ok(WatchOutcome::InProgress);
+            }
+        }
+        let context = status.map_or_else(String::new, |status| status.format_context());
+        return Err(SurgeError::Platform(format!(
+            "The detached remote installer on '{file_target}' exited before converging{context}"
+        )));
+    }
+
+    if had_log_output {
+        return Ok(WatchOutcome::InProgress);
+    }
+
+    Err(SurgeError::Platform(format!(
+        "Timed out after {}s without fresh remote installer progress on '{file_target}{}",
+        DETACHED_INSTALL_STALE_PROGRESS_TIMEOUT.as_secs(),
+        status.map_or_else(String::new, |status| format!(": {}", status.format_context()))
+    )))
+}
+
+/// Watch a detached node-local installer until it converges or fails.
+///
+/// Relays new installer log bytes to the local console, treats the node's
+/// update status file as the authoritative outcome, and fails when the
+/// process exits without converging, when progress goes stale, or when the
+/// overall monitor timeout elapses.
+pub(crate) async fn watch_remote_detached_install(
+    ssh_target: &str,
+    file_target: &str,
+    install_root: &Path,
+    start_log_offset: u64,
+) -> Result<()> {
+    let started_at = Instant::now();
+    let mut log_offset = start_log_offset;
+
+    loop {
+        if started_at.elapsed() >= DETACHED_INSTALL_MONITOR_TIMEOUT {
+            return Err(SurgeError::Platform(format!(
+                "Timed out after {}s waiting for the detached remote installer on '{file_target}' to converge",
+                DETACHED_INSTALL_MONITOR_TIMEOUT.as_secs()
+            )));
+        }
+
+        match poll_remote_detached_install_once(ssh_target, file_target, install_root, &mut log_offset).await {
+            Ok(WatchOutcome::Converged) => {
+                logline::success(&format!(
+                    "Detached remote installer on '{file_target}' converged ({}s).",
+                    started_at.elapsed().as_secs()
+                ));
+                return Ok(());
+            }
+            Ok(WatchOutcome::InProgress) => {}
+            Err(error) => {
+                if let Some(tail) = read_remote_detached_install_log_tail(ssh_target).await {
+                    return Err(SurgeError::Platform(format!(
+                        "{error} — last installer log lines:\n{tail}"
+                    )));
+                }
+                return Err(error);
+            }
+        }
+
+        tokio::time::sleep(DETACHED_INSTALL_POLL_INTERVAL).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_remote_detached_install_probe_reads_fields() {
+        let probe = parse_remote_detached_install_probe("pid=1234\nalive=yes\nlogsize=42\n").unwrap();
+        assert_eq!(probe.pid.as_deref(), Some("1234"));
+        assert!(probe.alive);
+        assert_eq!(probe.log_size, 42);
+
+        let probe = parse_remote_detached_install_probe("pid=\nalive=no\nlogsize=0\n").unwrap();
+        assert_eq!(probe.pid, None);
+        assert!(!probe.alive);
+    }
+
+    #[test]
+    fn launch_command_detaches_and_reports_pid() {
+        let command = build_remote_detached_install_launch_command("--no-start --reinstall");
+        assert!(command.contains("setsid sh -c \"$inner\""));
+        assert!(command.contains("nohup sh -c \"$inner\""));
+        assert!(command.contains("echo $$ > /tmp/.surge-installer.pid"));
+        assert!(command.contains("exec /tmp/.surge-installer --no-start --reinstall"));
+        assert!(command.contains("2>&1 < /dev/null &"));
+        assert!(command.contains("echo \"launched $(tr -d '[:space:]' < /tmp/.surge-installer.pid)\""));
+    }
+
+    #[test]
+    fn launch_command_without_flags() {
+        let command = build_remote_detached_install_launch_command("");
+        assert!(command.contains("exec /tmp/.surge-installer'"));
+        assert!(!command.contains("--no-start"));
+    }
+
+    #[test]
+    fn probe_command_reports_pid_aliveness_and_log_size() {
+        let command = build_remote_detached_install_probe_command();
+        assert!(command.contains("kill -0 \"$pid\""));
+        assert!(command.contains("printf 'pid=%s\\nalive=%s\\nlogsize=%s\\n'"));
+    }
+
+    #[test]
+    fn stop_and_cleanup_commands_target_expected_paths() {
+        let stop = build_remote_detached_install_stop_command();
+        assert!(stop.contains("kill \"$pid\""));
+        assert!(stop.contains("kill -KILL \"$pid\""));
+        assert!(stop.contains("rm -f \"$pidfile\""));
+
+        let cleanup = build_remote_detached_install_cleanup_command();
+        assert!(cleanup.contains("rm -f /tmp/.surge-installer /tmp/.surge-installer.pid"));
+    }
+
+    #[cfg(unix)]
+    fn script_for_temp_paths(script: &str, base: &Path) -> (String, std::path::PathBuf, std::path::PathBuf, std::path::PathBuf) {
+        let log_path = base.join(".surge-installer.log");
+        let pid_path = base.join(".surge-installer.pid");
+        let bin_path = base.join(".surge-installer");
+        let script = script
+            .replace("/tmp/.surge-installer.log", &log_path.to_string_lossy())
+            .replace("/tmp/.surge-installer.pid", &pid_path.to_string_lossy())
+            .replace("/tmp/.surge-installer", &bin_path.to_string_lossy());
+        (script, bin_path, log_path, pid_path)
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn detached_launch_command_runs_installer_detached_and_reports_pid() {
+        let temp_dir = tempfile::tempdir().expect("tempdir");
+        let (script, bin_path, log_path, pid_path) = script_for_temp_paths(
+            &build_remote_detached_install_launch_command(""),
+            temp_dir.path(),
+        );
+
+        // Fake installer: reports start/end and stays alive long enough to probe.
+        std::fs::write(&bin_path, "#!/bin/sh\necho installer-started\nsleep 1\necho installer-done\n").unwrap();
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&bin_path, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        // The parent exits immediately after launch, like an ending SSH session.
+        let output = std::process::Command::new("sh")
+            .arg("-c")
+            .arg(&script)
+            .output()
+            .expect("run launch script");
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(output.status.success(), "script failed: {stdout}");
+        assert!(stdout.contains("launched "), "expected a launched pid, got: {stdout}");
+
+        let pid = std::fs::read_to_string(&pid_path).expect("pidfile written").trim().to_string();
+        assert!(!pid.is_empty());
+        let pid_alive = |pid: &str| {
+            std::process::Command::new("kill")
+                .args(["-0", pid])
+                .output()
+                .expect("kill probe")
+                .status
+                .success()
+        };
+        assert!(pid_alive(&pid), "installer should be alive after the launcher exits");
+
+        // Let the fake installer run to completion, then verify the log.
+        std::thread::sleep(std::time::Duration::from_millis(1500));
+        assert!(!pid_alive(&pid), "installer should have exited");
+        let log = std::fs::read_to_string(&log_path).expect("log written");
+        assert!(log.contains("installer-started"), "log was: {log}");
+        assert!(log.contains("installer-done"), "log was: {log}");
+    }
+}

--- a/crates/surge-core/src/update/manager.rs
+++ b/crates/surge-core/src/update/manager.rs
@@ -3106,6 +3106,200 @@ echo started > new-child-started
     }
 
     #[tokio::test]
+    async fn test_download_and_apply_delta_aborts_when_verification_failures_exhaust_budget() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store_root = tmp.path().join("store");
+        let install_root = tmp.path().join("install");
+        let app_id = "test-app";
+        std::fs::create_dir_all(&store_root).unwrap();
+        std::fs::create_dir_all(&install_root).unwrap();
+        let app_store = app_scoped_store_root(&store_root, app_id);
+
+        let rid = current_rid();
+        let os = current_os_label_for_tests();
+
+        // Clean source trees for three releases; the installed app drifts by
+        // carrying an extra file that no delta removes, so every rebuilt
+        // archive hash-mismatches, and every stored full is corrupted, so
+        // every restore and the full-package fallback fail verification too.
+        let make_source = |name: &str, payload: &str| {
+            let dir = tmp.path().join(name);
+            std::fs::create_dir_all(&dir).unwrap();
+            std::fs::write(dir.join("payload.txt"), payload).unwrap();
+            dir
+        };
+        let source_v1 = make_source("source-v1", "v1 payload");
+        let source_v2 = make_source("source-v2", "v2 payload");
+        let source_v3 = make_source("source-v3", "v3 payload");
+
+        let pack = |dir: &Path| {
+            let mut packer = ArchivePacker::new(3).unwrap();
+            packer.add_directory(dir, "").unwrap();
+            packer.finalize().unwrap()
+        };
+        let full_v1 = pack(&source_v1);
+        let full_v2 = pack(&source_v2);
+        let full_v3 = pack(&source_v3);
+
+        let corrupt = |bytes: &[u8]| {
+            let mut corrupted = bytes.to_vec();
+            corrupted.push(0xff);
+            corrupted
+        };
+
+        let delta_v2 = zstd::encode_all(
+            build_sparse_file_patch(&full_v1, &full_v2, 3, 0, &ChunkedDiffOptions::default())
+                .unwrap()
+                .as_slice(),
+            3,
+        )
+        .unwrap();
+        let delta_v3 = zstd::encode_all(
+            build_sparse_file_patch(&full_v2, &full_v3, 3, 0, &ChunkedDiffOptions::default())
+                .unwrap()
+                .as_slice(),
+            3,
+        )
+        .unwrap();
+
+        let full_v1_name = format!("{app_id}-1.0.0-{rid}-full.tar.zst");
+        let full_v2_name = format!("{app_id}-1.1.0-{rid}-full.tar.zst");
+        let full_v3_name = format!("{app_id}-1.2.0-{rid}-full.tar.zst");
+        let delta_v2_name = format!("{app_id}-1.1.0-{rid}-delta.tar.zst");
+        let delta_v3_name = format!("{app_id}-1.2.0-{rid}-delta.tar.zst");
+
+        // Valid deltas; every full (base, intermediate, target) corrupted.
+        std::fs::write(app_store.join(&full_v1_name), corrupt(&full_v1)).unwrap();
+        std::fs::write(app_store.join(&full_v2_name), corrupt(&full_v2)).unwrap();
+        std::fs::write(app_store.join(&full_v3_name), corrupt(&full_v3)).unwrap();
+        std::fs::write(app_store.join(&delta_v2_name), &delta_v2).unwrap();
+        std::fs::write(app_store.join(&delta_v3_name), &delta_v3).unwrap();
+
+        let release =
+            |version: &str, genesis: bool, full_name: &str, full: &[u8], deltas: Vec<DeltaArtifact>| ReleaseEntry {
+                version: version.to_string(),
+                channels: vec!["stable".to_string()],
+                os: os.clone(),
+                rid: rid.clone(),
+                is_genesis: genesis,
+                full_filename: full_name.to_string(),
+                full_size: i64::try_from(full.len()).unwrap(),
+                full_sha256: sha256_hex(full),
+                full_compression_level: 0,
+                full_zstd_workers: 0,
+                preferred_delta_id: if deltas.is_empty() {
+                    String::new()
+                } else {
+                    "primary".to_string()
+                },
+                deltas,
+                created_utc: chrono::Utc::now().to_rfc3339(),
+                release_notes: String::new(),
+                name: String::new(),
+                main_exe: app_id.to_string(),
+                install_directory: app_id.to_string(),
+                supervisor_id: String::new(),
+                icon: String::new(),
+                shortcuts: Vec::new(),
+                persistent_assets: Vec::new(),
+                installers: Vec::new(),
+                environment: std::collections::BTreeMap::new(),
+            };
+        let index = ReleaseIndex {
+            app_id: app_id.to_string(),
+            releases: vec![
+                release("1.0.0", true, &full_v1_name, &full_v1, Vec::new()),
+                release(
+                    "1.1.0",
+                    false,
+                    &full_v2_name,
+                    &full_v2,
+                    vec![DeltaArtifact::sparse_file_ops_zstd(
+                        "primary",
+                        "1.0.0",
+                        &delta_v2_name,
+                        delta_v2.len() as i64,
+                        &sha256_hex(&delta_v2),
+                    )],
+                ),
+                release(
+                    "1.2.0",
+                    false,
+                    &full_v3_name,
+                    &full_v3,
+                    vec![DeltaArtifact::sparse_file_ops_zstd(
+                        "primary",
+                        "1.1.0",
+                        &delta_v3_name,
+                        delta_v3.len() as i64,
+                        &sha256_hex(&delta_v3),
+                    )],
+                ),
+            ],
+            ..ReleaseIndex::default()
+        };
+        write_app_scoped_release_index(&store_root, app_id, &index);
+
+        // Installed app for 1.0.0, drifted by an extra file no delta removes.
+        let active_app_dir = install_root.join("app");
+        std::fs::create_dir_all(active_app_dir.join(".surge")).unwrap();
+        std::fs::write(active_app_dir.join("payload.txt"), "v1 payload").unwrap();
+        std::fs::write(active_app_dir.join("extra.txt"), "drift").unwrap();
+        std::fs::write(
+            active_app_dir.join(crate::install::RUNTIME_MANIFEST_RELATIVE_PATH),
+            format!("id: {app_id}\nversion: 1.0.0\n"),
+        )
+        .unwrap();
+        std::fs::write(
+            active_app_dir.join(crate::install::LEGACY_RUNTIME_MANIFEST_RELATIVE_PATH),
+            format!("id: {app_id}\nversion: 1.0.0\n"),
+        )
+        .unwrap();
+
+        let ctx = Arc::new(Context::new());
+        ctx.set_storage(
+            StorageProvider::Filesystem,
+            store_root.to_str().unwrap(),
+            "",
+            "",
+            "",
+            "",
+        );
+
+        let mut manager = UpdateManager::new(ctx, app_id, "1.0.0", "stable", install_root.to_str().unwrap()).unwrap();
+        let info = manager.check_for_updates().await.unwrap().unwrap();
+        assert_eq!(info.apply_strategy, ApplyStrategy::Delta);
+
+        let error = manager
+            .download_and_apply(&info, None::<fn(ProgressInfo)>)
+            .await
+            .expect_err("a corrupt chain must fail the attempt")
+            .to_string();
+        assert!(
+            error.contains("verification failure budget exhausted"),
+            "expected the bounded-abort error, got: {error}"
+        );
+        assert!(
+            error.contains("4 verification failures in this attempt"),
+            "expected the failure count in the abort, got: {error}"
+        );
+
+        let status = status::read_update_status(&install_root).unwrap().unwrap();
+        assert_eq!(status.state, status::UpdateConvergenceState::Failed);
+        assert!(
+            status
+                .reason
+                .as_deref()
+                .unwrap()
+                .contains("verification failure budget exhausted")
+        );
+
+        // The install must be untouched: still running the pre-attempt version.
+        let installed = std::fs::read_to_string(install_root.join("app").join("payload.txt")).unwrap();
+        assert_eq!(installed, "v1 payload");
+    }
+
+    #[tokio::test]
     async fn test_download_and_apply_delta_prefers_app_scoped_release_index_lineage() {
         let tmp = tempfile::tempdir().unwrap();
         let store_root = tmp.path().join("store");

--- a/crates/surge-core/src/update/manager/apply.rs
+++ b/crates/surge-core/src/update/manager/apply.rs
@@ -26,15 +26,19 @@ pub(super) use self::installed_app::find_previous_app_dir;
 #[cfg(test)]
 pub(super) use self::installed_app::synthesize_current_full_archive_from_installed_app;
 
-/// Maximum verification failures a single update attempt may accumulate while
-/// restoring and applying the current package.
+/// Maximum verification-failure passes a single update attempt may pay for
+/// while restoring and applying the current package.
 ///
-/// The materialization ladder deliberately re-runs expensive work after
+/// The materialization ladder intentionally re-runs expensive work after
 /// verification failures (installed-app base -> release-graph base -> full
-/// package fallback). Without a budget, a persistently corrupt artifact chain
-/// re-runs GB-scale restore/apply passes over and over, advancing progress on
-/// every pass so the attempt looks healthy while it burns disk and CPU (see
-/// #237). The budget turns that into a bounded, readable failure.
+/// package fallback), which is what makes a single corrupted artifact cheap
+/// to recover from. When the whole chain is corrupt, however, every pass
+/// fails verification and the attempt can pay for GB-scale restore/apply
+/// work with no chance of converging (see #237). The budget caps how many
+/// failed verification passes one attempt pays for; the failure beyond the
+/// budget aborts the attempt with a readable, counted error and skips the
+/// remaining expensive passes, so the failure is visible instead of
+/// masquerading as healthy progress.
 pub(super) const MAX_VERIFY_FAILURES: u32 = 3;
 
 /// Marker prefix of the budget-abort error so the retry ladder can tell an
@@ -82,6 +86,7 @@ fn is_verification_failure(error: &SurgeError) -> bool {
             message.contains("SHA-256 mismatch")
                 || message.contains("Failed to apply delta")
                 || message.contains("Failed to decode")
+                || message.contains("Failed to decompress")
         }
         _ => false,
     }
@@ -536,6 +541,9 @@ mod tests {
         )));
         assert!(is_verification_failure(&SurgeError::Archive(
             "Failed to decode delta artifact".into()
+        )));
+        assert!(is_verification_failure(&SurgeError::Archive(
+            "Failed to decompress delta artifact: corrupt".into()
         )));
 
         assert!(!is_verification_failure(&SurgeError::Storage(

--- a/crates/surge-core/src/update/manager/apply.rs
+++ b/crates/surge-core/src/update/manager/apply.rs
@@ -26,6 +26,71 @@ pub(super) use self::installed_app::find_previous_app_dir;
 #[cfg(test)]
 pub(super) use self::installed_app::synthesize_current_full_archive_from_installed_app;
 
+/// Maximum verification failures a single update attempt may accumulate while
+/// restoring and applying the current package.
+///
+/// The materialization ladder deliberately re-runs expensive work after
+/// verification failures (installed-app base -> release-graph base -> full
+/// package fallback). Without a budget, a persistently corrupt artifact chain
+/// re-runs GB-scale restore/apply passes over and over, advancing progress on
+/// every pass so the attempt looks healthy while it burns disk and CPU (see
+/// #237). The budget turns that into a bounded, readable failure.
+pub(super) const MAX_VERIFY_FAILURES: u32 = 3;
+
+/// Marker prefix of the budget-abort error so the retry ladder can tell an
+/// abort apart from an ordinary verification failure (which it would
+/// otherwise retry with another expensive pass).
+const VERIFY_ABORT_MARKER: &str = "verification failure budget exhausted";
+
+/// Verification-failure budget for one update attempt. Each verification
+/// failure (hash mismatch, patch decode/apply failure, corrupted artifact)
+/// consumes the budget; once it is exhausted the attempt must fail with a
+/// readable error instead of re-running expensive work.
+pub(super) struct VerifyFailureBudget {
+    failures: Vec<String>,
+}
+
+impl VerifyFailureBudget {
+    #[must_use]
+    pub(super) fn new() -> Self {
+        Self { failures: Vec::new() }
+    }
+
+    /// Record a verification failure. Returns `Ok(())` while the budget is
+    /// not exhausted and an abort error on the first failure beyond it.
+    pub(super) fn record_failure(&mut self, context: &str) -> Result<()> {
+        self.failures.push(context.to_string());
+        if self.failures.len() <= usize::try_from(MAX_VERIFY_FAILURES).unwrap_or(usize::MAX) {
+            return Ok(());
+        }
+        let last = self.failures.last().map_or("", String::as_str);
+        Err(SurgeError::Update(format!(
+            "{VERIFY_ABORT_MARKER}: {} verification failures in this attempt ({} allowed, last: {last}); the release artifacts for this update chain appear corrupt or inconsistent. The attempt fails and backs off; retry later or republish the affected release.",
+            self.failures.len(),
+            MAX_VERIFY_FAILURES
+        )))
+    }
+}
+
+/// Whether an error indicates a verification failure (content/hash mismatch
+/// or a patch that could not be decoded/applied) as opposed to a transient
+/// or environmental failure (network, IO, missing object).
+fn is_verification_failure(error: &SurgeError) -> bool {
+    match error {
+        SurgeError::Integrity(_) | SurgeError::Diff(_) => true,
+        SurgeError::Archive(message) | SurgeError::Update(message) | SurgeError::Storage(message) => {
+            message.contains("SHA-256 mismatch")
+                || message.contains("Failed to apply delta")
+                || message.contains("Failed to decode")
+        }
+        _ => false,
+    }
+}
+
+fn is_verify_abort(error: &SurgeError) -> bool {
+    matches!(error, SurgeError::Update(message) if message.contains(VERIFY_ABORT_MARKER))
+}
+
 pub(super) async fn materialize_update_payload<F>(
     manager: &UpdateManager,
     info: &UpdateInfo,
@@ -38,6 +103,7 @@ pub(super) async fn materialize_update_payload<F>(
 where
     F: Fn(ProgressInfo) + Send + Sync,
 {
+    let mut verify_budget = VerifyFailureBudget::new();
     if matches!(info.apply_strategy, ApplyStrategy::Delta) {
         match materialize_delta_payload(
             manager,
@@ -47,11 +113,18 @@ where
             extract_dir,
             progress,
             progress_emitter,
+            &mut verify_budget,
         )
         .await
         {
             Ok(path) => Ok(path),
             Err(SurgeError::Cancelled) => Err(SurgeError::Cancelled),
+            Err(delta_error) if is_verify_abort(&delta_error) => {
+                // The verification budget is exhausted: failing now (with the
+                // bounded-abort error) instead of re-running the expensive
+                // full-package pass is the point of the budget.
+                Err(delta_error)
+            }
             Err(delta_error) => {
                 materialize_full_payload_after_delta_failure(
                     manager,
@@ -61,6 +134,7 @@ where
                     extract_dir,
                     progress,
                     delta_error,
+                    &mut verify_budget,
                 )
                 .await
             }
@@ -137,6 +211,7 @@ async fn materialize_full_payload_after_delta_failure<F>(
     extract_dir: &Path,
     progress: Option<&Arc<F>>,
     delta_error: SurgeError,
+    verify_budget: &mut VerifyFailureBudget,
 ) -> Result<PathBuf>
 where
     F: Fn(ProgressInfo) + Send + Sync,
@@ -195,6 +270,17 @@ where
     )
     .await
     .map_err(|fallback_error| {
+        if is_verification_failure(&fallback_error) {
+            // Terminal path: if this verification failure exhausts the
+            // budget, surface the bounded-abort error instead of the raw
+            // download error so the failure reason names the pattern.
+            if let Err(abort) = verify_budget.record_failure(&format!(
+                "full package fallback download of {}: {fallback_error}",
+                latest.full_filename
+            )) {
+                return abort;
+            }
+        }
         SurgeError::Update(format!(
             "Delta materialization failed: {delta_error}; full package fallback failed: {fallback_error}"
         ))
@@ -221,6 +307,7 @@ async fn materialize_delta_payload<F>(
     extract_dir: &Path,
     progress: Option<&Arc<F>>,
     progress_emitter: &PhaseProgressEmitter<'_, F>,
+    verify_budget: &mut VerifyFailureBudget,
 ) -> Result<PathBuf>
 where
     F: Fn(ProgressInfo) + Send + Sync,
@@ -243,7 +330,15 @@ where
         },
     );
 
-    let base_archive = restore_base_full_archive(manager, info, artifact_cache_dir, progress, progress_emitter).await?;
+    let base_archive = restore_base_full_archive(
+        manager,
+        info,
+        artifact_cache_dir,
+        progress,
+        progress_emitter,
+        verify_budget,
+    )
+    .await?;
     let rebuilt_archive = match apply_target_deltas(
         manager,
         info,
@@ -253,21 +348,28 @@ where
         progress_emitter,
         apply_delta_total_items,
         apply_delta_total_bytes,
+        verify_budget,
     )
     .await
     {
         Ok(archive) => archive,
         Err(delta_error)
             if base_archive.source == BaseFullArchiveSource::InstalledApp
+                && !is_verify_abort(&delta_error)
                 && should_retry_delta_with_release_graph(&delta_error) =>
         {
             warn!(
                 error = %delta_error,
                 "Installed app base did not produce a valid delta result; retrying with release graph base"
             );
-            let release_graph_base =
-                restore_release_graph_base_full_archive(manager, artifact_cache_dir, progress, progress_emitter)
-                    .await?;
+            let release_graph_base = restore_release_graph_base_full_archive(
+                manager,
+                artifact_cache_dir,
+                progress,
+                progress_emitter,
+                verify_budget,
+            )
+            .await?;
             apply_target_deltas(
                 manager,
                 info,
@@ -277,6 +379,7 @@ where
                 progress_emitter,
                 apply_delta_total_items,
                 apply_delta_total_bytes,
+                verify_budget,
             )
             .await
             .map_err(|retry_error| {
@@ -376,4 +479,69 @@ where
     );
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{MAX_VERIFY_FAILURES, VerifyFailureBudget, is_verification_failure, is_verify_abort};
+    use crate::error::SurgeError;
+
+    #[test]
+    fn verify_budget_allows_bounded_failures_then_aborts() {
+        let mut budget = VerifyFailureBudget::new();
+        for attempt in 1..=usize::try_from(MAX_VERIFY_FAILURES).unwrap() {
+            budget
+                .record_failure(&format!("failure {attempt}"))
+                .unwrap_or_else(|e| panic!("failure {attempt} should be within budget: {e}"));
+        }
+        let abort = budget
+            .record_failure("one failure too many")
+            .expect_err("the failure beyond the budget must abort");
+        let message = abort.to_string();
+        assert!(
+            message.contains("verification failure budget exhausted"),
+            "message was: {message}"
+        );
+        assert!(message.contains("one failure too many"), "message was: {message}");
+        assert!(
+            is_verify_abort(&abort),
+            "the abort error must be recognized by the ladder"
+        );
+    }
+
+    #[test]
+    fn verify_abort_is_not_ordinary_verification_failure() {
+        let mut budget = VerifyFailureBudget::new();
+        for _ in 0..=MAX_VERIFY_FAILURES {
+            let _ = budget.record_failure("fill");
+        }
+        let abort = budget.record_failure("overflow").unwrap_err();
+        assert!(
+            !is_verification_failure(&abort),
+            "an abort must not be charged again by another ladder step"
+        );
+    }
+
+    #[test]
+    fn verification_failure_classification_covers_hash_and_patch_errors() {
+        assert!(is_verification_failure(&SurgeError::Integrity(
+            "SHA-256 mismatch".into()
+        )));
+        assert!(is_verification_failure(&SurgeError::Diff("patch corrupt".into())));
+        assert!(is_verification_failure(&SurgeError::Update(
+            "SHA-256 mismatch for rebuilt full archive".into()
+        )));
+        assert!(is_verification_failure(&SurgeError::Storage(
+            "SHA-256 mismatch after download".into()
+        )));
+        assert!(is_verification_failure(&SurgeError::Archive(
+            "Failed to decode delta artifact".into()
+        )));
+
+        assert!(!is_verification_failure(&SurgeError::Storage(
+            "connection reset".into()
+        )));
+        assert!(!is_verification_failure(&SurgeError::NotFound("object missing".into())));
+        assert!(!is_verification_failure(&SurgeError::Cancelled));
+    }
 }

--- a/crates/surge-core/src/update/manager/apply/base.rs
+++ b/crates/surge-core/src/update/manager/apply/base.rs
@@ -21,6 +21,7 @@ use super::super::progress::{
 use super::super::progress_substep::{HEARTBEAT_INTERVAL, PhaseProgressEmitter, labels as apply_phase};
 use super::super::{UpdateInfo, UpdateManager};
 use super::installed_app::synthesize_current_full_archive_from_installed_app;
+use super::{VerifyFailureBudget, is_verification_failure};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(super) enum BaseFullArchiveSource {
@@ -39,6 +40,7 @@ pub(super) async fn restore_base_full_archive<F>(
     artifact_cache_dir: &Path,
     progress: Option<&Arc<F>>,
     progress_emitter: &PhaseProgressEmitter<'_, F>,
+    verify_budget: &mut VerifyFailureBudget,
 ) -> Result<BaseFullArchive>
 where
     F: Fn(ProgressInfo) + Send + Sync,
@@ -61,6 +63,12 @@ where
                 });
             }
             Err(installed_app_err) => {
+                if is_verification_failure(&installed_app_err) {
+                    verify_budget.record_failure(&format!(
+                        "installed-app base restoration of {}: {installed_app_err}",
+                        manager.current_version
+                    ))?;
+                }
                 debug!(
                     version = %manager.current_version,
                     error = %installed_app_err,
@@ -78,6 +86,7 @@ where
         artifact_cache_dir,
         progress,
         progress_emitter,
+        verify_budget,
     )
     .await
     .map(|archive| BaseFullArchive {
@@ -91,6 +100,7 @@ pub(super) async fn restore_release_graph_base_full_archive<F>(
     artifact_cache_dir: &Path,
     progress: Option<&Arc<F>>,
     progress_emitter: &PhaseProgressEmitter<'_, F>,
+    verify_budget: &mut VerifyFailureBudget,
 ) -> Result<BaseFullArchive>
 where
     F: Fn(ProgressInfo) + Send + Sync,
@@ -104,6 +114,7 @@ where
         artifact_cache_dir,
         progress,
         progress_emitter,
+        verify_budget,
     )
     .await
     .map(|archive| BaseFullArchive {
@@ -139,6 +150,7 @@ async fn restore_base_full_archive_from_release_graph<F>(
     artifact_cache_dir: &Path,
     progress: Option<&Arc<F>>,
     progress_emitter: &PhaseProgressEmitter<'_, F>,
+    verify_budget: &mut VerifyFailureBudget,
 ) -> Result<Vec<u8>>
 where
     F: Fn(ProgressInfo) + Send + Sync,
@@ -193,19 +205,30 @@ where
         .await
     {
         Ok(archive) => Ok(archive),
-        Err(restore_err) => synthesize_current_full_archive_from_installed_app(
-            &manager.install_dir,
-            &manager.current_version,
-            current_release,
-            artifact_cache_dir,
-            &manager.ctx,
-        )
-        .map_err(|fallback_err| {
-            SurgeError::Update(format!(
-                "Failed to restore base full archive for {}: {restore_err}; installed-app fallback failed: {fallback_err}",
-                manager.current_version
-            ))
-        }),
+        Err(restore_err) => {
+            if is_verification_failure(&restore_err) {
+                // Budget-gate the expensive installed-app synthesis fallback:
+                // once the attempt has burned its verification failures, fail
+                // with the bounded-abort error instead of re-running work.
+                verify_budget.record_failure(&format!(
+                    "release-graph restore of current package {}: {restore_err}",
+                    manager.current_version
+                ))?;
+            }
+            synthesize_current_full_archive_from_installed_app(
+                &manager.install_dir,
+                &manager.current_version,
+                current_release,
+                artifact_cache_dir,
+                &manager.ctx,
+            )
+            .map_err(|fallback_err| {
+                SurgeError::Update(format!(
+                    "Failed to restore base full archive for {}: {restore_err}; installed-app fallback failed: {fallback_err}",
+                    manager.current_version
+                ))
+            })
+        }
     }
 }
 

--- a/crates/surge-core/src/update/manager/apply/delta.rs
+++ b/crates/surge-core/src/update/manager/apply/delta.rs
@@ -54,8 +54,17 @@ where
 
         let delta_path = staging_dir.join(&delta.filename);
         let delta_compressed = tokio::fs::read(&delta_path).await?;
-        let patch = decode_delta_patch(delta_compressed.as_slice(), &delta)
-            .map_err(|e| SurgeError::Archive(format!("Failed to decompress delta {}: {e}", delta.filename)))?;
+        let patch = decode_delta_patch(delta_compressed.as_slice(), &delta).map_err(|e| {
+            let error = SurgeError::Archive(format!("Failed to decompress delta {}: {e}", delta.filename));
+            if is_verification_failure(&error) {
+                // A budget-exhausting failure returns the bounded-abort
+                // error instead of the raw decode error.
+                if let Err(abort) = verify_budget.record_failure(&error.to_string()) {
+                    return abort;
+                }
+            }
+            error
+        })?;
         let progress_for_delta = progress.cloned();
         let completed_bytes_before_delta = apply_delta_bytes_done;
         let completed_items_before_delta = apply_delta_items_done;

--- a/crates/surge-core/src/update/manager/apply/delta.rs
+++ b/crates/surge-core/src/update/manager/apply/delta.rs
@@ -14,6 +14,7 @@ use super::super::progress::{
 };
 use super::super::progress_substep::{PhaseProgressEmitter, labels as apply_phase};
 use super::super::{UpdateInfo, UpdateManager};
+use super::{VerifyFailureBudget, is_verification_failure};
 
 pub(super) async fn apply_target_deltas<F>(
     manager: &UpdateManager,
@@ -24,6 +25,7 @@ pub(super) async fn apply_target_deltas<F>(
     progress_emitter: &PhaseProgressEmitter<'_, F>,
     apply_delta_total_items: i64,
     apply_delta_total_bytes: i64,
+    verify_budget: &mut VerifyFailureBudget,
 ) -> Result<Vec<u8>>
 where
     F: Fn(ProgressInfo) + Send + Sync,
@@ -95,15 +97,27 @@ where
         };
 
         rebuilt_archive = apply_delta_patch_with_progress(&rebuilt_archive, &patch, &delta, Some(&delta_progress))
-            .map_err(|e| SurgeError::Update(format!("Failed to apply delta {}: {e}", delta.filename)))?;
+            .map_err(|e| {
+                let error = SurgeError::Update(format!("Failed to apply delta {}: {e}", delta.filename));
+                if is_verification_failure(&error) {
+                    // A budget-exhausting failure returns the bounded-abort
+                    // error instead of the raw apply error.
+                    if let Err(abort) = verify_budget.record_failure(&error.to_string()) {
+                        return abort;
+                    }
+                }
+                error
+            })?;
 
         if !release.full_sha256.is_empty() {
             let hash = sha256_hex(&rebuilt_archive);
             if hash != release.full_sha256 {
-                return Err(SurgeError::Update(format!(
+                let message = format!(
                     "SHA-256 mismatch for rebuilt full archive {}: expected {}, got {hash}",
                     release.version, release.full_sha256
-                )));
+                );
+                verify_budget.record_failure(&message)?;
+                return Err(SurgeError::Update(message));
             }
         }
 


### PR DESCRIPTION
## Fixes
Closes #237 — "Delta restore/apply can spend tens of GB of cancelled work without failing the attempt."

## Problem
When the delta chain is corrupt (corrupted base/intermediate full, drifted installed app, broken patch), the materialization ladder re-runs its expensive passes — installed-app base synthesis, release-graph restore, sparse re-apply, full-package fallback — each one re-downloading and re-verifying, each failure falling back to the next pass. The attempt burns GB-scale restore/apply work, keeps advancing progress heartbeats, and fails (if at all) with an unreadable error — while the supervisor retries it in a tight loop.

## Fix
A per-attempt `VerifyFailureBudget` (max 3 charged verification passes) shared across the whole materialization ladder in `materialize_update_payload`:

- charged verification passes: restore failures from corrupted base/intermediate fulls, delta decode failures, corrupt delta patch application, post-apply SHA-256 mismatches, and the full-package fallback download;
- the failure beyond the budget aborts the attempt with a readable `verification failure budget exhausted: N verification failures in this attempt (3 allowed, last: <failure>)` error, skips the remaining expensive passes, and lands in the update-status `Failed` reason so the supervisor surfaces it;
- transient network/IO failures are not charged; user cancellation never is;
- single-corruption recovery is unchanged (delta mismatch → full fallback succeeds; installed-app drift → release-graph retry) — those paths stay within budget.

The budget caps how many *failed verification passes* one attempt pays for and makes the terminal failure readable and counted; the ladder itself was already structurally bounded, so the point is a visible, bounded, actionable failure instead of silent GB-scale churn.

## Tests
- New integration test: corrupt chain (corrupted base + corrupted target full + drifted installed app) pays 4 failed verification passes across the ladder, attempt fails with the abort error, status is Failed, install untouched.
- New unit tests: budget exhaustion/abort, abort not re-classified as a plain verification failure, failure classification (charged vs not, including decode).
- Existing delta/restore/fallback integration tests all pass (recovery paths unchanged).