### PR TITLE
fix(install): run remote installers detached so orchestrator loss cannot strand the node

### DIFF
--- a/crates/surge-cli/src/commands/install/remote/detached.rs
+++ b/crates/surge-cli/src/commands/install/remote/detached.rs
@@ -9,7 +9,7 @@ pub(crate) const REMOTE_INSTALLER_PID_PATH: &str = "/tmp/.surge-installer.pid";
 
 /// A full package download on a slow tailnet link can take hours; the
 /// detached monitor must outlive the interactive 30-minute stream timeout.
-pub(crate) const DETACHED_INSTALL_MONITOR_TIMEOUT: Duration = Duration::from_mins(360);
+pub(crate) const DETACHED_INSTALL_MONITOR_TIMEOUT: Duration = Duration::from_hours(6);
 pub(crate) const DETACHED_INSTALL_POLL_INTERVAL: Duration = Duration::from_secs(2);
 /// The status file is the authoritative liveness signal; allow more slack
 /// than the interactive watchdog because every check is a fresh SSH round

--- a/crates/surge-cli/src/commands/install/remote/detached.rs
+++ b/crates/surge-cli/src/commands/install/remote/detached.rs
@@ -344,7 +344,10 @@ mod tests {
     }
 
     #[cfg(unix)]
-    fn script_for_temp_paths(script: &str, base: &Path) -> (String, std::path::PathBuf, std::path::PathBuf, std::path::PathBuf) {
+    fn script_for_temp_paths(
+        script: &str,
+        base: &Path,
+    ) -> (String, std::path::PathBuf, std::path::PathBuf, std::path::PathBuf) {
         let log_path = base.join(".surge-installer.log");
         let pid_path = base.join(".surge-installer.pid");
         let bin_path = base.join(".surge-installer");
@@ -359,13 +362,15 @@ mod tests {
     #[test]
     fn detached_launch_command_runs_installer_detached_and_reports_pid() {
         let temp_dir = tempfile::tempdir().expect("tempdir");
-        let (script, bin_path, log_path, pid_path) = script_for_temp_paths(
-            &build_remote_detached_install_launch_command(""),
-            temp_dir.path(),
-        );
+        let (script, bin_path, log_path, pid_path) =
+            script_for_temp_paths(&build_remote_detached_install_launch_command(""), temp_dir.path());
 
         // Fake installer: reports start/end and stays alive long enough to probe.
-        std::fs::write(&bin_path, "#!/bin/sh\necho installer-started\nsleep 1\necho installer-done\n").unwrap();
+        std::fs::write(
+            &bin_path,
+            "#!/bin/sh\necho installer-started\nsleep 1\necho installer-done\n",
+        )
+        .unwrap();
         use std::os::unix::fs::PermissionsExt;
         std::fs::set_permissions(&bin_path, std::fs::Permissions::from_mode(0o755)).unwrap();
 
@@ -379,7 +384,10 @@ mod tests {
         assert!(output.status.success(), "script failed: {stdout}");
         assert!(stdout.contains("launched "), "expected a launched pid, got: {stdout}");
 
-        let pid = std::fs::read_to_string(&pid_path).expect("pidfile written").trim().to_string();
+        let pid = std::fs::read_to_string(&pid_path)
+            .expect("pidfile written")
+            .trim()
+            .to_string();
         assert!(!pid.is_empty());
         let pid_alive = |pid: &str| {
             std::process::Command::new("kill")

--- a/crates/surge-cli/src/commands/install/remote/execution.rs
+++ b/crates/surge-cli/src/commands/install/remote/execution.rs
@@ -143,6 +143,9 @@ pub(crate) async fn stream_directory_entries_to_tailscale_node_with_command(
         if entries.len() == 1 { "y" } else { "ies" }
     );
     let transfer_spinner = make_spinner(&transfer_message);
+    let transfer_started_at = Instant::now();
+    let mut total_streamed = 0_u64;
+    let mut slow_link_warned = false;
     let transfer_result: Result<()> = async {
         let mut buffer = vec![0_u8; 128 * 1024];
         loop {
@@ -159,8 +162,20 @@ pub(crate) async fn stream_directory_entries_to_tailscale_node_with_command(
                 format!("streaming selected staged entries to '{node}'"),
             )
             .await?;
+            total_streamed = total_streamed.saturating_add(u64::try_from(read_bytes).unwrap_or(0));
             if let Some(spinner) = transfer_spinner.as_ref() {
                 spinner.tick();
+            }
+            if !slow_link_warned && transfer_started_at.elapsed() >= std::time::Duration::from_secs(45) {
+                let elapsed_secs = transfer_started_at.elapsed().as_secs_f64().max(1.0);
+                let rate = total_streamed as f64 / elapsed_secs;
+                if rate < 32_000.0 {
+                    slow_link_warned = true;
+                    logline::warn(&format!(
+                        "Slow transfer to '{node}' (~{} B/s). The transfer is resumable: if it is interrupted, re-run the same command to continue where it left off.",
+                        rate.round()
+                    ));
+                }
             }
         }
         await_transfer_progress(

--- a/crates/surge-cli/src/commands/install/remote/mod.rs
+++ b/crates/surge-cli/src/commands/install/remote/mod.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::cast_precision_loss, clippy::too_many_lines)]
 
 mod activation;
+mod detached;
 mod execution;
 mod installer_stage;
 mod published_installer;
@@ -24,10 +25,7 @@ use crate::commands::pack;
 use serde::Deserialize;
 use surge_core::update::manager::ApplyStrategy;
 
-pub(crate) use self::execution::{
-    REMOTE_INSTALLER_FINAL_PATH, resolve_tailscale_targets, run_tailscale_capture, run_tailscale_streaming,
-    run_tailscale_streaming_with_status_watchdog,
-};
+pub(crate) use self::execution::{resolve_tailscale_targets, run_tailscale_capture, run_tailscale_streaming};
 pub(crate) use self::published_installer::{
     build_installer_for_tailscale, missing_remote_installer_error, plan_remote_published_installer,
     plan_remote_published_installer_without_manifest, try_prepare_published_installer_for_tailscale,
@@ -46,7 +44,7 @@ pub(crate) use self::types::{
     RemoteTailscaleCachedState, RemoteTailscaleOperation, RemoteTailscaleTransferInputs,
     RemoteTailscaleTransferStrategy, ensure_supported_tailscale_rid,
 };
-pub(crate) use self::watchdog::RemoteSetupWatchdog;
+pub(crate) use self::watchdog::{RemoteSetupWatchdog, read_remote_update_status_file};
 
 #[cfg(test)]
 pub(crate) use self::activation::build_remote_app_copy_activation_script;
@@ -407,20 +405,84 @@ pub(super) async fn install_release_via_tailscale(
     } else {
         ""
     };
-    let run_cmd = format!(
-        "{REMOTE_INSTALLER_FINAL_PATH}{no_start_flag}{stage_flag}{reinstall_flag} && rm -f {REMOTE_INSTALLER_FINAL_PATH}"
-    );
-    let ssh_command = format!("sh -lc {}", shell_single_quote(&run_cmd));
-    if behavior.mode.is_stage() {
-        logline::info(&format!("Running installer in stage mode on '{file_target}'..."));
-    } else {
-        logline::info(&format!("Running installer on '{file_target}'..."));
-    }
     let remote_home = execution::detect_remote_home_directory(ssh_target).await?;
     let install_root_for_watchdog = staging::remote_install_root(&remote_home, app_id, &release.install_directory)?;
-    let watchdog = RemoteSetupWatchdog::new(ssh_target, &install_root_for_watchdog);
-    run_tailscale_streaming_with_status_watchdog(&["ssh", ssh_target, ssh_command.as_str()], "remote", watchdog)
+
+    // Reattach before staging: if a previously launched detached installer is
+    // still running, watch that install instead of starting a new one. This
+    // is what makes "re-run the same command" recover an install whose local
+    // orchestrator died instead of discarding progress.
+    let mut watch_log_offset = 0_u64;
+    let mut reattached = false;
+    let probe = detached::probe_remote_detached_install(ssh_target).await?;
+    if probe.alive {
+        let status_in_progress = read_remote_update_status_file(ssh_target, &install_root_for_watchdog)
+            .await?
+            .is_some_and(|status| status.state == "in_progress");
+        if status_in_progress {
+            logline::info(&format!(
+                "Detected a detached remote installer still running on '{file_target}' (pid {}); reattaching instead of starting a new install.",
+                probe.pid.as_deref().unwrap_or("unknown")
+            ));
+            watch_log_offset = probe.log_size;
+            reattached = true;
+        } else {
+            logline::warn(&format!(
+                "Found a leftover remote installer process on '{file_target}' without an in-progress install; stopping it before a fresh install."
+            ));
+            detached::stop_remote_detached_install(ssh_target).await?;
+        }
+    } else if let Some(status) = read_remote_update_status_file(ssh_target, &install_root_for_watchdog).await?
+        && status.state == "in_progress"
+    {
+        logline::warn(&format!(
+            "The previous remote installer on '{file_target}' exited without converging; starting a fresh install."
+        ));
+        if let Some(tail) = detached::read_remote_detached_install_tail(ssh_target).await {
+            logline::warn(&format!("Last installer log lines before the failure:\n{tail}"));
+        }
+    }
+
+    if !reattached {
+        warn_remote_full_download_downtime(
+            file_target,
+            app_id,
+            convergence_plan.action,
+            release,
+            behavior.mode.is_stage(),
+        );
+        if behavior.mode.is_stage() {
+            logline::info(&format!("Running installer in stage mode on '{file_target}'..."));
+        } else {
+            logline::info(&format!("Running installer on '{file_target}'..."));
+        }
+        stage_installer_file_for_tailscale(
+            ssh_target,
+            file_target,
+            &installer_path,
+            installer_size,
+            &installer_sha256,
+        )
         .await?;
+
+        // Launch the installer detached from this SSH session so a local
+        // orchestrator death cannot strand the node: the installer keeps
+        // running node-locally and this process only watches it.
+        let install_flags = format!("{no_start_flag}{stage_flag}{reinstall_flag}");
+        let launch_script = detached::build_remote_detached_install_launch_command(&install_flags);
+        let ssh_command = format!("sh -lc {}", shell_single_quote(&launch_script));
+        let launch_output = execution::run_tailscale_capture(&["ssh", ssh_target, ssh_command.as_str()]).await?;
+        logline::info(&format!(
+            "Remote installer launched on '{file_target}' ({}); the install will continue if this connection drops.",
+            launch_output.trim()
+        ));
+    }
+
+    detached::watch_remote_detached_install(ssh_target, file_target, &install_root_for_watchdog, watch_log_offset)
+        .await?;
+    if let Err(error) = detached::cleanup_remote_detached_install(ssh_target).await {
+        logline::warn(&format!("Could not remove remote installer transfer helpers: {error}"));
+    }
     if !behavior.mode.is_stage() {
         warn_if_remote_stage_cleanup_fails(ssh_target, app_id, release).await;
         verify_remote_runtime_after_install(
@@ -555,4 +617,36 @@ fn update_strategy_label(strategy: ApplyStrategy) -> &'static str {
         ApplyStrategy::Full => "full package",
         ApplyStrategy::Delta => "delta",
     }
+}
+
+/// Full-package transfers on a slow tailnet link take a long time, and a
+/// direct (non-staged) install keeps the app down for the whole transfer.
+/// Steer slow-link operators toward the staged flow, which downloads while
+/// the app stays up and cuts over quickly.
+const SLOW_LINK_STAGE_GUIDANCE_MIN_BYTES: i64 = 50 * 1024 * 1024;
+
+fn warn_remote_full_download_downtime(
+    file_target: &str,
+    app_id: &str,
+    action: RemoteConvergenceAction,
+    release: &ReleaseEntry,
+    stage_mode: bool,
+) {
+    if stage_mode {
+        return;
+    }
+    let stops_running_app = matches!(
+        action,
+        RemoteConvergenceAction::Reinstall | RemoteConvergenceAction::Update
+    );
+    if !stops_running_app || release.full_size < SLOW_LINK_STAGE_GUIDANCE_MIN_BYTES {
+        return;
+    }
+    logline::warn(&format!(
+        "This install will stop '{app_id}' on '{file_target}' and transfer {} over the tailscale link before the app comes back.",
+        crate::formatters::format_bytes(u64::try_from(release.full_size).unwrap_or(0))
+    ));
+    logline::warn(
+        "On a slow link that can take a long time. To keep the app up during the transfer, run the same command with --stage first, then re-run it to cut over.",
+    );
 }

--- a/crates/surge-cli/src/commands/install/remote/mod.rs
+++ b/crates/surge-cli/src/commands/install/remote/mod.rs
@@ -5,6 +5,7 @@ mod detached;
 mod execution;
 mod installer_stage;
 mod published_installer;
+mod reporting;
 mod runtime;
 mod stage_manifest;
 mod staging;
@@ -23,7 +24,6 @@ use super::{
 };
 use crate::commands::pack;
 use serde::Deserialize;
-use surge_core::update::manager::ApplyStrategy;
 
 pub(crate) use self::execution::{resolve_tailscale_targets, run_tailscale_capture, run_tailscale_streaming};
 pub(crate) use self::published_installer::{
@@ -109,7 +109,7 @@ pub(super) async fn install_release_via_tailscale(
         installer_mode,
         behavior.force,
     )?;
-    log_remote_convergence_plan(file_target, app_id, channel, release, &convergence_plan);
+    reporting::log_remote_convergence_plan(file_target, app_id, channel, release, &convergence_plan);
 
     if convergence_plan.action == RemoteConvergenceAction::Skip {
         logline::success(&format!(
@@ -444,7 +444,7 @@ pub(super) async fn install_release_via_tailscale(
     }
 
     if !reattached {
-        warn_remote_full_download_downtime(
+        reporting::warn_remote_full_download_downtime(
             file_target,
             app_id,
             convergence_plan.action,
@@ -511,142 +511,4 @@ pub(super) async fn install_release_via_tailscale(
     }
 
     Ok(())
-}
-
-fn log_remote_convergence_plan(
-    file_target: &str,
-    app_id: &str,
-    channel: &str,
-    release: &ReleaseEntry,
-    plan: &RemoteConvergencePlan,
-) {
-    let installed = plan.installed_version.as_deref().unwrap_or("<none>");
-    logline::info(&format!(
-        "Remote install plan for '{app_id}' on '{file_target}': {} ({} -> {}, channel '{channel}').",
-        remote_action_label(plan.action),
-        installed,
-        plan.target_version
-    ));
-
-    match plan.action {
-        RemoteConvergenceAction::Update => {
-            if let Some(update) = &plan.update_info {
-                let artifacts = selected_update_artifact_labels(update);
-                logline::info(&format!(
-                    "Selected update artifacts: {} ({} total), apply strategy: {}.",
-                    artifacts.join(", "),
-                    crate::formatters::format_bytes(u64::try_from(update.download_size.max(0)).unwrap_or(0)),
-                    update_strategy_label(update.apply_strategy)
-                ));
-                if let Some(reason) = &update.fallback_reason {
-                    logline::warn(&format!("Delta update unavailable; full package selected: {reason}"));
-                }
-            } else if let Some(reason) = &plan.reason {
-                logline::warn(&format!(
-                    "Update plan unavailable; full install transfer will be used: {reason}"
-                ));
-            }
-        }
-        RemoteConvergenceAction::CleanInstall | RemoteConvergenceAction::Reinstall => {
-            logline::info(&format!(
-                "Selected install artifact: {} ({}), transfer/apply strategy: full installer.",
-                release.full_filename,
-                crate::formatters::format_bytes(u64::try_from(release.full_size.max(0)).unwrap_or(0))
-            ));
-            if let Some(reason) = &plan.reason {
-                logline::info(&format!("Plan reason: {reason}"));
-            }
-        }
-        RemoteConvergenceAction::RepairMetadata => {
-            logline::info("Selected action only repairs runtime metadata; no package artifact should be downloaded.");
-        }
-        RemoteConvergenceAction::ConvergeRuntime => {
-            if let Some(reason) = &plan.reason {
-                logline::info(&format!("Plan reason: {reason}"));
-            }
-            logline::info(
-                "Selected action verifies runtime state and restarts the supervisor only if runtime proof is missing.",
-            );
-        }
-        RemoteConvergenceAction::Skip => {}
-    }
-}
-
-fn selected_update_artifact_labels(update: &surge_core::update::manager::UpdateInfo) -> Vec<String> {
-    if matches!(update.apply_strategy, ApplyStrategy::Delta) {
-        update
-            .apply_releases
-            .iter()
-            .filter_map(ReleaseEntry::selected_delta)
-            .map(|delta| {
-                format!(
-                    "{} ({})",
-                    delta.filename,
-                    crate::formatters::format_bytes(u64::try_from(delta.size.max(0)).unwrap_or(0))
-                )
-            })
-            .collect()
-    } else {
-        update
-            .apply_releases
-            .last()
-            .map(|release| {
-                vec![format!(
-                    "{} ({})",
-                    release.full_filename,
-                    crate::formatters::format_bytes(u64::try_from(release.full_size.max(0)).unwrap_or(0))
-                )]
-            })
-            .unwrap_or_default()
-    }
-}
-
-fn remote_action_label(action: RemoteConvergenceAction) -> &'static str {
-    match action {
-        RemoteConvergenceAction::CleanInstall => "clean install",
-        RemoteConvergenceAction::Update => "update existing install",
-        RemoteConvergenceAction::RepairMetadata => "repair runtime metadata",
-        RemoteConvergenceAction::ConvergeRuntime => "converge runtime",
-        RemoteConvergenceAction::Reinstall => "reinstall",
-        RemoteConvergenceAction::Skip => "skip",
-    }
-}
-
-fn update_strategy_label(strategy: ApplyStrategy) -> &'static str {
-    match strategy {
-        ApplyStrategy::Full => "full package",
-        ApplyStrategy::Delta => "delta",
-    }
-}
-
-/// Full-package transfers on a slow tailnet link take a long time, and a
-/// direct (non-staged) install keeps the app down for the whole transfer.
-/// Steer slow-link operators toward the staged flow, which downloads while
-/// the app stays up and cuts over quickly.
-const SLOW_LINK_STAGE_GUIDANCE_MIN_BYTES: i64 = 50 * 1024 * 1024;
-
-fn warn_remote_full_download_downtime(
-    file_target: &str,
-    app_id: &str,
-    action: RemoteConvergenceAction,
-    release: &ReleaseEntry,
-    stage_mode: bool,
-) {
-    if stage_mode {
-        return;
-    }
-    let stops_running_app = matches!(
-        action,
-        RemoteConvergenceAction::Reinstall | RemoteConvergenceAction::Update
-    );
-    if !stops_running_app || release.full_size < SLOW_LINK_STAGE_GUIDANCE_MIN_BYTES {
-        return;
-    }
-    logline::warn(&format!(
-        "This install will stop '{app_id}' on '{file_target}' and transfer {} over the tailscale link before the app comes back.",
-        crate::formatters::format_bytes(u64::try_from(release.full_size).unwrap_or(0))
-    ));
-    logline::warn(
-        "On a slow link that can take a long time. To keep the app up during the transfer, run the same command with --stage first, then re-run it to cut over.",
-    );
 }

--- a/crates/surge-cli/src/commands/install/remote/reporting.rs
+++ b/crates/surge-cli/src/commands/install/remote/reporting.rs
@@ -1,0 +1,143 @@
+//! Convergence-plan reporting and slow-link stage guidance for remote
+//! installs, split out of the orchestration module.
+
+use super::{ReleaseEntry, RemoteConvergenceAction, RemoteConvergencePlan, logline};
+use surge_core::update::manager::ApplyStrategy;
+
+pub(crate) fn log_remote_convergence_plan(
+    file_target: &str,
+    app_id: &str,
+    channel: &str,
+    release: &ReleaseEntry,
+    plan: &RemoteConvergencePlan,
+) {
+    let installed = plan.installed_version.as_deref().unwrap_or("<none>");
+    logline::info(&format!(
+        "Remote install plan for '{app_id}' on '{file_target}': {} ({} -> {}, channel '{channel}').",
+        remote_action_label(plan.action),
+        installed,
+        plan.target_version
+    ));
+
+    match plan.action {
+        RemoteConvergenceAction::Update => {
+            if let Some(update) = &plan.update_info {
+                let artifacts = selected_update_artifact_labels(update);
+                logline::info(&format!(
+                    "Selected update artifacts: {} ({} total), apply strategy: {}.",
+                    artifacts.join(", "),
+                    crate::formatters::format_bytes(u64::try_from(update.download_size.max(0)).unwrap_or(0)),
+                    update_strategy_label(update.apply_strategy)
+                ));
+                if let Some(reason) = &update.fallback_reason {
+                    logline::warn(&format!("Delta update unavailable; full package selected: {reason}"));
+                }
+            } else if let Some(reason) = &plan.reason {
+                logline::warn(&format!(
+                    "Update plan unavailable; full install transfer will be used: {reason}"
+                ));
+            }
+        }
+        RemoteConvergenceAction::CleanInstall | RemoteConvergenceAction::Reinstall => {
+            logline::info(&format!(
+                "Selected install artifact: {} ({}), transfer/apply strategy: full installer.",
+                release.full_filename,
+                crate::formatters::format_bytes(u64::try_from(release.full_size.max(0)).unwrap_or(0))
+            ));
+            if let Some(reason) = &plan.reason {
+                logline::info(&format!("Plan reason: {reason}"));
+            }
+        }
+        RemoteConvergenceAction::RepairMetadata => {
+            logline::info("Selected action only repairs runtime metadata; no package artifact should be downloaded.");
+        }
+        RemoteConvergenceAction::ConvergeRuntime => {
+            if let Some(reason) = &plan.reason {
+                logline::info(&format!("Plan reason: {reason}"));
+            }
+            logline::info(
+                "Selected action verifies runtime state and restarts the supervisor only if runtime proof is missing.",
+            );
+        }
+        RemoteConvergenceAction::Skip => {}
+    }
+}
+
+pub(crate) fn selected_update_artifact_labels(update: &surge_core::update::manager::UpdateInfo) -> Vec<String> {
+    if matches!(update.apply_strategy, ApplyStrategy::Delta) {
+        update
+            .apply_releases
+            .iter()
+            .filter_map(ReleaseEntry::selected_delta)
+            .map(|delta| {
+                format!(
+                    "{} ({})",
+                    delta.filename,
+                    crate::formatters::format_bytes(u64::try_from(delta.size.max(0)).unwrap_or(0))
+                )
+            })
+            .collect()
+    } else {
+        update
+            .apply_releases
+            .last()
+            .map(|release| {
+                vec![format!(
+                    "{} ({})",
+                    release.full_filename,
+                    crate::formatters::format_bytes(u64::try_from(release.full_size.max(0)).unwrap_or(0))
+                )]
+            })
+            .unwrap_or_default()
+    }
+}
+
+pub(crate) fn remote_action_label(action: RemoteConvergenceAction) -> &'static str {
+    match action {
+        RemoteConvergenceAction::CleanInstall => "clean install",
+        RemoteConvergenceAction::Update => "update existing install",
+        RemoteConvergenceAction::RepairMetadata => "repair runtime metadata",
+        RemoteConvergenceAction::ConvergeRuntime => "converge runtime",
+        RemoteConvergenceAction::Reinstall => "reinstall",
+        RemoteConvergenceAction::Skip => "skip",
+    }
+}
+
+pub(crate) fn update_strategy_label(strategy: ApplyStrategy) -> &'static str {
+    match strategy {
+        ApplyStrategy::Full => "full package",
+        ApplyStrategy::Delta => "delta",
+    }
+}
+
+/// Full-package transfers on a slow tailnet link take a long time, and a
+/// direct (non-staged) install keeps the app down for the whole transfer.
+/// Steer slow-link operators toward the staged flow, which downloads while
+/// the app stays up and cuts over quickly.
+const SLOW_LINK_STAGE_GUIDANCE_MIN_BYTES: i64 = 50 * 1024 * 1024;
+
+pub(crate) fn warn_remote_full_download_downtime(
+    file_target: &str,
+    app_id: &str,
+    action: RemoteConvergenceAction,
+    release: &ReleaseEntry,
+    stage_mode: bool,
+) {
+    if stage_mode {
+        return;
+    }
+    let stops_running_app = matches!(
+        action,
+        RemoteConvergenceAction::Reinstall | RemoteConvergenceAction::Update
+    );
+    if !stops_running_app || release.full_size < SLOW_LINK_STAGE_GUIDANCE_MIN_BYTES {
+        return;
+    }
+    logline::warn(&format!(
+        "This install will stop '{app_id}' on '{file_target}' and transfer {} over the tailscale link before the app comes back.",
+        crate::formatters::format_bytes(u64::try_from(release.full_size).unwrap_or(0))
+    ));
+    logline::warn(
+        "On a slow link that can take a long time. To keep the app up during the transfer, run the same command with --stage first, then re-run it to cut over.",
+    );
+}

--- a/crates/surge-cli/src/commands/install/remote/watchdog.rs
+++ b/crates/surge-cli/src/commands/install/remote/watchdog.rs
@@ -47,7 +47,7 @@ pub(super) async fn wait_for_tailscale_command_with_status_watchdog(
         }
 
         if last_progress_at.elapsed() >= watchdog.stale_timeout {
-            let status = read_remote_update_status(watchdog).await?;
+            let status = read_remote_update_status_file(&watchdog.ssh_node, &watchdog.install_root).await?;
             if let Some(status) = status.as_ref() {
                 if status.is_terminal_failure() {
                     let _ = child.kill().await;
@@ -85,14 +85,17 @@ pub(super) async fn wait_for_tailscale_command_with_status_watchdog(
     }
 }
 
-async fn read_remote_update_status(watchdog: &RemoteSetupWatchdog) -> Result<Option<RemoteUpdateStatusSnapshot>> {
-    let status_path = watchdog.install_root.join(UPDATE_STATUS_FILE_NAME);
+pub(crate) async fn read_remote_update_status_file(
+    ssh_node: &str,
+    install_root: &Path,
+) -> Result<Option<RemoteUpdateStatusSnapshot>> {
+    let status_path = install_root.join(UPDATE_STATUS_FILE_NAME);
     let script = format!(
         "status_path={}; if [ -f \"$status_path\" ]; then cat \"$status_path\"; fi",
         shell_single_quote(&status_path.to_string_lossy())
     );
     let command = format!("sh -c {}", shell_single_quote(&script));
-    let raw = run_tailscale_capture(&["ssh", watchdog.ssh_node.as_str(), command.as_str()]).await?;
+    let raw = run_tailscale_capture(&["ssh", ssh_node, command.as_str()]).await?;
     let trimmed = raw.trim();
     if trimmed.is_empty() {
         return Ok(None);
@@ -103,8 +106,8 @@ async fn read_remote_update_status(watchdog: &RemoteSetupWatchdog) -> Result<Opt
 }
 
 #[derive(Debug, Deserialize)]
-struct RemoteUpdateStatusSnapshot {
-    state: String,
+pub(crate) struct RemoteUpdateStatusSnapshot {
+    pub(crate) state: String,
     #[serde(default)]
     reason: Option<String>,
     #[serde(default)]
@@ -120,7 +123,11 @@ struct RemoteUpdateStatusSnapshot {
 }
 
 impl RemoteUpdateStatusSnapshot {
-    fn has_recent_progress(&self, stale_timeout: Duration) -> bool {
+    pub(crate) fn is_terminal_success(&self) -> bool {
+        self.state == "converged"
+    }
+
+    pub(crate) fn has_recent_progress(&self, stale_timeout: Duration) -> bool {
         let Some(last_progress_at_utc) = self.last_progress_at_utc.as_deref() else {
             return false;
         };
@@ -140,7 +147,7 @@ impl RemoteUpdateStatusSnapshot {
         self.state == "failed" || self.state == "pending_restart"
     }
 
-    fn format_context(&self) -> String {
+    pub(crate) fn format_context(&self) -> String {
         let mut parts = vec![format!("state={}", self.state)];
         if let Some(phase) = self
             .failure_phase

--- a/crates/surge-core/src/storage/mod.rs
+++ b/crates/surge-core/src/storage/mod.rs
@@ -3,6 +3,7 @@ pub mod filesystem;
 pub mod gcs;
 pub mod github_releases;
 pub mod s3;
+mod s3_wire;
 
 use crate::context::{StorageConfig, StorageProvider};
 use crate::error::{Result, SurgeError};

--- a/crates/surge-core/src/storage/s3.rs
+++ b/crates/surge-core/src/storage/s3.rs
@@ -12,7 +12,27 @@ use crate::context::StorageConfig;
 use crate::crypto::hmac_sha256::hmac_sha256;
 use crate::crypto::sha256::sha256_hex;
 use crate::error::{Result, SurgeError};
-use crate::storage::{ListEntry, ListResult, ObjectInfo, StorageBackend, TransferProgress, download_response_to_file};
+use crate::storage::{
+    ListEntry, ListResult, ObjectInfo, StorageBackend, TransferProgress, download_response_to_file,
+    download_response_to_file_from_offset,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ResumableDownloadResponseAction {
+    AppendFromOffset,
+    RestartFromZero,
+    Error,
+}
+
+fn resumable_download_response_action(status: reqwest::StatusCode) -> ResumableDownloadResponseAction {
+    if status == reqwest::StatusCode::PARTIAL_CONTENT {
+        ResumableDownloadResponseAction::AppendFromOffset
+    } else if status.is_success() {
+        ResumableDownloadResponseAction::RestartFromZero
+    } else {
+        ResumableDownloadResponseAction::Error
+    }
+}
 
 /// Characters that must NOT be percent-encoded in S3 URI paths (RFC 3986 unreserved + '/').
 const URI_ENCODE_SET: &AsciiSet = &NON_ALPHANUMERIC.remove(b'-').remove(b'.').remove(b'_').remove(b'~');
@@ -175,14 +195,28 @@ impl S3Backend {
         canonical_querystring: &str,
         payload_hash: &str,
         now: &chrono::DateTime<Utc>,
+        extra_headers: &[(String, String)],
     ) -> Vec<(String, String)> {
         let amz_date = now.format("%Y%m%dT%H%M%SZ").to_string();
         let date_stamp = now.format("%Y%m%d").to_string();
         let host = self.host_header();
 
         // Canonical headers (must be sorted by lowercase header name).
-        let canonical_headers = format!("host:{host}\nx-amz-content-sha256:{payload_hash}\nx-amz-date:{amz_date}\n");
-        let signed_headers = "host;x-amz-content-sha256;x-amz-date";
+        let mut header_lines = vec![format!("host:{host}")];
+        let mut signed_header_names: Vec<String> = vec!["host".to_string()];
+        for (name, value) in extra_headers {
+            let lower = name.to_ascii_lowercase();
+            header_lines.push(format!("{lower}:{value}"));
+            signed_header_names.push(lower);
+        }
+        header_lines.push(format!("x-amz-content-sha256:{payload_hash}"));
+        signed_header_names.push("x-amz-content-sha256".to_string());
+        header_lines.push(format!("x-amz-date:{amz_date}"));
+        signed_header_names.push("x-amz-date".to_string());
+        header_lines.sort();
+        signed_header_names.sort();
+        let canonical_headers = format!("{}\n", header_lines.join("\n"));
+        let signed_headers = signed_header_names.join(";");
 
         // Canonical request.
         let canonical_request = format!(
@@ -255,7 +289,7 @@ impl StorageBackend for S3Backend {
             format!("/{}", Self::encode_uri_path(&full_key))
         };
 
-        let headers = self.sign_request("PUT", &canonical_uri, "", &payload_hash, &now);
+        let headers = self.sign_request("PUT", &canonical_uri, "", &payload_hash, &now, &[]);
 
         let mut req = self.client.put(&url).body(data.to_vec());
         req = req.header("Content-Type", content_type);
@@ -285,7 +319,7 @@ impl StorageBackend for S3Backend {
             } else {
                 format!("/{}", Self::encode_uri_path(&full_key))
             };
-            let headers = self.sign_request("GET", &canonical_uri, "", &payload_hash, &now);
+            let headers = self.sign_request("GET", &canonical_uri, "", &payload_hash, &now, &[]);
             for (name, value) in &headers {
                 req = req.header(name.as_str(), value.as_str());
             }
@@ -318,7 +352,7 @@ impl StorageBackend for S3Backend {
             } else {
                 format!("/{}", Self::encode_uri_path(&full_key))
             };
-            let headers = self.sign_request("HEAD", &canonical_uri, "", &payload_hash, &now);
+            let headers = self.sign_request("HEAD", &canonical_uri, "", &payload_hash, &now, &[]);
             for (name, value) in &headers {
                 req = req.header(name.as_str(), value.as_str());
             }
@@ -378,7 +412,7 @@ impl StorageBackend for S3Backend {
             format!("/{}", Self::encode_uri_path(&full_key))
         };
 
-        let headers = self.sign_request("DELETE", &canonical_uri, "", &payload_hash, &now);
+        let headers = self.sign_request("DELETE", &canonical_uri, "", &payload_hash, &now, &[]);
 
         let mut req = self.client.delete(&url);
         for (name, value) in &headers {
@@ -428,7 +462,7 @@ impl StorageBackend for S3Backend {
             } else {
                 "/".to_string()
             };
-            let headers = self.sign_request("GET", &canonical_uri, &canonical_querystring, &payload_hash, &now);
+            let headers = self.sign_request("GET", &canonical_uri, &canonical_querystring, &payload_hash, &now, &[]);
             for (name, value) in &headers {
                 req = req.header(name.as_str(), value.as_str());
             }
@@ -458,7 +492,7 @@ impl StorageBackend for S3Backend {
             } else {
                 format!("/{}", Self::encode_uri_path(&full_key))
             };
-            let headers = self.sign_request("GET", &canonical_uri, "", &payload_hash, &now);
+            let headers = self.sign_request("GET", &canonical_uri, "", &payload_hash, &now, &[]);
             for (name, value) in &headers {
                 req = req.header(name.as_str(), value.as_str());
             }
@@ -479,6 +513,78 @@ impl StorageBackend for S3Backend {
         Ok(())
     }
 
+    fn supports_resumable_downloads(&self) -> bool {
+        true
+    }
+
+    async fn download_to_file_from_offset(
+        &self,
+        key: &str,
+        dest: &Path,
+        offset: u64,
+        progress: Option<&TransferProgress<'_>>,
+    ) -> Result<()> {
+        if offset == 0 {
+            return self.download_to_file(key, dest, progress).await;
+        }
+
+        let full_key = self.full_key(key);
+        let url = self.object_url(&full_key);
+        let range_header = format!("bytes={offset}-");
+
+        let mut req = self
+            .client
+            .get(&url)
+            .header(reqwest::header::RANGE, range_header.as_str());
+        if self.has_credentials() {
+            let payload_hash = sha256_hex(b"");
+            let now = Utc::now();
+            let canonical_uri = if self.path_style {
+                format!("/{}/{}", self.bucket, Self::encode_uri_path(&full_key))
+            } else {
+                format!("/{}/", Self::encode_uri_path(&full_key))
+            };
+            let headers = self.sign_request(
+                "GET",
+                &canonical_uri,
+                "",
+                &payload_hash,
+                &now,
+                &[("range".to_string(), range_header.clone())],
+            );
+            for (name, value) in &headers {
+                req = req.header(name.as_str(), value.as_str());
+            }
+        } else {
+            req = req.header("Host", self.host_header());
+        }
+
+        let resp = req.send().await?;
+        let status = resp.status();
+        match resumable_download_response_action(status) {
+            ResumableDownloadResponseAction::AppendFromOffset => {
+                download_response_to_file_from_offset(resp, dest, offset, progress).await?;
+            }
+            ResumableDownloadResponseAction::RestartFromZero => {
+                debug!(
+                    key = %full_key,
+                    dest = %dest.display(),
+                    offset,
+                    status = %status,
+                    "S3 endpoint ignored resumable range request; restarting download from byte zero"
+                );
+                download_response_to_file(resp, dest, progress).await?;
+            }
+            ResumableDownloadResponseAction::Error => {
+                let body = resp.text().await.unwrap_or_default();
+                return Self::check_response_status(status, &full_key, &body);
+            }
+        }
+
+        debug!(key = %full_key, dest = %dest.display(), offset, "S3 resumable download completed");
+        Ok(())
+    }
+
     async fn upload_from_file(&self, key: &str, src: &Path, progress: Option<&TransferProgress<'_>>) -> Result<()> {
         self.require_credentials("upload")?;
         let data = tokio::fs::read(src).await?;
@@ -495,7 +601,7 @@ impl StorageBackend for S3Backend {
             format!("/{}", Self::encode_uri_path(&full_key))
         };
 
-        let headers = self.sign_request("PUT", &canonical_uri, "", &payload_hash, &now);
+        let headers = self.sign_request("PUT", &canonical_uri, "", &payload_hash, &now, &[]);
 
         let mut req = self.client.put(&url).body(data);
         req = req.header("Content-Type", "application/octet-stream");
@@ -591,4 +697,29 @@ fn parse_list_objects_v2_xml(xml: &str) -> Result<ListResult> {
         next_marker,
         is_truncated,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resumable_download_response_action_maps_statuses() {
+        assert_eq!(
+            resumable_download_response_action(reqwest::StatusCode::PARTIAL_CONTENT),
+            ResumableDownloadResponseAction::AppendFromOffset
+        );
+        assert_eq!(
+            resumable_download_response_action(reqwest::StatusCode::OK),
+            ResumableDownloadResponseAction::RestartFromZero
+        );
+        assert_eq!(
+            resumable_download_response_action(reqwest::StatusCode::FORBIDDEN),
+            ResumableDownloadResponseAction::Error
+        );
+        assert_eq!(
+            resumable_download_response_action(reqwest::StatusCode::NOT_FOUND),
+            ResumableDownloadResponseAction::Error
+        );
+    }
 }

--- a/crates/surge-core/src/storage/s3.rs
+++ b/crates/surge-core/src/storage/s3.rs
@@ -4,16 +4,17 @@ use async_trait::async_trait;
 use std::path::Path;
 
 use chrono::Utc;
-use percent_encoding::{AsciiSet, NON_ALPHANUMERIC, utf8_percent_encode};
+use percent_encoding::utf8_percent_encode;
 use reqwest::Client;
 use tracing::{debug, trace};
 
+use super::s3_wire::{self, URI_ENCODE_PATH_SET};
 use crate::context::StorageConfig;
 use crate::crypto::hmac_sha256::hmac_sha256;
 use crate::crypto::sha256::sha256_hex;
 use crate::error::{Result, SurgeError};
 use crate::storage::{
-    ListEntry, ListResult, ObjectInfo, StorageBackend, TransferProgress, download_response_to_file,
+    ListResult, ObjectInfo, StorageBackend, TransferProgress, download_response_to_file,
     download_response_to_file_from_offset,
 };
 
@@ -33,17 +34,6 @@ fn resumable_download_response_action(status: reqwest::StatusCode) -> ResumableD
         ResumableDownloadResponseAction::Error
     }
 }
-
-/// Characters that must NOT be percent-encoded in S3 URI paths (RFC 3986 unreserved + '/').
-const URI_ENCODE_SET: &AsciiSet = &NON_ALPHANUMERIC.remove(b'-').remove(b'.').remove(b'_').remove(b'~');
-
-/// Same set but also preserves '/' (used for path components).
-const URI_ENCODE_PATH_SET: &AsciiSet = &NON_ALPHANUMERIC
-    .remove(b'-')
-    .remove(b'.')
-    .remove(b'_')
-    .remove(b'~')
-    .remove(b'/');
 
 /// S3-compatible storage backend.
 pub struct S3Backend {
@@ -249,29 +239,6 @@ impl S3Backend {
             ("Authorization".to_string(), authorization),
         ]
     }
-
-    /// URI-encode a single path segment (does not encode '/').
-    fn encode_uri_path(path: &str) -> String {
-        utf8_percent_encode(path, URI_ENCODE_PATH_SET).to_string()
-    }
-
-    /// URI-encode a query parameter value.
-    fn encode_uri_component(value: &str) -> String {
-        utf8_percent_encode(value, URI_ENCODE_SET).to_string()
-    }
-
-    /// Map an HTTP response status to a `SurgeError` when appropriate.
-    fn check_response_status(status: reqwest::StatusCode, key: &str, body: &str) -> Result<()> {
-        if status.is_success() {
-            return Ok(());
-        }
-        if status == reqwest::StatusCode::NOT_FOUND {
-            return Err(SurgeError::NotFound(format!("S3 object not found: {key}")));
-        }
-        Err(SurgeError::Storage(format!(
-            "S3 request failed (HTTP {status}): {body}"
-        )))
-    }
 }
 
 #[async_trait]
@@ -284,9 +251,9 @@ impl StorageBackend for S3Backend {
         let now = Utc::now();
 
         let canonical_uri = if self.path_style {
-            format!("/{}/{}", self.bucket, Self::encode_uri_path(&full_key))
+            format!("/{}/{}", self.bucket, s3_wire::encode_uri_path(&full_key))
         } else {
-            format!("/{}", Self::encode_uri_path(&full_key))
+            format!("/{}", s3_wire::encode_uri_path(&full_key))
         };
 
         let headers = self.sign_request("PUT", &canonical_uri, "", &payload_hash, &now, &[]);
@@ -300,7 +267,7 @@ impl StorageBackend for S3Backend {
         let resp = req.send().await?;
         let status = resp.status();
         let body = resp.text().await.unwrap_or_default();
-        Self::check_response_status(status, &full_key, &body)?;
+        s3_wire::check_response_status(status, &full_key, &body)?;
 
         debug!(key = %full_key, "S3 PUT completed");
         Ok(())
@@ -315,9 +282,9 @@ impl StorageBackend for S3Backend {
             let payload_hash = sha256_hex(b"");
             let now = Utc::now();
             let canonical_uri = if self.path_style {
-                format!("/{}/{}", self.bucket, Self::encode_uri_path(&full_key))
+                format!("/{}/{}", self.bucket, s3_wire::encode_uri_path(&full_key))
             } else {
-                format!("/{}", Self::encode_uri_path(&full_key))
+                format!("/{}", s3_wire::encode_uri_path(&full_key))
             };
             let headers = self.sign_request("GET", &canonical_uri, "", &payload_hash, &now, &[]);
             for (name, value) in &headers {
@@ -332,7 +299,7 @@ impl StorageBackend for S3Backend {
         let bytes = resp.bytes().await?;
         if !status.is_success() {
             let body = String::from_utf8_lossy(&bytes).to_string();
-            Self::check_response_status(status, &full_key, &body)?;
+            s3_wire::check_response_status(status, &full_key, &body)?;
         }
 
         debug!(key = %full_key, size = bytes.len(), "S3 GET completed");
@@ -348,9 +315,9 @@ impl StorageBackend for S3Backend {
             let payload_hash = sha256_hex(b"");
             let now = Utc::now();
             let canonical_uri = if self.path_style {
-                format!("/{}/{}", self.bucket, Self::encode_uri_path(&full_key))
+                format!("/{}/{}", self.bucket, s3_wire::encode_uri_path(&full_key))
             } else {
-                format!("/{}", Self::encode_uri_path(&full_key))
+                format!("/{}", s3_wire::encode_uri_path(&full_key))
             };
             let headers = self.sign_request("HEAD", &canonical_uri, "", &payload_hash, &now, &[]);
             for (name, value) in &headers {
@@ -407,9 +374,9 @@ impl StorageBackend for S3Backend {
         let now = Utc::now();
 
         let canonical_uri = if self.path_style {
-            format!("/{}/{}", self.bucket, Self::encode_uri_path(&full_key))
+            format!("/{}/{}", self.bucket, s3_wire::encode_uri_path(&full_key))
         } else {
-            format!("/{}", Self::encode_uri_path(&full_key))
+            format!("/{}", s3_wire::encode_uri_path(&full_key))
         };
 
         let headers = self.sign_request("DELETE", &canonical_uri, "", &payload_hash, &now, &[]);
@@ -424,7 +391,7 @@ impl StorageBackend for S3Backend {
         // S3 returns 204 for successful DELETE, and does not error on missing keys.
         if !status.is_success() && status != reqwest::StatusCode::NO_CONTENT {
             let body = resp.text().await.unwrap_or_default();
-            Self::check_response_status(status, &full_key, &body)?;
+            s3_wire::check_response_status(status, &full_key, &body)?;
         }
 
         debug!(key = %full_key, "S3 DELETE completed");
@@ -448,7 +415,13 @@ impl StorageBackend for S3Backend {
 
         let canonical_querystring = query_parts
             .iter()
-            .map(|(k, v)| format!("{}={}", Self::encode_uri_component(k), Self::encode_uri_component(v)))
+            .map(|(k, v)| {
+                format!(
+                    "{}={}",
+                    s3_wire::encode_uri_component(k),
+                    s3_wire::encode_uri_component(v)
+                )
+            })
             .collect::<Vec<_>>()
             .join("&");
 
@@ -473,10 +446,10 @@ impl StorageBackend for S3Backend {
         let resp = req.send().await?;
         let status = resp.status();
         let body = resp.text().await.unwrap_or_default();
-        Self::check_response_status(status, &full_prefix, &body)?;
+        s3_wire::check_response_status(status, &full_prefix, &body)?;
 
         // Parse S3 ListObjectsV2 XML response.
-        parse_list_objects_v2_xml(&body)
+        s3_wire::parse_list_objects_v2_xml(&body)
     }
 
     async fn download_to_file(&self, key: &str, dest: &Path, progress: Option<&TransferProgress<'_>>) -> Result<()> {
@@ -488,9 +461,9 @@ impl StorageBackend for S3Backend {
             let payload_hash = sha256_hex(b"");
             let now = Utc::now();
             let canonical_uri = if self.path_style {
-                format!("/{}/{}", self.bucket, Self::encode_uri_path(&full_key))
+                format!("/{}/{}", self.bucket, s3_wire::encode_uri_path(&full_key))
             } else {
-                format!("/{}", Self::encode_uri_path(&full_key))
+                format!("/{}", s3_wire::encode_uri_path(&full_key))
             };
             let headers = self.sign_request("GET", &canonical_uri, "", &payload_hash, &now, &[]);
             for (name, value) in &headers {
@@ -504,7 +477,7 @@ impl StorageBackend for S3Backend {
         let status = resp.status();
         if !status.is_success() {
             let body = resp.text().await.unwrap_or_default();
-            return Self::check_response_status(status, &full_key, &body);
+            return s3_wire::check_response_status(status, &full_key, &body);
         }
 
         download_response_to_file(resp, dest, progress).await?;
@@ -540,9 +513,9 @@ impl StorageBackend for S3Backend {
             let payload_hash = sha256_hex(b"");
             let now = Utc::now();
             let canonical_uri = if self.path_style {
-                format!("/{}/{}", self.bucket, Self::encode_uri_path(&full_key))
+                format!("/{}/{}", self.bucket, s3_wire::encode_uri_path(&full_key))
             } else {
-                format!("/{}/", Self::encode_uri_path(&full_key))
+                format!("/{}/", s3_wire::encode_uri_path(&full_key))
             };
             let headers = self.sign_request(
                 "GET",
@@ -577,7 +550,7 @@ impl StorageBackend for S3Backend {
             }
             ResumableDownloadResponseAction::Error => {
                 let body = resp.text().await.unwrap_or_default();
-                return Self::check_response_status(status, &full_key, &body);
+                return s3_wire::check_response_status(status, &full_key, &body);
             }
         }
 
@@ -596,9 +569,9 @@ impl StorageBackend for S3Backend {
         let now = Utc::now();
 
         let canonical_uri = if self.path_style {
-            format!("/{}/{}", self.bucket, Self::encode_uri_path(&full_key))
+            format!("/{}/{}", self.bucket, s3_wire::encode_uri_path(&full_key))
         } else {
-            format!("/{}", Self::encode_uri_path(&full_key))
+            format!("/{}", s3_wire::encode_uri_path(&full_key))
         };
 
         let headers = self.sign_request("PUT", &canonical_uri, "", &payload_hash, &now, &[]);
@@ -612,91 +585,13 @@ impl StorageBackend for S3Backend {
         let resp = req.send().await?;
         let status = resp.status();
         let body = resp.text().await.unwrap_or_default();
-        Self::check_response_status(status, &full_key, &body)?;
+        s3_wire::check_response_status(status, &full_key, &body)?;
 
         if let Some(cb) = progress {
             cb(total, total);
         }
         Ok(())
     }
-}
-
-// ---------------------------------------------------------------------------
-// XML parsing for S3 ListObjectsV2 response
-// ---------------------------------------------------------------------------
-
-/// Parse a ListObjectsV2 XML response into a `ListResult`.
-fn parse_list_objects_v2_xml(xml: &str) -> Result<ListResult> {
-    use quick_xml::Reader;
-    use quick_xml::events::Event;
-
-    let mut reader = Reader::from_str(xml);
-    let mut buf = Vec::new();
-    let mut entries = Vec::new();
-    let mut next_marker: Option<String> = None;
-    let mut is_truncated = false;
-
-    // State for parsing <Contents> elements.
-    let mut in_contents = false;
-    let mut current_key: Option<String> = None;
-    let mut current_size: Option<i64> = None;
-    let mut current_tag = String::new();
-
-    loop {
-        match reader.read_event_into(&mut buf) {
-            Ok(Event::Start(ref e)) => {
-                let tag = String::from_utf8_lossy(e.name().as_ref()).to_string();
-                if tag == "Contents" {
-                    in_contents = true;
-                    current_key = None;
-                    current_size = None;
-                }
-                current_tag = tag;
-            }
-            Ok(Event::End(ref e)) => {
-                let tag = String::from_utf8_lossy(e.name().as_ref()).to_string();
-                if tag == "Contents" {
-                    if let Some(key) = current_key.take() {
-                        entries.push(ListEntry {
-                            key,
-                            size: current_size.unwrap_or(0),
-                        });
-                    }
-                    in_contents = false;
-                }
-                current_tag.clear();
-            }
-            Ok(Event::Text(ref e)) => {
-                let text = String::from_utf8_lossy(e.as_ref()).to_string();
-                if in_contents {
-                    match current_tag.as_str() {
-                        "Key" => current_key = Some(text),
-                        "Size" => current_size = text.parse::<i64>().ok(),
-                        _ => {}
-                    }
-                } else {
-                    match current_tag.as_str() {
-                        "IsTruncated" => is_truncated = text == "true",
-                        "NextContinuationToken" => next_marker = Some(text),
-                        _ => {}
-                    }
-                }
-            }
-            Ok(Event::Eof) => break,
-            Err(e) => {
-                return Err(SurgeError::Storage(format!("Failed to parse S3 list response: {e}")));
-            }
-            _ => {}
-        }
-        buf.clear();
-    }
-
-    debug!(count = entries.len(), is_truncated, "S3 LIST parsed");
-    Ok(ListResult {
-        entries,
-        next_marker,
-        is_truncated,
-    })
 }
 
 #[cfg(test)]

--- a/crates/surge-core/src/storage/s3_wire.rs
+++ b/crates/surge-core/src/storage/s3_wire.rs
@@ -1,0 +1,117 @@
+//! S3 wire helpers: URI encoding, response-status mapping, and
+//! ListObjectsV2 XML parsing, split out of the backend impl to keep it
+//! under the maintainability line target.
+
+use percent_encoding::{AsciiSet, NON_ALPHANUMERIC, utf8_percent_encode};
+use tracing::debug;
+
+use crate::error::{Result, SurgeError};
+use crate::storage::{ListEntry, ListResult};
+
+/// Characters that must NOT be percent-encoded in S3 URI paths (RFC 3986 unreserved + '/').
+pub(super) const URI_ENCODE_SET: &AsciiSet = &NON_ALPHANUMERIC.remove(b'-').remove(b'.').remove(b'_').remove(b'~');
+
+/// Same set but also preserves '/' (used for path components).
+pub(super) const URI_ENCODE_PATH_SET: &AsciiSet = &NON_ALPHANUMERIC
+    .remove(b'-')
+    .remove(b'.')
+    .remove(b'_')
+    .remove(b'~')
+    .remove(b'/');
+
+/// URI-encode a single path segment (does not encode '/').
+pub(super) fn encode_uri_path(path: &str) -> String {
+    utf8_percent_encode(path, URI_ENCODE_PATH_SET).to_string()
+}
+
+/// URI-encode a query parameter value.
+pub(super) fn encode_uri_component(value: &str) -> String {
+    utf8_percent_encode(value, URI_ENCODE_SET).to_string()
+}
+
+/// Map an HTTP response status to a `SurgeError` when appropriate.
+pub(super) fn check_response_status(status: reqwest::StatusCode, key: &str, body: &str) -> Result<()> {
+    if status.is_success() {
+        return Ok(());
+    }
+    if status == reqwest::StatusCode::NOT_FOUND {
+        return Err(SurgeError::NotFound(format!("S3 object not found: {key}")));
+    }
+    Err(SurgeError::Storage(format!(
+        "S3 request failed (HTTP {status}): {body}"
+    )))
+}
+
+/// Parse a ListObjectsV2 XML response into a `ListResult`.
+pub(super) fn parse_list_objects_v2_xml(xml: &str) -> Result<ListResult> {
+    use quick_xml::Reader;
+    use quick_xml::events::Event;
+
+    let mut reader = Reader::from_str(xml);
+    let mut buf = Vec::new();
+    let mut entries = Vec::new();
+    let mut next_marker: Option<String> = None;
+    let mut is_truncated = false;
+
+    // State for parsing <Contents> elements.
+    let mut in_contents = false;
+    let mut current_key: Option<String> = None;
+    let mut current_size: Option<i64> = None;
+    let mut current_tag = String::new();
+
+    loop {
+        match reader.read_event_into(&mut buf) {
+            Ok(Event::Start(ref e)) => {
+                let tag = String::from_utf8_lossy(e.name().as_ref()).to_string();
+                if tag == "Contents" {
+                    in_contents = true;
+                    current_key = None;
+                    current_size = None;
+                }
+                current_tag = tag;
+            }
+            Ok(Event::End(ref e)) => {
+                let tag = String::from_utf8_lossy(e.name().as_ref()).to_string();
+                if tag == "Contents" {
+                    if let Some(key) = current_key.take() {
+                        entries.push(ListEntry {
+                            key,
+                            size: current_size.unwrap_or(0),
+                        });
+                    }
+                    in_contents = false;
+                }
+                current_tag.clear();
+            }
+            Ok(Event::Text(ref e)) => {
+                let text = String::from_utf8_lossy(e.as_ref()).to_string();
+                if in_contents {
+                    match current_tag.as_str() {
+                        "Key" => current_key = Some(text),
+                        "Size" => current_size = text.parse::<i64>().ok(),
+                        _ => {}
+                    }
+                } else {
+                    match current_tag.as_str() {
+                        "IsTruncated" => is_truncated = text == "true",
+                        "NextContinuationToken" => next_marker = Some(text),
+                        _ => {}
+                    }
+                }
+            }
+            Ok(Event::Eof) => break,
+            Err(e) => {
+                return Err(SurgeError::Storage(format!("Failed to parse S3 list response: {e}")));
+            }
+            _ => {}
+        }
+        buf.clear();
+    }
+
+    debug!(count = entries.len(), is_truncated, "S3 LIST parsed");
+    Ok(ListResult {
+        entries,
+        next_marker,
+        is_truncated,
+    })
+}


### PR DESCRIPTION
## Fixes
Closes #238 — "surge install --force over tailscale: killing the local CLI orphans the node with no app, no supervisor, no installer."

## Problem
The remote installer ran as a child of the SSH session. When the local CLI died mid-download (tooling timeout in the reported field case), the session ended, the installer was SIGHUP'd within a minute, and the node was left serviceless: supervisor already stopped, `.surge-update-status.json` frozen at 'package downloading', nothing on the node to recover it. Re-running the same command restarted the transfer from zero (the partial download was discarded).

## Fix
1. **Detached node-local installer.** A small launcher starts the staged installer in a new session (`setsid` when available, `nohup` otherwise), SIGHUP-immune, with output in `/tmp/.surge-installer.log` and its PID in `/tmp/.surge-installer.pid`. The local CLI only watches: it relays the installer log, treats the node's update-status file as the authoritative outcome, and bounds the watch (6 h cap, 5-minute stale-progress guard).
   - Re-running the same command **reattaches** to a still-running install (carrying the log offset) instead of discarding progress.
   - A leftover installer process without an in-progress status is stopped before a fresh install; a dead installer with a stale in-progress status logs its last lines before the fresh install proceeds.
2. **Resumable S3 downloads.** The S3 backend now implements `download_to_file_from_offset` (signed `Range` request, 206-append / 200-restart handling mirroring the Azure backend), so the node-side package download keeps its partial cache across interrupted attempts instead of restarting from zero.
3. **Slow-link steering.** Direct full-package installs of ≥50 MB that stop a running app warn that the app stays down for the whole transfer and point at the `--stage` flow (stage while the app is up, then cut over). The streamed app-copy transfer warns once after 45 s below 32 KB/s and notes the transfer is resumable.

## Tests
- Launcher: unit tests + a functional test (parent exits after launch; detached fake installer keeps running, PID reported, log written).
- Probe/parse, stop, cleanup, and log-tail command tests.
- S3 resumable response-action tests.
- Full workspace test suite, both clippy tiers, vendor sync, version sync all green.