### PR TITLE
fix(bench): scope update store to app-scoped storage prefix

### DIFF
--- a/crates/surge-bench/src/runner/installer.rs
+++ b/crates/surge-bench/src/runner/installer.rs
@@ -226,12 +226,12 @@ pub async fn run_installer_scenario(
 
     let manifest_path = work_dir.join("installer-bench.surge.yml");
     write_bench_manifest(&manifest_path, &store_dir, app_id, &rid, pack_zstd_level)?;
-    let ctx = configure_benchmark_context(&store_dir, pack_zstd_level, pack_max_threads, pack_memory_mb)?;
+    let ctx = configure_benchmark_context(&store_dir, app_id, pack_zstd_level, pack_max_threads, pack_memory_mb)?;
 
     let template = PayloadTemplate::new(scale, seed);
     template.write_base(&artifacts_dir, seed)?;
     let publication = publish_release(Arc::clone(&ctx), &manifest_path, app_id, &rid, &version, &artifacts_dir).await?;
-    let full_package_path = store_dir.join(&publication.full_build.filename);
+    let full_package_path = store_dir.join(app_id).join(&publication.full_build.filename);
 
     let surge_binary = resolve_tool_binary("SURGE_INSTALLER_BINARY", surge_binary_name_for_rid(&rid))?;
     let installer_launcher = resolve_tool_binary("SURGE_INSTALLER_LAUNCHER", installer_launcher_name_for_rid(&rid))?;

--- a/crates/surge-bench/src/runner/manifest.rs
+++ b/crates/surge-bench/src/runner/manifest.rs
@@ -37,7 +37,7 @@ pub(super) fn installer_manifest(
             bucket: store_dir.to_string_lossy().to_string(),
             region: String::new(),
             endpoint: String::new(),
-            prefix: String::new(),
+            prefix: app_id.to_string(),
         },
         release: InstallerRelease {
             full_filename: full_filename.to_string(),
@@ -74,9 +74,10 @@ pub(super) fn write_bench_manifest(
 storage:
   provider: filesystem
   bucket: {bucket}
+  prefix: {app_id}
 pack:
   delta:
-    strategy: archive-chunked-bsdiff
+    strategy: sparse-file-ops
   compression:
     format: zstd
     level: {pack_zstd_level}

--- a/crates/surge-bench/src/runner/update.rs
+++ b/crates/surge-bench/src/runner/update.rs
@@ -50,6 +50,7 @@ fn average_u64(values: &[u64]) -> u64 {
 
 pub(super) fn configure_benchmark_context(
     store_dir: &Path,
+    app_id: &str,
     pack_zstd_level: i32,
     pack_max_threads: Option<usize>,
     pack_memory_mb: u64,
@@ -65,6 +66,9 @@ pub(super) fn configure_benchmark_context(
         "",
         "",
     );
+    // The publisher must use the same app-scoped prefix the UpdateManager
+    // requires (surge-core #79: release index lives on <prefix>/<app_id>).
+    ctx.set_storage_prefix(app_id);
 
     let mut budget = ctx.resource_budget();
     let available_threads = std::thread::available_parallelism().map_or(1, std::num::NonZeroUsize::get);
@@ -143,7 +147,7 @@ pub async fn run_update_scenario(
     let manifest_path = work_dir.join("update-bench.surge.yml");
     write_bench_manifest(&manifest_path, &store_dir, app_id, &rid, pack_zstd_level)?;
 
-    let ctx = configure_benchmark_context(&store_dir, pack_zstd_level, pack_max_threads, pack_memory_mb)?;
+    let ctx = configure_benchmark_context(&store_dir, app_id, pack_zstd_level, pack_max_threads, pack_memory_mb)?;
 
     let template = PayloadTemplate::new(scale, seed);
     let base_input_bytes = template.write_base(&artifacts_dir, seed)?;
@@ -179,7 +183,8 @@ pub async fn run_update_scenario(
         let version = version_label(version_index);
         let publication =
             publish_release(Arc::clone(&ctx), &manifest_path, app_id, &rid, &version, &artifacts_dir).await?;
-        let release_index_size = fs::metadata(store_dir.join(RELEASES_FILE_COMPRESSED)).map_or(0, |meta| meta.len());
+        let release_index_size =
+            fs::metadata(store_dir.join(app_id).join(RELEASES_FILE_COMPRESSED)).map_or(0, |meta| meta.len());
         release_index_updates.push(publication.release_index_update);
         release_index_sizes.push(release_index_size);
 
@@ -280,7 +285,7 @@ pub async fn run_update_scenario(
     });
 
     let baseline_version = version_label(1);
-    let baseline_full = store_dir.join(&baseline_publication.full_build.filename);
+    let baseline_full = store_dir.join(app_id).join(&baseline_publication.full_build.filename);
     let baseline_bytes = fs::read(&baseline_full)?;
     let baseline_app_dir = install_dir.join("app");
     extractor::extract_to(&baseline_bytes, &baseline_app_dir, None)?;
@@ -295,7 +300,7 @@ pub async fn run_update_scenario(
             .ok_or_else(|| SurgeError::Config(format!("Install path is not valid UTF-8: {}", install_dir.display())))?,
     )?;
 
-    let releases_index_path = store_dir.join(RELEASES_FILE_COMPRESSED);
+    let releases_index_path = store_dir.join(app_id).join(RELEASES_FILE_COMPRESSED);
     let releases_index_size = fs::metadata(&releases_index_path).map_or(0, |meta| meta.len());
     let check_started = Instant::now();
     let info = update_manager

--- a/docs/performance/update-chains.md
+++ b/docs/performance/update-chains.md
@@ -18,9 +18,18 @@ That means the benchmark now measures:
 
 ## Current Findings
 
+> Measurement note: the figures below were recorded while the update
+> scenario ran the `archive-chunked-bsdiff` bench strategy. The bench
+> manifest now pins `sparse-file-ops`, the production default, so the
+> large-scale numbers are pending a rerun before they can be attributed
+> to the default strategy (see "When To Rerun"). Small-scale reference
+> under the new configuration: `sdk_only`, 20 deltas, scale 0.05 —
+> apply ≈ 8.5 s, download ≈ 102 KiB (48-core/251 GB host, seed 42).
+
 ### Localized long chains are acceptable
 
-Large anonymized profile, `sdk_only`, `100` deltas:
+Large anonymized profile, `sdk_only`, `100` deltas (measured under
+`archive-chunked-bsdiff` — see measurement note above):
 
 - client download stayed around `15.6 MiB`
 - client apply time was about `18s`
@@ -53,6 +62,10 @@ Meaning:
 
 ## What Is Not Solved Yet
 
+- the large-scale chain numbers above have not been re-measured under
+  the `sparse-file-ops` bench configuration; per-file apply was ~2.9x
+  slower than archive-chunked at small scale, so whether the 15.6 MiB /
+  18 s client figures hold at scale is open
 - retained full checkpoints still need long-history tuning in real feeds
 - broad-churn chains can still justify a fresh full checkpoint
 - local checkpoint retention policy may need calibration for very long-lived installs


### PR DESCRIPTION
## Purpose

The surge-bench update scenario was broken against current core. Since the
app-scoped prefix hardening (#79, e11b75e), `UpdateManager` requires the
release index on `<prefix>/<app_id>` (see the core test at
`update/manager.rs`), but the bench configured the context with an empty
prefix, so `PackBuilder` published the index to the base prefix and every
`--update-only` run died with:

```
Release index 'releases.yml.zst' not found on required app-scoped prefix
```

The fix mirrors the production shape: the bench manifest and context use
the app id as the storage prefix, and every store-path lookup (release
index, full package) follows the scoped layout. The installer scenario's
manifest gets the same prefix so online installs resolve the index.

Also switches the bench manifest from `archive-chunked-bsdiff` to
`sparse-file-ops`, the production default delta strategy — the real
update path was never benched at the default strategy.

## Behavior impact

Bench-only. No `surge-core`, CLI, FFI, or `.NET` changes.

## Test evidence

- `cargo test --workspace`: 527 passed, 0 failed
- `cargo fmt --all -- --check` clean
- `cargo clippy --workspace --lib --bins --examples -- -D warnings -D clippy::unwrap_used -D clippy::expect_used` clean
- `--update-only --scale 0.05 --scenario sdk-only --num-deltas 20` now runs end to end and asserts the install tree: apply 8526 ms, 104,328 bytes downloaded (48-core/251 GB host)
- same-session reference at the old strategy: 2931 ms apply / 98,714 bytes — per-file sparse apply is slower at small scale; flagged for large-scale verification in `docs/performance` follow-up