### PR TITLE
feat(auto): add delta, pack, and update autoresearch surfaces

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,9 +132,24 @@ If the local environment cannot run a listed command, document the exact gap in 
 
 ## Performance Memory
 - Benchmark and pack-policy memory lives under `docs/performance/`.
-- When changing pack defaults, delta strategy, `surge tune pack`, `surge-bench`, or `.github/workflows/benchmark.yml`, update the relevant files in `docs/performance/` in the same change.
+- When changing pack defaults, delta strategy, `surge tune pack`, `surge-bench`, or the `auto/` benchmark harnesses, update the relevant files in `docs/performance/` in the same change.
 - Keep benchmark payload descriptions anonymized and generic; do not add private product names or file names to docs, workflow labels, or benchmark fixtures.
-- Keep `.github/workflows/benchmark.yml` aligned with `docs/performance/benchmark-profiles.md` and `docs/performance/pack-policy.md`.
+
+## Autoresearch Methodology
+- "Autoresearch" in this repository means the iterative optimization loop rooted at `auto/`: define one metric, baseline it, propose one hypothesis, implement, measure, then record the result as `keep` or `discard`. Every experiment — successful or not — is recorded so the next agent does not repeat it.
+- Each autoresearch surface has its own folder under `auto/`:
+  - `program.md` — scope, constraints, baseline setup, metric definition, optimization ideas.
+  - `bench.sh` — the canonical benchmark for that surface, built on `surge-bench` (no ad hoc binaries); sources `auto/config.sh` for the shared build/seed/TSV helpers.
+  - `results.tsv` — append-only experiment log, one row per attempt: `commit  score  <metric>  status  description`. Use `0000000` as the commit field for `discard` entries that did not land, and the real short commit hash for `keep` and `baseline` rows.
+- Current surfaces — `auto/delta/` is the canonical surface when the user says "autoresearch" without further qualification:
+  - `auto/delta/` — delta patch size and diff/apply cost (bsdiff/chunked bsdiff, chunk sizing, patch compression); the core field-bandwidth and edge-apply cost.
+  - `auto/pack/` — full pack/archive build throughput and artifact size (zstd policy, packing layout); the publisher-side CI cost per release.
+  - `auto/update/` — end-to-end client update cost across a real delta chain (download bytes + apply time through the real `UpdateManager`); the number the fleet feels.
+- Reproducibility: `surge-bench` payloads are seeded (`--seed 42` by default; never change the seed without re-baselining). Re-baseline the reference configuration in the same session before claiming a win, and record medians (`BENCH_RUNS=3`) when the machine is shared. Do not claim cold-vs-warm or cross-machine deltas as wins.
+- **Before proposing a new optimization**, read the full `results.tsv` for the relevant surface plus recent dead-end commits (`git log --oneline --all | grep -iE "dead end|autoresearch"`).
+- **`keep`** means the same product behavior — byte-identical installed payload and release-index semantics for the same inputs — and a measurable score improvement that survives repeated runs on the same machine. **`discard`** means anything that changes behavior, breaks determinism, or fails to beat the same-session baseline. Record `discard` entries with enough detail (numbers, signatures, why) that the next agent does not re-test the idea.
+- Surface `program.md` files list a promotion gate (a larger or end-to-end `surge-bench` scenario) that must pass before a keep lands. Persistent findings that change defaults, policies, or tracked scenarios go to `docs/performance/` in the same change (see Performance Memory).
+- New surfaces follow the same pattern: one `program.md`, one `bench.sh` sourcing `auto/config.sh`, one `results.tsv` initialized with a measured baseline row.
 
 ## Anonymized Communication
 - In agent-authored issues, PRs, plans, summaries, and troubleshooting notes, use fictional placeholder names for products, customers, sites, hosts, and environments by default.

--- a/auto/config.sh
+++ b/auto/config.sh
@@ -1,0 +1,69 @@
+# Shared helpers for surge autoresearch surfaces.
+# Source from each surface's bench.sh:
+#   source "$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/config.sh"
+#
+# Every surface bench:
+#   1. runs the canonical surge-bench invocation (one metric, fixed seed),
+#   2. parses the score + secondary metrics from --json output,
+#   3. appends one row to the surface results.tsv:
+#        commit  score  <metric>  status  description
+#
+# Conventions:
+#   - status is one of: baseline | keep | discard
+#   - commit is the real short hash for rows tied to a landed change,
+#     0000000 for experiments that did not land (discard)
+#   - baseline rows carry the hash of the tree the baseline was measured on
+
+SURGE_ROOT="$(git rev-parse --show-toplevel)"
+BENCH_BIN="$SURGE_ROOT/target/release/surge-bench"
+BENCH_SEED="${BENCH_SEED:-42}"
+BENCH_RUNS="${BENCH_RUNS:-1}"
+
+# Build surge-bench when the release binary is missing or older than the
+# newest Rust/C source (diff backend changes live in vendor/bsdiff).
+ensure_bench_bin() {
+  local stale
+  stale="$(find "$SURGE_ROOT/crates" "$SURGE_ROOT/vendor" \
+    \( -name '*.rs' -o -name '*.c' -o -name '*.h' \) \
+    -newer "$BENCH_BIN" -print -quit 2>/dev/null || true)"
+  if [ ! -x "$BENCH_BIN" ] || [ -n "$stale" ]; then
+    echo "[config] Building surge-bench (release)..." >&2
+    (cd "$SURGE_ROOT" && RUSTFLAGS="-D warnings" cargo build --release -p surge-bench) >&2
+  fi
+}
+
+# bench_commit [status] — commit field for a results.tsv row.
+# Discards that did not land record 0000000.
+bench_commit() {
+  local status="${1:-}"
+  if [ "$status" = "discard" ]; then
+    printf '0000000'
+  else
+    git -C "$SURGE_ROOT" rev-parse --short HEAD
+  fi
+}
+
+# bench_json <results.json> <result-name> <field>
+# Fields: duration (ms), input_size, output_size
+bench_json() {
+  python3 - "$1" "$2" "$3" <<'PY'
+import json
+import sys
+
+report = json.load(open(sys.argv[1]))
+name, field = sys.argv[2], sys.argv[3]
+for r in report["results"]:
+    if r["name"] == name:
+        print(r[field])
+        break
+else:
+    sys.exit(f"result {name!r} not found in {sys.argv[1]}")
+PY
+}
+
+# append_result <results.tsv> <commit> <score> <metric> <status> <description>
+append_result() {
+  local tsv="$1" commit="$2" score="$3" metric="$4" status="$5" desc="$6"
+  printf '%s\t%s\t%s\t%s\t%s\n' "$commit" "$score" "$metric" "$status" "$desc" >>"$tsv"
+  echo "logged: [$status] score=$score $metric — $desc"
+}

--- a/auto/delta/bench.sh
+++ b/auto/delta/bench.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Canonical benchmark for the delta surface (patch size + diff/apply cost).
+#
+# Score  = chunked-bsdiff patch bytes for the mutated dominant file
+#          (lower is better; this is the field-bandwidth cost)
+# Metric = chunked bsdiff + chunked bspatch durations in ms
+#
+# Knobs (env vars):
+#   SCALE=0.25        payload scale (medium: diff behavior visible, loop is fast)
+#   SCENARIO=sdk-only localized churn in the dominant SDK (realistic update shape)
+#   LEVELS=3          zstd level for the archive sections of the microbench
+#   BENCH_SEED=42     payload PRNG seed (do not change without re-baselining)
+#   BENCH_RUNS=1      repeat the whole bench and record the median score
+#   INCLUDE_CLASSIC=0 set 1 to also report classic (non-chunked) bsdiff as a
+#                     reference metric (needs ~8x file size of RAM, slower)
+set -euo pipefail
+SURFACE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$(dirname "$SURFACE_DIR")"
+source config.sh
+
+SCALE="${SCALE:-0.25}"
+SCENARIO="${SCENARIO:-sdk-only}"
+LEVELS="${LEVELS:-3}"
+INCLUDE_CLASSIC="${INCLUDE_CLASSIC:-0}"
+
+ensure_bench_bin
+
+declare -a diff_flags
+if [ "$INCLUDE_CLASSIC" = "1" ]; then
+  diff_flags=(--skip-classic-diff=false)
+else
+  diff_flags=(--skip-classic-diff)
+fi
+
+declare -a jsons=()
+for _ in $(seq 1 "$BENCH_RUNS"); do
+  json="$(mktemp)"
+  "$BENCH_BIN" \
+    --scale "$SCALE" \
+    --scenario "$SCENARIO" \
+    --zstd-levels "$LEVELS" \
+    "${diff_flags[@]}" \
+    --skip-installers \
+    --skip-update-scenario \
+    --seed "$BENCH_SEED" \
+    --json >"$json"
+  jsons+=("$json")
+done
+trap 'rm -f "${jsons[@]}"' EXIT
+
+scores=()
+for json in "${jsons[@]}"; do
+  scores+=("$(bench_json "$json" "chunked bsdiff" output_size)")
+done
+# median of scores
+score="$(printf '%s\n' "${scores[@]}" | sort -n | awk 'NR==int((NR+1)/2){print; exit}')"
+
+diff_ms="$(bench_json "${jsons[0]}" "chunked bsdiff" duration)"
+patch_ms="$(bench_json "${jsons[0]}" "chunked bspatch" duration)"
+metric="diff_ms=${diff_ms} patch_ms=${patch_ms}"
+
+if [ "$INCLUDE_CLASSIC" = "1" ]; then
+  classic_bytes="$(bench_json "${jsons[0]}" "bsdiff" output_size)"
+  classic_ms="$(bench_json "${jsons[0]}" "bsdiff" duration)"
+  metric="$metric classic_bytes=${classic_bytes} classic_diff_ms=${classic_ms}"
+fi
+
+commit="$(bench_commit "${STATUS:-baseline}")"
+desc="scale=${SCALE} scenario=${SCENARIO} seed=${BENCH_SEED} runs=${BENCH_RUNS}"
+if [ "${#scores[@]}" -gt 1 ]; then
+  desc="$desc scores=[${scores[*]}]"
+fi
+
+# STATUS=keep/discard + DESC="..." to log a finished experiment, otherwise
+# this is a baseline row for the current tree.
+append_result "$SURFACE_DIR/results.tsv" "$commit" "$score" "$metric" "${STATUS:-baseline}" "${DESC:-$desc}"

--- a/auto/delta/program.md
+++ b/auto/delta/program.md
@@ -1,0 +1,135 @@
+# Delta Surface
+
+Autoresearch surface for delta generation cost and size: bsdiff / chunked-
+bsdiff, chunk sizing, and the compression applied to patches. This is the
+canonical surface when the user says "autoresearch" without further
+qualification.
+
+## Why this surface matters
+
+Surge ships updates to edge devices (camera units, payment terminals,
+access pads) over constrained field networks. The delta patch is the
+dominant cost on both ends:
+
+- publisher side: diff build time inside `surge pack` (CI cost per release)
+- client side: bytes downloaded + `bspatch` apply time on weak edge CPUs
+
+The installed result must never change: post-update install trees are
+byte-identical across any keep.
+
+## Scope
+
+In scope:
+
+- `crates/surge-core/src/diff/` — classic bsdiff backend (`wrapper.rs`,
+  `bsdiff_sys.rs`) and chunked bsdiff (`chunked.rs`, 64 MiB default chunks,
+  memory-aware thread count)
+- `crates/surge-core/vendor/` + `vendor/bsdiff` — the C bsdiff/bspatch
+  implementation (regenerate the publishable snapshot with
+  `./scripts/sync-surge-core-vendor.sh` when touching `vendor/bsdiff`)
+- `crates/surge-core/src/releases/delta/` — sparse file-ops patching
+  (per-file diff, the `sparse-file-ops` default) and archive-level
+  chunked/bsdiff patches
+- `crates/surge-core/src/pack/builder/delta.rs` — strategy selection,
+  chunk-size derivation from the memory budget (256 MiB default), and the
+  delta-vs-full fallback (`delta_size >= full_size` → publish full)
+
+Out of scope:
+
+- full-pack build cost (see `auto/pack/`)
+- end-to-end chain/checkpoint policy (see `auto/update/`)
+- anything that changes release-index semantics or installed payloads
+
+## Baseline Setup
+
+The canonical bench is `auto/delta/bench.sh`, a `surge-bench` microbench at
+medium scale with localized churn (the realistic repeated-update shape):
+
+```bash
+SCALE=0.25 SCENARIO=sdk-only ./bench.sh
+```
+
+- seed fixed at 42 (`--seed`), payloads generated identically every run
+- `--scenario sdk-only` mutates only a region of the dominant SDK file,
+  matching `sdk_only` in `docs/performance/benchmark-profiles.md`
+- the microbench diff section diffs the **full v1→v2 archive byte
+  stream** (the `ArchiveChunkedBsdiff` shape — archives are more
+  realistic than raw files, and it is the delta fallback path). The
+  production default per-file `sparse-file-ops` patching is measured
+  end to end by the update surface (`auto/update/`), which is also this
+  surface's promotion gate.
+- classic (non-chunked) bsdiff is skipped by default: it needs ~8x file
+  size of RAM and is not the production default path. Set
+  `INCLUDE_CLASSIC=1` to include it as a reference metric.
+
+Re-baseline the reference config in the same session before claiming any
+delta. The bench machine is a shared box; when load is uncertain, use
+`BENCH_RUNS=3` and record the median in the description.
+
+## Metric Definitions
+
+- **score** = `chunked bsdiff` `output_size` (archive patch bytes,
+  lower is better) for the v1→v2 archive at `SCALE`/`SCENARIO`
+- **metric** = `chunked bsdiff` + `chunked bspatch` + `bsdiff` durations
+  in ms, plus classic patch bytes when `INCLUDE_CLASSIC=1`
+
+Promotion gate before a keep lands: rerun the full validation scenario
+(large localized chain through the real `UpdateManager`) and confirm the
+applied install tree still matches and the real-chain download/apply
+numbers improved or held:
+
+```bash
+cargo run -p surge-bench --release -- --update-only --scale 1.0 \
+  --scenario sdk-only --num-deltas 100 --pack-zstd-level 3 \
+  --pack-memory-mb 256 --json
+```
+
+## Current State
+
+- production default strategy: `sparse-file-ops` (per-file chunked bsdiff,
+  zstd level 3, 256 MiB diff budget)
+- chunk size derived per pack from the memory budget: `per_thread / 12`,
+  clamped to `[4 MiB, 64 MiB]`
+- fallback: patch >= full package → publish a full checkpoint instead
+- zstd level 3 was measured fastest on the calibrated large profile
+  (see `docs/performance/pack-policy.md`)
+- baseline (b397c0c, 48-core/251 GB machine): 42,595-byte patch for the
+  v1→v2 archive at scale 0.25 sdk-only; chunked bsdiff 2,247 ms, chunked
+  bspatch 201 ms
+
+## Optimization Ideas
+
+Ranked by expected value; read `results.tsv` and
+`git log --oneline --all | grep -iE "dead end|autoresearch"` before
+starting any of these.
+
+1. **Chunk-size sweep.** The 64 MiB default (and the budget-derived clamp)
+   is never tuned per workload. Sweep 8/16/32/64/128 MiB for both the
+   dominant-SDK and broad-churn shapes; chunk boundaries determine which
+   unchanged regions diff cleanly.
+2. **Patch compression level.** Patches are zstd-compressed at the pack
+   level; patches are far more compressible than archives. A higher
+   zstd level *on the patch only* may shrink download bytes at negligible
+   edge apply cost (decompression is the cheap half).
+3. **Parallelism/memory trade.** `max_threads` scales with the memory
+   budget (`/12` per thread). Measure the time/bytes knee; the edge
+   publisher (CI) and the edge node have very different budgets.
+4. **bsdiff C-backend tuning.** Suffix-array construction dominates
+   classic bsdiff. Candidate: smaller rolling hash / block-restricted
+   matching for the localized-churn shape where most chunks are
+   unchanged (early-skip chunks whose hashes are identical before
+   diffing — needs a format version bump).
+5. **Per-file strategy heuristics.** Sparse ops already diff per file;
+   consider skipping the diff entirely for files below a threshold where
+   a full-file entry in the sparse patch would be smaller (measure the
+   overhead of the per-file patch header first).
+6. **Alternative algorithms** (xdelta/vcdiff, binpatch, lz4-based
+   rolling) as a fourth `PackDeltaStrategy`. Only after 1-5 show the
+   bsdiff family is the ceiling; a new format is a large surface area
+   (FFI, .NET, Kotlin are not involved, but restore/apply + tests are).
+
+## Dead Ends to Respect
+
+None recorded yet. Record every failed attempt here (and in
+`results.tsv`) with the measured numbers so the next agent does not
+re-test it.

--- a/auto/delta/results.tsv
+++ b/auto/delta/results.tsv
@@ -1,0 +1,2 @@
+commit	score_patch_bytes	diff_ms_patch_ms	status	description
+4578166	42595	diff_ms=2053.0842740000003 patch_ms=199.086682	baseline	scale=0.25 scenario=sdk-only seed=42 runs=1

--- a/auto/pack/bench.sh
+++ b/auto/pack/bench.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Canonical benchmark for the pack surface (full-pack build throughput
+# and artifact size).
+#
+# Score  = "Archive create (zstd=3)" duration in ms (publisher cost at
+#          the default level, lower is better)
+# Metric = archive output bytes (guardrail) + zstd compress/decompress +
+#          extract durations in ms
+#
+# Knobs (env vars):
+#   SCALE=0.05        payload scale (small: few-second loop)
+#   SCENARIO=full-release  broad churn (worst-case file churn for the packer)
+#   BENCH_SEED=42     payload PRNG seed (do not change without re-baselining)
+#   BENCH_RUNS=1      repeat the whole bench and record the median score
+#   LEVELS=3          zstd levels to sweep in the archive section
+set -euo pipefail
+SURFACE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$(dirname "$SURFACE_DIR")"
+source config.sh
+
+SCALE="${SCALE:-0.05}"
+SCENARIO="${SCENARIO:-full-release}"
+LEVELS="${LEVELS:-3}"
+
+ensure_bench_bin
+
+declare -a jsons=()
+for _ in $(seq 1 "$BENCH_RUNS"); do
+  json="$(mktemp)"
+  "$BENCH_BIN" \
+    --scale "$SCALE" \
+    --scenario "$SCENARIO" \
+    --zstd-levels "$LEVELS" \
+    --skip-classic-diff \
+    --skip-installers \
+    --skip-update-scenario \
+    --seed "$BENCH_SEED" \
+    --json >"$json"
+  jsons+=("$json")
+done
+trap 'rm -f "${jsons[@]}"' EXIT
+
+scores=()
+for json in "${jsons[@]}"; do
+  scores+=("$(bench_json "$json" "Archive create (zstd=3)" duration)")
+done
+# median of scores
+score="$(printf '%s\n' "${scores[@]}" | sort -n | awk 'NR==int((NR+1)/2){print; exit}')"
+
+first="${jsons[0]}"
+archive_bytes="$(bench_json "$first" "Archive create (zstd=3)" output_size)"
+zstd_ms="$(bench_json "$first" "Zstd compress (level=3)" duration)"
+unzstd_ms="$(bench_json "$first" "Zstd decompress" duration)"
+extract_ms="$(bench_json "$first" "Archive extract" duration)"
+metric="archive_bytes=${archive_bytes} zstd_ms=${zstd_ms} unzstd_ms=${unzstd_ms} extract_ms=${extract_ms}"
+
+commit="$(bench_commit "${STATUS:-baseline}")"
+desc="scale=${SCALE} scenario=${SCENARIO} seed=${BENCH_SEED} runs=${BENCH_RUNS}"
+if [ "${#scores[@]}" -gt 1 ]; then
+  desc="$desc scores=[${scores[*]}]"
+fi
+
+# STATUS=keep/discard + DESC="..." to log a finished experiment, otherwise
+# this is a baseline row for the current tree.
+append_result "$SURFACE_DIR/results.tsv" "$commit" "$score" "$metric" "${STATUS:-baseline}" "${DESC:-$desc}"

--- a/auto/pack/program.md
+++ b/auto/pack/program.md
@@ -1,0 +1,114 @@
+# Pack Surface
+
+Autoresearch surface for full-pack build throughput and artifact size:
+`ArchivePacker`, zstd compression policy, and the full-package build path
+in `PackBuilder`.
+
+## Why this surface matters
+
+Every release ships a full package (install + restore baseline +
+checkpoint fallback). The full pack is the publisher-side CI cost per
+release and the fallback download cost on nodes. The delta surface owns
+the incremental path; this surface owns everything that is not a delta.
+
+## Scope
+
+In scope:
+
+- `crates/surge-core/src/archive/packer.rs` — directory packing, zstd
+  compression (level, `zstdmt` worker count), file ordering and entry
+  layout
+- `crates/surge-core/src/archive/extractor.rs` — extract/restore cost
+  (client-side unpack is part of update time; keep it from regressing)
+- `crates/surge-core/src/pack/builder.rs` — full-pack build orchestration
+  (workers, memory budget, deterministic output)
+- `crates/surge-cli/src/commands/tune.rs` — `surge tune pack` candidate
+  sweeps (tune stays explicit/opt-in; autoresearch findings may change
+  which candidates it sweeps, not when it runs)
+
+Out of scope:
+
+- delta patch generation (see `auto/delta/`)
+- chain/checkpoint retention policy (see `auto/update/`)
+
+Hard constraints:
+
+- **Determinism is load-bearing.** Rebuilding the same release must yield
+  byte-identical archives (fingerprinted release-index entries depend on
+  it). A keep that changes archive bytes without changing inputs is a
+  discard, full stop.
+- Archive bytes are a guardrail: at fixed inputs the score is build time,
+  but a keep that grows the full package must justify the size/time
+  tradeoff in the results.tsv description (it changes fallback download
+  cost for the whole fleet).
+
+## Baseline Setup
+
+Canonical bench: `auto/pack/bench.sh`, the `surge-bench` microbench at
+small scale with broad churn (worst-case file churn for the packer):
+
+```bash
+SCALE=0.05 SCENARIO=full-release ./bench.sh
+```
+
+- seed fixed at 42, `--zstd-levels 3` so the run is fast; the score only
+  reads the `Archive create (zstd=3)` row
+- small scale keeps one loop iteration to a few seconds; raise to
+  `SCALE=0.25` when a candidate needs more signal (record it in the
+  description)
+- re-baseline in the same session; shared machine → `BENCH_RUNS=3`
+  median when load is uncertain
+
+Promotion gate before a keep lands: run the real pack path and confirm
+`Full pack build (baseline)` / `(incremental avg)` held or improved and
+the full artifact size did not grow beyond noise:
+
+```bash
+cargo run -p surge-bench --release -- --update-only --scale 0.25 \
+  --scenario full-release --num-deltas 10 --pack-zstd-level 3 \
+  --pack-memory-mb 256 --json
+```
+
+## Metric Definitions
+
+- **score** = `Archive create (zstd=3)` duration in ms (lower is better)
+- **metric** = archive output bytes, `Zstd compress (level=3)` ms,
+  `Zstd decompress` ms, `Archive extract` ms
+
+## Current State
+
+- zstd level 3 default: measured fastest on the calibrated large profile
+  and slightly smaller than level 1 (`docs/performance/pack-policy.md`)
+- `zstdmt` (multithread zstd) with worker count from the pack budget
+- deterministic file ordering; same inputs → same archive bytes
+- operational node policy: all visible cores, 256 MiB budget
+- baseline (b397c0c, 48-core/251 GB machine): `Archive create (zstd=3)`
+  81.9 ms, 7,997,458-byte archive at scale 0.05 full-release (archive
+  bytes were byte-identical across runs — determinism confirmed)
+
+## Optimization Ideas
+
+Ranked by expected value; read `results.tsv` and
+`git log --oneline --all | grep -iE "dead end|autoresearch"` first.
+
+1. **Worker-count knee.** `zstdmt` thread count is currently the whole
+   budget. Sweep 1/2/4/8/all at small scale: diminishing returns and
+   frame-sync overhead vary by payload shape; the 256 MiB budget may be
+   leaving throughput on the table (or paying for nothing).
+2. **File grouping by compressibility.** The packer compresses per entry
+   at one level. Measuring a two-tier policy (cheap level for
+   incompressible entries like large binaries, higher level for
+   text-heavy entries) at fixed total bytes — only if the size/time
+   tradeoff is defensible.
+3. **Entry ordering for parallelism.** Confirm the add order does not
+   serialize what could run concurrently; the packer's internal batching
+   is the suspect, not zstd.
+4. **Extract path.** `Archive extract` feeds restore/apply time; if a
+   pack change trades a bit of build time for faster client unpack
+   (same bytes), that is a candidate for the update surface's apply
+   metric — cross-reference before keeping.
+
+## Dead Ends to Respect
+
+None recorded yet. Record every failed attempt here and in
+`results.tsv` with the measured numbers.

--- a/auto/pack/results.tsv
+++ b/auto/pack/results.tsv
@@ -1,0 +1,2 @@
+commit	score_archive_create_ms	archive_bytes_zstd_ms	status	description
+4578166	78.346164	archive_bytes=7997458 zstd_ms=59.231683 unzstd_ms=32.514931 extract_ms=62.935144	baseline	scale=0.05 scenario=full-release seed=42 runs=1

--- a/auto/update/bench.sh
+++ b/auto/update/bench.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Canonical benchmark for the update surface (end-to-end client update
+# cost across a real delta chain).
+#
+# Score  = "Update apply (N deltas)" duration in ms: client wall time for
+#          check -> download -> verify -> apply (lower is better)
+# Metric = planned download bytes + publisher-side build/index timings
+#
+# The scenario publishes NUM_DELTAS real releases through the pack
+# builder to a filesystem store, then runs one real UpdateManager
+# check + download_and_apply and asserts the install tree matches the
+# final release.
+#
+# Knobs (env vars):
+#   SCALE=0.05        payload scale (small: fast loop, real UpdateManager)
+#   SCENARIO=sdk-only localized churn (long-lived-install shape)
+#   NUM_DELTAS=20     chain length the single update walks
+#   BENCH_SEED=42     payload PRNG seed (do not change without re-baselining)
+#   BENCH_RUNS=1      repeat the whole bench and record the median score
+set -euo pipefail
+SURFACE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$(dirname "$SURFACE_DIR")"
+source config.sh
+
+SCALE="${SCALE:-0.05}"
+SCENARIO="${SCENARIO:-sdk-only}"
+NUM_DELTAS="${NUM_DELTAS:-20}"
+PACK_LEVEL="${PACK_LEVEL:-3}"
+PACK_MEMORY_MB="${PACK_MEMORY_MB:-256}"
+
+ensure_bench_bin
+
+declare -a jsons=()
+for _ in $(seq 1 "$BENCH_RUNS"); do
+  json="$(mktemp)"
+  "$BENCH_BIN" \
+    --update-only \
+    --scale "$SCALE" \
+    --scenario "$SCENARIO" \
+    --num-deltas "$NUM_DELTAS" \
+    --pack-zstd-level "$PACK_LEVEL" \
+    --pack-memory-mb "$PACK_MEMORY_MB" \
+    --seed "$BENCH_SEED" \
+    --json >"$json"
+  jsons+=("$json")
+done
+trap 'rm -f "${jsons[@]}"' EXIT
+
+scores=()
+for json in "${jsons[@]}"; do
+  scores+=("$(bench_json "$json" "Update apply (${NUM_DELTAS} deltas)" duration)")
+done
+# median of scores
+score="$(printf '%s\n' "${scores[@]}" | sort -n | awk 'NR==int((NR+1)/2){print; exit}')"
+
+first="${jsons[0]}"
+download_bytes="$(bench_json "$first" "Update check (${NUM_DELTAS} deltas)" output_size)"
+delta_build_ms="$(bench_json "$first" "Delta pack build (avg)" duration)"
+index_ms="$(bench_json "$first" "Release index update (avg)" duration)"
+metric="download_bytes=${download_bytes} delta_build_ms=${delta_build_ms} index_ms=${index_ms}"
+
+commit="$(bench_commit "${STATUS:-baseline}")"
+desc="scale=${SCALE} scenario=${SCENARIO} num_deltas=${NUM_DELTAS} seed=${BENCH_SEED} runs=${BENCH_RUNS}"
+if [ "${#scores[@]}" -gt 1 ]; then
+  desc="$desc scores=[${scores[*]}]"
+fi
+
+# STATUS=keep/discard + DESC="..." to log a finished experiment, otherwise
+# this is a baseline row for the current tree.
+append_result "$SURFACE_DIR/results.tsv" "$commit" "$score" "$metric" "${STATUS:-baseline}" "${DESC:-$desc}"

--- a/auto/update/program.md
+++ b/auto/update/program.md
@@ -1,0 +1,127 @@
+# Update Surface
+
+Autoresearch surface for end-to-end client update cost: the real
+`UpdateManager` flow (check → download → verify → apply) across a delta
+chain.
+
+## Why this surface matters
+
+This is the number the fleet feels: bytes a node downloads over the
+field network, and how long the node is busy applying (edge CPUs are
+weak; an update that takes 20 minutes blocks the lane). Chain and
+checkpoint policy decides both. The delta and pack surfaces optimize the
+parts; this surface measures the whole and owns the policy knobs that
+shape it.
+
+## Scope
+
+In scope:
+
+- `crates/surge-core/src/update/manager/` — chain selection, download,
+  restore/apply, verification, progress
+- `crates/surge-core/src/releases/restore*` + `artifact_cache.rs` —
+  checkpoint reuse, local cache retention
+- `crates/surge-core/src/releases/delta/mod.rs` — chain walk and
+  apply-ladder logic
+- policy knobs that shape the client path: `max_chain_length`,
+  `checkpoint_every`, `keep_latest_fulls`, local full-count retention
+
+Out of scope:
+
+- per-file diff algorithm cost (see `auto/delta/`)
+- full-pack build cost (see `auto/pack/`)
+- publisher-side publish timing (tracked as a metric, not the score)
+
+## Baseline Setup
+
+Canonical bench: `auto/update/bench.sh`, the real update scenario at
+small scale — small enough for a fast loop, real enough to exercise
+index lookup, chain selection, download, verify, and apply:
+
+```bash
+SCALE=0.05 SCENARIO=sdk-only NUM_DELTAS=20 ./bench.sh
+```
+
+- seed fixed at 42; the scenario publishes `NUM_DELTAS` real releases
+  through the pack builder to a filesystem store, then runs one real
+  `UpdateManager` check + `download_and_apply` from the first version
+- the generated bench manifest pins `strategy: sparse-file-ops` (the
+  production default) and an app-scoped storage prefix (post-#79
+  contract: the release index lives on `<prefix>/<app_id>`)
+- the scenario asserts the final install tree matches the last release —
+  a keep that changes the applied payload fails the bench
+- re-baseline in the same session; this bench is IO-bound on the local
+  disk, so serial runs only (no parallel GPU/IO work)
+
+Promotion gate before a keep lands: the large localized chain is the
+reference for long-lived installs (numbers live in
+`docs/performance/update-chains.md`):
+
+```bash
+cargo run -p surge-bench --release -- --update-only --scale 1.0 \
+  --scenario sdk-only --num-deltas 100 --pack-zstd-level 3 \
+  --pack-memory-mb 256 --json
+```
+
+Confirm download bytes and apply time held or improved and the install
+tree still matches.
+
+## Metric Definitions
+
+- **score** = `Update apply (N deltas)` duration in ms (client wall time
+  for check→download→verify→apply, lower is better)
+- **metric** = `Update check (N deltas)` `output_size` (planned download
+  bytes), `Delta pack build (avg)` ms, `Full pack build (incremental
+  avg)` ms, `Release index update (avg)` ms
+
+## Current State
+
+- sparse file-ops deltas, zstd 3, `max_chain_length` 8,
+  `checkpoint_every` 10, keep 2 latest fulls (pack-policy defaults)
+- localized 100-delta chain at large scale: download ≈ 15.6 MiB, apply
+  ≈ 18 s — acceptable (`docs/performance/update-chains.md`)
+- broad churn is bounded by file-aware deltas + full fallback
+- publisher cost for a 101-release chain ≈ 337 s — retention policy
+  still matters
+- baseline (b397c0c, 48-core/251 GB machine, scale 0.05, 20 deltas):
+  apply 8,569 ms, download 104,328 bytes, delta build 810 ms
+- same-session reference: the `archive-chunked-bsdiff` strategy applied
+  the identical chain in 2,931 ms (98,714 bytes) — per-file sparse apply
+  is ~2.9x slower at this small scale; verify at large scale before
+  drawing conclusions (per-file patches are smaller there)
+
+Open questions from `docs/performance/update-chains.md`:
+
+- long-history tuning for retained full checkpoints in real feeds
+- when a broad-churn chain should force a fresh full checkpoint
+- local checkpoint cache limits for very long-lived installs
+
+## Optimization Ideas
+
+Ranked by expected value; read `results.tsv` and
+`git log --oneline --all | grep -iE "dead end|autoresearch"` first.
+
+1. **Verification cost.** SHA-256 over the full payload on the client is
+   measured in the microbench (`SHA-256 (file)`). Sweep: verify-then-
+   apply vs apply-then-verify ordering, streaming hashes during
+   download, and whether the delta's embedded hashes let us skip
+   re-hashing untouched files in sparse ops.
+2. **Checkpoint reuse.** Local cache retention (`keepFullCount: 1`)
+   decides whether a chain walk rebuilds fulls from deltas or reuses a
+   cached checkpoint. Measure the apply-time knee as a function of
+   `keepFullCount` and chain distance from the nearest checkpoint.
+3. **Chain walk planning cost.** `Update check` reads the compressed
+   release index and walks the chain; for long histories the index
+   grows unboundedly. Measure check time vs history length and tune
+   `max_chain_length`/`checkpoint_every` against the large chain.
+4. **Restore parallelism.** Sparse apply writes per-file patches; check
+   whether patch application parallelizes safely across files (it may
+   already) and whether the 256 MiB budget is the binding constraint on
+   apply throughput for broad-churn deltas.
+5. **Download overlap.** Whether verify can start before the full
+   download lands (streaming hash) on the common delta path.
+
+## Dead Ends to Respect
+
+None recorded yet. Record every failed attempt here and in
+`results.tsv` with the measured numbers.

--- a/auto/update/results.tsv
+++ b/auto/update/results.tsv
@@ -1,0 +1,2 @@
+commit	score_apply_ms	download_bytes_delta_build_ms	status	description
+4578166	8525.814539	download_bytes=104328 delta_build_ms=796.1179999999999 index_ms=0.707	baseline	scale=0.05 scenario=sdk-only num_deltas=20 seed=42 runs=1

--- a/crates/surge-bench/src/runner/installer.rs
+++ b/crates/surge-bench/src/runner/installer.rs
@@ -226,12 +226,12 @@ pub async fn run_installer_scenario(
 
     let manifest_path = work_dir.join("installer-bench.surge.yml");
     write_bench_manifest(&manifest_path, &store_dir, app_id, &rid, pack_zstd_level)?;
-    let ctx = configure_benchmark_context(&store_dir, pack_zstd_level, pack_max_threads, pack_memory_mb)?;
+    let ctx = configure_benchmark_context(&store_dir, app_id, pack_zstd_level, pack_max_threads, pack_memory_mb)?;
 
     let template = PayloadTemplate::new(scale, seed);
     template.write_base(&artifacts_dir, seed)?;
     let publication = publish_release(Arc::clone(&ctx), &manifest_path, app_id, &rid, &version, &artifacts_dir).await?;
-    let full_package_path = store_dir.join(&publication.full_build.filename);
+    let full_package_path = store_dir.join(app_id).join(&publication.full_build.filename);
 
     let surge_binary = resolve_tool_binary("SURGE_INSTALLER_BINARY", surge_binary_name_for_rid(&rid))?;
     let installer_launcher = resolve_tool_binary("SURGE_INSTALLER_LAUNCHER", installer_launcher_name_for_rid(&rid))?;

--- a/crates/surge-bench/src/runner/manifest.rs
+++ b/crates/surge-bench/src/runner/manifest.rs
@@ -37,7 +37,7 @@ pub(super) fn installer_manifest(
             bucket: store_dir.to_string_lossy().to_string(),
             region: String::new(),
             endpoint: String::new(),
-            prefix: String::new(),
+            prefix: app_id.to_string(),
         },
         release: InstallerRelease {
             full_filename: full_filename.to_string(),
@@ -74,9 +74,10 @@ pub(super) fn write_bench_manifest(
 storage:
   provider: filesystem
   bucket: {bucket}
+  prefix: {app_id}
 pack:
   delta:
-    strategy: archive-chunked-bsdiff
+    strategy: sparse-file-ops
   compression:
     format: zstd
     level: {pack_zstd_level}

--- a/crates/surge-bench/src/runner/update.rs
+++ b/crates/surge-bench/src/runner/update.rs
@@ -50,6 +50,7 @@ fn average_u64(values: &[u64]) -> u64 {
 
 pub(super) fn configure_benchmark_context(
     store_dir: &Path,
+    app_id: &str,
     pack_zstd_level: i32,
     pack_max_threads: Option<usize>,
     pack_memory_mb: u64,
@@ -65,6 +66,9 @@ pub(super) fn configure_benchmark_context(
         "",
         "",
     );
+    // The publisher must use the same app-scoped prefix the UpdateManager
+    // requires (surge-core #79: release index lives on <prefix>/<app_id>).
+    ctx.set_storage_prefix(app_id);
 
     let mut budget = ctx.resource_budget();
     let available_threads = std::thread::available_parallelism().map_or(1, std::num::NonZeroUsize::get);
@@ -143,7 +147,7 @@ pub async fn run_update_scenario(
     let manifest_path = work_dir.join("update-bench.surge.yml");
     write_bench_manifest(&manifest_path, &store_dir, app_id, &rid, pack_zstd_level)?;
 
-    let ctx = configure_benchmark_context(&store_dir, pack_zstd_level, pack_max_threads, pack_memory_mb)?;
+    let ctx = configure_benchmark_context(&store_dir, app_id, pack_zstd_level, pack_max_threads, pack_memory_mb)?;
 
     let template = PayloadTemplate::new(scale, seed);
     let base_input_bytes = template.write_base(&artifacts_dir, seed)?;
@@ -179,7 +183,8 @@ pub async fn run_update_scenario(
         let version = version_label(version_index);
         let publication =
             publish_release(Arc::clone(&ctx), &manifest_path, app_id, &rid, &version, &artifacts_dir).await?;
-        let release_index_size = fs::metadata(store_dir.join(RELEASES_FILE_COMPRESSED)).map_or(0, |meta| meta.len());
+        let release_index_size =
+            fs::metadata(store_dir.join(app_id).join(RELEASES_FILE_COMPRESSED)).map_or(0, |meta| meta.len());
         release_index_updates.push(publication.release_index_update);
         release_index_sizes.push(release_index_size);
 
@@ -280,7 +285,7 @@ pub async fn run_update_scenario(
     });
 
     let baseline_version = version_label(1);
-    let baseline_full = store_dir.join(&baseline_publication.full_build.filename);
+    let baseline_full = store_dir.join(app_id).join(&baseline_publication.full_build.filename);
     let baseline_bytes = fs::read(&baseline_full)?;
     let baseline_app_dir = install_dir.join("app");
     extractor::extract_to(&baseline_bytes, &baseline_app_dir, None)?;
@@ -295,7 +300,7 @@ pub async fn run_update_scenario(
             .ok_or_else(|| SurgeError::Config(format!("Install path is not valid UTF-8: {}", install_dir.display())))?,
     )?;
 
-    let releases_index_path = store_dir.join(RELEASES_FILE_COMPRESSED);
+    let releases_index_path = store_dir.join(app_id).join(RELEASES_FILE_COMPRESSED);
     let releases_index_size = fs::metadata(&releases_index_path).map_or(0, |meta| meta.len());
     let check_started = Instant::now();
     let info = update_manager

--- a/docs/performance/README.md
+++ b/docs/performance/README.md
@@ -16,6 +16,21 @@ Files:
 - [pack-policy.md](/home/peters/github/surge/docs/performance/pack-policy.md): current defaults, why they were chosen, and what tune is allowed to write
 - [update-chains.md](/home/peters/github/surge/docs/performance/update-chains.md): what is known about long delta chains and what remains unresolved
 
+## Autoresearch Surfaces
+
+The iterative optimization loop lives under `auto/` (see `Autoresearch
+Methodology` in the repository `AGENTS.md`). Each surface measures one
+family of these findings through `surge-bench` and logs every attempt
+in its append-only `results.tsv`:
+
+- `auto/delta/` — delta patch size and diff/apply cost (canonical surface)
+- `auto/pack/` — full pack build throughput and artifact size
+- `auto/update/` — end-to-end client update cost across a delta chain
+
+The scenario/scale definitions in `benchmark-profiles.md` stay the single
+source of truth; surface `program.md` files reference them instead of
+defining new payload shapes.
+
 Maintenance rules:
 
 - Keep payload descriptions anonymized and generic.


### PR DESCRIPTION
## Purpose

Imports the iterative optimization loop (Karpathy-style, as used in the
sibling nativesdk repo): define one metric, baseline it, propose one
hypothesis, implement, measure, then record the result as `keep` or
`discard`. Every experiment — successful or not — is recorded in an
append-only log so the next agent does not repeat dead ends.

Each surface has `program.md` (scope, constraints, metric definition,
ranked optimization ideas), `bench.sh` (canonical `surge-bench`
invocation, fixed seed, JSON-parsed score + metrics), and
`results.tsv` (append-only log: `commit score <metric> status
description`). `auto/config.sh` holds the shared build/seed/TSV helpers.

The three surfaces cover the three cost centers of an edge-fleet update
engine:

- `auto/delta/` — **canonical surface**. Delta patch size (field
  bandwidth) and diff/apply cost for the bsdiff/chunked-bsdiff family.
- `auto/pack/` — full pack/archive build throughput (publisher CI cost
  per release) with archive bytes as a guardrail; determinism is a hard
  constraint.
- `auto/update/` — end-to-end client update cost across a real delta
  chain (download bytes + apply time through the real `UpdateManager`);
  owns chain/checkpoint/retention policy.

`AGENTS.md` gains the `## Autoresearch Methodology` section (keep/discard
rules, dead-end corpus rule, promotion gates). The stale references to
`.github/workflows/benchmark.yml` (deleted in e4ab9e0) are dropped from
`AGENTS.md` and `docs/performance/README.md` points at the new surfaces.

## Behavior impact

No runtime code. New harness entrypoints plus docs.

## Test evidence

All three benches run end to end; baselines seeded at the parent commit
(4578166), 48-core/251 GB host:

| surface | score | metric |
|---|---|---|
| delta | 42,595 B patch (0.25, sdk-only) | 2053 ms diff, 199 ms apply |
| pack | 78.3 ms archive create (0.05, full-release) | 7,997,458 B archive, byte-identical across runs |
| update | 8526 ms apply (0.05, 20 deltas) | 104,328 B downloaded, 796 ms delta build |

## Notes

Stacked on the bench fix PR (#244) — the update surface needs the
app-scoped store layout to run.