### PR TITLE
fix(storage): adapt XML parsing to quick-xml 0.42 string APIs

### DIFF
--- a/crates/surge-core/src/storage/azure/listing.rs
+++ b/crates/surge-core/src/storage/azure/listing.rs
@@ -36,7 +36,7 @@ pub(super) fn parse_azure_list_blobs_xml(xml: &str) -> Result<ListResult> {
     loop {
         match reader.read_event_into(&mut buf) {
             Ok(Event::Start(ref e)) => {
-                let tag = String::from_utf8_lossy(e.name().as_ref()).to_string();
+                let tag = e.name().as_ref().to_string();
                 match tag.as_str() {
                     "Blob" => {
                         in_blob = true;
@@ -51,7 +51,7 @@ pub(super) fn parse_azure_list_blobs_xml(xml: &str) -> Result<ListResult> {
                 current_tag = tag;
             }
             Ok(Event::End(ref e)) => {
-                let tag = String::from_utf8_lossy(e.name().as_ref()).to_string();
+                let tag = e.name().as_ref().to_string();
                 match tag.as_str() {
                     "Blob" => {
                         if let Some(name) = current_name.take() {
@@ -71,7 +71,7 @@ pub(super) fn parse_azure_list_blobs_xml(xml: &str) -> Result<ListResult> {
                 current_tag.clear();
             }
             Ok(Event::Text(ref e)) => {
-                let text = String::from_utf8_lossy(e.as_ref()).to_string();
+                let text = e.as_ref().to_string();
                 if in_blob && !in_properties && current_tag == "Name" {
                     current_name = Some(text);
                 } else if in_properties && current_tag == "Content-Length" {

--- a/crates/surge-core/src/storage/gcs/xml_listing.rs
+++ b/crates/surge-core/src/storage/gcs/xml_listing.rs
@@ -22,7 +22,7 @@ pub(super) fn parse_gcs_xml_list_response(xml: &str) -> Result<ListResult> {
     loop {
         match reader.read_event_into(&mut buf) {
             Ok(Event::Start(ref e)) => {
-                let tag = String::from_utf8_lossy(e.name().as_ref()).to_string();
+                let tag = e.name().as_ref().to_string();
                 if tag == "Contents" {
                     in_contents = true;
                     current_key = None;
@@ -31,7 +31,7 @@ pub(super) fn parse_gcs_xml_list_response(xml: &str) -> Result<ListResult> {
                 current_tag = tag;
             }
             Ok(Event::End(ref e)) => {
-                let tag = String::from_utf8_lossy(e.name().as_ref()).to_string();
+                let tag = e.name().as_ref().to_string();
                 if tag == "Contents" {
                     if let Some(key) = current_key.take() {
                         entries.push(ListEntry {
@@ -44,7 +44,7 @@ pub(super) fn parse_gcs_xml_list_response(xml: &str) -> Result<ListResult> {
                 current_tag.clear();
             }
             Ok(Event::Text(ref e)) => {
-                let text = String::from_utf8_lossy(e.as_ref()).to_string();
+                let text = e.as_ref().to_string();
                 if in_contents {
                     match current_tag.as_str() {
                         "Key" => current_key = Some(text),

--- a/crates/surge-core/src/storage/s3_wire.rs
+++ b/crates/surge-core/src/storage/s3_wire.rs
@@ -62,7 +62,7 @@ pub(super) fn parse_list_objects_v2_xml(xml: &str) -> Result<ListResult> {
     loop {
         match reader.read_event_into(&mut buf) {
             Ok(Event::Start(ref e)) => {
-                let tag = String::from_utf8_lossy(e.name().as_ref()).to_string();
+                let tag = e.name().as_ref().to_string();
                 if tag == "Contents" {
                     in_contents = true;
                     current_key = None;
@@ -71,7 +71,7 @@ pub(super) fn parse_list_objects_v2_xml(xml: &str) -> Result<ListResult> {
                 current_tag = tag;
             }
             Ok(Event::End(ref e)) => {
-                let tag = String::from_utf8_lossy(e.name().as_ref()).to_string();
+                let tag = e.name().as_ref().to_string();
                 if tag == "Contents" {
                     if let Some(key) = current_key.take() {
                         entries.push(ListEntry {
@@ -84,7 +84,7 @@ pub(super) fn parse_list_objects_v2_xml(xml: &str) -> Result<ListResult> {
                 current_tag.clear();
             }
             Ok(Event::Text(ref e)) => {
-                let text = String::from_utf8_lossy(e.as_ref()).to_string();
+                let text = e.as_ref().to_string();
                 if in_contents {
                     match current_tag.as_str() {
                         "Key" => current_key = Some(text),


### PR DESCRIPTION
## Purpose

Main has failed to compile since the quick-xml 0.41 → 0.42 dependabot
bump (#243, merged with red CI on Aug 26). 0.42 made event names
`QName` (str-based) and `BytesText` str-backed, so the
`String::from_utf8_lossy(...)` conversions in the three list parsers
(S3, Azure, GCS) no longer type-check — 9 errors, `s3_wire.rs`,
`azure/listing.rs`, `gcs/xml_listing.rs`.

Drop the lossy conversions; `.as_ref()` yields `&str` directly on the
new types.

## Behavior impact

None — byte-identical parsing for well-formed XML. `from_utf8_lossy`
on these event payloads was a no-op in practice (they were already
valid UTF-8 strings in 0.42; in 0.41 they decoded the same bytes).

## Test evidence

Against the 0.42.0 lock (main's Cargo.lock):

- `cargo check --workspace --all-targets --all-features --locked` clean
- `cargo test --workspace` (RUSTFLAGS="-D warnings"): 527 passed, 0 failed
- `cargo fmt --all -- --check` clean
- `cargo clippy --workspace --lib --bins --examples -- -D warnings -D clippy::unwrap_used -D clippy::expect_used` clean

Merging this unblocks #244 and #245 (their CI runs on the merge ref and
inherited main's broken lock).