### PR TITLE
Match interpreted app identity before update swap

### DIFF
--- a/crates/surge-core/src/update/manager.rs
+++ b/crates/surge-core/src/update/manager.rs
@@ -4697,6 +4697,123 @@ echo started > new-child-started
         );
     }
 
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    #[tokio::test]
+    async fn test_download_and_apply_quarantines_previous_swap_before_relative_script_rescan() {
+        use std::os::unix::fs::PermissionsExt;
+        use std::process::{Command, Stdio};
+
+        let tmp = tempfile::tempdir().unwrap();
+        let store_root = tmp.path().join("store");
+        let install_root = tmp.path().join("install");
+        let app_id = "test-app";
+        std::fs::create_dir_all(&store_root).unwrap();
+        std::fs::create_dir_all(&install_root).unwrap();
+        let app_store = app_scoped_store_root(&store_root, app_id);
+
+        let current_app_dir = install_root.join("app");
+        std::fs::create_dir_all(&current_app_dir).unwrap();
+        std::fs::write(current_app_dir.join("payload.txt"), "old payload").unwrap();
+        write_runtime_identity(&current_app_dir, app_id, "1.0.0", "payload.txt", "");
+
+        let previous_swap_dir = install_root.join(".surge-app-prev");
+        std::fs::create_dir_all(&previous_swap_dir).unwrap();
+        write_runtime_identity(&previous_swap_dir, app_id, "0.9.0", "stale-script", "");
+        let stale_script = previous_swap_dir.join("stale-script");
+        std::fs::write(&stale_script, "#!/bin/sh\nprintf ready > \"$1\"\nread _\n").unwrap();
+        let mut permissions = std::fs::metadata(&stale_script).unwrap().permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&stale_script, permissions).unwrap();
+
+        let rid = current_rid();
+        let full_filename = format!("{app_id}-1.1.0-{rid}-full.tar.zst");
+        let full_path = app_store.join(&full_filename);
+        let mut packer = ArchivePacker::new(3).unwrap();
+        packer.add_buffer("payload.txt", b"new payload", 0o644).unwrap();
+        packer.finalize_to_file(&full_path).unwrap();
+
+        let mut latest = make_entry("1.1.0", "stable", &current_os_label_for_tests(), &rid);
+        latest.is_genesis = true;
+        latest.main_exe = "payload.txt".to_string();
+        latest.full_filename = full_filename;
+        latest.full_size = std::fs::metadata(&full_path).unwrap().len() as i64;
+        latest.full_sha256 = sha256_hex_file(&full_path).unwrap();
+        latest.deltas.clear();
+        latest.preferred_delta_id.clear();
+        write_app_scoped_release_index(
+            &store_root,
+            app_id,
+            &ReleaseIndex {
+                app_id: app_id.to_string(),
+                releases: vec![latest],
+                ..ReleaseIndex::default()
+            },
+        );
+
+        let ctx = Arc::new(Context::new());
+        ctx.set_storage(
+            StorageProvider::Filesystem,
+            store_root.to_str().unwrap(),
+            "",
+            "",
+            "",
+            "",
+        );
+        let mut manager = UpdateManager::new(ctx, app_id, "1.0.0", "stable", install_root.to_str().unwrap()).unwrap();
+        let info = manager.check_for_updates().await.unwrap().unwrap();
+        let ready_path = install_root.join("late-relative-script-ready");
+        let late_process = Arc::new(Mutex::new(None));
+        let late_process_for_progress = Arc::clone(&late_process);
+        let previous_swap_dir_for_progress = previous_swap_dir.clone();
+        let ready_path_for_progress = ready_path.clone();
+
+        manager
+            .download_and_apply(
+                &info,
+                Some(move |progress: ProgressInfo| {
+                    if progress.phase_label != finalize_phase::PREPARING_SWAP {
+                        return;
+                    }
+                    let mut late_process = late_process_for_progress
+                        .lock()
+                        .unwrap_or_else(std::sync::PoisonError::into_inner);
+                    if late_process.is_some() {
+                        return;
+                    }
+                    let child = Command::new("./stale-script")
+                        .current_dir(&previous_swap_dir_for_progress)
+                        .arg(&ready_path_for_progress)
+                        .stdin(Stdio::piped())
+                        .spawn()
+                        .unwrap();
+                    let deadline = std::time::Instant::now() + Duration::from_secs(1);
+                    while !ready_path_for_progress.is_file() {
+                        assert!(
+                            std::time::Instant::now() < deadline,
+                            "late relative script did not finish loading"
+                        );
+                        std::thread::sleep(Duration::from_millis(10));
+                    }
+                    *late_process = Some(child);
+                }),
+            )
+            .await
+            .unwrap();
+
+        let mut late_process = late_process
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .take()
+            .expect("preparing-swap callback should launch the late relative script");
+        let status = late_process.wait().unwrap();
+        assert!(!status.success());
+        assert!(!install_root.join(".surge-app-prev-quiescing").exists());
+        assert_eq!(
+            std::fs::read_to_string(install_root.join("app").join("payload.txt")).unwrap(),
+            "new payload"
+        );
+    }
+
     #[tokio::test]
     async fn test_download_and_apply_prunes_old_version_snapshots_to_retention_limit() {
         let tmp = tempfile::tempdir().unwrap();

--- a/crates/surge-core/src/update/manager.rs
+++ b/crates/surge-core/src/update/manager.rs
@@ -4477,6 +4477,74 @@ echo started > new-child-started
         assert!(!install_root.join(".surge-app-prev").exists());
     }
 
+    #[tokio::test]
+    async fn test_download_and_apply_handles_missing_current_release_identity_by_platform() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store_root = tmp.path().join("store");
+        let install_root = tmp.path().join("install");
+        let app_id = "test-app";
+        std::fs::create_dir_all(&store_root).unwrap();
+        std::fs::create_dir_all(&install_root).unwrap();
+        let app_store = app_scoped_store_root(&store_root, app_id);
+
+        let active_app_dir = install_root.join("app");
+        std::fs::create_dir_all(&active_app_dir).unwrap();
+        std::fs::write(active_app_dir.join("old-app"), "old payload").unwrap();
+
+        let rid = current_rid();
+        let full_filename = format!("{app_id}-1.1.0-{rid}-full.tar.zst");
+        let full_path = app_store.join(&full_filename);
+        let mut packer = ArchivePacker::new(3).unwrap();
+        packer.add_buffer("new-app", b"new payload", 0o755).unwrap();
+        packer.finalize_to_file(&full_path).unwrap();
+
+        let mut latest = make_entry("1.1.0", "stable", &current_os_label_for_tests(), &rid);
+        latest.is_genesis = true;
+        latest.main_exe = "new-app".to_string();
+        latest.full_filename = full_filename;
+        latest.full_size = std::fs::metadata(&full_path).unwrap().len() as i64;
+        latest.full_sha256 = sha256_hex_file(&full_path).unwrap();
+        latest.deltas.clear();
+        latest.preferred_delta_id.clear();
+        let index = ReleaseIndex {
+            app_id: app_id.to_string(),
+            releases: vec![latest],
+            ..ReleaseIndex::default()
+        };
+        write_app_scoped_release_index(&store_root, app_id, &index);
+
+        let ctx = Arc::new(Context::new());
+        ctx.set_storage(
+            StorageProvider::Filesystem,
+            store_root.to_str().unwrap(),
+            "",
+            "",
+            "",
+            "",
+        );
+        let mut manager = UpdateManager::new(ctx, app_id, "1.0.0", "stable", install_root.to_str().unwrap()).unwrap();
+        let info = manager.check_for_updates().await.unwrap().unwrap();
+        assert!(manager.current_release_identity.is_none());
+
+        let result = manager.download_and_apply(&info, None::<fn(ProgressInfo)>).await;
+
+        #[cfg(unix)]
+        {
+            let error = result.unwrap_err();
+            assert!(error.to_string().contains("Current release 1.0.0 is unavailable"));
+            assert_eq!(
+                std::fs::read_to_string(active_app_dir.join("old-app")).unwrap(),
+                "old payload"
+            );
+            assert!(!active_app_dir.join("new-app").exists());
+        }
+        #[cfg(not(unix))]
+        {
+            result.unwrap();
+            assert!(active_app_dir.join("new-app").is_file());
+        }
+    }
+
     #[cfg(any(target_os = "linux", target_os = "macos"))]
     #[tokio::test]
     async fn test_download_and_apply_quiesces_installed_executable_when_target_name_changes() {

--- a/crates/surge-core/src/update/manager/finalize.rs
+++ b/crates/surge-core/src/update/manager/finalize.rs
@@ -37,6 +37,38 @@ use super::{RELEASE_GRAPH_CHECKPOINT_FULLS, SupervisorRestartOutcome, UpdateInfo
 /// backend must not stall the rest of finalize indefinitely.
 const PRUNE_INDEX_FETCH_TIMEOUT: Duration = Duration::from_secs(30);
 
+#[cfg(unix)]
+const PREVIOUS_SWAP_QUARANTINE_DIR: &str = ".surge-app-prev-quiescing";
+
+#[cfg(unix)]
+fn restore_interrupted_previous_swap_quarantine(previous_swap_dir: &Path, quarantine_dir: &Path) -> Result<()> {
+    let previous_exists = previous_swap_dir.try_exists()?;
+    let quarantine_exists = quarantine_dir.try_exists()?;
+    if previous_exists && quarantine_exists {
+        return Err(SurgeError::Update(
+            "Both the previous swap directory and its quiescence quarantine exist; refusing to choose one".to_string(),
+        ));
+    }
+    if quarantine_exists {
+        atomic_rename(quarantine_dir, previous_swap_dir).map_err(|error| {
+            SurgeError::Update(format!(
+                "Failed to restore the interrupted previous swap quarantine: {error}"
+            ))
+        })?;
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn restore_previous_swap_after_error(previous_swap_dir: &Path, quarantine_dir: &Path, error: SurgeError) -> SurgeError {
+    match atomic_rename(quarantine_dir, previous_swap_dir) {
+        Ok(()) => error,
+        Err(restore_error) => SurgeError::Update(format!(
+            "{error}; failed to restore the previous swap directory from its quiescence quarantine: {restore_error}"
+        )),
+    }
+}
+
 #[allow(clippy::too_many_lines)]
 pub(super) async fn finalize_update<F>(
     manager: &UpdateManager,
@@ -64,6 +96,10 @@ where
     let active_app_dir = manager.install_dir.join("app");
     let next_app_dir = manager.install_dir.join(".surge-app-next");
     let previous_swap_dir = manager.install_dir.join(".surge-app-prev");
+    #[cfg(unix)]
+    let previous_swap_quarantine_dir = manager.install_dir.join(PREVIOUS_SWAP_QUARANTINE_DIR);
+    #[cfg(unix)]
+    restore_interrupted_previous_swap_quarantine(&previous_swap_dir, &previous_swap_quarantine_dir)?;
     let active_app_was_present = active_app_dir.is_dir();
     let fallback_previous_app_dir = if active_app_was_present {
         None
@@ -160,7 +196,12 @@ where
         if let Some(prepared) = &prepared {
             lifecycle::terminate_prepared_app_processes(prepared)?;
         }
-        prepared.map(|prepared| (prepared, previous_swap_identity.main_exe))
+        let prepared = prepared.ok_or_else(|| {
+            SurgeError::Update(
+                "Previous swap application entrypoint disappeared before it could be quiesced".to_string(),
+            )
+        })?;
+        Some((prepared, previous_swap_identity.main_exe))
     } else {
         None
     };
@@ -169,13 +210,43 @@ where
     if next_app_dir.exists() {
         tokio::fs::remove_dir_all(&next_app_dir).await?;
     }
-    if previous_swap_dir.exists() {
-        tokio::fs::remove_dir_all(&previous_swap_dir).await?;
-    }
     #[cfg(unix)]
     if let Some((previous_swap_quiescence, previous_main_exe)) = &previous_swap_quiescence {
-        lifecycle::terminate_prepared_app_processes(previous_swap_quiescence)?;
-        lifecycle::terminate_superseded_app_processes(&manager.install_dir, &active_app_dir, previous_main_exe)?;
+        atomic_rename(&previous_swap_dir, &previous_swap_quarantine_dir)?;
+        let quarantine_result = (|| {
+            let quarantined_quiescence = lifecycle::prepare_app_quiescence(
+                &previous_swap_quarantine_dir,
+                previous_main_exe,
+                manager.allow_in_process_swap,
+            )?
+            .ok_or_else(|| {
+                SurgeError::Update(
+                    "Previous swap application entrypoint disappeared while entering quiescence quarantine".to_string(),
+                )
+            })?;
+            lifecycle::terminate_prepared_app_processes(&quarantined_quiescence)?;
+            lifecycle::terminate_prepared_app_processes(previous_swap_quiescence)?;
+            lifecycle::terminate_superseded_app_processes(&manager.install_dir, &active_app_dir, previous_main_exe)?;
+            Ok::<(), SurgeError>(())
+        })();
+        if let Err(error) = quarantine_result {
+            return Err(restore_previous_swap_after_error(
+                &previous_swap_dir,
+                &previous_swap_quarantine_dir,
+                error,
+            ));
+        }
+        if let Err(error) = tokio::fs::remove_dir_all(&previous_swap_quarantine_dir).await {
+            return Err(restore_previous_swap_after_error(
+                &previous_swap_dir,
+                &previous_swap_quarantine_dir,
+                error.into(),
+            ));
+        }
+    }
+    #[cfg(not(unix))]
+    if previous_swap_dir.exists() {
+        tokio::fs::remove_dir_all(&previous_swap_dir).await?;
     }
 
     progress_emitter.emit_substep(6, finalize_phase::SWAPPING_APP_DIRECTORY, 93);

--- a/crates/surge-core/src/update/manager/finalize.rs
+++ b/crates/surge-core/src/update/manager/finalize.rs
@@ -64,7 +64,8 @@ where
     let active_app_dir = manager.install_dir.join("app");
     let next_app_dir = manager.install_dir.join(".surge-app-next");
     let previous_swap_dir = manager.install_dir.join(".surge-app-prev");
-    let fallback_previous_app_dir = if active_app_dir.is_dir() {
+    let active_app_was_present = active_app_dir.is_dir();
+    let fallback_previous_app_dir = if active_app_was_present {
         None
     } else {
         apply::find_previous_app_dir(&manager.install_dir, &manager.current_version)
@@ -123,6 +124,17 @@ where
     }
 
     progress_emitter.emit_substep(6, finalize_phase::QUIESCING_ACTIVE_APP, 92);
+    #[cfg(unix)]
+    let current_quiescence = if let Some(current_app_dir) = current_app_dir {
+        lifecycle::prepare_app_quiescence(current_app_dir, current_main_exe, manager.allow_in_process_swap)?
+    } else {
+        None
+    };
+    #[cfg(unix)]
+    if let Some(current_quiescence) = &current_quiescence {
+        lifecycle::terminate_prepared_app_processes(current_quiescence)?;
+    }
+    #[cfg(not(unix))]
     if let Some(current_app_dir) = current_app_dir {
         lifecycle::terminate_active_app_processes_before_swap(
             current_app_dir,
@@ -131,7 +143,7 @@ where
         )?;
     }
     #[cfg(unix)]
-    if previous_swap_dir.is_dir() {
+    let previous_swap_quiescence = if previous_swap_dir.is_dir() {
         let previous_swap_identity = super::current_install::load_previous_swap(manager, &previous_swap_dir)?
             .ok_or_else(|| {
                 SurgeError::Update(
@@ -140,12 +152,18 @@ where
                 )
             })?;
         lifecycle::request_supervisor_shutdown(&manager.install_dir, &previous_swap_identity.supervisor_id).await?;
-        lifecycle::terminate_active_app_processes_before_swap(
+        let prepared = lifecycle::prepare_app_quiescence(
             &previous_swap_dir,
             &previous_swap_identity.main_exe,
             manager.allow_in_process_swap,
         )?;
-    }
+        if let Some(prepared) = &prepared {
+            lifecycle::terminate_prepared_app_processes(prepared)?;
+        }
+        prepared.map(|prepared| (prepared, previous_swap_identity.main_exe))
+    } else {
+        None
+    };
 
     progress_emitter.emit_substep(6, finalize_phase::PREPARING_SWAP, 92);
     if next_app_dir.exists() {
@@ -154,12 +172,28 @@ where
     if previous_swap_dir.exists() {
         tokio::fs::remove_dir_all(&previous_swap_dir).await?;
     }
+    #[cfg(unix)]
+    if let Some((previous_swap_quiescence, previous_main_exe)) = &previous_swap_quiescence {
+        lifecycle::terminate_prepared_app_processes(previous_swap_quiescence)?;
+        lifecycle::terminate_superseded_app_processes(&manager.install_dir, &active_app_dir, previous_main_exe)?;
+    }
 
     progress_emitter.emit_substep(6, finalize_phase::SWAPPING_APP_DIRECTORY, 93);
     atomic_rename(extracted_final_dir, &next_app_dir)?;
 
-    if active_app_dir.is_dir() {
+    if active_app_was_present {
         atomic_rename(&active_app_dir, &previous_swap_dir)?;
+        #[cfg(unix)]
+        if let Err(error) = (|| {
+            if let Some(current_quiescence) = &current_quiescence {
+                lifecycle::terminate_prepared_app_processes(current_quiescence)?;
+            }
+            lifecycle::terminate_superseded_app_processes(&manager.install_dir, &active_app_dir, current_main_exe)?;
+            Ok::<(), SurgeError>(())
+        })() {
+            let _ = atomic_rename(&previous_swap_dir, &active_app_dir);
+            return Err(error);
+        }
     }
     if let Err(err) = atomic_rename(&next_app_dir, &active_app_dir) {
         // Best effort rollback to previous active content.
@@ -167,6 +201,13 @@ where
             let _ = atomic_rename(&previous_swap_dir, &active_app_dir);
         }
         return Err(err);
+    }
+    #[cfg(unix)]
+    if !active_app_was_present {
+        if let Some(current_quiescence) = &current_quiescence {
+            lifecycle::terminate_prepared_app_processes(current_quiescence)?;
+        }
+        lifecycle::terminate_superseded_app_processes(&manager.install_dir, &active_app_dir, current_main_exe)?;
     }
 
     let previous_app_dir_for_assets = if previous_swap_dir.is_dir() {

--- a/crates/surge-core/src/update/manager/lifecycle.rs
+++ b/crates/surge-core/src/update/manager/lifecycle.rs
@@ -19,11 +19,13 @@ const SUPERVISOR_RESTART_RETRY_DELAY: Duration = Duration::from_millis(500);
 
 mod process_quiescence;
 
+#[cfg(not(unix))]
+pub(super) use self::process_quiescence::terminate_active_app_processes_before_swap;
+pub(super) use self::process_quiescence::terminate_superseded_app_processes;
+#[cfg(unix)]
+pub(super) use self::process_quiescence::{prepare_app_quiescence, terminate_prepared_app_processes};
 #[cfg(all(test, any(target_os = "linux", target_os = "macos")))]
 pub(in crate::update::manager) use self::process_quiescence::{spawn_native_test_app, wait_for_native_test_app};
-pub(super) use self::process_quiescence::{
-    terminate_active_app_processes_before_swap, terminate_superseded_app_processes,
-};
 
 #[derive(Debug, Clone)]
 pub(super) enum SupervisorRestartOutcome {

--- a/crates/surge-core/src/update/manager/lifecycle/process_quiescence.rs
+++ b/crates/surge-core/src/update/manager/lifecycle/process_quiescence.rs
@@ -1,3 +1,5 @@
+#[cfg(unix)]
+use std::ffi::OsString;
 use std::path::Path;
 #[cfg(unix)]
 use std::time::Duration;
@@ -16,6 +18,8 @@ use crate::error::Result;
 use crate::error::SurgeError;
 use crate::platform::process::current_pid;
 
+#[cfg(unix)]
+mod active_entrypoint;
 #[cfg(unix)]
 mod interpreted_main;
 pub(in crate::update::manager) fn terminate_superseded_app_processes(
@@ -58,23 +62,10 @@ fn terminate_active_app_processes_except(
         return Ok(0);
     }
 
-    let active_app_root = std::fs::canonicalize(active_app_dir).map_err(|e| {
-        SurgeError::Platform(format!(
-            "Failed to resolve active application directory before swap: {e}"
-        ))
+    let active_entrypoint = active_entrypoint::Identity::resolve(active_app_dir, main_exe)?.ok_or_else(|| {
+        SurgeError::Platform("Failed to resolve active application executable before swap".to_string())
     })?;
-    let active_exe = std::fs::canonicalize(active_app_root.join(main_exe)).map_err(|e| {
-        SurgeError::Platform(format!(
-            "Failed to resolve active application executable before swap: {e}"
-        ))
-    })?;
-    if !active_exe.starts_with(&active_app_root) {
-        return Err(SurgeError::Platform(format!(
-            "Active application executable '{}' resolves outside the active application directory; refusing to signal a shared executable",
-            active_app_root.join(main_exe).display()
-        )));
-    }
-    if updater_runs_from_active_exe(&active_exe, protected_pid)? {
+    if updater_runs_from_active_exe(&active_entrypoint.resolved, protected_pid)? {
         if !allow_in_process_swap {
             return Err(SurgeError::Platform(
                 "The updater is running from the active application executable; refusing an in-process directory swap. Apply the update from an external Surge updater."
@@ -85,9 +76,9 @@ fn terminate_active_app_processes_except(
             "The updater is running from the active application executable; in-process swap explicitly allowed, quiescing other active application processes only"
         );
     }
-    let interpreted_main = interpreted_main::resolve(&active_exe)?;
+    let interpreted_main = interpreted_main::resolve(&active_entrypoint.resolved)?;
     terminate_matching_app_processes(main_exe, protected_pid, "active", |process| {
-        is_active_app_process(&active_exe, interpreted_main.as_ref(), process)
+        is_active_app_process(&active_entrypoint, interpreted_main.as_ref(), process)
     })
 }
 
@@ -224,16 +215,6 @@ where
     }
 }
 
-#[cfg(all(unix, not(target_os = "macos")))]
-fn is_active_app_exe(active_exe: &Path, exe: &Path) -> bool {
-    exe == active_exe
-}
-
-#[cfg(target_os = "macos")]
-fn is_active_app_exe(active_exe: &Path, exe: &Path) -> bool {
-    exe == active_exe || std::fs::canonicalize(exe).is_ok_and(|resolved| resolved == active_exe)
-}
-
 #[cfg(all(test, any(target_os = "linux", target_os = "macos")))]
 const NATIVE_TEST_APP_FILTER: &str =
     "update::manager::lifecycle::process_quiescence::tests::native_app_process_fixture";
@@ -267,11 +248,17 @@ pub(in crate::update::manager) fn spawn_native_test_app(app_path: &Path) -> std:
 
 #[cfg(all(test, any(target_os = "linux", target_os = "macos")))]
 pub(in crate::update::manager) fn wait_for_native_test_app(app_path: &Path, child_pid: u32) {
-    let resolved_app_path = std::fs::canonicalize(app_path).unwrap();
-    let deadline = std::time::Instant::now() + Duration::from_secs(5);
-    while !app_process_pids(u32::MAX, &|process| is_active_app_exe(&resolved_app_path, &process.exe))
+    let active_app_dir = app_path.parent().unwrap();
+    let main_exe = app_path.file_name().unwrap().to_str().unwrap();
+    let active_entrypoint = active_entrypoint::Identity::resolve(active_app_dir, main_exe)
         .unwrap()
-        .contains(&child_pid)
+        .unwrap();
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    while !app_process_pids(u32::MAX, &|process| {
+        is_active_app_process(&active_entrypoint, None, process)
+    })
+    .unwrap()
+    .contains(&child_pid)
     {
         assert!(
             std::time::Instant::now() < deadline,
@@ -283,38 +270,22 @@ pub(in crate::update::manager) fn wait_for_native_test_app(app_path: &Path, chil
 
 #[cfg(unix)]
 fn is_active_app_process(
-    active_exe: &Path,
+    active_entrypoint: &active_entrypoint::Identity,
     interpreted_main: Option<&interpreted_main::Identity>,
     process: &AppProcess,
 ) -> bool {
-    is_active_app_exe(active_exe, &process.exe)
+    active_entrypoint.matches_executable(&process.exe)
         || process
             .command
             .first()
-            .is_some_and(|argument| process_argument_resolves_to(argument, process.cwd.as_deref(), active_exe))
+            .is_some_and(|argument| active_entrypoint.matches_argument(argument, process.cwd.as_deref()))
         || interpreted_main.is_some_and(|identity| {
             identity.matches_interpreter(&process.exe, process.command.first().map(OsString::as_os_str))
                 && process
                     .command
                     .get(identity.script_argument_index)
-                    .is_some_and(|argument| process_argument_resolves_to(argument, process.cwd.as_deref(), active_exe))
+                    .is_some_and(|argument| active_entrypoint.matches_argument(argument, process.cwd.as_deref()))
         })
-}
-
-#[cfg(unix)]
-fn process_argument_resolves_to(argument: &std::ffi::OsStr, cwd: Option<&Path>, expected: &Path) -> bool {
-    let argument = Path::new(argument);
-    if argument.as_os_str().is_empty() {
-        return false;
-    }
-    let candidate = if argument.is_absolute() {
-        argument.to_path_buf()
-    } else if let Some(cwd) = cwd {
-        cwd.join(argument)
-    } else {
-        return false;
-    };
-    std::fs::canonicalize(candidate).is_ok_and(|resolved| resolved == expected)
 }
 
 #[cfg(unix)]
@@ -443,6 +414,57 @@ mod tests {
     }
 
     #[cfg(any(target_os = "linux", target_os = "macos"))]
+    #[test]
+    fn symlinked_active_entrypoint_does_not_terminate_other_processes_using_shared_target() {
+        use std::os::unix::fs::symlink;
+        use std::process::Command;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let active_app_dir = tmp.path().join("app");
+        std::fs::create_dir_all(&active_app_dir).unwrap();
+        let app_path = active_app_dir.join("demo");
+        symlink("/bin/sleep", &app_path).unwrap();
+        let active_entrypoint = active_entrypoint::Identity::resolve(&active_app_dir, "demo")
+            .unwrap()
+            .unwrap();
+        assert!(active_entrypoint.requires_argument());
+
+        let mut app_child = Command::new(&app_path).arg("30").spawn().unwrap();
+        let app_child_pid = app_child.id();
+        let mut unrelated_child = Command::new("/bin/sleep").arg("30").spawn().unwrap();
+        let unrelated_child_pid = unrelated_child.id();
+
+        let deadline = std::time::Instant::now() + Duration::from_secs(1);
+        loop {
+            let matches = app_process_pids(u32::MAX, &|process| {
+                is_active_app_process(&active_entrypoint, None, process)
+            })
+            .unwrap();
+            if matches.contains(&app_child_pid) {
+                assert!(!matches.contains(&unrelated_child_pid));
+                break;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "test child did not expose the symlinked app launch identity"
+            );
+            std::thread::sleep(Duration::from_millis(10));
+        }
+
+        let terminated = terminate_active_app_processes_except(&active_app_dir, "demo", u32::MAX, false);
+        let app_status = app_child.wait().unwrap();
+        let unrelated_still_running = unrelated_child.try_wait().unwrap().is_none();
+        if unrelated_still_running {
+            unrelated_child.kill().unwrap();
+        }
+        let _ = unrelated_child.wait();
+
+        assert_eq!(terminated.unwrap(), 1);
+        assert!(!app_status.success());
+        assert!(unrelated_still_running);
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
     fn assert_interpreted_active_app_process_is_terminated_before_swap(
         shebang: &str,
         isolated_env_interpreter: Option<&str>,
@@ -473,8 +495,10 @@ mod tests {
         let mut permissions = std::fs::metadata(&app_path).unwrap().permissions();
         permissions.set_mode(0o755);
         std::fs::set_permissions(&app_path, permissions).unwrap();
-        let resolved_app_path = std::fs::canonicalize(&app_path).unwrap();
-        let interpreted_main = interpreted_main::resolve(&resolved_app_path).unwrap().unwrap();
+        let active_entrypoint = active_entrypoint::Identity::resolve(&active_app_dir, "demo-script")
+            .unwrap()
+            .unwrap();
+        let interpreted_main = interpreted_main::resolve(&active_entrypoint.resolved).unwrap().unwrap();
 
         let spawn_deadline = std::time::Instant::now() + Duration::from_secs(1);
         let mut child = loop {
@@ -496,7 +520,7 @@ mod tests {
         let child_pid = child.id();
         let deadline = std::time::Instant::now() + Duration::from_secs(1);
         while !app_process_pids(u32::MAX, &|process| {
-            is_active_app_process(&resolved_app_path, Some(&interpreted_main), process)
+            is_active_app_process(&active_entrypoint, Some(&interpreted_main), process)
         })
         .unwrap()
         .contains(&child_pid)
@@ -508,7 +532,8 @@ mod tests {
             std::thread::sleep(Duration::from_millis(10));
         }
 
-        let terminated = terminate_active_app_processes_except(&active_app_dir, "demo-script", u32::MAX, false).unwrap();
+        let terminated =
+            terminate_active_app_processes_except(&active_app_dir, "demo-script", u32::MAX, false).unwrap();
         let status = child.wait().unwrap();
 
         assert_eq!(terminated, 1);
@@ -517,29 +542,18 @@ mod tests {
 
     #[cfg(any(target_os = "linux", target_os = "macos"))]
     #[test]
-    fn shared_symlink_entrypoint_refuses_swap_without_signalling_unrelated_process() {
-        use std::os::unix::fs::symlink;
-        use std::process::Command;
-
+    fn missing_active_entrypoint_refuses_swap() {
         let tmp = tempfile::tempdir().unwrap();
         let active_app_dir = tmp.path().join("app");
         std::fs::create_dir_all(&active_app_dir).unwrap();
-        symlink("/bin/sleep", active_app_dir.join("demo")).unwrap();
 
-        let mut unrelated_child = Command::new("/bin/sleep").arg("30").spawn().unwrap();
-        let error = terminate_active_app_processes_except(&active_app_dir, "demo", u32::MAX, false).unwrap_err();
-        let unrelated_still_running = unrelated_child.try_wait().unwrap().is_none();
-        if unrelated_still_running {
-            unrelated_child.kill().unwrap();
-        }
-        let _ = unrelated_child.wait();
+        let error = terminate_active_app_processes_except(&active_app_dir, "missing", u32::MAX, false).unwrap_err();
 
         assert!(
             error
                 .to_string()
-                .contains("resolves outside the active application directory")
+                .contains("Failed to resolve active application executable before swap")
         );
-        assert!(unrelated_still_running);
     }
 
     #[cfg(any(target_os = "linux", target_os = "macos"))]

--- a/crates/surge-core/src/update/manager/lifecycle/process_quiescence.rs
+++ b/crates/surge-core/src/update/manager/lifecycle/process_quiescence.rs
@@ -690,6 +690,46 @@ mod tests {
     }
 
     #[cfg(any(target_os = "linux", target_os = "macos"))]
+    fn interpreted_test_process_snapshot(pid: u32) -> String {
+        #[cfg(target_os = "linux")]
+        {
+            let exe = std::fs::read_link(format!("/proc/{pid}/exe"));
+            let command =
+                std::fs::read(format!("/proc/{pid}/cmdline")).map(|bytes| discovery::parse_proc_cmdline(&bytes));
+            let cwd = std::fs::read_link(format!("/proc/{pid}/cwd"));
+            return format!("exe={exe:?}, command={command:?}, cwd={cwd:?}");
+        }
+
+        #[cfg(target_os = "macos")]
+        {
+            use sysinfo::{Pid, ProcessRefreshKind, ProcessesToUpdate, System, UpdateKind};
+
+            let pid = Pid::from_u32(pid);
+            let mut system = System::new();
+            let refreshed = system.refresh_processes_specifics(
+                ProcessesToUpdate::Some(&[pid]),
+                true,
+                ProcessRefreshKind::nothing()
+                    .with_exe(UpdateKind::Always)
+                    .with_cmd(UpdateKind::Always)
+                    .with_cwd(UpdateKind::Always),
+            );
+            return system.process(pid).map_or_else(
+                || format!("process unavailable after refreshing {refreshed} entries"),
+                |process| {
+                    format!(
+                        "exe={:?}, command={:?}, cwd={:?}, status={:?}",
+                        process.exe(),
+                        process.cmd(),
+                        process.cwd(),
+                        process.status()
+                    )
+                },
+            );
+        }
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
     fn assert_interpreted_active_app_process_is_terminated_before_swap(shebang: &str) {
         use std::os::unix::fs::PermissionsExt;
         use std::process::{Command, Stdio};
@@ -724,24 +764,38 @@ mod tests {
         };
         let child_pid = child.id();
         let deadline = std::time::Instant::now() + Duration::from_secs(1);
-        while !app_process_pids(u32::MAX, &|process| {
-            is_active_app_process(&active_entrypoint, Some(&interpreted_main), process)
-        })
-        .unwrap()
-        .contains(&child_pid)
-        {
+        loop {
+            let matches = app_process_pids(u32::MAX, &|process| {
+                is_active_app_process(&active_entrypoint, Some(&interpreted_main), process)
+            })
+            .unwrap_or_else(|error| {
+                panic!(
+                    "{error}; child process snapshot: {}",
+                    interpreted_test_process_snapshot(child_pid)
+                )
+            });
+            if matches.contains(&child_pid) {
+                break;
+            }
             assert!(
                 std::time::Instant::now() < deadline,
-                "test child did not expose the interpreted app launch identity"
+                "test child did not expose the interpreted app launch identity; child process snapshot: {}",
+                interpreted_test_process_snapshot(child_pid)
             );
             std::thread::sleep(Duration::from_millis(10));
         }
 
-        let terminated =
-            terminate_active_app_processes_except(&active_app_dir, "demo-script", u32::MAX, false).unwrap();
+        let terminated = terminate_active_app_processes_except(&active_app_dir, "demo-script", u32::MAX, false)
+            .unwrap_or_else(|error| {
+                panic!(
+                    "{error}; child process snapshot: {}",
+                    interpreted_test_process_snapshot(child_pid)
+                )
+            });
+        let process_snapshot = interpreted_test_process_snapshot(child_pid);
         let status = child.wait().unwrap();
 
-        assert_eq!(terminated, 1);
+        assert_eq!(terminated, 1, "child process snapshot before wait: {process_snapshot}");
         assert!(!status.success());
     }
 

--- a/crates/surge-core/src/update/manager/lifecycle/process_quiescence.rs
+++ b/crates/surge-core/src/update/manager/lifecycle/process_quiescence.rs
@@ -470,7 +470,7 @@ mod tests {
         isolated_env_interpreter: Option<&str>,
     ) {
         use std::os::unix::fs::PermissionsExt;
-        use std::process::Command;
+        use std::process::{Command, Stdio};
 
         let tmp = tempfile::tempdir().unwrap();
         let active_app_dir = tmp.path().join("app");
@@ -491,7 +491,7 @@ mod tests {
             (shebang.to_string(), None)
         };
         let app_path = active_app_dir.join("demo-script");
-        std::fs::write(&app_path, format!("{shebang}\nwhile :; do sleep 1; done\n")).unwrap();
+        std::fs::write(&app_path, format!("{shebang}\nread _\n")).unwrap();
         let mut permissions = std::fs::metadata(&app_path).unwrap().permissions();
         permissions.set_mode(0o755);
         std::fs::set_permissions(&app_path, permissions).unwrap();
@@ -503,6 +503,7 @@ mod tests {
         let spawn_deadline = std::time::Instant::now() + Duration::from_secs(1);
         let mut child = loop {
             let mut command = Command::new(&app_path);
+            command.stdin(Stdio::piped());
             if let Some(child_path) = &child_path {
                 command.env("PATH", child_path);
             }

--- a/crates/surge-core/src/update/manager/lifecycle/process_quiescence.rs
+++ b/crates/surge-core/src/update/manager/lifecycle/process_quiescence.rs
@@ -325,6 +325,17 @@ fn is_active_app_process(
     let Some(identity) = interpreted_main else {
         return Ok(false);
     };
+    let Some(argument) = process.command.get(identity.script_argument_index) else {
+        if !process.command_inspected && identity.executable_may_match(&process.exe)? {
+            return Err(SurgeError::Platform(
+                "Cannot inspect the command line of the active application interpreter before swap".to_string(),
+            ));
+        }
+        return Ok(false);
+    };
+    if !active_entrypoint.matches_argument(argument, process.cwd.as_deref())? {
+        return Ok(false);
+    }
     if !process.command_inspected && identity.executable_may_match(&process.exe)? {
         return Err(SurgeError::Platform(
             "Cannot inspect the command line of the active application interpreter before swap".to_string(),
@@ -333,11 +344,7 @@ fn is_active_app_process(
     if !identity.matches_interpreter(&process.exe, process.command.first().map(OsString::as_os_str))? {
         return Ok(false);
     }
-    let Some(argument) = process.command.get(identity.script_argument_index) else {
-        return Ok(false);
-    };
-
-    active_entrypoint.matches_argument(argument, process.cwd.as_deref())
+    Ok(true)
 }
 
 #[cfg(unix)]
@@ -746,6 +753,29 @@ mod tests {
         );
     }
 
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    #[test]
+    fn unrelated_script_operand_does_not_resolve_an_ambiguous_env_interpreter() {
+        let tmp = tempfile::tempdir().unwrap();
+        let active_app_dir = tmp.path().join("app");
+        std::fs::create_dir_all(&active_app_dir).unwrap();
+        let app_path = active_app_dir.join("demo-script");
+        let interpreter_name = "surge-test-unresolvable-env-interpreter";
+        std::fs::write(&app_path, format!("#!/usr/bin/env {interpreter_name}\n")).unwrap();
+        let active_entrypoint = active_entrypoint::Identity::resolve(&active_app_dir, "demo-script")
+            .unwrap()
+            .unwrap();
+        let interpreted_main = interpreted_main::resolve(&active_entrypoint.resolved).unwrap().unwrap();
+        let process = AppProcess {
+            exe: std::fs::canonicalize("/bin/sh").unwrap(),
+            command: vec![OsString::from(interpreter_name), OsString::from("/other/script")],
+            command_inspected: true,
+            cwd: Some(active_app_dir),
+        };
+
+        assert!(!is_active_app_process(&active_entrypoint, Some(&interpreted_main), &process).unwrap());
+    }
+
     #[cfg(target_os = "macos")]
     #[test]
     fn direct_interpreted_app_with_multiple_options_is_terminated_before_swap() {
@@ -755,5 +785,30 @@ mod tests {
     #[test]
     fn env_interpreted_app_with_multiple_options_is_terminated_before_swap() {
         assert_interpreted_active_app_process_is_terminated_before_swap("#!/usr/bin/env /bin/sh -e -u");
+    }
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn empty_argv0_does_not_shift_a_symlinked_entrypoint_operand() {
+        use std::os::unix::fs::symlink;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let active_app_dir = tmp.path().join("app");
+        std::fs::create_dir_all(&active_app_dir).unwrap();
+        let app_path = active_app_dir.join("demo");
+        symlink("/bin/sleep", &app_path).unwrap();
+        let active_entrypoint = active_entrypoint::Identity::resolve(&active_app_dir, "demo")
+            .unwrap()
+            .unwrap();
+        let mut command = vec![0];
+        command.extend_from_slice(app_path.as_os_str().as_encoded_bytes());
+        command.push(0);
+        let process = AppProcess {
+            exe: std::fs::canonicalize("/bin/sleep").unwrap(),
+            command: discovery::parse_proc_cmdline(&command),
+            command_inspected: true,
+            cwd: Some(active_app_dir),
+        };
+
+        assert!(!is_active_app_process(&active_entrypoint, None, &process).unwrap());
     }
 }

--- a/crates/surge-core/src/update/manager/lifecycle/process_quiescence.rs
+++ b/crates/surge-core/src/update/manager/lifecycle/process_quiescence.rs
@@ -46,7 +46,12 @@ fn terminate_superseded_app_processes_except(
     protected_pid: u32,
 ) -> Result<usize> {
     terminate_matching_app_processes(main_exe, protected_pid, "superseded", |process| {
-        is_superseded_app_exe(install_dir, active_app_dir, main_exe, &process.exe)
+        Ok(is_superseded_app_exe(
+            install_dir,
+            active_app_dir,
+            main_exe,
+            &process.exe,
+        ))
     })
 }
 
@@ -93,6 +98,7 @@ fn refuse_in_process_swap(
             ))
         })?,
         command: std::env::args_os().collect(),
+        command_inspected: true,
         cwd: Some(std::env::current_dir().map_err(|e| {
             SurgeError::Platform(format!(
                 "Failed to resolve updater working directory before application swap: {e}"
@@ -122,7 +128,7 @@ fn refuse_process_in_swap(
     })?;
     let same_executable =
         active_metadata.dev() == updater_metadata.dev() && active_metadata.ino() == updater_metadata.ino();
-    if same_executable || is_active_app_process(active_entrypoint, interpreted_main, process) {
+    if same_executable || is_active_app_process(active_entrypoint, interpreted_main, process)? {
         return Err(SurgeError::Platform(
             "The updater is running as the active application process; refusing an in-process directory swap. Apply the update from an external Surge updater."
                 .to_string(),
@@ -140,7 +146,7 @@ fn terminate_matching_app_processes<F>(
     matches_exe: F,
 ) -> Result<usize>
 where
-    F: Fn(&AppProcess) -> bool,
+    F: Fn(&AppProcess) -> Result<bool>,
 {
     use nix::errno::Errno;
     use nix::sys::signal::Signal;
@@ -225,7 +231,7 @@ fn terminate_active_app_processes_except(
 #[cfg(unix)]
 fn wait_until_app_processes_exit<F>(protected_pid: u32, matches_exe: &F, timeout: Duration) -> Result<bool>
 where
-    F: Fn(&AppProcess) -> bool,
+    F: Fn(&AppProcess) -> Result<bool>,
 {
     let deadline = std::time::Instant::now() + timeout;
     loop {
@@ -297,26 +303,41 @@ fn is_active_app_process(
     active_entrypoint: &active_entrypoint::Identity,
     interpreted_main: Option<&interpreted_main::Identity>,
     process: &AppProcess,
-) -> bool {
+) -> Result<bool> {
     if active_entrypoint.matches_executable(&process.exe) {
-        return true;
+        return Ok(true);
     }
-    if active_entrypoint.matches_resolved_executable(&process.exe)
-        && process
-            .command
-            .first()
-            .is_some_and(|argument| active_entrypoint.matches_argument(argument, process.cwd.as_deref()))
-    {
-        return true;
+    if active_entrypoint.matches_resolved_executable(&process.exe) {
+        let Some(argument) = process.command.first() else {
+            return if process.command_inspected {
+                Ok(false)
+            } else {
+                Err(SurgeError::Platform(
+                    "Cannot inspect the command line of the active application executable before swap".to_string(),
+                ))
+            };
+        };
+        if active_entrypoint.matches_argument(argument, process.cwd.as_deref())? {
+            return Ok(true);
+        }
     }
 
-    interpreted_main.is_some_and(|identity| {
-        identity.matches_interpreter(&process.exe, process.command.first().map(OsString::as_os_str))
-            && process
-                .command
-                .get(identity.script_argument_index)
-                .is_some_and(|argument| active_entrypoint.matches_argument(argument, process.cwd.as_deref()))
-    })
+    let Some(identity) = interpreted_main else {
+        return Ok(false);
+    };
+    if !process.command_inspected && identity.executable_may_match(&process.exe)? {
+        return Err(SurgeError::Platform(
+            "Cannot inspect the command line of the active application interpreter before swap".to_string(),
+        ));
+    }
+    if !identity.matches_interpreter(&process.exe, process.command.first().map(OsString::as_os_str))? {
+        return Ok(false);
+    }
+    let Some(argument) = process.command.get(identity.script_argument_index) else {
+        return Ok(false);
+    };
+
+    active_entrypoint.matches_argument(argument, process.cwd.as_deref())
 }
 
 #[cfg(unix)]
@@ -338,8 +359,9 @@ fn is_superseded_app_exe(install_dir: &Path, active_app_dir: &Path, main_exe: &s
     first == ".surge-app-prev" || first.starts_with("app-") || components.next().is_none()
 }
 
-#[cfg(all(test, unix))]
+#[cfg(test)]
 mod tests {
+    #[cfg(unix)]
     use super::*;
 
     #[cfg(unix)]
@@ -459,6 +481,7 @@ mod tests {
         let process = AppProcess {
             exe: std::fs::canonicalize("/bin/sh").unwrap(),
             command: vec![OsString::from("/bin/sh"), app_path.into_os_string()],
+            command_inspected: true,
             cwd: Some(active_app_dir),
         };
 
@@ -481,10 +504,82 @@ mod tests {
         let process = AppProcess {
             exe: std::fs::canonicalize("/bin/sleep").unwrap(),
             command: vec![app_path.into_os_string()],
+            command_inspected: true,
             cwd: Some(active_app_dir),
         };
 
-        assert!(!is_active_app_process(&active_entrypoint, None, &process));
+        assert!(!is_active_app_process(&active_entrypoint, None, &process).unwrap());
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    #[test]
+    fn interpreter_argv0_does_not_match_an_unrelated_executable() {
+        let tmp = tempfile::tempdir().unwrap();
+        let active_app_dir = tmp.path().join("app");
+        std::fs::create_dir_all(&active_app_dir).unwrap();
+        let app_path = active_app_dir.join("demo-script");
+        std::fs::write(&app_path, "#!/bin/sh\n").unwrap();
+        let active_entrypoint = active_entrypoint::Identity::resolve(&active_app_dir, "demo-script")
+            .unwrap()
+            .unwrap();
+        let interpreted_main = interpreted_main::resolve(&active_entrypoint.resolved).unwrap().unwrap();
+        let process = AppProcess {
+            exe: std::fs::canonicalize("/bin/sleep").unwrap(),
+            command: vec![OsString::from("/bin/sh"), app_path.into_os_string()],
+            command_inspected: true,
+            cwd: Some(active_app_dir),
+        };
+
+        assert!(!is_active_app_process(&active_entrypoint, Some(&interpreted_main), &process).unwrap());
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    #[test]
+    fn missing_interpreter_command_line_refuses_swap() {
+        let tmp = tempfile::tempdir().unwrap();
+        let active_app_dir = tmp.path().join("app");
+        std::fs::create_dir_all(&active_app_dir).unwrap();
+        let app_path = active_app_dir.join("demo-script");
+        std::fs::write(&app_path, "#!/bin/sh\n").unwrap();
+        let active_entrypoint = active_entrypoint::Identity::resolve(&active_app_dir, "demo-script")
+            .unwrap()
+            .unwrap();
+        let interpreted_main = interpreted_main::resolve(&active_entrypoint.resolved).unwrap().unwrap();
+        let process = AppProcess {
+            exe: std::fs::canonicalize("/bin/sh").unwrap(),
+            command: Vec::new(),
+            command_inspected: false,
+            cwd: None,
+        };
+
+        let error = is_active_app_process(&active_entrypoint, Some(&interpreted_main), &process).unwrap_err();
+
+        assert!(error.to_string().contains("Cannot inspect the command line"));
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    #[test]
+    fn missing_interpreter_working_directory_refuses_relative_identity() {
+        let tmp = tempfile::tempdir().unwrap();
+        let active_app_dir = tmp.path().join("app");
+        std::fs::create_dir_all(&active_app_dir).unwrap();
+        let app_path = active_app_dir.join("demo-script");
+        std::fs::write(&app_path, "#!/bin/sh\n").unwrap();
+        let active_entrypoint = active_entrypoint::Identity::resolve(&active_app_dir, "demo-script")
+            .unwrap()
+            .unwrap();
+        let interpreted_main = interpreted_main::resolve(&active_entrypoint.resolved).unwrap().unwrap();
+        let process = AppProcess {
+            exe: std::fs::canonicalize("/bin/sh").unwrap(),
+            command: vec![OsString::from("/bin/sh"), OsString::from("demo-script")],
+            command_inspected: true,
+            cwd: None,
+        };
+
+        let error = is_active_app_process(&active_entrypoint, Some(&interpreted_main), &process).unwrap_err();
+
+        assert!(error.to_string().contains("launch directory"));
+        assert!(error.to_string().contains("process identity is ambiguous"));
     }
 
     #[cfg(any(target_os = "linux", target_os = "macos"))]
@@ -539,31 +634,13 @@ mod tests {
     }
 
     #[cfg(any(target_os = "linux", target_os = "macos"))]
-    fn assert_interpreted_active_app_process_is_terminated_before_swap(
-        shebang: &str,
-        isolated_env_interpreter: Option<&str>,
-    ) {
+    fn assert_interpreted_active_app_process_is_terminated_before_swap(shebang: &str) {
         use std::os::unix::fs::PermissionsExt;
         use std::process::{Command, Stdio};
 
         let tmp = tempfile::tempdir().unwrap();
         let active_app_dir = tmp.path().join("app");
         std::fs::create_dir_all(&active_app_dir).unwrap();
-        let (shebang, child_path) = if let Some(interpreter_name) = isolated_env_interpreter {
-            let interpreter_dir = tmp.path().join("child-path");
-            std::fs::create_dir_all(&interpreter_dir).unwrap();
-            let interpreter_path = interpreter_dir.join(interpreter_name);
-            std::os::unix::fs::symlink("/bin/sh", &interpreter_path).unwrap();
-            let updater_path = std::env::var_os("PATH").unwrap_or_default();
-            let mut child_paths = vec![interpreter_dir];
-            child_paths.extend(std::env::split_paths(&updater_path));
-            (
-                format!("#!/usr/bin/env {interpreter_name}"),
-                Some(std::env::join_paths(child_paths).unwrap()),
-            )
-        } else {
-            (shebang.to_string(), None)
-        };
         let app_path = active_app_dir.join("demo-script");
         std::fs::write(&app_path, format!("{shebang}\nread _\n")).unwrap();
         let mut permissions = std::fs::metadata(&app_path).unwrap().permissions();
@@ -578,9 +655,6 @@ mod tests {
         let mut child = loop {
             let mut command = Command::new(&app_path);
             command.stdin(Stdio::piped());
-            if let Some(child_path) = &child_path {
-                command.env("PATH", child_path);
-            }
             match command.spawn() {
                 Ok(child) => break child,
                 Err(error)
@@ -634,29 +708,52 @@ mod tests {
     #[cfg(any(target_os = "linux", target_os = "macos"))]
     #[test]
     fn interpreted_active_app_process_is_terminated_before_swap() {
-        assert_interpreted_active_app_process_is_terminated_before_swap("#!/bin/sh", None);
+        assert_interpreted_active_app_process_is_terminated_before_swap("#!/bin/sh");
     }
 
     #[cfg(any(target_os = "linux", target_os = "macos"))]
     #[test]
     fn interpreted_active_app_with_multiple_interpreter_options_is_terminated_before_swap() {
-        assert_interpreted_active_app_process_is_terminated_before_swap("#!/usr/bin/env -S /bin/sh -e -u", None);
+        assert_interpreted_active_app_process_is_terminated_before_swap("#!/usr/bin/env -S /bin/sh -e -u");
     }
 
     #[cfg(any(target_os = "linux", target_os = "macos"))]
     #[test]
-    fn env_interpreted_app_uses_launched_process_identity_when_paths_differ() {
-        assert_interpreted_active_app_process_is_terminated_before_swap("", Some("surge-test-env-interpreter"));
+    fn env_interpreted_app_with_unavailable_launch_environment_refuses_swap() {
+        let tmp = tempfile::tempdir().unwrap();
+        let active_app_dir = tmp.path().join("app");
+        std::fs::create_dir_all(&active_app_dir).unwrap();
+        let interpreter_name = "surge-test-unresolvable-env-interpreter";
+        let app_path = active_app_dir.join("demo-script");
+        std::fs::write(&app_path, format!("#!/usr/bin/env {interpreter_name}\n")).unwrap();
+        let active_entrypoint = active_entrypoint::Identity::resolve(&active_app_dir, "demo-script")
+            .unwrap()
+            .unwrap();
+        let interpreted_main = interpreted_main::resolve(&active_entrypoint.resolved).unwrap().unwrap();
+        let process = AppProcess {
+            exe: std::fs::canonicalize("/bin/sh").unwrap(),
+            command: vec![OsString::from(interpreter_name), app_path.into_os_string()],
+            command_inspected: true,
+            cwd: Some(active_app_dir),
+        };
+
+        let error = is_active_app_process(&active_entrypoint, Some(&interpreted_main), &process).unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("Failed to resolve active application env interpreter")
+        );
     }
 
     #[cfg(target_os = "macos")]
     #[test]
     fn direct_interpreted_app_with_multiple_options_is_terminated_before_swap() {
-        assert_interpreted_active_app_process_is_terminated_before_swap("#!/bin/sh -e -u", None);
+        assert_interpreted_active_app_process_is_terminated_before_swap("#!/bin/sh -e -u");
     }
     #[cfg(target_os = "macos")]
     #[test]
     fn env_interpreted_app_with_multiple_options_is_terminated_before_swap() {
-        assert_interpreted_active_app_process_is_terminated_before_swap("#!/usr/bin/env /bin/sh -e -u", None);
+        assert_interpreted_active_app_process_is_terminated_before_swap("#!/usr/bin/env /bin/sh -e -u");
     }
 }

--- a/crates/surge-core/src/update/manager/lifecycle/process_quiescence.rs
+++ b/crates/surge-core/src/update/manager/lifecycle/process_quiescence.rs
@@ -1,5 +1,3 @@
-#[cfg(unix)]
-use std::io::Read;
 use std::path::Path;
 #[cfg(unix)]
 use std::time::Duration;
@@ -18,6 +16,8 @@ use crate::error::Result;
 use crate::error::SurgeError;
 use crate::platform::process::current_pid;
 
+#[cfg(unix)]
+mod interpreted_main;
 pub(in crate::update::manager) fn terminate_superseded_app_processes(
     install_dir: &Path,
     active_app_dir: &Path,
@@ -85,14 +85,9 @@ fn terminate_active_app_processes_except(
             "The updater is running from the active application executable; in-process swap explicitly allowed, quiescing other active application processes only"
         );
     }
-    let interpreted_main = is_interpreted_main(&active_exe)?;
-    if interpreted_main {
-        return Err(SurgeError::Platform(
-            "Cannot safely quiesce an interpreted active application executable before swap".to_string(),
-        ));
-    }
+    let interpreted_main = interpreted_main::resolve(&active_exe)?;
     terminate_matching_app_processes(main_exe, protected_pid, "active", |process| {
-        is_active_app_process(&active_exe, interpreted_main, process)
+        is_active_app_process(&active_exe, interpreted_main.as_ref(), process)
     })
 }
 
@@ -287,30 +282,19 @@ pub(in crate::update::manager) fn wait_for_native_test_app(app_path: &Path, chil
 }
 
 #[cfg(unix)]
-fn is_interpreted_main(active_exe: &Path) -> Result<bool> {
-    let mut file = std::fs::File::open(active_exe).map_err(|e| {
-        SurgeError::Platform(format!(
-            "Failed to inspect active application executable before swap: {e}"
-        ))
-    })?;
-    let mut prefix = [0_u8; 2];
-    let read = file.read(&mut prefix).map_err(|e| {
-        SurgeError::Platform(format!(
-            "Failed to inspect active application executable before swap: {e}"
-        ))
-    })?;
-    Ok(read == prefix.len() && prefix == *b"#!")
-}
-
-#[cfg(unix)]
-fn is_active_app_process(active_exe: &Path, interpreted_main: bool, process: &AppProcess) -> bool {
+fn is_active_app_process(
+    active_exe: &Path,
+    interpreted_main: Option<&interpreted_main::Identity>,
+    process: &AppProcess,
+) -> bool {
     is_active_app_exe(active_exe, &process.exe)
-        || interpreted_main
-            && process
-                .command
-                .iter()
-                .take(3)
-                .any(|argument| process_argument_resolves_to(argument, process.cwd.as_deref(), active_exe))
+        || interpreted_main.is_some_and(|identity| {
+            process.exe == identity.interpreter
+                && process
+                    .command
+                    .get(identity.script_argument_index)
+                    .is_some_and(|argument| process_argument_resolves_to(argument, process.cwd.as_deref(), active_exe))
+        })
 }
 
 #[cfg(unix)]
@@ -455,8 +439,7 @@ mod tests {
     }
 
     #[cfg(any(target_os = "linux", target_os = "macos"))]
-    #[test]
-    fn interpreted_active_app_refuses_swap_without_signalling_running_process() {
+    fn assert_interpreted_active_app_process_is_terminated_before_swap(shebang: &str) {
         use std::os::unix::fs::PermissionsExt;
         use std::process::Command;
 
@@ -464,20 +447,46 @@ mod tests {
         let active_app_dir = tmp.path().join("app");
         std::fs::create_dir_all(&active_app_dir).unwrap();
         let app_path = active_app_dir.join("demo-script");
-        std::fs::write(&app_path, "#!/bin/sh\nwhile :; do sleep 1; done\n").unwrap();
+        std::fs::write(&app_path, format!("{shebang}\nwhile :; do sleep 1; done\n")).unwrap();
         let mut permissions = std::fs::metadata(&app_path).unwrap().permissions();
         permissions.set_mode(0o755);
         std::fs::set_permissions(&app_path, permissions).unwrap();
-        let mut child = Command::new(&app_path).spawn().unwrap();
-        let error = terminate_active_app_processes_except(&active_app_dir, "demo-script", u32::MAX, false).unwrap_err();
-        let child_still_running = child.try_wait().unwrap().is_none();
-        if child_still_running {
-            child.kill().unwrap();
-        }
-        let _ = child.wait();
+        let resolved_app_path = std::fs::canonicalize(&app_path).unwrap();
+        let interpreted_main = interpreted_main::resolve(&resolved_app_path).unwrap().unwrap();
 
-        assert!(error.to_string().contains("Cannot safely quiesce an interpreted"));
-        assert!(child_still_running);
+        let spawn_deadline = std::time::Instant::now() + Duration::from_secs(1);
+        let mut child = loop {
+            match Command::new(&app_path).spawn() {
+                Ok(child) => break child,
+                Err(error)
+                    if error.raw_os_error() == Some(nix::errno::Errno::ETXTBSY as i32)
+                        && std::time::Instant::now() < spawn_deadline =>
+                {
+                    std::thread::sleep(Duration::from_millis(10));
+                }
+                Err(error) => panic!("failed to launch interpreted app fixture: {error}"),
+            }
+        };
+        let child_pid = child.id();
+        let deadline = std::time::Instant::now() + Duration::from_secs(1);
+        while !app_process_pids(u32::MAX, &|process| {
+            is_active_app_process(&resolved_app_path, Some(&interpreted_main), process)
+        })
+        .unwrap()
+        .contains(&child_pid)
+        {
+            assert!(
+                std::time::Instant::now() < deadline,
+                "test child did not expose the interpreted app launch identity"
+            );
+            std::thread::sleep(Duration::from_millis(10));
+        }
+
+        let terminated = terminate_active_app_processes_except(&active_app_dir, "demo-script", u32::MAX, false).unwrap();
+        let status = child.wait().unwrap();
+
+        assert_eq!(terminated, 1);
+        assert!(!status.success());
     }
 
     #[cfg(any(target_os = "linux", target_os = "macos"))]
@@ -505,5 +514,17 @@ mod tests {
                 .contains("resolves outside the active application directory")
         );
         assert!(unrelated_still_running);
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    #[test]
+    fn interpreted_active_app_process_is_terminated_before_swap() {
+        assert_interpreted_active_app_process_is_terminated_before_swap("#!/bin/sh");
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    #[test]
+    fn interpreted_active_app_with_multiple_interpreter_options_is_terminated_before_swap() {
+        assert_interpreted_active_app_process_is_terminated_before_swap("#!/usr/bin/env -S /bin/sh -e -u");
     }
 }

--- a/crates/surge-core/src/update/manager/lifecycle/process_quiescence.rs
+++ b/crates/surge-core/src/update/manager/lifecycle/process_quiescence.rs
@@ -289,7 +289,7 @@ fn is_active_app_process(
 ) -> bool {
     is_active_app_exe(active_exe, &process.exe)
         || interpreted_main.is_some_and(|identity| {
-            process.exe == identity.interpreter
+            identity.matches_interpreter(&process.exe, process.command.first().map(OsString::as_os_str))
                 && process
                     .command
                     .get(identity.script_argument_index)
@@ -439,13 +439,34 @@ mod tests {
     }
 
     #[cfg(any(target_os = "linux", target_os = "macos"))]
-    fn assert_interpreted_active_app_process_is_terminated_before_swap(shebang: &str) {
+    fn assert_interpreted_active_app_process_is_terminated_before_swap(
+        shebang: &str,
+        isolated_env_interpreter: Option<&str>,
+    ) {
         use std::os::unix::fs::PermissionsExt;
         use std::process::Command;
 
         let tmp = tempfile::tempdir().unwrap();
         let active_app_dir = tmp.path().join("app");
         std::fs::create_dir_all(&active_app_dir).unwrap();
+        let (shebang, child_path) = if let Some(interpreter_name) = isolated_env_interpreter {
+            let interpreter_dir = tmp.path().join("child-path");
+            std::fs::create_dir_all(&interpreter_dir).unwrap();
+            let interpreter_path = interpreter_dir.join(interpreter_name);
+            std::fs::copy("/bin/sh", &interpreter_path).unwrap();
+            let mut permissions = std::fs::metadata(&interpreter_path).unwrap().permissions();
+            permissions.set_mode(0o755);
+            std::fs::set_permissions(&interpreter_path, permissions).unwrap();
+            let updater_path = std::env::var_os("PATH").unwrap_or_default();
+            let mut child_paths = vec![interpreter_dir];
+            child_paths.extend(std::env::split_paths(&updater_path));
+            (
+                format!("#!/usr/bin/env {interpreter_name}"),
+                Some(std::env::join_paths(child_paths).unwrap()),
+            )
+        } else {
+            (shebang.to_string(), None)
+        };
         let app_path = active_app_dir.join("demo-script");
         std::fs::write(&app_path, format!("{shebang}\nwhile :; do sleep 1; done\n")).unwrap();
         let mut permissions = std::fs::metadata(&app_path).unwrap().permissions();
@@ -456,7 +477,11 @@ mod tests {
 
         let spawn_deadline = std::time::Instant::now() + Duration::from_secs(1);
         let mut child = loop {
-            match Command::new(&app_path).spawn() {
+            let mut command = Command::new(&app_path);
+            if let Some(child_path) = &child_path {
+                command.env("PATH", child_path);
+            }
+            match command.spawn() {
                 Ok(child) => break child,
                 Err(error)
                     if error.raw_os_error() == Some(nix::errno::Errno::ETXTBSY as i32)
@@ -519,12 +544,24 @@ mod tests {
     #[cfg(any(target_os = "linux", target_os = "macos"))]
     #[test]
     fn interpreted_active_app_process_is_terminated_before_swap() {
-        assert_interpreted_active_app_process_is_terminated_before_swap("#!/bin/sh");
+        assert_interpreted_active_app_process_is_terminated_before_swap("#!/bin/sh", None);
     }
 
     #[cfg(any(target_os = "linux", target_os = "macos"))]
     #[test]
     fn interpreted_active_app_with_multiple_interpreter_options_is_terminated_before_swap() {
-        assert_interpreted_active_app_process_is_terminated_before_swap("#!/usr/bin/env -S /bin/sh -e -u");
+        assert_interpreted_active_app_process_is_terminated_before_swap("#!/usr/bin/env -S /bin/sh -e -u", None);
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    #[test]
+    fn env_interpreted_app_uses_launched_process_identity_when_paths_differ() {
+        assert_interpreted_active_app_process_is_terminated_before_swap("", Some("surge-test-env-interpreter"));
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn direct_interpreted_app_with_multiple_options_is_terminated_before_swap() {
+        assert_interpreted_active_app_process_is_terminated_before_swap("#!/bin/sh -e -u", None);
     }
 }

--- a/crates/surge-core/src/update/manager/lifecycle/process_quiescence.rs
+++ b/crates/surge-core/src/update/manager/lifecycle/process_quiescence.rs
@@ -22,6 +22,14 @@ use crate::platform::process::current_pid;
 mod active_entrypoint;
 #[cfg(unix)]
 mod interpreted_main;
+
+#[cfg(unix)]
+pub(in crate::update::manager) struct PreparedAppQuiescence {
+    main_exe: String,
+    active_entrypoint: active_entrypoint::Identity,
+    interpreted_main: Option<interpreted_main::Identity>,
+}
+
 pub(in crate::update::manager) fn terminate_superseded_app_processes(
     install_dir: &Path,
     active_app_dir: &Path,
@@ -30,12 +38,55 @@ pub(in crate::update::manager) fn terminate_superseded_app_processes(
     terminate_superseded_app_processes_except(install_dir, active_app_dir, main_exe, current_pid())
 }
 
+#[cfg(not(unix))]
 pub(in crate::update::manager) fn terminate_active_app_processes_before_swap(
     active_app_dir: &Path,
     main_exe: &str,
     allow_in_process_swap: bool,
 ) -> Result<usize> {
     terminate_active_app_processes_except(active_app_dir, main_exe, current_pid(), allow_in_process_swap)
+}
+
+#[cfg(unix)]
+pub(in crate::update::manager) fn prepare_app_quiescence(
+    active_app_dir: &Path,
+    main_exe: &str,
+    allow_in_process_swap: bool,
+) -> Result<Option<PreparedAppQuiescence>> {
+    prepare_app_quiescence_except(active_app_dir, main_exe, current_pid(), allow_in_process_swap)
+}
+
+#[cfg(unix)]
+fn prepare_app_quiescence_except(
+    active_app_dir: &Path,
+    main_exe: &str,
+    protected_pid: u32,
+    allow_in_process_swap: bool,
+) -> Result<Option<PreparedAppQuiescence>> {
+    let main_exe = main_exe.trim();
+    if main_exe.is_empty() {
+        return Ok(None);
+    }
+
+    let active_entrypoint = active_entrypoint::Identity::resolve(active_app_dir, main_exe)?.ok_or_else(|| {
+        SurgeError::Platform("Failed to resolve active application executable before swap".to_string())
+    })?;
+    let interpreted_main = interpreted_main::resolve(&active_entrypoint.resolved)?;
+    if allow_in_process_swap {
+        info!("In-process swap explicitly allowed, quiescing other active application processes only");
+    } else {
+        refuse_in_process_swap(&active_entrypoint, interpreted_main.as_ref(), protected_pid)?;
+    }
+    Ok(Some(PreparedAppQuiescence {
+        main_exe: main_exe.to_string(),
+        active_entrypoint,
+        interpreted_main,
+    }))
+}
+
+#[cfg(unix)]
+pub(in crate::update::manager) fn terminate_prepared_app_processes(prepared: &PreparedAppQuiescence) -> Result<usize> {
+    terminate_prepared_app_processes_except(prepared, current_pid())
 }
 
 #[cfg(unix)]
@@ -55,29 +106,25 @@ fn terminate_superseded_app_processes_except(
     })
 }
 
-#[cfg(unix)]
+#[cfg(all(unix, test))]
 fn terminate_active_app_processes_except(
     active_app_dir: &Path,
     main_exe: &str,
     protected_pid: u32,
     allow_in_process_swap: bool,
 ) -> Result<usize> {
-    let main_exe = main_exe.trim();
-    if main_exe.is_empty() {
+    let Some(prepared) = prepare_app_quiescence_except(active_app_dir, main_exe, protected_pid, allow_in_process_swap)?
+    else {
         return Ok(0);
-    }
+    };
 
-    let active_entrypoint = active_entrypoint::Identity::resolve(active_app_dir, main_exe)?.ok_or_else(|| {
-        SurgeError::Platform("Failed to resolve active application executable before swap".to_string())
-    })?;
-    let interpreted_main = interpreted_main::resolve(&active_entrypoint.resolved)?;
-    if allow_in_process_swap {
-        info!("In-process swap explicitly allowed, quiescing other active application processes only");
-    } else {
-        refuse_in_process_swap(&active_entrypoint, interpreted_main.as_ref(), protected_pid)?;
-    }
-    terminate_matching_app_processes(main_exe, protected_pid, "active", |process| {
-        is_active_app_process(&active_entrypoint, interpreted_main.as_ref(), process)
+    terminate_prepared_app_processes_except(&prepared, protected_pid)
+}
+
+#[cfg(unix)]
+fn terminate_prepared_app_processes_except(prepared: &PreparedAppQuiescence, protected_pid: u32) -> Result<usize> {
+    terminate_matching_app_processes(&prepared.main_exe, protected_pid, "active", |process| {
+        is_active_app_process(&prepared.active_entrypoint, prepared.interpreted_main.as_ref(), process)
     })
 }
 
@@ -789,6 +836,58 @@ mod tests {
     #[test]
     fn interpreted_active_app_process_is_terminated_before_swap() {
         assert_interpreted_active_app_process_is_terminated_before_swap("#!/bin/sh");
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    #[test]
+    fn prepared_interpreted_identity_catches_process_started_before_path_withdrawal() {
+        use std::os::unix::fs::PermissionsExt;
+        use std::process::{Command, Stdio};
+
+        let tmp = tempfile::tempdir().unwrap();
+        let active_app_dir = tmp.path().join("app");
+        let previous_app_dir = tmp.path().join(".surge-app-prev");
+        std::fs::create_dir_all(&active_app_dir).unwrap();
+        let app_path = active_app_dir.join("demo-script");
+        let ready_path = tmp.path().join("ready");
+        std::fs::write(&app_path, "#!/bin/sh\nprintf ready > \"$1\"\nread _\n").unwrap();
+        let mut permissions = std::fs::metadata(&app_path).unwrap().permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&app_path, permissions).unwrap();
+
+        let prepared = prepare_app_quiescence_except(&active_app_dir, "demo-script", u32::MAX, false)
+            .unwrap()
+            .unwrap();
+        assert_eq!(terminate_prepared_app_processes_except(&prepared, u32::MAX).unwrap(), 0);
+
+        let mut child = Command::new(&app_path)
+            .arg(&ready_path)
+            .stdin(Stdio::piped())
+            .spawn()
+            .unwrap();
+        let child_pid = child.id();
+        let deadline = std::time::Instant::now() + Duration::from_secs(1);
+        while !ready_path.is_file() {
+            assert!(
+                std::time::Instant::now() < deadline,
+                "test child did not finish loading the interpreted app"
+            );
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        assert!(
+            app_process_pids(u32::MAX, &|process| {
+                is_active_app_process(&prepared.active_entrypoint, prepared.interpreted_main.as_ref(), process)
+            })
+            .unwrap()
+            .contains(&child_pid)
+        );
+
+        std::fs::rename(&active_app_dir, &previous_app_dir).unwrap();
+        let terminated = terminate_prepared_app_processes_except(&prepared, u32::MAX).unwrap();
+        let status = child.wait().unwrap();
+
+        assert_eq!(terminated, 1);
+        assert!(!status.success());
     }
 
     #[cfg(any(target_os = "linux", target_os = "macos"))]

--- a/crates/surge-core/src/update/manager/lifecycle/process_quiescence.rs
+++ b/crates/surge-core/src/update/manager/lifecycle/process_quiescence.rs
@@ -288,6 +288,10 @@ fn is_active_app_process(
     process: &AppProcess,
 ) -> bool {
     is_active_app_exe(active_exe, &process.exe)
+        || process
+            .command
+            .first()
+            .is_some_and(|argument| process_argument_resolves_to(argument, process.cwd.as_deref(), active_exe))
         || interpreted_main.is_some_and(|identity| {
             identity.matches_interpreter(&process.exe, process.command.first().map(OsString::as_os_str))
                 && process
@@ -453,10 +457,7 @@ mod tests {
             let interpreter_dir = tmp.path().join("child-path");
             std::fs::create_dir_all(&interpreter_dir).unwrap();
             let interpreter_path = interpreter_dir.join(interpreter_name);
-            std::fs::copy("/bin/sh", &interpreter_path).unwrap();
-            let mut permissions = std::fs::metadata(&interpreter_path).unwrap().permissions();
-            permissions.set_mode(0o755);
-            std::fs::set_permissions(&interpreter_path, permissions).unwrap();
+            std::os::unix::fs::symlink("/bin/sh", &interpreter_path).unwrap();
             let updater_path = std::env::var_os("PATH").unwrap_or_default();
             let mut child_paths = vec![interpreter_dir];
             child_paths.extend(std::env::split_paths(&updater_path));
@@ -563,5 +564,10 @@ mod tests {
     #[test]
     fn direct_interpreted_app_with_multiple_options_is_terminated_before_swap() {
         assert_interpreted_active_app_process_is_terminated_before_swap("#!/bin/sh -e -u", None);
+    }
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn env_interpreted_app_with_multiple_options_is_terminated_before_swap() {
+        assert_interpreted_active_app_process_is_terminated_before_swap("#!/usr/bin/env /bin/sh -e -u", None);
     }
 }

--- a/crates/surge-core/src/update/manager/lifecycle/process_quiescence.rs
+++ b/crates/surge-core/src/update/manager/lifecycle/process_quiescence.rs
@@ -326,12 +326,12 @@ fn is_active_app_process(
     let Some(identity) = interpreted_main else {
         return Ok(false);
     };
+    if process.command.iter().all(|argument| argument.is_empty()) && identity.executable_may_match(&process.exe)? {
+        return Err(SurgeError::Platform(
+            "Cannot inspect the command line of the active application interpreter before swap".to_string(),
+        ));
+    }
     let Some(argument) = process.command.get(identity.script_argument_index) else {
-        if process.command.iter().all(|argument| argument.is_empty()) && identity.executable_may_match(&process.exe)? {
-            return Err(SurgeError::Platform(
-                "Cannot inspect the command line of the active application interpreter before swap".to_string(),
-            ));
-        }
         return Ok(false);
     };
     if !active_entrypoint.matches_argument(argument, process.cwd.as_deref())? {
@@ -580,6 +580,30 @@ mod tests {
         let process = AppProcess {
             exe: std::fs::canonicalize("/bin/sh").unwrap(),
             command: vec![OsString::new()],
+            command_inspected: true,
+            cwd: None,
+        };
+
+        let error = is_active_app_process(&active_entrypoint, Some(&interpreted_main), &process).unwrap_err();
+
+        assert!(error.to_string().contains("Cannot inspect the command line"));
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    #[test]
+    fn all_empty_interpreter_command_line_refuses_swap() {
+        let tmp = tempfile::tempdir().unwrap();
+        let active_app_dir = tmp.path().join("app");
+        std::fs::create_dir_all(&active_app_dir).unwrap();
+        let app_path = active_app_dir.join("demo-script");
+        std::fs::write(&app_path, "#!/bin/sh\n").unwrap();
+        let active_entrypoint = active_entrypoint::Identity::resolve(&active_app_dir, "demo-script")
+            .unwrap()
+            .unwrap();
+        let interpreted_main = interpreted_main::resolve(&active_entrypoint.resolved).unwrap().unwrap();
+        let process = AppProcess {
+            exe: std::fs::canonicalize("/bin/sh").unwrap(),
+            command: vec![OsString::new(), OsString::new()],
             command_inspected: true,
             cwd: None,
         };

--- a/crates/surge-core/src/update/manager/lifecycle/process_quiescence.rs
+++ b/crates/surge-core/src/update/manager/lifecycle/process_quiescence.rs
@@ -690,46 +690,6 @@ mod tests {
     }
 
     #[cfg(any(target_os = "linux", target_os = "macos"))]
-    fn interpreted_test_process_snapshot(pid: u32) -> String {
-        #[cfg(target_os = "linux")]
-        {
-            let exe = std::fs::read_link(format!("/proc/{pid}/exe"));
-            let command =
-                std::fs::read(format!("/proc/{pid}/cmdline")).map(|bytes| discovery::parse_proc_cmdline(&bytes));
-            let cwd = std::fs::read_link(format!("/proc/{pid}/cwd"));
-            return format!("exe={exe:?}, command={command:?}, cwd={cwd:?}");
-        }
-
-        #[cfg(target_os = "macos")]
-        {
-            use sysinfo::{Pid, ProcessRefreshKind, ProcessesToUpdate, System, UpdateKind};
-
-            let pid = Pid::from_u32(pid);
-            let mut system = System::new();
-            let refreshed = system.refresh_processes_specifics(
-                ProcessesToUpdate::Some(&[pid]),
-                true,
-                ProcessRefreshKind::nothing()
-                    .with_exe(UpdateKind::Always)
-                    .with_cmd(UpdateKind::Always)
-                    .with_cwd(UpdateKind::Always),
-            );
-            return system.process(pid).map_or_else(
-                || format!("process unavailable after refreshing {refreshed} entries"),
-                |process| {
-                    format!(
-                        "exe={:?}, command={:?}, cwd={:?}, status={:?}",
-                        process.exe(),
-                        process.cmd(),
-                        process.cwd(),
-                        process.status()
-                    )
-                },
-            );
-        }
-    }
-
-    #[cfg(any(target_os = "linux", target_os = "macos"))]
     fn assert_interpreted_active_app_process_is_terminated_before_swap(shebang: &str) {
         use std::os::unix::fs::PermissionsExt;
         use std::process::{Command, Stdio};
@@ -764,38 +724,24 @@ mod tests {
         };
         let child_pid = child.id();
         let deadline = std::time::Instant::now() + Duration::from_secs(1);
-        loop {
-            let matches = app_process_pids(u32::MAX, &|process| {
-                is_active_app_process(&active_entrypoint, Some(&interpreted_main), process)
-            })
-            .unwrap_or_else(|error| {
-                panic!(
-                    "{error}; child process snapshot: {}",
-                    interpreted_test_process_snapshot(child_pid)
-                )
-            });
-            if matches.contains(&child_pid) {
-                break;
-            }
+        while !app_process_pids(u32::MAX, &|process| {
+            is_active_app_process(&active_entrypoint, Some(&interpreted_main), process)
+        })
+        .unwrap()
+        .contains(&child_pid)
+        {
             assert!(
                 std::time::Instant::now() < deadline,
-                "test child did not expose the interpreted app launch identity; child process snapshot: {}",
-                interpreted_test_process_snapshot(child_pid)
+                "test child did not expose the interpreted app launch identity"
             );
             std::thread::sleep(Duration::from_millis(10));
         }
 
-        let terminated = terminate_active_app_processes_except(&active_app_dir, "demo-script", u32::MAX, false)
-            .unwrap_or_else(|error| {
-                panic!(
-                    "{error}; child process snapshot: {}",
-                    interpreted_test_process_snapshot(child_pid)
-                )
-            });
-        let process_snapshot = interpreted_test_process_snapshot(child_pid);
+        let terminated =
+            terminate_active_app_processes_except(&active_app_dir, "demo-script", u32::MAX, false).unwrap();
         let status = child.wait().unwrap();
 
-        assert_eq!(terminated, 1, "child process snapshot before wait: {process_snapshot}");
+        assert_eq!(terminated, 1);
         assert!(!status.success());
     }
 

--- a/crates/surge-core/src/update/manager/lifecycle/process_quiescence.rs
+++ b/crates/surge-core/src/update/manager/lifecycle/process_quiescence.rs
@@ -308,14 +308,15 @@ fn is_active_app_process(
         return Ok(true);
     }
     if active_entrypoint.matches_resolved_executable(&process.exe) {
+        if process.command.iter().all(|argument| argument.is_empty()) {
+            return Err(SurgeError::Platform(
+                "Cannot inspect the command line of the active application executable before swap".to_string(),
+            ));
+        }
         let Some(argument) = process.command.first() else {
-            return if process.command_inspected {
-                Ok(false)
-            } else {
-                Err(SurgeError::Platform(
-                    "Cannot inspect the command line of the active application executable before swap".to_string(),
-                ))
-            };
+            return Err(SurgeError::Platform(
+                "Cannot inspect the command line of the active application executable before swap".to_string(),
+            ));
         };
         if active_entrypoint.matches_argument(argument, process.cwd.as_deref())? {
             return Ok(true);
@@ -326,7 +327,7 @@ fn is_active_app_process(
         return Ok(false);
     };
     let Some(argument) = process.command.get(identity.script_argument_index) else {
-        if !process.command_inspected && identity.executable_may_match(&process.exe)? {
+        if process.command.iter().all(|argument| argument.is_empty()) && identity.executable_may_match(&process.exe)? {
             return Err(SurgeError::Platform(
                 "Cannot inspect the command line of the active application interpreter before swap".to_string(),
             ));
@@ -560,6 +561,54 @@ mod tests {
         };
 
         let error = is_active_app_process(&active_entrypoint, Some(&interpreted_main), &process).unwrap_err();
+
+        assert!(error.to_string().contains("Cannot inspect the command line"));
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    #[test]
+    fn empty_inspected_interpreter_command_line_refuses_swap() {
+        let tmp = tempfile::tempdir().unwrap();
+        let active_app_dir = tmp.path().join("app");
+        std::fs::create_dir_all(&active_app_dir).unwrap();
+        let app_path = active_app_dir.join("demo-script");
+        std::fs::write(&app_path, "#!/bin/sh\n").unwrap();
+        let active_entrypoint = active_entrypoint::Identity::resolve(&active_app_dir, "demo-script")
+            .unwrap()
+            .unwrap();
+        let interpreted_main = interpreted_main::resolve(&active_entrypoint.resolved).unwrap().unwrap();
+        let process = AppProcess {
+            exe: std::fs::canonicalize("/bin/sh").unwrap(),
+            command: vec![OsString::new()],
+            command_inspected: true,
+            cwd: None,
+        };
+
+        let error = is_active_app_process(&active_entrypoint, Some(&interpreted_main), &process).unwrap_err();
+
+        assert!(error.to_string().contains("Cannot inspect the command line"));
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    #[test]
+    fn empty_inspected_symlink_command_line_refuses_swap() {
+        use std::os::unix::fs::symlink;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let active_app_dir = tmp.path().join("app");
+        std::fs::create_dir_all(&active_app_dir).unwrap();
+        symlink("/bin/sleep", active_app_dir.join("demo")).unwrap();
+        let active_entrypoint = active_entrypoint::Identity::resolve(&active_app_dir, "demo")
+            .unwrap()
+            .unwrap();
+        let process = AppProcess {
+            exe: std::fs::canonicalize("/bin/sleep").unwrap(),
+            command: vec![OsString::new()],
+            command_inspected: true,
+            cwd: None,
+        };
+
+        let error = is_active_app_process(&active_entrypoint, None, &process).unwrap_err();
 
         assert!(error.to_string().contains("Cannot inspect the command line"));
     }

--- a/crates/surge-core/src/update/manager/lifecycle/process_quiescence.rs
+++ b/crates/surge-core/src/update/manager/lifecycle/process_quiescence.rs
@@ -65,47 +65,71 @@ fn terminate_active_app_processes_except(
     let active_entrypoint = active_entrypoint::Identity::resolve(active_app_dir, main_exe)?.ok_or_else(|| {
         SurgeError::Platform("Failed to resolve active application executable before swap".to_string())
     })?;
-    if updater_runs_from_active_exe(&active_entrypoint.resolved, protected_pid)? {
-        if !allow_in_process_swap {
-            return Err(SurgeError::Platform(
-                "The updater is running from the active application executable; refusing an in-process directory swap. Apply the update from an external Surge updater."
-                    .to_string(),
-            ));
-        }
-        info!(
-            "The updater is running from the active application executable; in-process swap explicitly allowed, quiescing other active application processes only"
-        );
-    }
     let interpreted_main = interpreted_main::resolve(&active_entrypoint.resolved)?;
+    if allow_in_process_swap {
+        info!("In-process swap explicitly allowed, quiescing other active application processes only");
+    } else {
+        refuse_in_process_swap(&active_entrypoint, interpreted_main.as_ref(), protected_pid)?;
+    }
     terminate_matching_app_processes(main_exe, protected_pid, "active", |process| {
         is_active_app_process(&active_entrypoint, interpreted_main.as_ref(), process)
     })
 }
 
 #[cfg(unix)]
-fn updater_runs_from_active_exe(active_exe: &Path, protected_pid: u32) -> Result<bool> {
-    use std::os::unix::fs::MetadataExt;
-
+fn refuse_in_process_swap(
+    active_entrypoint: &active_entrypoint::Identity,
+    interpreted_main: Option<&interpreted_main::Identity>,
+    protected_pid: u32,
+) -> Result<()> {
     if protected_pid != current_pid() {
-        return Ok(false);
+        return Ok(());
     }
 
-    let updater_exe = std::env::current_exe().map_err(|e| {
-        SurgeError::Platform(format!(
-            "Failed to resolve updater process identity before application swap: {e}"
-        ))
-    })?;
-    let active_metadata = std::fs::metadata(active_exe).map_err(|e| {
+    let process = AppProcess {
+        exe: std::env::current_exe().map_err(|e| {
+            SurgeError::Platform(format!(
+                "Failed to resolve updater process identity before application swap: {e}"
+            ))
+        })?,
+        command: std::env::args_os().collect(),
+        cwd: Some(std::env::current_dir().map_err(|e| {
+            SurgeError::Platform(format!(
+                "Failed to resolve updater working directory before application swap: {e}"
+            ))
+        })?),
+    };
+    refuse_process_in_swap(active_entrypoint, interpreted_main, &process)
+}
+
+#[cfg(unix)]
+fn refuse_process_in_swap(
+    active_entrypoint: &active_entrypoint::Identity,
+    interpreted_main: Option<&interpreted_main::Identity>,
+    process: &AppProcess,
+) -> Result<()> {
+    use std::os::unix::fs::MetadataExt;
+
+    let active_metadata = std::fs::metadata(&active_entrypoint.resolved).map_err(|e| {
         SurgeError::Platform(format!(
             "Failed to inspect active application identity before swap: {e}"
         ))
     })?;
-    let updater_metadata = std::fs::metadata(&updater_exe).map_err(|e| {
+    let updater_metadata = std::fs::metadata(&process.exe).map_err(|e| {
         SurgeError::Platform(format!(
             "Failed to inspect updater process identity before application swap: {e}"
         ))
     })?;
-    Ok(active_metadata.dev() == updater_metadata.dev() && active_metadata.ino() == updater_metadata.ino())
+    let same_executable =
+        active_metadata.dev() == updater_metadata.dev() && active_metadata.ino() == updater_metadata.ino();
+    if same_executable || is_active_app_process(active_entrypoint, interpreted_main, process) {
+        return Err(SurgeError::Platform(
+            "The updater is running as the active application process; refusing an in-process directory swap. Apply the update from an external Surge updater."
+                .to_string(),
+        ));
+    }
+
+    Ok(())
 }
 
 #[cfg(unix)]
@@ -274,18 +298,25 @@ fn is_active_app_process(
     interpreted_main: Option<&interpreted_main::Identity>,
     process: &AppProcess,
 ) -> bool {
-    active_entrypoint.matches_executable(&process.exe)
-        || process
+    if active_entrypoint.matches_executable(&process.exe) {
+        return true;
+    }
+    if active_entrypoint.matches_resolved_executable(&process.exe)
+        && process
             .command
             .first()
             .is_some_and(|argument| active_entrypoint.matches_argument(argument, process.cwd.as_deref()))
-        || interpreted_main.is_some_and(|identity| {
-            identity.matches_interpreter(&process.exe, process.command.first().map(OsString::as_os_str))
-                && process
-                    .command
-                    .get(identity.script_argument_index)
-                    .is_some_and(|argument| active_entrypoint.matches_argument(argument, process.cwd.as_deref()))
-        })
+    {
+        return true;
+    }
+
+    interpreted_main.is_some_and(|identity| {
+        identity.matches_interpreter(&process.exe, process.command.first().map(OsString::as_os_str))
+            && process
+                .command
+                .get(identity.script_argument_index)
+                .is_some_and(|argument| active_entrypoint.matches_argument(argument, process.cwd.as_deref()))
+    })
 }
 
 #[cfg(unix)]
@@ -411,6 +442,49 @@ mod tests {
         let terminated = terminate_active_app_processes_except(&active_app_dir, "demo", current_pid(), true).unwrap();
 
         assert_eq!(terminated, 0);
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    #[test]
+    fn interpreted_in_process_updater_refuses_swap() {
+        let tmp = tempfile::tempdir().unwrap();
+        let active_app_dir = tmp.path().join("app");
+        std::fs::create_dir_all(&active_app_dir).unwrap();
+        let app_path = active_app_dir.join("demo-script");
+        std::fs::write(&app_path, "#!/bin/sh\n").unwrap();
+        let active_entrypoint = active_entrypoint::Identity::resolve(&active_app_dir, "demo-script")
+            .unwrap()
+            .unwrap();
+        let interpreted_main = interpreted_main::resolve(&active_entrypoint.resolved).unwrap().unwrap();
+        let process = AppProcess {
+            exe: std::fs::canonicalize("/bin/sh").unwrap(),
+            command: vec![OsString::from("/bin/sh"), app_path.into_os_string()],
+            cwd: Some(active_app_dir),
+        };
+
+        let error = refuse_process_in_swap(&active_entrypoint, Some(&interpreted_main), &process).unwrap_err();
+
+        assert!(error.to_string().contains("refusing an in-process directory swap"));
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    #[test]
+    fn configured_argv0_does_not_match_an_unrelated_executable() {
+        let tmp = tempfile::tempdir().unwrap();
+        let active_app_dir = tmp.path().join("app");
+        std::fs::create_dir_all(&active_app_dir).unwrap();
+        let app_path = active_app_dir.join("demo");
+        std::fs::write(&app_path, "fixture").unwrap();
+        let active_entrypoint = active_entrypoint::Identity::resolve(&active_app_dir, "demo")
+            .unwrap()
+            .unwrap();
+        let process = AppProcess {
+            exe: std::fs::canonicalize("/bin/sleep").unwrap(),
+            command: vec![app_path.into_os_string()],
+            cwd: Some(active_app_dir),
+        };
+
+        assert!(!is_active_app_process(&active_entrypoint, None, &process));
     }
 
     #[cfg(any(target_os = "linux", target_os = "macos"))]

--- a/crates/surge-core/src/update/manager/lifecycle/process_quiescence/active_entrypoint.rs
+++ b/crates/surge-core/src/update/manager/lifecycle/process_quiescence/active_entrypoint.rs
@@ -93,7 +93,7 @@ fn argument_resolves_to(argument: &OsStr, cwd: Option<&Path>, expected: &Path) -
         ArgumentPath::Missing => Ok(false),
         ArgumentPath::Ambiguous => ambiguous_relative_argument(argument, expected),
         ArgumentPath::Absolute(candidate) => {
-            if std::fs::canonicalize(candidate).is_ok_and(|resolved| resolved == expected) {
+            if candidate == expected || std::fs::canonicalize(candidate).is_ok_and(|resolved| resolved == expected) {
                 Ok(true)
             } else {
                 ambiguous_relative_argument(argument, expected)

--- a/crates/surge-core/src/update/manager/lifecycle/process_quiescence/active_entrypoint.rs
+++ b/crates/surge-core/src/update/manager/lifecycle/process_quiescence/active_entrypoint.rs
@@ -4,6 +4,7 @@ use std::path::{Path, PathBuf};
 use crate::error::{Result, SurgeError};
 
 pub(super) struct Identity {
+    configured_launch_path: PathBuf,
     path: PathBuf,
     pub(super) resolved: PathBuf,
     require_entrypoint_argument: bool,
@@ -11,6 +12,11 @@ pub(super) struct Identity {
 
 impl Identity {
     pub(super) fn resolve(active_app_dir: &Path, main_exe: &str) -> Result<Option<Self>> {
+        let configured_launch_path = std::path::absolute(active_app_dir.join(main_exe)).map_err(|e| {
+            SurgeError::Platform(format!(
+                "Failed to resolve configured active application path before swap: {e}"
+            ))
+        })?;
         let active_app_root = match std::fs::canonicalize(active_app_dir) {
             Ok(path) => path,
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
@@ -32,6 +38,7 @@ impl Identity {
         };
 
         Ok(Some(Self {
+            configured_launch_path,
             require_entrypoint_argument: configured_path != resolved,
             path: configured_path,
             resolved,
@@ -50,7 +57,7 @@ impl Identity {
 
     pub(super) fn matches_argument(&self, argument: &OsStr, cwd: Option<&Path>) -> Result<bool> {
         if self.require_entrypoint_argument {
-            argument_preserves_entrypoint(argument, cwd, &self.path)
+            argument_preserves_entrypoint(argument, cwd, &self.path, &self.configured_launch_path)
         } else {
             argument_resolves_to(argument, cwd, &self.resolved)
         }
@@ -62,12 +69,17 @@ impl Identity {
     }
 }
 
-fn argument_preserves_entrypoint(argument: &OsStr, cwd: Option<&Path>, expected: &Path) -> Result<bool> {
+fn argument_preserves_entrypoint(
+    argument: &OsStr,
+    cwd: Option<&Path>,
+    expected: &Path,
+    configured_launch_path: &Path,
+) -> Result<bool> {
     match absolute_argument(argument, cwd) {
         ArgumentPath::Missing => return Ok(false),
         ArgumentPath::Ambiguous => return ambiguous_relative_argument(argument, expected),
         ArgumentPath::Absolute(candidate) => {
-            if candidate == expected {
+            if candidate == expected || candidate == configured_launch_path {
                 return Ok(true);
             }
         }
@@ -168,6 +180,32 @@ mod tests {
         assert!(
             identity
                 .matches_argument(active_app_dir.join("demo").as_os_str(), None)
+                .unwrap()
+        );
+        assert!(
+            !identity
+                .matches_argument(shared_dir.join("demo").as_os_str(), None)
+                .unwrap()
+        );
+    }
+
+    #[test]
+    fn active_directory_alias_preserves_configured_launch_identity() {
+        let tmp = tempfile::tempdir().unwrap();
+        let active_app_dir = tmp.path().join("app");
+        let active_app_alias = tmp.path().join("app-alias");
+        let shared_dir = active_app_dir.join("shared");
+        std::fs::create_dir_all(&shared_dir).unwrap();
+        std::fs::write(shared_dir.join("demo"), "fixture").unwrap();
+        symlink("shared/demo", active_app_dir.join("demo")).unwrap();
+        symlink(&active_app_dir, &active_app_alias).unwrap();
+
+        let identity = Identity::resolve(&active_app_alias, "demo").unwrap().unwrap();
+
+        assert!(identity.requires_argument());
+        assert!(
+            identity
+                .matches_argument(active_app_alias.join("demo").as_os_str(), None)
                 .unwrap()
         );
         assert!(

--- a/crates/surge-core/src/update/manager/lifecycle/process_quiescence/active_entrypoint.rs
+++ b/crates/surge-core/src/update/manager/lifecycle/process_quiescence/active_entrypoint.rs
@@ -48,7 +48,7 @@ impl Identity {
                 && std::fs::canonicalize(executable).is_ok_and(|resolved| resolved == self.resolved)
     }
 
-    pub(super) fn matches_argument(&self, argument: &OsStr, cwd: Option<&Path>) -> bool {
+    pub(super) fn matches_argument(&self, argument: &OsStr, cwd: Option<&Path>) -> Result<bool> {
         if self.require_entrypoint_argument {
             argument_preserves_entrypoint(argument, cwd, &self.path)
         } else {
@@ -62,29 +62,63 @@ impl Identity {
     }
 }
 
-fn argument_preserves_entrypoint(argument: &OsStr, cwd: Option<&Path>, expected: &Path) -> bool {
-    let Some(candidate) = absolute_argument(argument, cwd) else {
-        return false;
-    };
-    candidate == expected
+fn argument_preserves_entrypoint(argument: &OsStr, cwd: Option<&Path>, expected: &Path) -> Result<bool> {
+    match absolute_argument(argument, cwd) {
+        ArgumentPath::Missing => return Ok(false),
+        ArgumentPath::Ambiguous => return ambiguous_relative_argument(argument, expected),
+        ArgumentPath::Absolute(candidate) => {
+            if candidate == expected {
+                return Ok(true);
+            }
+        }
+    }
+
+    ambiguous_relative_argument(argument, expected)
 }
 
-fn argument_resolves_to(argument: &OsStr, cwd: Option<&Path>, expected: &Path) -> bool {
-    let Some(candidate) = absolute_argument(argument, cwd) else {
-        return false;
-    };
-    std::fs::canonicalize(candidate).is_ok_and(|resolved| resolved == expected)
+fn argument_resolves_to(argument: &OsStr, cwd: Option<&Path>, expected: &Path) -> Result<bool> {
+    match absolute_argument(argument, cwd) {
+        ArgumentPath::Missing => Ok(false),
+        ArgumentPath::Ambiguous => ambiguous_relative_argument(argument, expected),
+        ArgumentPath::Absolute(candidate) => {
+            if std::fs::canonicalize(candidate).is_ok_and(|resolved| resolved == expected) {
+                Ok(true)
+            } else {
+                ambiguous_relative_argument(argument, expected)
+            }
+        }
+    }
 }
 
-fn absolute_argument(argument: &OsStr, cwd: Option<&Path>) -> Option<PathBuf> {
+fn ambiguous_relative_argument(argument: &OsStr, expected: &Path) -> Result<bool> {
+    let argument = Path::new(argument);
+    if argument.is_relative() && argument.file_name() == expected.file_name() {
+        return Err(SurgeError::Platform(format!(
+            "Cannot establish the launch directory for relative active application argument '{}'; refusing to swap while its process identity is ambiguous",
+            argument.display()
+        )));
+    }
+
+    Ok(false)
+}
+
+enum ArgumentPath {
+    Missing,
+    Absolute(PathBuf),
+    Ambiguous,
+}
+
+fn absolute_argument(argument: &OsStr, cwd: Option<&Path>) -> ArgumentPath {
     let argument = Path::new(argument);
     if argument.as_os_str().is_empty() {
-        return None;
+        return ArgumentPath::Missing;
     }
     if argument.is_absolute() {
-        Some(argument.to_path_buf())
+        ArgumentPath::Absolute(argument.to_path_buf())
+    } else if let Some(cwd) = cwd {
+        ArgumentPath::Absolute(cwd.join(argument))
     } else {
-        cwd.map(|cwd| cwd.join(argument))
+        ArgumentPath::Ambiguous
     }
 }
 
@@ -107,8 +141,16 @@ mod tests {
         let identity = Identity::resolve(&active_app_dir, "bin/demo").unwrap().unwrap();
 
         assert!(identity.requires_argument());
-        assert!(identity.matches_argument(active_app_dir.join("bin/demo").as_os_str(), None));
-        assert!(!identity.matches_argument(shared_dir.join("demo").as_os_str(), None));
+        assert!(
+            identity
+                .matches_argument(active_app_dir.join("bin/demo").as_os_str(), None)
+                .unwrap()
+        );
+        assert!(
+            !identity
+                .matches_argument(shared_dir.join("demo").as_os_str(), None)
+                .unwrap()
+        );
     }
 
     #[test]
@@ -123,7 +165,15 @@ mod tests {
         let identity = Identity::resolve(&active_app_dir, "demo").unwrap().unwrap();
 
         assert!(identity.requires_argument());
-        assert!(identity.matches_argument(active_app_dir.join("demo").as_os_str(), None));
-        assert!(!identity.matches_argument(shared_dir.join("demo").as_os_str(), None));
+        assert!(
+            identity
+                .matches_argument(active_app_dir.join("demo").as_os_str(), None)
+                .unwrap()
+        );
+        assert!(
+            !identity
+                .matches_argument(shared_dir.join("demo").as_os_str(), None)
+                .unwrap()
+        );
     }
 }

--- a/crates/surge-core/src/update/manager/lifecycle/process_quiescence/active_entrypoint.rs
+++ b/crates/surge-core/src/update/manager/lifecycle/process_quiescence/active_entrypoint.rs
@@ -32,17 +32,20 @@ impl Identity {
         };
 
         Ok(Some(Self {
-            require_entrypoint_argument: !resolved.starts_with(&active_app_root),
+            require_entrypoint_argument: configured_path != resolved,
             path: configured_path,
             resolved,
         }))
     }
 
     pub(super) fn matches_executable(&self, executable: &Path) -> bool {
-        !self.require_entrypoint_argument
-            && (executable == self.resolved
-                || cfg!(target_os = "macos")
-                    && std::fs::canonicalize(executable).is_ok_and(|resolved| resolved == self.resolved))
+        !self.require_entrypoint_argument && self.matches_resolved_executable(executable)
+    }
+
+    pub(super) fn matches_resolved_executable(&self, executable: &Path) -> bool {
+        executable == self.resolved
+            || cfg!(target_os = "macos")
+                && std::fs::canonicalize(executable).is_ok_and(|resolved| resolved == self.resolved)
     }
 
     pub(super) fn matches_argument(&self, argument: &OsStr, cwd: Option<&Path>) -> bool {
@@ -105,6 +108,22 @@ mod tests {
 
         assert!(identity.requires_argument());
         assert!(identity.matches_argument(active_app_dir.join("bin/demo").as_os_str(), None));
+        assert!(!identity.matches_argument(shared_dir.join("demo").as_os_str(), None));
+    }
+
+    #[test]
+    fn entrypoint_symlink_within_app_preserves_configured_launch_identity() {
+        let tmp = tempfile::tempdir().unwrap();
+        let active_app_dir = tmp.path().join("app");
+        let shared_dir = active_app_dir.join("shared");
+        std::fs::create_dir_all(&shared_dir).unwrap();
+        std::fs::write(shared_dir.join("demo"), "fixture").unwrap();
+        symlink("shared/demo", active_app_dir.join("demo")).unwrap();
+
+        let identity = Identity::resolve(&active_app_dir, "demo").unwrap().unwrap();
+
+        assert!(identity.requires_argument());
+        assert!(identity.matches_argument(active_app_dir.join("demo").as_os_str(), None));
         assert!(!identity.matches_argument(shared_dir.join("demo").as_os_str(), None));
     }
 }

--- a/crates/surge-core/src/update/manager/lifecycle/process_quiescence/active_entrypoint.rs
+++ b/crates/surge-core/src/update/manager/lifecycle/process_quiescence/active_entrypoint.rs
@@ -1,0 +1,110 @@
+use std::ffi::OsStr;
+use std::path::{Path, PathBuf};
+
+use crate::error::{Result, SurgeError};
+
+pub(super) struct Identity {
+    path: PathBuf,
+    pub(super) resolved: PathBuf,
+    require_entrypoint_argument: bool,
+}
+
+impl Identity {
+    pub(super) fn resolve(active_app_dir: &Path, main_exe: &str) -> Result<Option<Self>> {
+        let active_app_root = match std::fs::canonicalize(active_app_dir) {
+            Ok(path) => path,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(e) => {
+                return Err(SurgeError::Platform(format!(
+                    "Failed to resolve active application directory before swap: {e}"
+                )));
+            }
+        };
+        let configured_path = active_app_root.join(main_exe);
+        let resolved = match std::fs::canonicalize(&configured_path) {
+            Ok(path) => path,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(e) => {
+                return Err(SurgeError::Platform(format!(
+                    "Failed to resolve active application executable before swap: {e}"
+                )));
+            }
+        };
+
+        Ok(Some(Self {
+            require_entrypoint_argument: !resolved.starts_with(&active_app_root),
+            path: configured_path,
+            resolved,
+        }))
+    }
+
+    pub(super) fn matches_executable(&self, executable: &Path) -> bool {
+        !self.require_entrypoint_argument
+            && (executable == self.resolved
+                || cfg!(target_os = "macos")
+                    && std::fs::canonicalize(executable).is_ok_and(|resolved| resolved == self.resolved))
+    }
+
+    pub(super) fn matches_argument(&self, argument: &OsStr, cwd: Option<&Path>) -> bool {
+        if self.require_entrypoint_argument {
+            argument_preserves_entrypoint(argument, cwd, &self.path)
+        } else {
+            argument_resolves_to(argument, cwd, &self.resolved)
+        }
+    }
+
+    #[cfg(test)]
+    pub(super) fn requires_argument(&self) -> bool {
+        self.require_entrypoint_argument
+    }
+}
+
+fn argument_preserves_entrypoint(argument: &OsStr, cwd: Option<&Path>, expected: &Path) -> bool {
+    let Some(candidate) = absolute_argument(argument, cwd) else {
+        return false;
+    };
+    candidate == expected
+}
+
+fn argument_resolves_to(argument: &OsStr, cwd: Option<&Path>, expected: &Path) -> bool {
+    let Some(candidate) = absolute_argument(argument, cwd) else {
+        return false;
+    };
+    std::fs::canonicalize(candidate).is_ok_and(|resolved| resolved == expected)
+}
+
+fn absolute_argument(argument: &OsStr, cwd: Option<&Path>) -> Option<PathBuf> {
+    let argument = Path::new(argument);
+    if argument.as_os_str().is_empty() {
+        return None;
+    }
+    if argument.is_absolute() {
+        Some(argument.to_path_buf())
+    } else {
+        cwd.map(|cwd| cwd.join(argument))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::os::unix::fs::symlink;
+
+    use super::*;
+
+    #[test]
+    fn nested_parent_symlink_preserves_configured_launch_identity() {
+        let tmp = tempfile::tempdir().unwrap();
+        let active_app_dir = tmp.path().join("app");
+        let shared_dir = tmp.path().join("shared");
+        std::fs::create_dir_all(&active_app_dir).unwrap();
+        std::fs::create_dir_all(&shared_dir).unwrap();
+        std::fs::write(shared_dir.join("demo"), "fixture").unwrap();
+        symlink(&shared_dir, active_app_dir.join("bin")).unwrap();
+
+        let identity = Identity::resolve(&active_app_dir, "bin/demo").unwrap().unwrap();
+
+        assert!(identity.requires_argument());
+        assert!(identity.matches_argument(active_app_dir.join("bin/demo").as_os_str(), None));
+        assert!(!identity.matches_argument(shared_dir.join("demo").as_os_str(), None));
+    }
+}

--- a/crates/surge-core/src/update/manager/lifecycle/process_quiescence/discovery.rs
+++ b/crates/surge-core/src/update/manager/lifecycle/process_quiescence/discovery.rs
@@ -40,10 +40,10 @@ where
         if pid == protected_pid {
             continue;
         }
-        let Ok(exe) = std::fs::read_link(format!("/proc/{pid}/exe")).map(normalize_proc_exe_path) else {
+        let Ok(mut exe) = std::fs::read_link(format!("/proc/{pid}/exe")).map(normalize_proc_exe_path) else {
             continue;
         };
-        let Some((command, command_inspected)) = inspect_linux_process_command(pid)? else {
+        let Some((command, command_inspected)) = inspect_linux_process_command(pid, &mut exe)? else {
             continue;
         };
         let process = AppProcess {
@@ -108,25 +108,41 @@ pub(super) fn parse_proc_cmdline(bytes: &[u8]) -> Vec<OsString> {
 }
 
 #[cfg(target_os = "linux")]
-fn inspect_linux_process_command(pid: u32) -> Result<Option<(Vec<OsString>, bool)>> {
+fn inspect_linux_process_command(pid: u32, executable: &mut PathBuf) -> Result<Option<(Vec<OsString>, bool)>> {
+    let deadline = std::time::Instant::now() + Duration::from_millis(100);
     let mut command = Vec::new();
     let mut command_inspected = false;
-    for attempt in 0..3 {
-        if attempt > 0 {
-            std::thread::sleep(Duration::from_millis(1));
-        }
+    loop {
         if let Ok(bytes) = std::fs::read(format!("/proc/{pid}/cmdline")) {
             command = parse_proc_cmdline(&bytes);
             command_inspected = true;
         }
-        if command.iter().any(|argument| !argument.is_empty()) {
+
+        let executable_changed = std::fs::read_link(format!("/proc/{pid}/exe"))
+            .map(normalize_proc_exe_path)
+            .is_ok_and(|observed| {
+                if observed == *executable {
+                    false
+                } else {
+                    *executable = observed;
+                    true
+                }
+            });
+        if executable_changed {
+            command.clear();
+            command_inspected = false;
+        }
+        if !executable_changed && command.iter().any(|argument| !argument.is_empty()) {
             return Ok(Some((command, command_inspected)));
         }
         if linux_process_is_gone_or_zombie(pid)? {
             return Ok(None);
         }
+        if std::time::Instant::now() >= deadline {
+            return Ok(Some((command, command_inspected)));
+        }
+        std::thread::sleep(Duration::from_millis(1));
     }
-    Ok(Some((command, command_inspected)))
 }
 
 #[cfg(target_os = "linux")]

--- a/crates/surge-core/src/update/manager/lifecycle/process_quiescence/discovery.rs
+++ b/crates/surge-core/src/update/manager/lifecycle/process_quiescence/discovery.rs
@@ -5,12 +5,16 @@
 use std::ffi::OsString;
 #[cfg(unix)]
 use std::path::PathBuf;
+#[cfg(target_os = "linux")]
+use std::time::Duration;
 
 #[cfg(target_os = "macos")]
 use std::path::Path;
 
 #[cfg(unix)]
 use crate::error::Result;
+#[cfg(target_os = "linux")]
+use crate::error::SurgeError;
 
 #[cfg(unix)]
 pub(super) struct AppProcess {
@@ -25,8 +29,6 @@ pub(super) fn app_process_pids<F>(protected_pid: u32, matches_exe: &F) -> Result
 where
     F: Fn(&AppProcess) -> Result<bool>,
 {
-    use crate::error::SurgeError;
-
     let entries = std::fs::read_dir("/proc")
         .map_err(|e| SurgeError::Platform(format!("Failed to enumerate processes from /proc: {e}")))?;
 
@@ -41,9 +43,9 @@ where
         let Ok(exe) = std::fs::read_link(format!("/proc/{pid}/exe")).map(normalize_proc_exe_path) else {
             continue;
         };
-        let command = std::fs::read(format!("/proc/{pid}/cmdline"));
-        let command_inspected = command.is_ok();
-        let command = command.map_or_else(|_| Vec::new(), |bytes| parse_proc_cmdline(&bytes));
+        let Some((command, command_inspected)) = inspect_linux_process_command(pid)? else {
+            continue;
+        };
         let process = AppProcess {
             exe,
             command,
@@ -105,6 +107,49 @@ pub(super) fn parse_proc_cmdline(bytes: &[u8]) -> Vec<OsString> {
         .collect()
 }
 
+#[cfg(target_os = "linux")]
+fn inspect_linux_process_command(pid: u32) -> Result<Option<(Vec<OsString>, bool)>> {
+    let mut command = Vec::new();
+    let mut command_inspected = false;
+    for attempt in 0..3 {
+        if attempt > 0 {
+            std::thread::sleep(Duration::from_millis(1));
+        }
+        if let Ok(bytes) = std::fs::read(format!("/proc/{pid}/cmdline")) {
+            command = parse_proc_cmdline(&bytes);
+            command_inspected = true;
+        }
+        if command.iter().any(|argument| !argument.is_empty()) {
+            return Ok(Some((command, command_inspected)));
+        }
+        if linux_process_is_gone_or_zombie(pid)? {
+            return Ok(None);
+        }
+    }
+    Ok(Some((command, command_inspected)))
+}
+
+#[cfg(target_os = "linux")]
+fn linux_process_is_gone_or_zombie(pid: u32) -> Result<bool> {
+    let stat = match std::fs::read_to_string(format!("/proc/{pid}/stat")) {
+        Ok(stat) => stat,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(true),
+        Err(error) => {
+            return Err(SurgeError::Platform(format!(
+                "Failed to inspect process PID {pid} state before swap: {error}"
+            )));
+        }
+    };
+    proc_stat_is_zombie(&stat)
+        .ok_or_else(|| SurgeError::Platform(format!("Failed to parse process PID {pid} state before swap")))
+}
+
+#[cfg(target_os = "linux")]
+fn proc_stat_is_zombie(stat: &str) -> Option<bool> {
+    let state = stat.rsplit_once(") ")?.1.as_bytes().first()?;
+    Some(matches!(*state, b'Z' | b'X'))
+}
+
 #[cfg(all(unix, not(any(target_os = "linux", target_os = "macos"))))]
 pub(super) fn app_process_pids<F>(_protected_pid: u32, _matches_exe: &F) -> Result<Vec<u32>>
 where
@@ -162,5 +207,13 @@ mod tests {
             vec![OsString::new(), OsString::from("/opt/demo/app/demo"), OsString::new()]
         );
         assert!(parse_proc_cmdline(b"").is_empty());
+    }
+
+    #[test]
+    fn proc_stat_recognizes_gone_process_states() {
+        assert_eq!(proc_stat_is_zombie("123 (demo) Z 1"), Some(true));
+        assert_eq!(proc_stat_is_zombie("123 (demo) X 1"), Some(true));
+        assert_eq!(proc_stat_is_zombie("123 (demo) S 1"), Some(false));
+        assert_eq!(proc_stat_is_zombie("malformed"), None);
     }
 }

--- a/crates/surge-core/src/update/manager/lifecycle/process_quiescence/discovery.rs
+++ b/crates/surge-core/src/update/manager/lifecycle/process_quiescence/discovery.rs
@@ -25,8 +25,6 @@ pub(super) fn app_process_pids<F>(protected_pid: u32, matches_exe: &F) -> Result
 where
     F: Fn(&AppProcess) -> Result<bool>,
 {
-    use std::os::unix::ffi::OsStringExt;
-
     use crate::error::SurgeError;
 
     let entries = std::fs::read_dir("/proc")
@@ -45,16 +43,7 @@ where
         };
         let command = std::fs::read(format!("/proc/{pid}/cmdline"));
         let command_inspected = command.is_ok();
-        let command = command.map_or_else(
-            |_| Vec::new(),
-            |bytes| {
-                bytes
-                    .split(|byte| *byte == 0)
-                    .filter(|argument| !argument.is_empty())
-                    .map(|argument| OsString::from_vec(argument.to_vec()))
-                    .collect()
-            },
-        );
+        let command = command.map_or_else(|_| Vec::new(), |bytes| parse_proc_cmdline(&bytes));
         let process = AppProcess {
             exe,
             command,
@@ -99,6 +88,21 @@ where
     }
 
     Ok(pids)
+}
+
+#[cfg(target_os = "linux")]
+pub(super) fn parse_proc_cmdline(bytes: &[u8]) -> Vec<OsString> {
+    use std::os::unix::ffi::OsStringExt;
+
+    if bytes.is_empty() {
+        return Vec::new();
+    }
+
+    let arguments = bytes.strip_suffix(&[0]).unwrap_or(bytes);
+    arguments
+        .split(|byte| *byte == 0)
+        .map(|argument| OsString::from_vec(argument.to_vec()))
+        .collect()
 }
 
 #[cfg(all(unix, not(any(target_os = "linux", target_os = "macos"))))]
@@ -149,5 +153,14 @@ mod tests {
         std::fs::write(&executable, "fixture").unwrap();
 
         assert_eq!(normalize_proc_exe_path(executable.clone()), executable);
+    }
+
+    #[test]
+    fn proc_cmdline_preserves_empty_argument_positions() {
+        assert_eq!(
+            parse_proc_cmdline(b"\0/opt/demo/app/demo\0\0"),
+            vec![OsString::new(), OsString::from("/opt/demo/app/demo"), OsString::new()]
+        );
+        assert!(parse_proc_cmdline(b"").is_empty());
     }
 }

--- a/crates/surge-core/src/update/manager/lifecycle/process_quiescence/discovery.rs
+++ b/crates/surge-core/src/update/manager/lifecycle/process_quiescence/discovery.rs
@@ -16,13 +16,14 @@ use crate::error::Result;
 pub(super) struct AppProcess {
     pub(super) exe: PathBuf,
     pub(super) command: Vec<OsString>,
+    pub(super) command_inspected: bool,
     pub(super) cwd: Option<PathBuf>,
 }
 
 #[cfg(target_os = "linux")]
 pub(super) fn app_process_pids<F>(protected_pid: u32, matches_exe: &F) -> Result<Vec<u32>>
 where
-    F: Fn(&AppProcess) -> bool,
+    F: Fn(&AppProcess) -> Result<bool>,
 {
     use std::os::unix::ffi::OsStringExt;
 
@@ -31,65 +32,79 @@ where
     let entries = std::fs::read_dir("/proc")
         .map_err(|e| SurgeError::Platform(format!("Failed to enumerate processes from /proc: {e}")))?;
 
-    Ok(entries
-        .filter_map(std::result::Result::ok)
-        .filter_map(|entry| entry.file_name().to_string_lossy().parse::<u32>().ok())
-        .filter(|pid| *pid != protected_pid)
-        .filter_map(|pid| {
-            let exe = std::fs::read_link(format!("/proc/{pid}/exe"))
-                .map(normalize_proc_exe_path)
-                .ok()?;
-            let command = std::fs::read(format!("/proc/{pid}/cmdline")).map_or_else(
-                |_| Vec::new(),
-                |bytes| {
-                    bytes
-                        .split(|byte| *byte == 0)
-                        .filter(|argument| !argument.is_empty())
-                        .map(|argument| OsString::from_vec(argument.to_vec()))
-                        .collect()
-                },
-            );
-            let process = AppProcess {
-                exe,
-                command,
-                cwd: std::fs::read_link(format!("/proc/{pid}/cwd")).ok(),
-            };
-            matches_exe(&process).then_some(pid)
-        })
-        .collect())
+    let mut pids = Vec::new();
+    for entry in entries.filter_map(std::result::Result::ok) {
+        let Some(pid) = entry.file_name().to_string_lossy().parse::<u32>().ok() else {
+            continue;
+        };
+        if pid == protected_pid {
+            continue;
+        }
+        let Ok(exe) = std::fs::read_link(format!("/proc/{pid}/exe")).map(normalize_proc_exe_path) else {
+            continue;
+        };
+        let command = std::fs::read(format!("/proc/{pid}/cmdline"));
+        let command_inspected = command.is_ok();
+        let command = command.map_or_else(
+            |_| Vec::new(),
+            |bytes| {
+                bytes
+                    .split(|byte| *byte == 0)
+                    .filter(|argument| !argument.is_empty())
+                    .map(|argument| OsString::from_vec(argument.to_vec()))
+                    .collect()
+            },
+        );
+        let process = AppProcess {
+            exe,
+            command,
+            command_inspected,
+            cwd: std::fs::read_link(format!("/proc/{pid}/cwd")).ok(),
+        };
+        if matches_exe(&process)? {
+            pids.push(pid);
+        }
+    }
+
+    Ok(pids)
 }
 
 #[cfg(target_os = "macos")]
 pub(super) fn app_process_pids<F>(protected_pid: u32, matches_exe: &F) -> Result<Vec<u32>>
 where
-    F: Fn(&AppProcess) -> bool,
+    F: Fn(&AppProcess) -> Result<bool>,
 {
     use sysinfo::{ProcessesToUpdate, System};
 
     let mut system = System::new();
     let _ = system.refresh_processes(ProcessesToUpdate::All, true);
-    Ok(system
-        .processes()
-        .iter()
-        .filter_map(|(pid, process)| {
-            let pid = pid.as_u32();
-            if pid == protected_pid {
-                return None;
-            }
-            let app_process = AppProcess {
-                exe: process.exe()?.to_path_buf(),
-                command: process.cmd().to_vec(),
-                cwd: process.cwd().map(Path::to_path_buf),
-            };
-            matches_exe(&app_process).then_some(pid)
-        })
-        .collect())
+    let mut pids = Vec::new();
+    for (pid, process) in system.processes() {
+        let pid = pid.as_u32();
+        if pid == protected_pid {
+            continue;
+        }
+        let Some(exe) = process.exe() else {
+            continue;
+        };
+        let app_process = AppProcess {
+            exe: exe.to_path_buf(),
+            command: process.cmd().to_vec(),
+            command_inspected: !process.cmd().is_empty(),
+            cwd: process.cwd().map(Path::to_path_buf),
+        };
+        if matches_exe(&app_process)? {
+            pids.push(pid);
+        }
+    }
+
+    Ok(pids)
 }
 
 #[cfg(all(unix, not(any(target_os = "linux", target_os = "macos"))))]
 pub(super) fn app_process_pids<F>(_protected_pid: u32, _matches_exe: &F) -> Result<Vec<u32>>
 where
-    F: Fn(&AppProcess) -> bool,
+    F: Fn(&AppProcess) -> Result<bool>,
 {
     use crate::error::SurgeError;
 

--- a/crates/surge-core/src/update/manager/lifecycle/process_quiescence/interpreted_main.rs
+++ b/crates/surge-core/src/update/manager/lifecycle/process_quiescence/interpreted_main.rs
@@ -1,12 +1,26 @@
+use std::ffi::{OsStr, OsString};
 use std::io::Read;
-use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 
 use crate::error::{Result, SurgeError};
 
 pub(super) struct Identity {
-    pub(super) interpreter: PathBuf,
+    interpreter: Interpreter,
     pub(super) script_argument_index: usize,
+}
+
+enum Interpreter {
+    Resolved(PathBuf),
+    EnvCommand(OsString),
+}
+
+impl Identity {
+    pub(super) fn matches_interpreter(&self, executable: &Path, argv0: Option<&OsStr>) -> bool {
+        match &self.interpreter {
+            Interpreter::Resolved(expected) => executable == expected,
+            Interpreter::EnvCommand(expected) => argv0 == Some(expected.as_os_str()),
+        }
+    }
 }
 
 pub(super) fn resolve(active_exe: &Path) -> Result<Option<Identity>> {
@@ -51,11 +65,11 @@ pub(super) fn resolve(active_exe: &Path) -> Result<Option<Identity>> {
                     "Active application env shebang has no interpreter command".to_string(),
                 ));
             };
-            (resolve_interpreter_path(program)?, fixed_arguments.len())
+            (Interpreter::EnvCommand(OsString::from(program)), fixed_arguments.len())
         } else {
             (
-                resolve_interpreter_path(interpreter)?,
-                usize::from(!argument.is_empty()),
+                Interpreter::Resolved(resolve_direct_interpreter_path(interpreter)?),
+                direct_interpreter_argument_count(argument)?,
             )
         };
 
@@ -123,37 +137,25 @@ fn split_command_words(command: &str) -> Result<Vec<String>> {
     Ok(words)
 }
 
-fn resolve_interpreter_path(interpreter: &str) -> Result<PathBuf> {
+fn resolve_direct_interpreter_path(interpreter: &str) -> Result<PathBuf> {
     let interpreter = Path::new(interpreter);
-    if interpreter.is_absolute() || interpreter.components().count() > 1 {
-        return std::fs::canonicalize(interpreter).map_err(|e| {
-            SurgeError::Platform(format!(
-                "Failed to resolve active application interpreter '{}': {e}",
-                interpreter.display()
-            ))
-        });
-    }
-
-    let path = std::env::var_os("PATH").ok_or_else(|| {
+    std::fs::canonicalize(interpreter).map_err(|e| {
         SurgeError::Platform(format!(
-            "Failed to resolve active application interpreter '{}': PATH is unavailable",
+            "Failed to resolve active application interpreter '{}': {e}",
             interpreter.display()
         ))
-    })?;
-    std::env::split_paths(&path)
-        .map(|directory| directory.join(interpreter))
-        .find_map(|candidate| {
-            let metadata = candidate.metadata().ok()?;
-            (metadata.is_file() && metadata.permissions().mode() & 0o111 != 0)
-                .then(|| std::fs::canonicalize(candidate).ok())
-                .flatten()
-        })
-        .ok_or_else(|| {
-            SurgeError::Platform(format!(
-                "Failed to resolve active application interpreter '{}' from PATH",
-                interpreter.display()
-            ))
-        })
+    })
+}
+
+fn direct_interpreter_argument_count(argument: &str) -> Result<usize> {
+    #[cfg(target_os = "macos")]
+    {
+        return Ok(split_command_words(argument)?.len());
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        Ok(usize::from(!argument.is_empty()))
+    }
 }
 
 #[cfg(test)]

--- a/crates/surge-core/src/update/manager/lifecycle/process_quiescence/interpreted_main.rs
+++ b/crates/surge-core/src/update/manager/lifecycle/process_quiescence/interpreted_main.rs
@@ -14,6 +14,11 @@ enum Interpreter {
     EnvCommand(OsString),
 }
 
+struct EnvCommand {
+    program: OsString,
+    fixed_argument_count: usize,
+}
+
 impl Identity {
     pub(super) fn matches_interpreter(&self, executable: &Path, argv0: Option<&OsStr>) -> bool {
         match &self.interpreter {
@@ -67,12 +72,7 @@ pub(super) fn resolve(active_exe: &Path) -> Result<Option<Identity>> {
     let (interpreter, fixed_argument_count) =
         if Path::new(interpreter).file_name().and_then(|name| name.to_str()) == Some("env") {
             let command = parse_env_command(argument)?;
-            let Some((program, fixed_arguments)) = command.split_first() else {
-                return Err(SurgeError::Platform(
-                    "Active application env shebang has no interpreter command".to_string(),
-                ));
-            };
-            (Interpreter::EnvCommand(OsString::from(program)), fixed_arguments.len())
+            (Interpreter::EnvCommand(command.program), command.fixed_argument_count)
         } else {
             (
                 Interpreter::Resolved(resolve_direct_interpreter_path(interpreter)?),
@@ -86,23 +86,110 @@ pub(super) fn resolve(active_exe: &Path) -> Result<Option<Identity>> {
     }))
 }
 
-fn parse_env_command(argument: &str) -> Result<Vec<String>> {
+fn parse_env_command(argument: &str) -> Result<EnvCommand> {
     let split_command = argument
         .strip_prefix("--split-string=")
         .or_else(|| argument.strip_prefix("-S"))
         .or_else(|| argument.strip_prefix("--split-string "))
         .map(str::trim_start);
     let command = split_command.unwrap_or(argument);
-    let words = split_command_words(command)?;
+    let words = split_env_command_words(command)?;
     #[cfg(not(target_os = "macos"))]
     if split_command.is_none() && words.len() > 1 {
         return Err(SurgeError::Platform(
             "Active application env shebang with multiple arguments must use -S".to_string(),
         ));
     }
-    Ok(words)
+
+    let command_index = env_command_index(&words)?;
+    Ok(EnvCommand {
+        program: OsString::from(&words[command_index]),
+        fixed_argument_count: words.len() - command_index - 1,
+    })
 }
 
+fn split_env_command_words(command: &str) -> Result<Vec<String>> {
+    if command
+        .chars()
+        .any(|character| matches!(character, '\\' | '\'' | '"' | '$' | '#'))
+    {
+        return Err(SurgeError::Platform(
+            "Active application env shebang uses unsupported split-string quoting, escaping, expansion, or comments"
+                .to_string(),
+        ));
+    }
+
+    Ok(command.split_whitespace().map(ToString::to_string).collect())
+}
+
+fn env_command_index(words: &[String]) -> Result<usize> {
+    let mut index = 0;
+    let mut options = true;
+
+    while let Some(word) = words.get(index) {
+        if options {
+            match word.as_str() {
+                "--" => {
+                    options = false;
+                    index += 1;
+                    continue;
+                }
+                "-i" | "--ignore-environment" | "-0" | "--null" | "-v" | "--debug" | "--list-signal-handling" => {
+                    index += 1;
+                    continue;
+                }
+                "-u" | "--unset" | "-C" | "--chdir" | "-P" => {
+                    if words.get(index + 1).is_none() {
+                        return Err(SurgeError::Platform(format!(
+                            "Active application env shebang option '{word}' has no value"
+                        )));
+                    }
+                    index += 2;
+                    continue;
+                }
+                _ if word.starts_with("--unset=") || word.starts_with("--chdir=") => {
+                    index += 1;
+                    continue;
+                }
+                _ if (word.starts_with("-u") || word.starts_with("-C") || word.starts_with("-P")) && word.len() > 2 => {
+                    index += 1;
+                    continue;
+                }
+                _ if word.starts_with('-') => {
+                    return Err(SurgeError::Platform(format!(
+                        "Active application env shebang uses unsupported option '{word}'"
+                    )));
+                }
+                _ => {}
+            }
+        }
+
+        if is_env_assignment(word) {
+            options = false;
+            index += 1;
+            continue;
+        }
+
+        return Ok(index);
+    }
+
+    Err(SurgeError::Platform(
+        "Active application env shebang has no interpreter command".to_string(),
+    ))
+}
+
+fn is_env_assignment(word: &str) -> bool {
+    let Some((name, _)) = word.split_once('=') else {
+        return false;
+    };
+    let mut characters = name.chars();
+    characters
+        .next()
+        .is_some_and(|character| character == '_' || character.is_ascii_alphabetic())
+        && characters.all(|character| character == '_' || character.is_ascii_alphanumeric())
+}
+
+#[cfg(any(target_os = "macos", test))]
 fn split_command_words(command: &str) -> Result<Vec<String>> {
     let mut words = Vec::new();
     let mut word = String::new();
@@ -147,12 +234,40 @@ fn split_command_words(command: &str) -> Result<Vec<String>> {
 
 fn resolve_direct_interpreter_path(interpreter: &str) -> Result<PathBuf> {
     let interpreter = Path::new(interpreter);
-    std::fs::canonicalize(interpreter).map_err(|e| {
+    if !interpreter.is_absolute() {
+        return Err(SurgeError::Platform(format!(
+            "Active application interpreter '{}' must be an absolute path",
+            interpreter.display()
+        )));
+    }
+    let resolved = std::fs::canonicalize(interpreter).map_err(|e| {
         SurgeError::Platform(format!(
             "Failed to resolve active application interpreter '{}': {e}",
             interpreter.display()
         ))
-    })
+    })?;
+    let mut file = std::fs::File::open(&resolved).map_err(|e| {
+        SurgeError::Platform(format!(
+            "Failed to inspect active application interpreter '{}': {e}",
+            resolved.display()
+        ))
+    })?;
+    let mut prefix = [0_u8; 2];
+    if file.read(&mut prefix).map_err(|e| {
+        SurgeError::Platform(format!(
+            "Failed to inspect active application interpreter '{}': {e}",
+            resolved.display()
+        ))
+    })? == prefix.len()
+        && prefix == *b"#!"
+    {
+        return Err(SurgeError::Platform(format!(
+            "Active application interpreter '{}' is itself a shebang script; nested interpreters are unsupported",
+            resolved.display()
+        )));
+    }
+
+    Ok(resolved)
 }
 
 fn direct_interpreter_argument_count(argument: &str) -> Result<usize> {
@@ -176,5 +291,41 @@ mod tests {
             split_command_words("/bin/sh '-e value' plain\\ value").unwrap(),
             vec!["/bin/sh", "-e value", "plain value"]
         );
+    }
+
+    #[test]
+    fn env_command_skips_options_assignments_and_separator() {
+        let command = parse_env_command("-S -i -u OLD -- FEATURE=true /bin/sh -e").unwrap();
+        assert_eq!(command.program, OsString::from("/bin/sh"));
+        assert_eq!(command.fixed_argument_count, 1);
+    }
+
+    #[test]
+    fn env_command_rejects_unknown_options_instead_of_treating_them_as_the_interpreter() {
+        let error = parse_env_command("-S --argv0 app /bin/sh").err().unwrap();
+        assert!(error.to_string().contains("unsupported option '--argv0'"));
+    }
+
+    #[test]
+    fn env_command_rejects_escape_sequences_instead_of_misparsing_operand_boundaries() {
+        let error = parse_env_command(r"-S /bin/sh\_-e").err().unwrap();
+        assert!(error.to_string().contains("unsupported split-string"));
+    }
+
+    #[test]
+    fn direct_interpreter_must_be_absolute() {
+        let error = resolve_direct_interpreter_path("./interpreter").unwrap_err();
+        assert!(error.to_string().contains("must be an absolute path"));
+    }
+
+    #[test]
+    fn nested_shebang_interpreter_is_rejected() {
+        let tmp = tempfile::tempdir().unwrap();
+        let interpreter = tmp.path().join("interpreter");
+        std::fs::write(&interpreter, "#!/bin/sh\n").unwrap();
+
+        let error = resolve_direct_interpreter_path(interpreter.to_str().unwrap()).unwrap_err();
+
+        assert!(error.to_string().contains("nested interpreters are unsupported"));
     }
 }

--- a/crates/surge-core/src/update/manager/lifecycle/process_quiescence/interpreted_main.rs
+++ b/crates/surge-core/src/update/manager/lifecycle/process_quiescence/interpreted_main.rs
@@ -188,7 +188,7 @@ pub(super) fn resolve(active_exe: &Path) -> Result<Option<Identity>> {
             (Interpreter::EnvCommand(command), fixed_argument_count)
         } else {
             #[cfg(target_os = "macos")]
-            let fixed_argument_count = direct_interpreter_argument_count(argument)?;
+            let fixed_argument_count = macos_direct_interpreter_argument_count(argument);
             #[cfg(not(target_os = "macos"))]
             let fixed_argument_count = direct_interpreter_argument_count(argument);
             (
@@ -449,9 +449,9 @@ fn ensure_supported_env_interpreter(interpreter: &str) -> Result<()> {
     )))
 }
 
-#[cfg(target_os = "macos")]
-fn direct_interpreter_argument_count(argument: &str) -> Result<usize> {
-    Ok(split_command_words(argument)?.len())
+#[cfg(any(target_os = "macos", test))]
+fn macos_direct_interpreter_argument_count(argument: &str) -> usize {
+    argument.split_ascii_whitespace().count()
 }
 
 #[cfg(not(target_os = "macos"))]
@@ -468,6 +468,14 @@ mod tests {
         assert_eq!(
             split_command_words("/bin/sh '-e value' plain\\ value").unwrap(),
             vec!["/bin/sh", "-e value", "plain value"]
+        );
+    }
+
+    #[test]
+    fn macos_direct_interpreter_arguments_are_counted_literally() {
+        assert_eq!(
+            macos_direct_interpreter_argument_count(r#"-e 'two words' plain\ value"#),
+            5
         );
     }
 

--- a/crates/surge-core/src/update/manager/lifecycle/process_quiescence/interpreted_main.rs
+++ b/crates/surge-core/src/update/manager/lifecycle/process_quiescence/interpreted_main.rs
@@ -1,0 +1,170 @@
+use std::io::Read;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+
+use crate::error::{Result, SurgeError};
+
+pub(super) struct Identity {
+    pub(super) interpreter: PathBuf,
+    pub(super) script_argument_index: usize,
+}
+
+pub(super) fn resolve(active_exe: &Path) -> Result<Option<Identity>> {
+    let mut file = std::fs::File::open(active_exe).map_err(|e| {
+        SurgeError::Platform(format!(
+            "Failed to inspect active application executable before swap: {e}"
+        ))
+    })?;
+    let mut prefix = Vec::new();
+    file.by_ref().take(4097).read_to_end(&mut prefix).map_err(|e| {
+        SurgeError::Platform(format!(
+            "Failed to inspect active application executable before swap: {e}"
+        ))
+    })?;
+    if !prefix.starts_with(b"#!") {
+        return Ok(None);
+    }
+
+    let line_end = prefix.iter().position(|byte| *byte == b'\n').unwrap_or(prefix.len());
+    if line_end > 4096 {
+        return Err(SurgeError::Platform(
+            "Active application shebang exceeds the supported 4096-byte limit".to_string(),
+        ));
+    }
+    let shebang = std::str::from_utf8(&prefix[2..line_end])
+        .map_err(|e| SurgeError::Platform(format!("Active application shebang is not valid UTF-8: {e}")))?
+        .trim();
+    let interpreter_end = shebang.find(char::is_whitespace).unwrap_or(shebang.len());
+    let interpreter = &shebang[..interpreter_end];
+    let argument = shebang[interpreter_end..].trim();
+    if interpreter.is_empty() {
+        return Err(SurgeError::Platform(
+            "Active application shebang has no interpreter".to_string(),
+        ));
+    }
+
+    let (interpreter, fixed_argument_count) =
+        if Path::new(interpreter).file_name().and_then(|name| name.to_str()) == Some("env") {
+            let command = parse_env_command(argument)?;
+            let Some((program, fixed_arguments)) = command.split_first() else {
+                return Err(SurgeError::Platform(
+                    "Active application env shebang has no interpreter command".to_string(),
+                ));
+            };
+            (resolve_interpreter_path(program)?, fixed_arguments.len())
+        } else {
+            (
+                resolve_interpreter_path(interpreter)?,
+                usize::from(!argument.is_empty()),
+            )
+        };
+
+    Ok(Some(Identity {
+        interpreter,
+        script_argument_index: 1 + fixed_argument_count,
+    }))
+}
+
+fn parse_env_command(argument: &str) -> Result<Vec<String>> {
+    let split_command = argument
+        .strip_prefix("--split-string=")
+        .or_else(|| argument.strip_prefix("-S"))
+        .or_else(|| argument.strip_prefix("--split-string "))
+        .map(str::trim_start);
+    let command = split_command.unwrap_or(argument);
+    let words = split_command_words(command)?;
+    if split_command.is_none() && words.len() > 1 {
+        return Err(SurgeError::Platform(
+            "Active application env shebang with multiple arguments must use -S".to_string(),
+        ));
+    }
+    Ok(words)
+}
+
+fn split_command_words(command: &str) -> Result<Vec<String>> {
+    let mut words = Vec::new();
+    let mut word = String::new();
+    let mut quote = None;
+    let mut escaped = false;
+    let mut started = false;
+
+    for character in command.chars() {
+        if escaped {
+            word.push(character);
+            escaped = false;
+            started = true;
+        } else if character == '\\' && quote != Some('\'') {
+            escaped = true;
+            started = true;
+        } else if matches!(character, '\'' | '"') && quote == Some(character) {
+            quote = None;
+        } else if matches!(character, '\'' | '"') && quote.is_none() {
+            quote = Some(character);
+            started = true;
+        } else if character.is_whitespace() && quote.is_none() {
+            if started {
+                words.push(std::mem::take(&mut word));
+                started = false;
+            }
+        } else {
+            word.push(character);
+            started = true;
+        }
+    }
+
+    if escaped || quote.is_some() {
+        return Err(SurgeError::Platform(
+            "Active application env shebang contains an unterminated escape or quote".to_string(),
+        ));
+    }
+    if started {
+        words.push(word);
+    }
+    Ok(words)
+}
+
+fn resolve_interpreter_path(interpreter: &str) -> Result<PathBuf> {
+    let interpreter = Path::new(interpreter);
+    if interpreter.is_absolute() || interpreter.components().count() > 1 {
+        return std::fs::canonicalize(interpreter).map_err(|e| {
+            SurgeError::Platform(format!(
+                "Failed to resolve active application interpreter '{}': {e}",
+                interpreter.display()
+            ))
+        });
+    }
+
+    let path = std::env::var_os("PATH").ok_or_else(|| {
+        SurgeError::Platform(format!(
+            "Failed to resolve active application interpreter '{}': PATH is unavailable",
+            interpreter.display()
+        ))
+    })?;
+    std::env::split_paths(&path)
+        .map(|directory| directory.join(interpreter))
+        .find_map(|candidate| {
+            let metadata = candidate.metadata().ok()?;
+            (metadata.is_file() && metadata.permissions().mode() & 0o111 != 0)
+                .then(|| std::fs::canonicalize(candidate).ok())
+                .flatten()
+        })
+        .ok_or_else(|| {
+            SurgeError::Platform(format!(
+                "Failed to resolve active application interpreter '{}' from PATH",
+                interpreter.display()
+            ))
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn split_command_words_preserves_quoted_and_escaped_arguments() {
+        assert_eq!(
+            split_command_words("/bin/sh '-e value' plain\\ value").unwrap(),
+            vec!["/bin/sh", "-e value", "plain value"]
+        );
+    }
+}

--- a/crates/surge-core/src/update/manager/lifecycle/process_quiescence/interpreted_main.rs
+++ b/crates/surge-core/src/update/manager/lifecycle/process_quiescence/interpreted_main.rs
@@ -93,6 +93,18 @@ fn paths_resolve_to_same_executable(actual: &Path, expected: &Path) -> bool {
         .ok()
         .zip(std::fs::metadata(expected).ok())
         .is_some_and(|(actual, expected)| actual.dev() == expected.dev() && actual.ino() == expected.ino())
+        || macos_system_shell_identity_matches(actual, expected)
+}
+
+#[cfg(target_os = "macos")]
+fn macos_system_shell_identity_matches(actual: &Path, expected: &Path) -> bool {
+    // macOS reports a stable /bin/sh script process as /bin/bash while retaining /bin/sh as argv[0].
+    actual == Path::new("/bin/bash") && expected == Path::new("/bin/sh")
+}
+
+#[cfg(not(target_os = "macos"))]
+fn macos_system_shell_identity_matches(_actual: &Path, _expected: &Path) -> bool {
+    false
 }
 
 fn resolve_env_command(command: &EnvCommand) -> Result<PathBuf> {
@@ -480,6 +492,19 @@ mod tests {
             macos_direct_interpreter_argument_count(r"-e 'two words' plain\ value"),
             5
         );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn macos_system_sh_matches_reported_bash_process_identity() {
+        assert!(paths_resolve_to_same_executable(
+            Path::new("/bin/bash"),
+            Path::new("/bin/sh")
+        ));
+        assert!(!paths_resolve_to_same_executable(
+            Path::new("/bin/sleep"),
+            Path::new("/bin/sh")
+        ));
     }
 
     #[test]

--- a/crates/surge-core/src/update/manager/lifecycle/process_quiescence/interpreted_main.rs
+++ b/crates/surge-core/src/update/manager/lifecycle/process_quiescence/interpreted_main.rs
@@ -474,7 +474,7 @@ mod tests {
     #[test]
     fn macos_direct_interpreter_arguments_are_counted_literally() {
         assert_eq!(
-            macos_direct_interpreter_argument_count(r#"-e 'two words' plain\ value"#),
+            macos_direct_interpreter_argument_count(r"-e 'two words' plain\ value"),
             5
         );
     }

--- a/crates/surge-core/src/update/manager/lifecycle/process_quiescence/interpreted_main.rs
+++ b/crates/surge-core/src/update/manager/lifecycle/process_quiescence/interpreted_main.rs
@@ -17,7 +17,14 @@ enum Interpreter {
 impl Identity {
     pub(super) fn matches_interpreter(&self, executable: &Path, argv0: Option<&OsStr>) -> bool {
         match &self.interpreter {
-            Interpreter::Resolved(expected) => executable == expected,
+            Interpreter::Resolved(expected) => {
+                executable == expected
+                    || argv0.is_some_and(|argument| {
+                        let argument = Path::new(argument);
+                        argument.is_absolute()
+                            && std::fs::canonicalize(argument).is_ok_and(|resolved| resolved == *expected)
+                    })
+            }
             Interpreter::EnvCommand(expected) => argv0 == Some(expected.as_os_str()),
         }
     }
@@ -87,6 +94,7 @@ fn parse_env_command(argument: &str) -> Result<Vec<String>> {
         .map(str::trim_start);
     let command = split_command.unwrap_or(argument);
     let words = split_command_words(command)?;
+    #[cfg(not(target_os = "macos"))]
     if split_command.is_none() && words.len() > 1 {
         return Err(SurgeError::Platform(
             "Active application env shebang with multiple arguments must use -S".to_string(),

--- a/crates/surge-core/src/update/manager/lifecycle/process_quiescence/interpreted_main.rs
+++ b/crates/surge-core/src/update/manager/lifecycle/process_quiescence/interpreted_main.rs
@@ -69,9 +69,7 @@ impl Identity {
                     return Ok(true);
                 }
                 let program = Path::new(&expected.program);
-                Ok(matches!(expected.search_path, EnvSearchPath::Inherited)
-                    && program.components().count() == 1
-                    && executable.file_name() == program.file_name())
+                Ok(matches!(expected.search_path, EnvSearchPath::Inherited) && program.components().count() == 1)
             }
         }
     }
@@ -274,6 +272,7 @@ fn env_command_index(words: &[String]) -> Result<(usize, EnvSearchPath)> {
     let mut index = 0;
     let mut options = true;
     let mut search_path = None;
+    let mut path_unset = false;
     let mut ignore_environment = false;
 
     while let Some(word) = words.get(index) {
@@ -294,24 +293,40 @@ fn env_command_index(words: &[String]) -> Result<(usize, EnvSearchPath)> {
                     continue;
                 }
                 "-u" | "--unset" | "-C" | "--chdir" | "-P" => {
-                    if words.get(index + 1).is_none() {
+                    let Some(value) = words.get(index + 1) else {
                         return Err(SurgeError::Platform(format!(
                             "Active application env shebang option '{word}' has no value"
                         )));
-                    }
+                    };
                     if word == "-P" {
-                        search_path = words.get(index + 1).cloned();
+                        search_path = Some(value.clone());
+                        path_unset = false;
+                    } else if matches!(word.as_str(), "-u" | "--unset") && value == "PATH" {
+                        search_path = None;
+                        path_unset = true;
                     }
                     index += 2;
                     continue;
                 }
-                _ if word.starts_with("--unset=") || word.starts_with("--chdir=") => {
+                _ if word.starts_with("--unset=") => {
+                    if word.strip_prefix("--unset=") == Some("PATH") {
+                        search_path = None;
+                        path_unset = true;
+                    }
+                    index += 1;
+                    continue;
+                }
+                _ if word.starts_with("--chdir=") => {
                     index += 1;
                     continue;
                 }
                 _ if (word.starts_with("-u") || word.starts_with("-C") || word.starts_with("-P")) && word.len() > 2 => {
                     if let Some(path) = word.strip_prefix("-P") {
                         search_path = Some(path.to_string());
+                        path_unset = false;
+                    } else if word.strip_prefix("-u") == Some("PATH") {
+                        search_path = None;
+                        path_unset = true;
                     }
                     index += 1;
                     continue;
@@ -329,6 +344,7 @@ fn env_command_index(words: &[String]) -> Result<(usize, EnvSearchPath)> {
             options = false;
             if let Some(search_path_assignment) = word.strip_prefix("PATH=") {
                 search_path = Some(search_path_assignment.to_string());
+                path_unset = false;
             }
             index += 1;
             continue;
@@ -336,7 +352,7 @@ fn env_command_index(words: &[String]) -> Result<(usize, EnvSearchPath)> {
 
         let search_path = match search_path {
             Some(search_path) => EnvSearchPath::Explicit(OsString::from(search_path)),
-            None if ignore_environment => EnvSearchPath::Default,
+            None if ignore_environment || path_unset => EnvSearchPath::Default,
             None => EnvSearchPath::Inherited,
         };
         return Ok((index, search_path));
@@ -348,14 +364,7 @@ fn env_command_index(words: &[String]) -> Result<(usize, EnvSearchPath)> {
 }
 
 fn is_env_assignment(word: &str) -> bool {
-    let Some((name, _)) = word.split_once('=') else {
-        return false;
-    };
-    let mut characters = name.chars();
-    characters
-        .next()
-        .is_some_and(|character| character == '_' || character.is_ascii_alphabetic())
-        && characters.all(|character| character == '_' || character.is_ascii_alphanumeric())
+    word.contains('=')
 }
 
 fn resolve_direct_interpreter_path(interpreter: &str) -> Result<PathBuf> {
@@ -516,6 +525,36 @@ mod tests {
     }
 
     #[test]
+    fn env_command_accepts_non_shell_assignment_names() {
+        let command = parse_env_command("-S A-B=value /bin/sh").unwrap();
+
+        assert_eq!(command.program, OsString::from("/bin/sh"));
+        assert_eq!(command.fixed_argument_count, 0);
+        assert_eq!(command.search_path, EnvSearchPath::Inherited);
+    }
+
+    #[test]
+    fn env_path_unset_uses_the_default_search_path() {
+        for argument in ["-S -u PATH sh", "-S --unset=PATH sh", "-S -uPATH sh"] {
+            let command = parse_env_command(argument).unwrap();
+
+            assert_eq!(command.search_path, EnvSearchPath::Default);
+        }
+
+        let command = parse_env_command("-S -u PATH PATH=/opt/interpreters sh").unwrap();
+        assert_eq!(
+            command.search_path,
+            EnvSearchPath::Explicit(OsString::from("/opt/interpreters"))
+        );
+
+        let command = parse_env_command("-S -u PATH -P /opt/interpreters sh").unwrap();
+        assert_eq!(
+            command.search_path,
+            EnvSearchPath::Explicit(OsString::from("/opt/interpreters"))
+        );
+    }
+
+    #[test]
     fn env_command_preserves_explicit_search_path() {
         let command = parse_env_command("-S -i -P /opt/interpreters demo-interpreter -e").unwrap();
 
@@ -626,6 +665,20 @@ mod tests {
         };
 
         assert!(identity.executable_may_match(&interpreter).unwrap());
+    }
+
+    #[test]
+    fn inherited_env_path_retains_symlink_target_uncertainty() {
+        let identity = Identity {
+            interpreter: Interpreter::EnvCommand(EnvCommand {
+                program: OsString::from("sh"),
+                fixed_argument_count: 0,
+                search_path: EnvSearchPath::Inherited,
+            }),
+            script_argument_index: 1,
+        };
+
+        assert!(identity.executable_may_match(Path::new("/bin/sleep")).unwrap());
     }
 
     #[test]

--- a/crates/surge-core/src/update/manager/lifecycle/process_quiescence/interpreted_main.rs
+++ b/crates/surge-core/src/update/manager/lifecycle/process_quiescence/interpreted_main.rs
@@ -11,28 +11,96 @@ pub(super) struct Identity {
 
 enum Interpreter {
     Resolved(PathBuf),
-    EnvCommand(OsString),
+    EnvCommand(EnvCommand),
 }
 
 struct EnvCommand {
     program: OsString,
     fixed_argument_count: usize,
+    search_path: Option<OsString>,
 }
 
 impl Identity {
-    pub(super) fn matches_interpreter(&self, executable: &Path, argv0: Option<&OsStr>) -> bool {
+    pub(super) fn matches_interpreter(&self, executable: &Path, argv0: Option<&OsStr>) -> Result<bool> {
         match &self.interpreter {
-            Interpreter::Resolved(expected) => {
-                executable == expected
-                    || argv0.is_some_and(|argument| {
-                        let argument = Path::new(argument);
-                        argument.is_absolute()
-                            && std::fs::canonicalize(argument).is_ok_and(|resolved| resolved == *expected)
-                    })
+            Interpreter::Resolved(expected) => Ok(paths_resolve_to_same_executable(executable, expected)),
+            Interpreter::EnvCommand(expected) => {
+                if argv0 != Some(expected.program.as_os_str()) {
+                    return Ok(false);
+                }
+                let resolved = resolve_env_command(expected)?;
+                if paths_resolve_to_same_executable(executable, &resolved) {
+                    Ok(true)
+                } else {
+                    Err(SurgeError::Platform(format!(
+                        "Cannot verify env interpreter '{}' from the updater environment; refusing to swap while its process identity is ambiguous",
+                        expected.program.to_string_lossy()
+                    )))
+                }
             }
-            Interpreter::EnvCommand(expected) => argv0 == Some(expected.as_os_str()),
         }
     }
+
+    pub(super) fn executable_may_match(&self, executable: &Path) -> Result<bool> {
+        match &self.interpreter {
+            Interpreter::Resolved(expected) => Ok(paths_resolve_to_same_executable(executable, expected)),
+            Interpreter::EnvCommand(expected) => {
+                let resolved = resolve_env_command(expected)?;
+                Ok(paths_resolve_to_same_executable(executable, &resolved))
+            }
+        }
+    }
+}
+
+fn paths_resolve_to_same_executable(actual: &Path, expected: &Path) -> bool {
+    if actual == expected {
+        return true;
+    }
+    let Ok(actual) = std::fs::canonicalize(actual) else {
+        return false;
+    };
+    std::fs::canonicalize(expected).is_ok_and(|expected| actual == expected)
+}
+
+fn resolve_env_command(command: &EnvCommand) -> Result<PathBuf> {
+    let program = Path::new(&command.program);
+    if program.is_absolute() {
+        return std::fs::canonicalize(program).map_err(|e| {
+            SurgeError::Platform(format!(
+                "Failed to resolve active application env interpreter '{}': {e}",
+                program.display()
+            ))
+        });
+    }
+    if program.components().count() != 1 {
+        return Err(SurgeError::Platform(format!(
+            "Cannot safely resolve relative env interpreter '{}' before swap",
+            program.display()
+        )));
+    }
+
+    let search_path = command
+        .search_path
+        .clone()
+        .or_else(|| std::env::var_os("PATH"))
+        .unwrap_or_else(|| OsString::from("/usr/bin:/bin"));
+    for directory in std::env::split_paths(&search_path) {
+        if directory.as_os_str().is_empty() || directory.is_relative() {
+            return Err(SurgeError::Platform(format!(
+                "Cannot safely resolve env interpreter '{}' through a relative PATH entry before swap",
+                program.display()
+            )));
+        }
+        let candidate = directory.join(program);
+        if let Ok(candidate) = std::fs::canonicalize(candidate) {
+            return Ok(candidate);
+        }
+    }
+
+    Err(SurgeError::Platform(format!(
+        "Failed to resolve active application env interpreter '{}' from the updater PATH",
+        program.display()
+    )))
 }
 
 pub(super) fn resolve(active_exe: &Path) -> Result<Option<Identity>> {
@@ -57,6 +125,11 @@ pub(super) fn resolve(active_exe: &Path) -> Result<Option<Identity>> {
             "Active application shebang exceeds the supported 4096-byte limit".to_string(),
         ));
     }
+    if prefix[2..line_end].contains(&0) {
+        return Err(SurgeError::Platform(
+            "Active application shebang contains an embedded NUL byte".to_string(),
+        ));
+    }
     let shebang = std::str::from_utf8(&prefix[2..line_end])
         .map_err(|e| SurgeError::Platform(format!("Active application shebang is not valid UTF-8: {e}")))?
         .trim();
@@ -72,7 +145,8 @@ pub(super) fn resolve(active_exe: &Path) -> Result<Option<Identity>> {
     let (interpreter, fixed_argument_count) =
         if Path::new(interpreter).file_name().and_then(|name| name.to_str()) == Some("env") {
             let command = parse_env_command(argument)?;
-            (Interpreter::EnvCommand(command.program), command.fixed_argument_count)
+            let fixed_argument_count = command.fixed_argument_count;
+            (Interpreter::EnvCommand(command), fixed_argument_count)
         } else {
             (
                 Interpreter::Resolved(resolve_direct_interpreter_path(interpreter)?),
@@ -101,10 +175,11 @@ fn parse_env_command(argument: &str) -> Result<EnvCommand> {
         ));
     }
 
-    let command_index = env_command_index(&words)?;
+    let (command_index, search_path) = env_command_index(&words)?;
     Ok(EnvCommand {
         program: OsString::from(&words[command_index]),
         fixed_argument_count: words.len() - command_index - 1,
+        search_path: search_path.map(OsString::from),
     })
 }
 
@@ -122,9 +197,10 @@ fn split_env_command_words(command: &str) -> Result<Vec<String>> {
     Ok(command.split_whitespace().map(ToString::to_string).collect())
 }
 
-fn env_command_index(words: &[String]) -> Result<usize> {
+fn env_command_index(words: &[String]) -> Result<(usize, Option<String>)> {
     let mut index = 0;
     let mut options = true;
+    let mut search_path = None;
 
     while let Some(word) = words.get(index) {
         if options {
@@ -144,6 +220,9 @@ fn env_command_index(words: &[String]) -> Result<usize> {
                             "Active application env shebang option '{word}' has no value"
                         )));
                     }
+                    if word == "-P" {
+                        search_path = words.get(index + 1).cloned();
+                    }
                     index += 2;
                     continue;
                 }
@@ -152,6 +231,9 @@ fn env_command_index(words: &[String]) -> Result<usize> {
                     continue;
                 }
                 _ if (word.starts_with("-u") || word.starts_with("-C") || word.starts_with("-P")) && word.len() > 2 => {
+                    if let Some(path) = word.strip_prefix("-P") {
+                        search_path = Some(path.to_string());
+                    }
                     index += 1;
                     continue;
                 }
@@ -170,7 +252,7 @@ fn env_command_index(words: &[String]) -> Result<usize> {
             continue;
         }
 
-        return Ok(index);
+        return Ok((index, search_path));
     }
 
     Err(SurgeError::Platform(
@@ -301,6 +383,14 @@ mod tests {
     }
 
     #[test]
+    fn env_command_preserves_explicit_search_path() {
+        let command = parse_env_command("-S -P /opt/interpreters demo-interpreter -e").unwrap();
+
+        assert_eq!(command.program, OsString::from("demo-interpreter"));
+        assert_eq!(command.search_path, Some(OsString::from("/opt/interpreters")));
+    }
+
+    #[test]
     fn env_command_rejects_unknown_options_instead_of_treating_them_as_the_interpreter() {
         let error = parse_env_command("-S --argv0 app /bin/sh").err().unwrap();
         assert!(error.to_string().contains("unsupported option '--argv0'"));
@@ -327,5 +417,16 @@ mod tests {
         let error = resolve_direct_interpreter_path(interpreter.to_str().unwrap()).unwrap_err();
 
         assert!(error.to_string().contains("nested interpreters are unsupported"));
+    }
+
+    #[test]
+    fn shebang_with_embedded_nul_is_rejected() {
+        let tmp = tempfile::tempdir().unwrap();
+        let app = tmp.path().join("app");
+        std::fs::write(&app, b"#!/usr/bin/env sh\0 -e\n").unwrap();
+
+        let error = resolve(&app).err().unwrap();
+
+        assert!(error.to_string().contains("embedded NUL"));
     }
 }

--- a/crates/surge-core/src/update/manager/lifecycle/process_quiescence/interpreted_main.rs
+++ b/crates/surge-core/src/update/manager/lifecycle/process_quiescence/interpreted_main.rs
@@ -104,6 +104,12 @@ fn resolve_env_command(command: &EnvCommand) -> Result<PathBuf> {
                 program.display()
             ))
         })?;
+        if !is_executable_file(&resolved) {
+            return Err(SurgeError::Platform(format!(
+                "Active application env interpreter '{}' is not executable",
+                program.display()
+            )));
+        }
         return validate_resolved_interpreter(resolved);
     }
     if program.components().count() != 1 {
@@ -126,9 +132,13 @@ fn resolve_env_command(command: &EnvCommand) -> Result<PathBuf> {
             )));
         }
         let candidate = directory.join(program);
-        if let Ok(candidate) = std::fs::canonicalize(candidate) {
-            return validate_resolved_interpreter(candidate);
+        let Ok(candidate) = std::fs::canonicalize(candidate) else {
+            continue;
+        };
+        if !is_executable_file(&candidate) {
+            continue;
         }
+        return validate_resolved_interpreter(candidate);
     }
 
     Err(SurgeError::Platform(format!(
@@ -336,49 +346,6 @@ fn is_env_assignment(word: &str) -> bool {
         && characters.all(|character| character == '_' || character.is_ascii_alphanumeric())
 }
 
-#[cfg(any(target_os = "macos", test))]
-fn split_command_words(command: &str) -> Result<Vec<String>> {
-    let mut words = Vec::new();
-    let mut word = String::new();
-    let mut quote = None;
-    let mut escaped = false;
-    let mut started = false;
-
-    for character in command.chars() {
-        if escaped {
-            word.push(character);
-            escaped = false;
-            started = true;
-        } else if character == '\\' && quote != Some('\'') {
-            escaped = true;
-            started = true;
-        } else if matches!(character, '\'' | '"') && quote == Some(character) {
-            quote = None;
-        } else if matches!(character, '\'' | '"') && quote.is_none() {
-            quote = Some(character);
-            started = true;
-        } else if character.is_whitespace() && quote.is_none() {
-            if started {
-                words.push(std::mem::take(&mut word));
-                started = false;
-            }
-        } else {
-            word.push(character);
-            started = true;
-        }
-    }
-
-    if escaped || quote.is_some() {
-        return Err(SurgeError::Platform(
-            "Active application env shebang contains an unterminated escape or quote".to_string(),
-        ));
-    }
-    if started {
-        words.push(word);
-    }
-    Ok(words)
-}
-
 fn resolve_direct_interpreter_path(interpreter: &str) -> Result<PathBuf> {
     let interpreter = Path::new(interpreter);
     if !interpreter.is_absolute() {
@@ -403,22 +370,58 @@ fn validate_resolved_interpreter(resolved: PathBuf) -> Result<PathBuf> {
             resolved.display()
         ))
     })?;
-    let mut prefix = [0_u8; 2];
-    if file.read(&mut prefix).map_err(|e| {
+    let mut prefix = [0_u8; 4];
+    let prefix_len = file.read(&mut prefix).map_err(|e| {
         SurgeError::Platform(format!(
             "Failed to inspect active application interpreter '{}': {e}",
             resolved.display()
         ))
-    })? == prefix.len()
-        && prefix == *b"#!"
-    {
+    })?;
+    if prefix[..prefix_len].starts_with(b"#!") {
         return Err(SurgeError::Platform(format!(
             "Active application interpreter '{}' is itself a shebang script; nested interpreters are unsupported",
             resolved.display()
         )));
     }
+    if prefix_len < prefix.len() || !is_supported_native_executable(prefix) {
+        return Err(SurgeError::Platform(format!(
+            "Active application interpreter '{}' is not a supported native executable; shell fallback interpreters are unsupported",
+            resolved.display()
+        )));
+    }
 
     Ok(resolved)
+}
+
+fn is_executable_file(path: &Path) -> bool {
+    use nix::unistd::{AccessFlags, access};
+
+    path.is_file() && access(path, AccessFlags::X_OK).is_ok()
+}
+
+#[cfg(target_os = "linux")]
+fn is_supported_native_executable(prefix: [u8; 4]) -> bool {
+    prefix == *b"\x7fELF"
+}
+
+#[cfg(target_os = "macos")]
+fn is_supported_native_executable(prefix: [u8; 4]) -> bool {
+    matches!(
+        prefix,
+        [0xfe, 0xed, 0xfa, 0xce]
+            | [0xfe, 0xed, 0xfa, 0xcf]
+            | [0xce, 0xfa, 0xed, 0xfe]
+            | [0xcf, 0xfa, 0xed, 0xfe]
+            | [0xca, 0xfe, 0xba, 0xbe]
+            | [0xca, 0xfe, 0xba, 0xbf]
+            | [0xbe, 0xba, 0xfe, 0xca]
+            | [0xbf, 0xba, 0xfe, 0xca]
+    )
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+fn is_supported_native_executable(_prefix: [u8; 4]) -> bool {
+    true
 }
 
 fn ensure_supported_env_interpreter(interpreter: &str) -> Result<()> {
@@ -463,12 +466,12 @@ fn direct_interpreter_argument_count(argument: &str) -> usize {
 mod tests {
     use super::*;
 
-    #[test]
-    fn split_command_words_preserves_quoted_and_escaped_arguments() {
-        assert_eq!(
-            split_command_words("/bin/sh '-e value' plain\\ value").unwrap(),
-            vec!["/bin/sh", "-e value", "plain value"]
-        );
+    fn make_executable(path: &Path) {
+        use std::os::unix::fs::PermissionsExt;
+
+        let mut permissions = std::fs::metadata(path).unwrap().permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(path, permissions).unwrap();
     }
 
     #[test]
@@ -500,9 +503,11 @@ mod tests {
 
     #[test]
     fn env_path_assignment_preserves_launch_resolution() {
+        use std::os::unix::fs::symlink;
+
         let tmp = tempfile::tempdir().unwrap();
         let interpreter = tmp.path().join("demo-interpreter");
-        std::fs::write(&interpreter, "fixture").unwrap();
+        symlink("/bin/sh", &interpreter).unwrap();
         let command = parse_env_command(&format!("-S PATH={} demo-interpreter -e", tmp.path().display())).unwrap();
         let identity = Identity {
             interpreter: Interpreter::EnvCommand(command),
@@ -513,10 +518,54 @@ mod tests {
     }
 
     #[test]
+    fn env_path_lookup_skips_non_executable_candidates() {
+        use std::os::unix::fs::symlink;
+
+        let first = tempfile::tempdir().unwrap();
+        let second = tempfile::tempdir().unwrap();
+        std::fs::write(first.path().join("demo-interpreter"), "not executable").unwrap();
+        let expected = second.path().join("demo-interpreter");
+        symlink("/bin/sh", &expected).unwrap();
+        let search_path = std::env::join_paths([first.path(), second.path()]).unwrap();
+        let command = EnvCommand {
+            program: OsString::from("demo-interpreter"),
+            fixed_argument_count: 0,
+            search_path: EnvSearchPath::Explicit(search_path),
+        };
+
+        assert!(paths_resolve_to_same_executable(
+            &resolve_env_command(&command).unwrap(),
+            &expected
+        ));
+    }
+
+    #[test]
+    fn env_command_rejects_executable_shell_fallback_text() {
+        let tmp = tempfile::tempdir().unwrap();
+        let interpreter = tmp.path().join("demo-interpreter");
+        std::fs::write(&interpreter, "echo fallback\n").unwrap();
+        make_executable(&interpreter);
+        let command = EnvCommand {
+            program: interpreter.into_os_string(),
+            fixed_argument_count: 0,
+            search_path: EnvSearchPath::Inherited,
+        };
+
+        let error = resolve_env_command(&command).unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("shell fallback interpreters are unsupported")
+        );
+    }
+
+    #[test]
     fn absolute_env_command_rejects_nested_interpreter() {
         let tmp = tempfile::tempdir().unwrap();
         let interpreter = tmp.path().join("demo-interpreter");
         std::fs::write(&interpreter, "#!/bin/sh\n").unwrap();
+        make_executable(&interpreter);
         let command = parse_env_command(interpreter.to_str().unwrap()).unwrap();
 
         let error = resolve_env_command(&command).unwrap_err();
@@ -529,6 +578,7 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let interpreter = tmp.path().join("demo-interpreter");
         std::fs::write(&interpreter, "#!/bin/sh\n").unwrap();
+        make_executable(&interpreter);
         let command = parse_env_command(&format!("-S -P {} demo-interpreter", tmp.path().display())).unwrap();
 
         let error = resolve_env_command(&command).unwrap_err();

--- a/crates/surge-core/src/update/manager/lifecycle/process_quiescence/interpreted_main.rs
+++ b/crates/surge-core/src/update/manager/lifecycle/process_quiescence/interpreted_main.rs
@@ -14,6 +14,7 @@ const SHEBANG_IDENTITY_LIMIT: usize = 256;
 #[cfg(not(target_os = "macos"))]
 const SHEBANG_READ_LIMIT: u64 = 257;
 const SUPPORTED_ENV_INTERPRETERS: [&str; 2] = ["/usr/bin/env", "/bin/env"];
+const DEFAULT_ENV_SEARCH_PATH: &str = "/usr/bin:/bin";
 
 pub(super) struct Identity {
     interpreter: Interpreter,
@@ -28,7 +29,14 @@ enum Interpreter {
 struct EnvCommand {
     program: OsString,
     fixed_argument_count: usize,
-    search_path: Option<OsString>,
+    search_path: EnvSearchPath,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum EnvSearchPath {
+    Inherited,
+    Default,
+    Explicit(OsString),
 }
 
 impl Identity {
@@ -61,7 +69,7 @@ impl Identity {
                     return Ok(true);
                 }
                 let program = Path::new(&expected.program);
-                Ok(expected.search_path.is_none()
+                Ok(matches!(expected.search_path, EnvSearchPath::Inherited)
                     && program.components().count() == 1
                     && executable.file_name() == program.file_name())
             }
@@ -105,11 +113,11 @@ fn resolve_env_command(command: &EnvCommand) -> Result<PathBuf> {
         )));
     }
 
-    let search_path = command
-        .search_path
-        .clone()
-        .or_else(|| std::env::var_os("PATH"))
-        .unwrap_or_else(|| OsString::from("/usr/bin:/bin"));
+    let search_path = match &command.search_path {
+        EnvSearchPath::Inherited => std::env::var_os("PATH").unwrap_or_else(|| OsString::from(DEFAULT_ENV_SEARCH_PATH)),
+        EnvSearchPath::Default => OsString::from(DEFAULT_ENV_SEARCH_PATH),
+        EnvSearchPath::Explicit(search_path) => search_path.clone(),
+    };
     for directory in std::env::split_paths(&search_path) {
         if directory.as_os_str().is_empty() || directory.is_relative() {
             return Err(SurgeError::Platform(format!(
@@ -162,10 +170,10 @@ pub(super) fn resolve(active_exe: &Path) -> Result<Option<Identity>> {
     }
     let shebang = std::str::from_utf8(&prefix[2..line_end])
         .map_err(|e| SurgeError::Platform(format!("Active application shebang is not valid UTF-8: {e}")))?
-        .trim();
-    let interpreter_end = shebang.find(char::is_whitespace).unwrap_or(shebang.len());
+        .trim_matches(is_shebang_separator);
+    let interpreter_end = shebang.find(is_shebang_separator).unwrap_or(shebang.len());
     let interpreter = &shebang[..interpreter_end];
-    let argument = shebang[interpreter_end..].trim();
+    let argument = shebang[interpreter_end..].trim_matches(is_shebang_separator);
     if interpreter.is_empty() {
         return Err(SurgeError::Platform(
             "Active application shebang has no interpreter".to_string(),
@@ -195,12 +203,16 @@ pub(super) fn resolve(active_exe: &Path) -> Result<Option<Identity>> {
     }))
 }
 
+fn is_shebang_separator(character: char) -> bool {
+    matches!(character, ' ' | '\t')
+}
+
 fn parse_env_command(argument: &str) -> Result<EnvCommand> {
     let split_command = argument
         .strip_prefix("--split-string=")
         .or_else(|| argument.strip_prefix("-S"))
         .or_else(|| argument.strip_prefix("--split-string "))
-        .map(str::trim_start);
+        .map(|command| command.trim_start_matches(|character: char| character.is_ascii_whitespace()));
     let command = split_command.unwrap_or(argument);
     let words = split_env_command_words(command)?;
     #[cfg(not(target_os = "macos"))]
@@ -214,7 +226,7 @@ fn parse_env_command(argument: &str) -> Result<EnvCommand> {
     Ok(EnvCommand {
         program: OsString::from(&words[command_index]),
         fixed_argument_count: words.len() - command_index - 1,
-        search_path: search_path.map(OsString::from),
+        search_path,
     })
 }
 
@@ -229,13 +241,18 @@ fn split_env_command_words(command: &str) -> Result<Vec<String>> {
         ));
     }
 
-    Ok(command.split_whitespace().map(ToString::to_string).collect())
+    Ok(command
+        .split(|character: char| character.is_ascii_whitespace())
+        .filter(|word| !word.is_empty())
+        .map(ToString::to_string)
+        .collect())
 }
 
-fn env_command_index(words: &[String]) -> Result<(usize, Option<String>)> {
+fn env_command_index(words: &[String]) -> Result<(usize, EnvSearchPath)> {
     let mut index = 0;
     let mut options = true;
     let mut search_path = None;
+    let mut ignore_environment = false;
 
     while let Some(word) = words.get(index) {
         if options {
@@ -245,7 +262,12 @@ fn env_command_index(words: &[String]) -> Result<(usize, Option<String>)> {
                     index += 1;
                     continue;
                 }
-                "-i" | "--ignore-environment" | "-0" | "--null" | "-v" | "--debug" | "--list-signal-handling" => {
+                "-i" | "--ignore-environment" => {
+                    ignore_environment = true;
+                    index += 1;
+                    continue;
+                }
+                "-0" | "--null" | "-v" | "--debug" | "--list-signal-handling" => {
                     index += 1;
                     continue;
                 }
@@ -290,6 +312,11 @@ fn env_command_index(words: &[String]) -> Result<(usize, Option<String>)> {
             continue;
         }
 
+        let search_path = match search_path {
+            Some(search_path) => EnvSearchPath::Explicit(OsString::from(search_path)),
+            None if ignore_environment => EnvSearchPath::Default,
+            None => EnvSearchPath::Inherited,
+        };
         return Ok((index, search_path));
     }
 
@@ -449,14 +476,18 @@ mod tests {
         let command = parse_env_command("-S -i -u OLD -- FEATURE=true /bin/sh -e").unwrap();
         assert_eq!(command.program, OsString::from("/bin/sh"));
         assert_eq!(command.fixed_argument_count, 1);
+        assert_eq!(command.search_path, EnvSearchPath::Default);
     }
 
     #[test]
     fn env_command_preserves_explicit_search_path() {
-        let command = parse_env_command("-S -P /opt/interpreters demo-interpreter -e").unwrap();
+        let command = parse_env_command("-S -i -P /opt/interpreters demo-interpreter -e").unwrap();
 
         assert_eq!(command.program, OsString::from("demo-interpreter"));
-        assert_eq!(command.search_path, Some(OsString::from("/opt/interpreters")));
+        assert_eq!(
+            command.search_path,
+            EnvSearchPath::Explicit(OsString::from("/opt/interpreters"))
+        );
     }
 
     #[test]
@@ -506,7 +537,7 @@ mod tests {
             interpreter: Interpreter::EnvCommand(EnvCommand {
                 program: OsString::from("sh"),
                 fixed_argument_count: 0,
-                search_path: None,
+                search_path: EnvSearchPath::Inherited,
             }),
             script_argument_index: 1,
         };
@@ -524,6 +555,17 @@ mod tests {
     fn env_command_rejects_escape_sequences_instead_of_misparsing_operand_boundaries() {
         let error = parse_env_command(r"-S /bin/sh\_-e").err().unwrap();
         assert!(error.to_string().contains("unsupported split-string"));
+    }
+
+    #[test]
+    fn env_split_string_preserves_unicode_whitespace_as_command_data() {
+        let command = parse_env_command("-S /tmp/demo\u{a0}interpreter -e").unwrap();
+
+        assert_eq!(command.program, OsString::from("/tmp/demo\u{a0}interpreter"));
+        assert_eq!(command.fixed_argument_count, 1);
+
+        let attached = parse_env_command("-S\u{a0}/bin/sh").unwrap();
+        assert_eq!(attached.program, OsString::from("\u{a0}/bin/sh"));
     }
 
     #[test]
@@ -579,6 +621,19 @@ mod tests {
         let error = resolve(&app).err().unwrap();
 
         assert!(error.to_string().contains("not a supported system env executable"));
+    }
+
+    #[test]
+    fn unicode_whitespace_in_interpreter_path_is_not_a_shebang_separator() {
+        use std::os::unix::fs::symlink;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let interpreter = tmp.path().join("demo\u{a0}interpreter");
+        let app = tmp.path().join("app");
+        symlink("/bin/sh", &interpreter).unwrap();
+        std::fs::write(&app, format!("#!{}\n", interpreter.display())).unwrap();
+
+        assert!(resolve(&app).unwrap().is_some());
     }
 
     #[test]

--- a/crates/surge-core/src/update/manager/lifecycle/process_quiescence/interpreted_main.rs
+++ b/crates/surge-core/src/update/manager/lifecycle/process_quiescence/interpreted_main.rs
@@ -69,7 +69,10 @@ impl Identity {
                     return Ok(true);
                 }
                 let program = Path::new(&expected.program);
-                Ok(matches!(expected.search_path, EnvSearchPath::Inherited) && program.components().count() == 1)
+                Ok(
+                    matches!(expected.search_path, EnvSearchPath::Inherited | EnvSearchPath::Default)
+                        && program.components().count() == 1,
+                )
             }
         }
     }
@@ -674,6 +677,20 @@ mod tests {
                 program: OsString::from("sh"),
                 fixed_argument_count: 0,
                 search_path: EnvSearchPath::Inherited,
+            }),
+            script_argument_index: 1,
+        };
+
+        assert!(identity.executable_may_match(Path::new("/bin/sleep")).unwrap());
+    }
+
+    #[test]
+    fn default_env_path_retains_candidate_uncertainty() {
+        let identity = Identity {
+            interpreter: Interpreter::EnvCommand(EnvCommand {
+                program: OsString::from("sh"),
+                fixed_argument_count: 0,
+                search_path: EnvSearchPath::Default,
             }),
             script_argument_index: 1,
         };

--- a/crates/surge-core/src/update/manager/lifecycle/process_quiescence/interpreted_main.rs
+++ b/crates/surge-core/src/update/manager/lifecycle/process_quiescence/interpreted_main.rs
@@ -90,12 +90,13 @@ fn paths_resolve_to_same_executable(actual: &Path, expected: &Path) -> bool {
 fn resolve_env_command(command: &EnvCommand) -> Result<PathBuf> {
     let program = Path::new(&command.program);
     if program.is_absolute() {
-        return std::fs::canonicalize(program).map_err(|e| {
+        let resolved = std::fs::canonicalize(program).map_err(|e| {
             SurgeError::Platform(format!(
                 "Failed to resolve active application env interpreter '{}': {e}",
                 program.display()
             ))
-        });
+        })?;
+        return validate_resolved_interpreter(resolved);
     }
     if program.components().count() != 1 {
         return Err(SurgeError::Platform(format!(
@@ -118,7 +119,7 @@ fn resolve_env_command(command: &EnvCommand) -> Result<PathBuf> {
         }
         let candidate = directory.join(program);
         if let Ok(candidate) = std::fs::canonicalize(candidate) {
-            return Ok(candidate);
+            return validate_resolved_interpreter(candidate);
         }
     }
 
@@ -365,6 +366,10 @@ fn resolve_direct_interpreter_path(interpreter: &str) -> Result<PathBuf> {
             interpreter.display()
         ))
     })?;
+    validate_resolved_interpreter(resolved)
+}
+
+fn validate_resolved_interpreter(resolved: PathBuf) -> Result<PathBuf> {
     let mut file = std::fs::File::open(&resolved).map_err(|e| {
         SurgeError::Platform(format!(
             "Failed to inspect active application interpreter '{}': {e}",
@@ -466,6 +471,30 @@ mod tests {
         };
 
         assert!(identity.executable_may_match(&interpreter).unwrap());
+    }
+
+    #[test]
+    fn absolute_env_command_rejects_nested_interpreter() {
+        let tmp = tempfile::tempdir().unwrap();
+        let interpreter = tmp.path().join("demo-interpreter");
+        std::fs::write(&interpreter, "#!/bin/sh\n").unwrap();
+        let command = parse_env_command(interpreter.to_str().unwrap()).unwrap();
+
+        let error = resolve_env_command(&command).unwrap_err();
+
+        assert!(error.to_string().contains("nested interpreters are unsupported"));
+    }
+
+    #[test]
+    fn search_path_env_command_rejects_nested_interpreter() {
+        let tmp = tempfile::tempdir().unwrap();
+        let interpreter = tmp.path().join("demo-interpreter");
+        std::fs::write(&interpreter, "#!/bin/sh\n").unwrap();
+        let command = parse_env_command(&format!("-S -P {} demo-interpreter", tmp.path().display())).unwrap();
+
+        let error = resolve_env_command(&command).unwrap_err();
+
+        assert!(error.to_string().contains("nested interpreters are unsupported"));
     }
 
     #[test]

--- a/crates/surge-core/src/update/manager/lifecycle/process_quiescence/interpreted_main.rs
+++ b/crates/surge-core/src/update/manager/lifecycle/process_quiescence/interpreted_main.rs
@@ -5,6 +5,16 @@ use std::path::{Path, PathBuf};
 
 use crate::error::{Result, SurgeError};
 
+#[cfg(target_os = "macos")]
+const SHEBANG_IDENTITY_LIMIT: usize = 512;
+#[cfg(target_os = "macos")]
+const SHEBANG_READ_LIMIT: u64 = 513;
+#[cfg(not(target_os = "macos"))]
+const SHEBANG_IDENTITY_LIMIT: usize = 256;
+#[cfg(not(target_os = "macos"))]
+const SHEBANG_READ_LIMIT: u64 = 257;
+const SUPPORTED_ENV_INTERPRETERS: [&str; 2] = ["/usr/bin/env", "/bin/env"];
+
 pub(super) struct Identity {
     interpreter: Interpreter,
     pub(super) script_argument_index: usize,
@@ -47,7 +57,13 @@ impl Identity {
             Interpreter::Resolved(expected) => Ok(paths_resolve_to_same_executable(executable, expected)),
             Interpreter::EnvCommand(expected) => {
                 let resolved = resolve_env_command(expected)?;
-                Ok(paths_resolve_to_same_executable(executable, &resolved))
+                if paths_resolve_to_same_executable(executable, &resolved) {
+                    return Ok(true);
+                }
+                let program = Path::new(&expected.program);
+                Ok(expected.search_path.is_none()
+                    && program.components().count() == 1
+                    && executable.file_name() == program.file_name())
             }
         }
     }
@@ -119,20 +135,24 @@ pub(super) fn resolve(active_exe: &Path) -> Result<Option<Identity>> {
         ))
     })?;
     let mut prefix = Vec::new();
-    file.by_ref().take(4097).read_to_end(&mut prefix).map_err(|e| {
-        SurgeError::Platform(format!(
-            "Failed to inspect active application executable before swap: {e}"
-        ))
-    })?;
+    file.by_ref()
+        .take(SHEBANG_READ_LIMIT)
+        .read_to_end(&mut prefix)
+        .map_err(|e| {
+            SurgeError::Platform(format!(
+                "Failed to inspect active application executable before swap: {e}"
+            ))
+        })?;
     if !prefix.starts_with(b"#!") {
         return Ok(None);
     }
 
     let line_end = prefix.iter().position(|byte| *byte == b'\n').unwrap_or(prefix.len());
-    if line_end > 4096 {
-        return Err(SurgeError::Platform(
-            "Active application shebang exceeds the supported 4096-byte limit".to_string(),
-        ));
+    if line_end >= SHEBANG_IDENTITY_LIMIT {
+        return Err(SurgeError::Platform(format!(
+            "Active application shebang exceeds the supported {}-byte process identity limit",
+            SHEBANG_IDENTITY_LIMIT - 1
+        )));
     }
     if prefix[2..line_end].contains(&0) {
         return Err(SurgeError::Platform(
@@ -153,13 +173,18 @@ pub(super) fn resolve(active_exe: &Path) -> Result<Option<Identity>> {
 
     let (interpreter, fixed_argument_count) =
         if Path::new(interpreter).file_name().and_then(|name| name.to_str()) == Some("env") {
+            ensure_supported_env_interpreter(interpreter)?;
             let command = parse_env_command(argument)?;
             let fixed_argument_count = command.fixed_argument_count;
             (Interpreter::EnvCommand(command), fixed_argument_count)
         } else {
+            #[cfg(target_os = "macos")]
+            let fixed_argument_count = direct_interpreter_argument_count(argument)?;
+            #[cfg(not(target_os = "macos"))]
+            let fixed_argument_count = direct_interpreter_argument_count(argument);
             (
                 Interpreter::Resolved(resolve_direct_interpreter_path(interpreter)?),
-                direct_interpreter_argument_count(argument)?,
+                fixed_argument_count,
             )
         };
 
@@ -257,6 +282,9 @@ fn env_command_index(words: &[String]) -> Result<(usize, Option<String>)> {
 
         if is_env_assignment(word) {
             options = false;
+            if let Some(search_path_assignment) = word.strip_prefix("PATH=") {
+                search_path = Some(search_path_assignment.to_string());
+            }
             index += 1;
             continue;
         }
@@ -361,15 +389,42 @@ fn resolve_direct_interpreter_path(interpreter: &str) -> Result<PathBuf> {
     Ok(resolved)
 }
 
+fn ensure_supported_env_interpreter(interpreter: &str) -> Result<()> {
+    let interpreter = Path::new(interpreter);
+    if !interpreter.is_absolute() {
+        return Err(SurgeError::Platform(format!(
+            "Active application env interpreter '{}' must be an absolute path",
+            interpreter.display()
+        )));
+    }
+    let resolved = std::fs::canonicalize(interpreter).map_err(|e| {
+        SurgeError::Platform(format!(
+            "Failed to resolve active application env interpreter '{}': {e}",
+            interpreter.display()
+        ))
+    })?;
+    if SUPPORTED_ENV_INTERPRETERS
+        .iter()
+        .map(Path::new)
+        .any(|supported| paths_resolve_to_same_executable(&resolved, supported))
+    {
+        return Ok(());
+    }
+
+    Err(SurgeError::Platform(format!(
+        "Active application env interpreter '{}' is not a supported system env executable",
+        interpreter.display()
+    )))
+}
+
+#[cfg(target_os = "macos")]
 fn direct_interpreter_argument_count(argument: &str) -> Result<usize> {
-    #[cfg(target_os = "macos")]
-    {
-        return Ok(split_command_words(argument)?.len());
-    }
-    #[cfg(not(target_os = "macos"))]
-    {
-        Ok(usize::from(!argument.is_empty()))
-    }
+    Ok(split_command_words(argument)?.len())
+}
+
+#[cfg(not(target_os = "macos"))]
+fn direct_interpreter_argument_count(argument: &str) -> usize {
+    usize::from(!argument.is_empty())
 }
 
 #[cfg(test)]
@@ -397,6 +452,37 @@ mod tests {
 
         assert_eq!(command.program, OsString::from("demo-interpreter"));
         assert_eq!(command.search_path, Some(OsString::from("/opt/interpreters")));
+    }
+
+    #[test]
+    fn env_path_assignment_preserves_launch_resolution() {
+        let tmp = tempfile::tempdir().unwrap();
+        let interpreter = tmp.path().join("demo-interpreter");
+        std::fs::write(&interpreter, "fixture").unwrap();
+        let command = parse_env_command(&format!("-S PATH={} demo-interpreter -e", tmp.path().display())).unwrap();
+        let identity = Identity {
+            interpreter: Interpreter::EnvCommand(command),
+            script_argument_index: 2,
+        };
+
+        assert!(identity.executable_may_match(&interpreter).unwrap());
+    }
+
+    #[test]
+    fn inherited_env_path_retains_same_named_candidate_uncertainty() {
+        let tmp = tempfile::tempdir().unwrap();
+        let interpreter = tmp.path().join("sh");
+        std::fs::write(&interpreter, "fixture").unwrap();
+        let identity = Identity {
+            interpreter: Interpreter::EnvCommand(EnvCommand {
+                program: OsString::from("sh"),
+                fixed_argument_count: 0,
+                search_path: None,
+            }),
+            script_argument_index: 1,
+        };
+
+        assert!(identity.executable_may_match(&interpreter).unwrap());
     }
 
     #[test]
@@ -437,6 +523,33 @@ mod tests {
         let error = resolve(&app).err().unwrap();
 
         assert!(error.to_string().contains("embedded NUL"));
+    }
+
+    #[test]
+    fn shebang_beyond_process_identity_limit_is_rejected() {
+        let tmp = tempfile::tempdir().unwrap();
+        let app = tmp.path().join("app");
+        let mut contents = b"#!/usr/bin/env -S /bin/sh".to_vec();
+        contents.resize(SHEBANG_IDENTITY_LIMIT, b' ');
+        contents.push(b'\n');
+        std::fs::write(&app, contents).unwrap();
+
+        let error = resolve(&app).err().unwrap();
+
+        assert!(error.to_string().contains("process identity limit"));
+    }
+
+    #[test]
+    fn custom_env_interpreter_is_rejected() {
+        let tmp = tempfile::tempdir().unwrap();
+        let custom_env = tmp.path().join("env");
+        let app = tmp.path().join("app");
+        std::fs::write(&custom_env, "fixture").unwrap();
+        std::fs::write(&app, format!("#!{} /bin/sh\n", custom_env.display())).unwrap();
+
+        let error = resolve(&app).err().unwrap();
+
+        assert!(error.to_string().contains("not a supported system env executable"));
     }
 
     #[test]

--- a/crates/surge-core/src/update/manager/lifecycle/process_quiescence/interpreted_main.rs
+++ b/crates/surge-core/src/update/manager/lifecycle/process_quiescence/interpreted_main.rs
@@ -1,5 +1,6 @@
 use std::ffi::{OsStr, OsString};
 use std::io::Read;
+use std::os::unix::fs::MetadataExt;
 use std::path::{Path, PathBuf};
 
 use crate::error::{Result, SurgeError};
@@ -56,10 +57,18 @@ fn paths_resolve_to_same_executable(actual: &Path, expected: &Path) -> bool {
     if actual == expected {
         return true;
     }
-    let Ok(actual) = std::fs::canonicalize(actual) else {
-        return false;
-    };
-    std::fs::canonicalize(expected).is_ok_and(|expected| actual == expected)
+    if std::fs::canonicalize(actual)
+        .ok()
+        .zip(std::fs::canonicalize(expected).ok())
+        .is_some_and(|(actual, expected)| actual == expected)
+    {
+        return true;
+    }
+
+    std::fs::metadata(actual)
+        .ok()
+        .zip(std::fs::metadata(expected).ok())
+        .is_some_and(|(actual, expected)| actual.dev() == expected.dev() && actual.ino() == expected.ino())
 }
 
 fn resolve_env_command(command: &EnvCommand) -> Result<PathBuf> {
@@ -428,5 +437,16 @@ mod tests {
         let error = resolve(&app).err().unwrap();
 
         assert!(error.to_string().contains("embedded NUL"));
+    }
+
+    #[test]
+    fn hard_link_interpreter_aliases_share_executable_identity() {
+        let tmp = tempfile::tempdir().unwrap();
+        let interpreter = tmp.path().join("interpreter");
+        let alias = tmp.path().join("interpreter-alias");
+        std::fs::write(&interpreter, "fixture").unwrap();
+        std::fs::hard_link(&interpreter, &alias).unwrap();
+
+        assert!(paths_resolve_to_same_executable(&interpreter, &alias));
     }
 }


### PR DESCRIPTION
## Summary

- resolve the exact interpreter and script operand used by an installed entrypoint
- preserve configured launch identity across supported aliases while rejecting ambiguous matches
- capture interpreted identity before path withdrawal and rescan after the swap boundary closes
- quarantine the previous application before deletion so late process discovery cannot target reused paths

## Why

A script-based application appears as its interpreter process. Safe pre-swap quiescence must prove both the launched interpreter and installed script without matching unrelated interpreter processes.

This is stack 1 of 16.

- Base: `main`
- Next: #259

Relates to fintermobilityas/youpark#1310.

## Validation

- exact layer `9600b94` passed focused interpreted-process and swap-race regressions, rustfmt, blocking Clippy, and maintainability
- complete stack `c48f19f` passed 681 Rust workspace tests, both blocking Clippy tiers, vendor/version/format/maintainability checks, .NET formatting, and all 58 .NET tests

No migration is required.
