### PR TITLE
Fail closed during pre-swap app quiescence

### DIFF
--- a/crates/surge-core/src/supervisor/state.rs
+++ b/crates/surge-core/src/supervisor/state.rs
@@ -33,6 +33,38 @@ pub fn supervisor_exe_file(install_dir: &Path, supervisor_id: &str) -> PathBuf {
     supervisor_state_path(install_dir, supervisor_id, ".exe")
 }
 
+#[must_use]
+#[cfg(unix)]
+pub fn supervisor_takeover_pid_file(install_dir: &Path, supervisor_id: &str) -> PathBuf {
+    supervisor_state_path(install_dir, supervisor_id, ".takeover.pid")
+}
+
+#[cfg(unix)]
+pub fn write_supervisor_takeover_pid(install_dir: &Path, supervisor_id: &str, pid: u32) -> Result<()> {
+    std::fs::write(
+        supervisor_takeover_pid_file(install_dir, supervisor_id),
+        pid.to_string(),
+    )?;
+    Ok(())
+}
+
+#[must_use]
+#[cfg(unix)]
+pub fn take_supervisor_takeover_pid(install_dir: &Path, supervisor_id: &str) -> Option<u32> {
+    let path = supervisor_takeover_pid_file(install_dir, supervisor_id);
+    let pid = std::fs::read_to_string(&path)
+        .ok()
+        .and_then(|contents| contents.trim().parse::<u32>().ok())
+        .filter(|pid| *pid != 0);
+    let _ = std::fs::remove_file(path);
+    pid
+}
+
+#[cfg(unix)]
+pub fn clear_supervisor_takeover_pid(install_dir: &Path, supervisor_id: &str) {
+    let _ = std::fs::remove_file(supervisor_takeover_pid_file(install_dir, supervisor_id));
+}
+
 /// Persist the supervised executable path so the spawning side can omit it from
 /// the supervisor's argv. Keeping the app path out of argv stops an external
 /// `pkill -f <app-path>` from also matching the supervisor process.
@@ -136,5 +168,16 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(supervisor_exe_file(dir.path(), "demo-supervisor"), "   \n").unwrap();
         assert_eq!(read_supervisor_exe_path(dir.path(), "demo-supervisor"), None);
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn supervisor_takeover_pid_is_consumed_once() {
+        let dir = tempfile::tempdir().unwrap();
+
+        write_supervisor_takeover_pid(dir.path(), "demo-supervisor", 42).unwrap();
+
+        assert_eq!(take_supervisor_takeover_pid(dir.path(), "demo-supervisor"), Some(42));
+        assert_eq!(take_supervisor_takeover_pid(dir.path(), "demo-supervisor"), None);
     }
 }

--- a/crates/surge-core/src/update/manager.rs
+++ b/crates/surge-core/src/update/manager.rs
@@ -4,6 +4,8 @@ mod apply;
 mod artifacts;
 mod current_install;
 mod finalize;
+#[cfg(unix)]
+mod finalize_quiescence;
 mod lifecycle;
 mod progress;
 mod progress_substep;
@@ -1112,10 +1114,16 @@ mod tests {
     #[tokio::test]
     async fn test_request_supervisor_shutdown_noop_when_supervisor_is_unknown() {
         let tmp = tempfile::tempdir().unwrap();
-        lifecycle::request_supervisor_shutdown(tmp.path(), "").await.unwrap();
-        lifecycle::request_supervisor_shutdown(tmp.path(), "missing")
-            .await
-            .unwrap();
+        assert_eq!(
+            lifecycle::request_supervisor_shutdown(tmp.path(), "").await.unwrap(),
+            None
+        );
+        assert_eq!(
+            lifecycle::request_supervisor_shutdown(tmp.path(), "missing")
+                .await
+                .unwrap(),
+            None
+        );
     }
 
     #[tokio::test]
@@ -1140,17 +1148,38 @@ mod tests {
             panic!("timed out waiting for stop file to be created");
         });
 
-        lifecycle::request_supervisor_shutdown_with_timeout(
-            install_dir,
-            supervisor_id,
-            Duration::from_secs(2),
-            Duration::from_millis(10),
-        )
-        .await
-        .unwrap();
+        assert_eq!(
+            lifecycle::request_supervisor_shutdown_with_timeout(
+                install_dir,
+                supervisor_id,
+                Duration::from_secs(2),
+                Duration::from_millis(10),
+            )
+            .await
+            .unwrap(),
+            None
+        );
 
         waiter.await.unwrap();
         assert!(!stop_file.exists());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_request_supervisor_shutdown_consumes_existing_takeover_when_pid_file_is_missing() {
+        let tmp = tempfile::tempdir().unwrap();
+        crate::supervisor::state::write_supervisor_takeover_pid(tmp.path(), "test-supervisor", 42).unwrap();
+
+        assert_eq!(
+            lifecycle::request_supervisor_shutdown(tmp.path(), "test-supervisor")
+                .await
+                .unwrap(),
+            Some(42)
+        );
+        assert_eq!(
+            crate::supervisor::state::take_supervisor_takeover_pid(tmp.path(), "test-supervisor"),
+            None
+        );
     }
 
     #[tokio::test]

--- a/crates/surge-core/src/update/manager.rs
+++ b/crates/surge-core/src/update/manager.rs
@@ -625,7 +625,6 @@ mod tests {
         app_store
     }
 
-    #[cfg(not(unix))]
     fn write_app_scoped_release_index_with_current(
         store_root: &Path,
         app_id: &str,

--- a/crates/surge-core/src/update/manager.rs
+++ b/crates/surge-core/src/update/manager.rs
@@ -998,6 +998,82 @@ mod tests {
     }
 
     #[test]
+    fn restore_check_state_rejects_changed_installed_version_text() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store_root = tmp.path().join("store");
+        let install_root = tmp.path().join("install");
+        let active_app_dir = install_root.join("app");
+        std::fs::create_dir_all(&store_root).unwrap();
+        std::fs::create_dir_all(&active_app_dir).unwrap();
+        write_runtime_identity(&active_app_dir, "app", "1.0.0", "app", "supervisor");
+
+        let ctx = Arc::new(Context::new());
+        ctx.set_storage(
+            StorageProvider::Filesystem,
+            store_root.to_str().unwrap(),
+            "",
+            "",
+            "",
+            "",
+        );
+        let mut checked =
+            UpdateManager::new(Arc::clone(&ctx), "app", "1.0", "stable", install_root.to_str().unwrap()).unwrap();
+        checked.current_release_identity = current_install::load(&checked).unwrap();
+        let check_state = checked.capture_check_state();
+
+        write_runtime_identity(&active_app_dir, "app", "1.0", "app", "supervisor");
+        let mut applying = UpdateManager::new(ctx, "app", "1.0", "stable", install_root.to_str().unwrap()).unwrap();
+
+        let error = applying.restore_check_state(&check_state).unwrap_err();
+
+        assert!(error.to_string().contains("identity changed"));
+    }
+
+    #[tokio::test]
+    async fn check_for_updates_rejects_invalid_runtime_identity_on_every_platform() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store_root = tmp.path().join("store");
+        let install_root = tmp.path().join("install");
+        let app_id = "test-app";
+        let active_app_dir = install_root.join("app");
+        std::fs::create_dir_all(&store_root).unwrap();
+        std::fs::create_dir_all(active_app_dir.join(".surge")).unwrap();
+        std::fs::write(
+            active_app_dir.join(crate::install::RUNTIME_MANIFEST_RELATIVE_PATH),
+            "invalid: [runtime manifest",
+        )
+        .unwrap();
+
+        let rid = current_rid();
+        let mut latest = make_entry("1.1.0", "stable", &current_os_label_for_tests(), &rid);
+        latest.is_genesis = true;
+        latest.deltas.clear();
+        latest.preferred_delta_id.clear();
+        let index = ReleaseIndex {
+            app_id: app_id.to_string(),
+            releases: vec![latest],
+            ..ReleaseIndex::default()
+        };
+        write_app_scoped_release_index_with_current(&store_root, app_id, &index, "1.0.0");
+
+        let ctx = Arc::new(Context::new());
+        ctx.set_storage(
+            StorageProvider::Filesystem,
+            store_root.to_str().unwrap(),
+            "",
+            "",
+            "",
+            "",
+        );
+        let mut manager = UpdateManager::new(ctx, app_id, "1.0.0", "stable", install_root.to_str().unwrap()).unwrap();
+
+        let error = manager.check_for_updates().await.unwrap_err();
+
+        assert!(error.to_string().contains("Failed to parse runtime manifest"));
+        assert!(manager.current_release_identity.is_none());
+    }
+
+    #[test]
     fn test_os_normalization() {
         assert_eq!(release_index::normalize_os_label("windows"), "win");
         assert_eq!(release_index::normalize_os_label("win"), "win");

--- a/crates/surge-core/src/update/manager.rs
+++ b/crates/surge-core/src/update/manager.rs
@@ -625,6 +625,28 @@ mod tests {
         app_store
     }
 
+    #[cfg(not(unix))]
+    fn write_app_scoped_release_index_with_current(
+        store_root: &Path,
+        app_id: &str,
+        index: &ReleaseIndex,
+        current_version: &str,
+    ) -> PathBuf {
+        let mut index = index.clone();
+        if !index.releases.iter().any(|release| release.version == current_version) {
+            let mut current = index.releases.first().cloned().unwrap_or_default();
+            current.version = current_version.to_string();
+            current.is_genesis = true;
+            current.full_filename.clear();
+            current.full_size = 0;
+            current.full_sha256.clear();
+            current.deltas.clear();
+            current.preferred_delta_id.clear();
+            index.releases.push(current);
+        }
+        write_app_scoped_release_index(store_root, app_id, &index)
+    }
+
     fn write_runtime_identity(active_app_dir: &Path, app_id: &str, version: &str, main_exe: &str, supervisor_id: &str) {
         write_runtime_identity_with_environment(active_app_dir, app_id, version, main_exe, supervisor_id, &[]);
     }

--- a/crates/surge-core/src/update/manager/finalize.rs
+++ b/crates/surge-core/src/update/manager/finalize.rs
@@ -28,6 +28,11 @@ use crate::releases::restore::{
 };
 use crate::supervisor::state::supervisor_pid_file;
 
+#[cfg(unix)]
+use super::finalize_quiescence::{
+    prepare_and_quiesce_active_app_before_swap, prepare_and_quiesce_previous_swap_before_reuse,
+    restore_previous_supervisor_after_quiescence_failure,
+};
 use super::progress::{ProgressInfo, emit_progress};
 use super::progress_substep::{HEARTBEAT_INTERVAL, PhaseProgressEmitter, labels as finalize_phase};
 use super::{RELEASE_GRAPH_CHECKPOINT_FULLS, SupervisorRestartOutcome, UpdateInfo, UpdateManager, apply, lifecycle};
@@ -119,7 +124,7 @@ where
         ));
     }
     #[cfg(unix)]
-    let (current_version, current_main_exe, current_supervisor_id) = if current_app_dir.is_some() {
+    let (current_version, current_main_exe, current_supervisor_id, current_environment) = if current_app_dir.is_some() {
         let installed_identity = super::current_install::load(manager)?;
         if installed_identity != manager.current_release_identity {
             return Err(SurgeError::Update(
@@ -137,9 +142,10 @@ where
             current.version.as_str(),
             current.main_exe.as_str(),
             current.supervisor_id.as_str(),
+            Some(&current.environment),
         )
     } else {
-        ("", "", "")
+        ("", "", "", None)
     };
     #[cfg(not(unix))]
     let (current_main_exe, current_supervisor_id) = manager.current_release_identity.as_ref().map_or_else(
@@ -149,7 +155,7 @@ where
     let supervisor_was_running = !current_supervisor_id.trim().is_empty()
         && supervisor_pid_file(&manager.install_dir, current_supervisor_id).is_file();
 
-    if supervisor_was_running {
+    let supervised_child_pid = if supervisor_was_running {
         progress_emitter
             .run_with_heartbeat(
                 6,
@@ -158,10 +164,12 @@ where
                 HEARTBEAT_INTERVAL,
                 lifecycle::request_supervisor_shutdown(&manager.install_dir, current_supervisor_id),
             )
-            .await?;
+            .await?
     } else {
-        lifecycle::request_supervisor_shutdown(&manager.install_dir, current_supervisor_id).await?;
-    }
+        lifecycle::request_supervisor_shutdown(&manager.install_dir, current_supervisor_id).await?
+    };
+    #[cfg(unix)]
+    let supervisor_requires_restoration = supervisor_was_running || supervised_child_pid.is_some();
 
     progress_emitter.emit_substep(6, finalize_phase::QUIESCING_ACTIVE_APP, 92);
     #[cfg(unix)]
@@ -172,7 +180,9 @@ where
             current_version,
             current_main_exe,
             current_supervisor_id,
-            supervisor_was_running,
+            current_environment,
+            supervisor_requires_restoration,
+            supervised_child_pid,
             manager.allow_in_process_swap,
         )?
     } else {
@@ -180,6 +190,7 @@ where
     };
     #[cfg(not(unix))]
     if let Some(current_app_dir) = current_app_dir {
+        let _ = supervised_child_pid;
         lifecycle::terminate_active_app_processes_before_swap(
             current_app_dir,
             current_main_exe,
@@ -195,7 +206,9 @@ where
             current_version,
             current_main_exe,
             current_supervisor_id,
-            supervisor_was_running,
+            current_environment,
+            supervisor_requires_restoration,
+            supervised_child_pid,
         )
         .await?
     } else {
@@ -226,34 +239,31 @@ where
             Ok::<(), SurgeError>(())
         })();
         if let Err(error) = quarantine_result {
-            let error = restore_previous_swap_after_error(
-                &previous_swap_dir,
-                &previous_swap_quarantine_dir,
-                error,
-            );
+            let error = restore_previous_swap_after_error(&previous_swap_dir, &previous_swap_quarantine_dir, error);
             return Err(restore_previous_supervisor_after_quiescence_failure(
                 &manager.install_dir,
                 current_app_dir,
                 current_version,
                 current_main_exe,
                 current_supervisor_id,
-                supervisor_was_running,
+                current_environment,
+                supervisor_requires_restoration,
+                supervised_child_pid,
                 error,
             ));
         }
         if let Err(error) = tokio::fs::remove_dir_all(&previous_swap_quarantine_dir).await {
-            let error = restore_previous_swap_after_error(
-                &previous_swap_dir,
-                &previous_swap_quarantine_dir,
-                error.into(),
-            );
+            let error =
+                restore_previous_swap_after_error(&previous_swap_dir, &previous_swap_quarantine_dir, error.into());
             return Err(restore_previous_supervisor_after_quiescence_failure(
                 &manager.install_dir,
                 current_app_dir,
                 current_version,
                 current_main_exe,
                 current_supervisor_id,
-                supervisor_was_running,
+                current_environment,
+                supervisor_requires_restoration,
+                supervised_child_pid,
                 error,
             ));
         }
@@ -283,30 +293,34 @@ where
                 current_version,
                 current_main_exe,
                 current_supervisor_id,
-                supervisor_was_running,
+                current_environment,
+                supervisor_requires_restoration,
+                supervised_child_pid,
                 error,
             ));
         }
     }
     #[cfg(unix)]
-    if !active_app_was_present {
-        if let Err(error) = (|| {
+    if !active_app_was_present
+        && let Err(error) = (|| {
             if let Some(current_quiescence) = &current_quiescence {
                 lifecycle::terminate_prepared_app_processes(current_quiescence)?;
             }
             lifecycle::terminate_superseded_app_processes(&manager.install_dir, &active_app_dir, current_main_exe)?;
             Ok::<(), SurgeError>(())
-        })() {
-            return Err(restore_previous_supervisor_after_quiescence_failure(
-                &manager.install_dir,
-                current_app_dir,
-                current_version,
-                current_main_exe,
-                current_supervisor_id,
-                supervisor_was_running,
-                error,
-            ));
-        }
+        })()
+    {
+        return Err(restore_previous_supervisor_after_quiescence_failure(
+            &manager.install_dir,
+            current_app_dir,
+            current_version,
+            current_main_exe,
+            current_supervisor_id,
+            current_environment,
+            supervisor_requires_restoration,
+            supervised_child_pid,
+            error,
+        ));
     }
     if let Err(err) = atomic_rename(&next_app_dir, &active_app_dir) {
         // Best effort rollback to previous active content.
@@ -509,292 +523,4 @@ where
     );
 
     Ok(restart_outcome)
-}
-
-#[cfg(unix)]
-fn prepare_and_quiesce_active_app_before_swap(
-    install_dir: &Path,
-    current_app_dir: &Path,
-    current_version: &str,
-    current_main_exe: &str,
-    current_supervisor_id: &str,
-    supervisor_was_running: bool,
-    allow_in_process_swap: bool,
-) -> Result<Option<lifecycle::PreparedAppQuiescence>> {
-    let result = (|| {
-        let prepared = lifecycle::prepare_app_quiescence(current_app_dir, current_main_exe, allow_in_process_swap)?;
-        if let Some(prepared) = &prepared {
-            lifecycle::terminate_prepared_app_processes(prepared)?;
-        }
-        Ok(prepared)
-    })();
-    let Err(error) = result else {
-        return result;
-    };
-
-    Err(restore_previous_supervisor_after_quiescence_failure(
-        install_dir,
-        Some(current_app_dir),
-        current_version,
-        current_main_exe,
-        current_supervisor_id,
-        supervisor_was_running,
-        error,
-    ))
-}
-
-#[cfg(unix)]
-fn restore_previous_supervisor_after_quiescence_failure(
-    install_dir: &Path,
-    current_app_dir: Option<&Path>,
-    current_version: &str,
-    current_main_exe: &str,
-    current_supervisor_id: &str,
-    supervisor_was_running: bool,
-    error: SurgeError,
-) -> SurgeError {
-    if supervisor_was_running && let Some(current_app_dir) = current_app_dir {
-        request_previous_supervisor_restoration(
-            install_dir,
-            current_app_dir,
-            current_version,
-            current_main_exe,
-            current_supervisor_id,
-        );
-    }
-
-    error
-}
-
-#[cfg(unix)]
-async fn prepare_and_quiesce_previous_swap_before_reuse(
-    manager: &UpdateManager,
-    previous_swap_dir: &Path,
-    current_app_dir: Option<&Path>,
-    current_version: &str,
-    current_main_exe: &str,
-    current_supervisor_id: &str,
-    supervisor_was_running: bool,
-) -> Result<Option<(lifecycle::PreparedAppQuiescence, String)>> {
-    let result: Result<Option<(lifecycle::PreparedAppQuiescence, String)>> = async {
-        let previous_swap_identity = super::current_install::load_previous_swap(manager, previous_swap_dir)?
-            .ok_or_else(|| {
-                SurgeError::Update(
-                    "Previous swap directory has no persisted process identity; refusing to delete or reuse it"
-                        .to_string(),
-                )
-            })?;
-        lifecycle::request_supervisor_shutdown(&manager.install_dir, &previous_swap_identity.supervisor_id).await?;
-        let prepared = lifecycle::prepare_app_quiescence(
-            previous_swap_dir,
-            &previous_swap_identity.main_exe,
-            manager.allow_in_process_swap,
-        )?
-        .ok_or_else(|| {
-            SurgeError::Update(
-                "Previous swap application entrypoint disappeared before it could be quiesced".to_string(),
-            )
-        })?;
-        lifecycle::terminate_prepared_app_processes(&prepared)?;
-        Ok(Some((prepared, previous_swap_identity.main_exe)))
-    }
-    .await;
-
-    let Err(error) = result else {
-        return result;
-    };
-    Err(restore_previous_supervisor_after_quiescence_failure(
-        &manager.install_dir,
-        current_app_dir,
-        current_version,
-        current_main_exe,
-        current_supervisor_id,
-        supervisor_was_running,
-        error,
-    ))
-}
-
-#[cfg(unix)]
-fn request_previous_supervisor_restoration(
-    install_dir: &Path,
-    current_app_dir: &Path,
-    current_version: &str,
-    current_main_exe: &str,
-    current_supervisor_id: &str,
-) {
-    let restore_outcome = lifecycle::restore_previous_supervisor_after_failed_quiescence(
-        install_dir,
-        current_app_dir,
-        current_version,
-        current_main_exe,
-        current_supervisor_id,
-    );
-    match restore_outcome {
-        SupervisorRestartOutcome::NotApplicable => {
-            warn!(
-                supervisor_id = current_supervisor_id,
-                "Previous supervisor could not be restored after application quiescence failed"
-            );
-        }
-        SupervisorRestartOutcome::PendingRestart { reason, failure_phase } => {
-            warn!(
-                supervisor_id = current_supervisor_id,
-                reason, failure_phase, "Requested previous supervisor restoration after application quiescence failed"
-            );
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    #[cfg(target_os = "linux")]
-    use std::os::unix::fs::PermissionsExt;
-    #[cfg(target_os = "linux")]
-    use std::path::PathBuf;
-    #[cfg(target_os = "linux")]
-    use std::process::{Command, Stdio};
-
-    #[cfg(target_os = "linux")]
-    use super::*;
-
-    #[cfg(target_os = "linux")]
-    #[test]
-    fn quiescence_failure_restores_previous_supervisor_and_preserves_error() {
-        let tmp = tempfile::tempdir().unwrap();
-        let install_dir = tmp.path();
-        let active_app_dir = install_dir.join("app");
-        std::fs::create_dir_all(&active_app_dir).unwrap();
-
-        let app_path = active_app_dir.join("cwd-changing-demo-script");
-        std::fs::write(&app_path, "#!/bin/sh\ncd /\nread _\n").unwrap();
-        make_executable(&app_path);
-
-        write_test_supervisor(&active_app_dir);
-
-        let spawn_deadline = std::time::Instant::now() + Duration::from_secs(1);
-        let mut child = loop {
-            match Command::new("./cwd-changing-demo-script")
-                .current_dir(&active_app_dir)
-                .stdin(Stdio::piped())
-                .spawn()
-            {
-                Ok(child) => break child,
-                Err(error)
-                    if error.raw_os_error() == Some(nix::errno::Errno::ETXTBSY as i32)
-                        && std::time::Instant::now() < spawn_deadline =>
-                {
-                    std::thread::sleep(Duration::from_millis(10));
-                }
-                Err(error) => panic!("failed to launch changed-cwd app fixture: {error}"),
-            }
-        };
-        let cwd_path = PathBuf::from(format!("/proc/{}/cwd", child.id()));
-        let deadline = std::time::Instant::now() + Duration::from_secs(2);
-        while std::fs::read_link(&cwd_path).ok().as_deref() != Some(Path::new("/")) {
-            assert!(std::time::Instant::now() < deadline, "test child did not change cwd");
-            std::thread::sleep(Duration::from_millis(10));
-        }
-
-        let result = prepare_and_quiesce_active_app_before_swap(
-            install_dir,
-            &active_app_dir,
-            "1.0.0",
-            "cwd-changing-demo-script",
-            "demo-supervisor",
-            true,
-            false,
-        );
-        let child_still_running = child.try_wait().unwrap().is_none();
-        if child_still_running {
-            child.kill().unwrap();
-        }
-        let _ = child.wait();
-
-        let error = result.err().unwrap();
-        assert!(error.to_string().contains("process identity is ambiguous"));
-        assert!(child_still_running);
-        assert!(supervisor_pid_file(install_dir, "demo-supervisor").is_file());
-        assert_eq!(
-            crate::supervisor::state::read_supervisor_exe_path(install_dir, "demo-supervisor").as_deref(),
-            Some(app_path.as_path())
-        );
-    }
-
-    #[cfg(target_os = "linux")]
-    #[tokio::test]
-    async fn previous_swap_identity_failure_restores_current_supervisor() {
-        let tmp = tempfile::tempdir().unwrap();
-        let install_dir = tmp.path().join("install");
-        let store_dir = tmp.path().join("store");
-        let active_app_dir = install_dir.join("app");
-        let previous_swap_dir = install_dir.join(".surge-app-prev");
-        std::fs::create_dir_all(&active_app_dir).unwrap();
-        std::fs::create_dir_all(&previous_swap_dir).unwrap();
-        std::fs::create_dir_all(&store_dir).unwrap();
-
-        let app_path = active_app_dir.join("current-app");
-        std::fs::write(&app_path, "#!/bin/sh\nexit 0\n").unwrap();
-        make_executable(&app_path);
-        write_test_supervisor(&active_app_dir);
-
-        let ctx = std::sync::Arc::new(crate::context::Context::new());
-        ctx.set_storage(
-            crate::context::StorageProvider::Filesystem,
-            store_dir.to_str().unwrap(),
-            "",
-            "",
-            "",
-            "",
-        );
-        let manager = UpdateManager::new(ctx, "test-app", "1.0.0", "stable", install_dir.to_str().unwrap()).unwrap();
-
-        let error = prepare_and_quiesce_previous_swap_before_reuse(
-            &manager,
-            &previous_swap_dir,
-            Some(&active_app_dir),
-            "1.0.0",
-            "current-app",
-            "demo-supervisor",
-            true,
-        )
-        .await
-        .err()
-        .unwrap();
-
-        assert!(error.to_string().contains("no persisted process identity"));
-        assert!(supervisor_pid_file(&install_dir, "demo-supervisor").is_file());
-        assert_eq!(
-            crate::supervisor::state::read_supervisor_exe_path(&install_dir, "demo-supervisor").as_deref(),
-            Some(app_path.as_path())
-        );
-    }
-
-    #[cfg(target_os = "linux")]
-    fn write_test_supervisor(active_app_dir: &Path) {
-        let supervisor_path = active_app_dir.join(crate::platform::process::supervisor_binary_name());
-        std::fs::write(
-            &supervisor_path,
-            r#"#!/bin/sh
-id=""
-dir=""
-while [ "$#" -gt 0 ]; do
-  case "$1" in
-    --id) id="$2"; shift 2 ;;
-    --dir) dir="$2"; shift 2 ;;
-    *) shift ;;
-  esac
-done
-echo $$ > "$dir/.surge-supervisor-$id.pid"
-"#,
-        )
-        .unwrap();
-        make_executable(&supervisor_path);
-    }
-
-    #[cfg(target_os = "linux")]
-    fn make_executable(path: &Path) {
-        let mut permissions = std::fs::metadata(path).unwrap().permissions();
-        permissions.set_mode(0o755);
-        std::fs::set_permissions(path, permissions).unwrap();
-    }
 }

--- a/crates/surge-core/src/update/manager/finalize.rs
+++ b/crates/surge-core/src/update/manager/finalize.rs
@@ -119,7 +119,7 @@ where
         ));
     }
     #[cfg(unix)]
-    let (current_main_exe, current_supervisor_id) = if current_app_dir.is_some() {
+    let (current_version, current_main_exe, current_supervisor_id) = if current_app_dir.is_some() {
         let installed_identity = super::current_install::load(manager)?;
         if installed_identity != manager.current_release_identity {
             return Err(SurgeError::Update(
@@ -133,9 +133,13 @@ where
                 manager.current_version
             ))
         })?;
-        (current.main_exe.as_str(), current.supervisor_id.as_str())
+        (
+            current.version.as_str(),
+            current.main_exe.as_str(),
+            current.supervisor_id.as_str(),
+        )
     } else {
-        ("", "")
+        ("", "", "")
     };
     #[cfg(not(unix))]
     let (current_main_exe, current_supervisor_id) = manager.current_release_identity.as_ref().map_or_else(
@@ -162,14 +166,18 @@ where
     progress_emitter.emit_substep(6, finalize_phase::QUIESCING_ACTIVE_APP, 92);
     #[cfg(unix)]
     let current_quiescence = if let Some(current_app_dir) = current_app_dir {
-        lifecycle::prepare_app_quiescence(current_app_dir, current_main_exe, manager.allow_in_process_swap)?
+        prepare_and_quiesce_active_app_before_swap(
+            &manager.install_dir,
+            current_app_dir,
+            current_version,
+            current_main_exe,
+            current_supervisor_id,
+            supervisor_was_running,
+            manager.allow_in_process_swap,
+        )?
     } else {
         None
     };
-    #[cfg(unix)]
-    if let Some(current_quiescence) = &current_quiescence {
-        lifecycle::terminate_prepared_app_processes(current_quiescence)?;
-    }
     #[cfg(not(unix))]
     if let Some(current_app_dir) = current_app_dir {
         lifecycle::terminate_active_app_processes_before_swap(
@@ -230,17 +238,35 @@ where
             Ok::<(), SurgeError>(())
         })();
         if let Err(error) = quarantine_result {
-            return Err(restore_previous_swap_after_error(
+            let error = restore_previous_swap_after_error(
                 &previous_swap_dir,
                 &previous_swap_quarantine_dir,
+                error,
+            );
+            return Err(restore_previous_supervisor_after_quiescence_failure(
+                &manager.install_dir,
+                current_app_dir,
+                current_version,
+                current_main_exe,
+                current_supervisor_id,
+                supervisor_was_running,
                 error,
             ));
         }
         if let Err(error) = tokio::fs::remove_dir_all(&previous_swap_quarantine_dir).await {
-            return Err(restore_previous_swap_after_error(
+            let error = restore_previous_swap_after_error(
                 &previous_swap_dir,
                 &previous_swap_quarantine_dir,
                 error.into(),
+            );
+            return Err(restore_previous_supervisor_after_quiescence_failure(
+                &manager.install_dir,
+                current_app_dir,
+                current_version,
+                current_main_exe,
+                current_supervisor_id,
+                supervisor_was_running,
+                error,
             ));
         }
     }
@@ -263,7 +289,35 @@ where
             Ok::<(), SurgeError>(())
         })() {
             let _ = atomic_rename(&previous_swap_dir, &active_app_dir);
-            return Err(error);
+            return Err(restore_previous_supervisor_after_quiescence_failure(
+                &manager.install_dir,
+                Some(&active_app_dir),
+                current_version,
+                current_main_exe,
+                current_supervisor_id,
+                supervisor_was_running,
+                error,
+            ));
+        }
+    }
+    #[cfg(unix)]
+    if !active_app_was_present {
+        if let Err(error) = (|| {
+            if let Some(current_quiescence) = &current_quiescence {
+                lifecycle::terminate_prepared_app_processes(current_quiescence)?;
+            }
+            lifecycle::terminate_superseded_app_processes(&manager.install_dir, &active_app_dir, current_main_exe)?;
+            Ok::<(), SurgeError>(())
+        })() {
+            return Err(restore_previous_supervisor_after_quiescence_failure(
+                &manager.install_dir,
+                current_app_dir,
+                current_version,
+                current_main_exe,
+                current_supervisor_id,
+                supervisor_was_running,
+                error,
+            ));
         }
     }
     if let Err(err) = atomic_rename(&next_app_dir, &active_app_dir) {
@@ -272,13 +326,6 @@ where
             let _ = atomic_rename(&previous_swap_dir, &active_app_dir);
         }
         return Err(err);
-    }
-    #[cfg(unix)]
-    if !active_app_was_present {
-        if let Some(current_quiescence) = &current_quiescence {
-            lifecycle::terminate_prepared_app_processes(current_quiescence)?;
-        }
-        lifecycle::terminate_superseded_app_processes(&manager.install_dir, &active_app_dir, current_main_exe)?;
     }
 
     let previous_app_dir_for_assets = if previous_swap_dir.is_dir() {
@@ -474,4 +521,175 @@ where
     );
 
     Ok(restart_outcome)
+}
+
+#[cfg(unix)]
+fn prepare_and_quiesce_active_app_before_swap(
+    install_dir: &Path,
+    current_app_dir: &Path,
+    current_version: &str,
+    current_main_exe: &str,
+    current_supervisor_id: &str,
+    supervisor_was_running: bool,
+    allow_in_process_swap: bool,
+) -> Result<Option<lifecycle::PreparedAppQuiescence>> {
+    let result = (|| {
+        let prepared = lifecycle::prepare_app_quiescence(current_app_dir, current_main_exe, allow_in_process_swap)?;
+        if let Some(prepared) = &prepared {
+            lifecycle::terminate_prepared_app_processes(prepared)?;
+        }
+        Ok(prepared)
+    })();
+    let Err(error) = result else {
+        return result;
+    };
+
+    Err(restore_previous_supervisor_after_quiescence_failure(
+        install_dir,
+        Some(current_app_dir),
+        current_version,
+        current_main_exe,
+        current_supervisor_id,
+        supervisor_was_running,
+        error,
+    ))
+}
+
+#[cfg(unix)]
+fn restore_previous_supervisor_after_quiescence_failure(
+    install_dir: &Path,
+    current_app_dir: Option<&Path>,
+    current_version: &str,
+    current_main_exe: &str,
+    current_supervisor_id: &str,
+    supervisor_was_running: bool,
+    error: SurgeError,
+) -> SurgeError {
+    if supervisor_was_running && let Some(current_app_dir) = current_app_dir {
+        let restore_outcome = lifecycle::restore_previous_supervisor_after_failed_quiescence(
+            install_dir,
+            current_app_dir,
+            current_version,
+            current_main_exe,
+            current_supervisor_id,
+        );
+        match restore_outcome {
+            SupervisorRestartOutcome::NotApplicable => {
+                warn!(
+                    supervisor_id = current_supervisor_id,
+                    "Previous supervisor could not be restored after active application quiescence failed"
+                );
+            }
+            SupervisorRestartOutcome::PendingRestart { reason, failure_phase } => {
+                warn!(
+                    supervisor_id = current_supervisor_id,
+                    reason,
+                    failure_phase,
+                    "Requested previous supervisor restoration after active application quiescence failed"
+                );
+            }
+        }
+    }
+
+    error
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(target_os = "linux")]
+    use std::os::unix::fs::PermissionsExt;
+    #[cfg(target_os = "linux")]
+    use std::path::PathBuf;
+    #[cfg(target_os = "linux")]
+    use std::process::{Command, Stdio};
+
+    #[cfg(target_os = "linux")]
+    use super::*;
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn quiescence_failure_restores_previous_supervisor_and_preserves_error() {
+        let tmp = tempfile::tempdir().unwrap();
+        let install_dir = tmp.path();
+        let active_app_dir = install_dir.join("app");
+        std::fs::create_dir_all(&active_app_dir).unwrap();
+
+        let app_path = active_app_dir.join("cwd-changing-demo-script");
+        std::fs::write(&app_path, "#!/bin/sh\ncd /\nread _\n").unwrap();
+        make_executable(&app_path);
+
+        let supervisor_path = active_app_dir.join(crate::platform::process::supervisor_binary_name());
+        std::fs::write(
+            &supervisor_path,
+            r#"#!/bin/sh
+id=""
+dir=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --id) id="$2"; shift 2 ;;
+    --dir) dir="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+echo $$ > "$dir/.surge-supervisor-$id.pid"
+"#,
+        )
+        .unwrap();
+        make_executable(&supervisor_path);
+
+        let spawn_deadline = std::time::Instant::now() + Duration::from_secs(1);
+        let mut child = loop {
+            match Command::new("./cwd-changing-demo-script")
+                .current_dir(&active_app_dir)
+                .stdin(Stdio::piped())
+                .spawn()
+            {
+                Ok(child) => break child,
+                Err(error)
+                    if error.raw_os_error() == Some(nix::errno::Errno::ETXTBSY as i32)
+                        && std::time::Instant::now() < spawn_deadline =>
+                {
+                    std::thread::sleep(Duration::from_millis(10));
+                }
+                Err(error) => panic!("failed to launch changed-cwd app fixture: {error}"),
+            }
+        };
+        let cwd_path = PathBuf::from(format!("/proc/{}/cwd", child.id()));
+        let deadline = std::time::Instant::now() + Duration::from_secs(2);
+        while std::fs::read_link(&cwd_path).ok().as_deref() != Some(Path::new("/")) {
+            assert!(std::time::Instant::now() < deadline, "test child did not change cwd");
+            std::thread::sleep(Duration::from_millis(10));
+        }
+
+        let result = prepare_and_quiesce_active_app_before_swap(
+            install_dir,
+            &active_app_dir,
+            "1.0.0",
+            "cwd-changing-demo-script",
+            "demo-supervisor",
+            true,
+            false,
+        );
+        let child_still_running = child.try_wait().unwrap().is_none();
+        if child_still_running {
+            child.kill().unwrap();
+        }
+        let _ = child.wait();
+
+        let error = result.err().unwrap();
+        assert!(error.to_string().contains("process identity is ambiguous"));
+        assert!(child_still_running);
+        assert!(supervisor_pid_file(install_dir, "demo-supervisor").is_file());
+        assert_eq!(
+            crate::supervisor::state::read_supervisor_exe_path(install_dir, "demo-supervisor").as_deref(),
+            Some(app_path.as_path())
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    fn make_executable(path: &Path) {
+        let mut permissions = std::fs::metadata(path).unwrap().permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(path, permissions).unwrap();
+    }
 }

--- a/crates/surge-core/src/update/manager/finalize.rs
+++ b/crates/surge-core/src/update/manager/finalize.rs
@@ -188,28 +188,16 @@ where
     }
     #[cfg(unix)]
     let previous_swap_quiescence = if previous_swap_dir.is_dir() {
-        let previous_swap_identity = super::current_install::load_previous_swap(manager, &previous_swap_dir)?
-            .ok_or_else(|| {
-                SurgeError::Update(
-                    "Previous swap directory has no persisted process identity; refusing to delete or reuse it"
-                        .to_string(),
-                )
-            })?;
-        lifecycle::request_supervisor_shutdown(&manager.install_dir, &previous_swap_identity.supervisor_id).await?;
-        let prepared = lifecycle::prepare_app_quiescence(
+        prepare_and_quiesce_previous_swap_before_reuse(
+            manager,
             &previous_swap_dir,
-            &previous_swap_identity.main_exe,
-            manager.allow_in_process_swap,
-        )?;
-        if let Some(prepared) = &prepared {
-            lifecycle::terminate_prepared_app_processes(prepared)?;
-        }
-        let prepared = prepared.ok_or_else(|| {
-            SurgeError::Update(
-                "Previous swap application entrypoint disappeared before it could be quiesced".to_string(),
-            )
-        })?;
-        Some((prepared, previous_swap_identity.main_exe))
+            current_app_dir,
+            current_version,
+            current_main_exe,
+            current_supervisor_id,
+            supervisor_was_running,
+        )
+        .await?
     } else {
         None
     };
@@ -566,32 +554,95 @@ fn restore_previous_supervisor_after_quiescence_failure(
     error: SurgeError,
 ) -> SurgeError {
     if supervisor_was_running && let Some(current_app_dir) = current_app_dir {
-        let restore_outcome = lifecycle::restore_previous_supervisor_after_failed_quiescence(
+        request_previous_supervisor_restoration(
             install_dir,
             current_app_dir,
             current_version,
             current_main_exe,
             current_supervisor_id,
         );
-        match restore_outcome {
-            SupervisorRestartOutcome::NotApplicable => {
-                warn!(
-                    supervisor_id = current_supervisor_id,
-                    "Previous supervisor could not be restored after active application quiescence failed"
-                );
-            }
-            SupervisorRestartOutcome::PendingRestart { reason, failure_phase } => {
-                warn!(
-                    supervisor_id = current_supervisor_id,
-                    reason,
-                    failure_phase,
-                    "Requested previous supervisor restoration after active application quiescence failed"
-                );
-            }
-        }
     }
 
     error
+}
+
+#[cfg(unix)]
+async fn prepare_and_quiesce_previous_swap_before_reuse(
+    manager: &UpdateManager,
+    previous_swap_dir: &Path,
+    current_app_dir: Option<&Path>,
+    current_version: &str,
+    current_main_exe: &str,
+    current_supervisor_id: &str,
+    supervisor_was_running: bool,
+) -> Result<Option<(lifecycle::PreparedAppQuiescence, String)>> {
+    let result: Result<Option<(lifecycle::PreparedAppQuiescence, String)>> = async {
+        let previous_swap_identity = super::current_install::load_previous_swap(manager, previous_swap_dir)?
+            .ok_or_else(|| {
+                SurgeError::Update(
+                    "Previous swap directory has no persisted process identity; refusing to delete or reuse it"
+                        .to_string(),
+                )
+            })?;
+        lifecycle::request_supervisor_shutdown(&manager.install_dir, &previous_swap_identity.supervisor_id).await?;
+        let prepared = lifecycle::prepare_app_quiescence(
+            previous_swap_dir,
+            &previous_swap_identity.main_exe,
+            manager.allow_in_process_swap,
+        )?
+        .ok_or_else(|| {
+            SurgeError::Update(
+                "Previous swap application entrypoint disappeared before it could be quiesced".to_string(),
+            )
+        })?;
+        lifecycle::terminate_prepared_app_processes(&prepared)?;
+        Ok(Some((prepared, previous_swap_identity.main_exe)))
+    }
+    .await;
+
+    let Err(error) = result else {
+        return result;
+    };
+    Err(restore_previous_supervisor_after_quiescence_failure(
+        &manager.install_dir,
+        current_app_dir,
+        current_version,
+        current_main_exe,
+        current_supervisor_id,
+        supervisor_was_running,
+        error,
+    ))
+}
+
+#[cfg(unix)]
+fn request_previous_supervisor_restoration(
+    install_dir: &Path,
+    current_app_dir: &Path,
+    current_version: &str,
+    current_main_exe: &str,
+    current_supervisor_id: &str,
+) {
+    let restore_outcome = lifecycle::restore_previous_supervisor_after_failed_quiescence(
+        install_dir,
+        current_app_dir,
+        current_version,
+        current_main_exe,
+        current_supervisor_id,
+    );
+    match restore_outcome {
+        SupervisorRestartOutcome::NotApplicable => {
+            warn!(
+                supervisor_id = current_supervisor_id,
+                "Previous supervisor could not be restored after application quiescence failed"
+            );
+        }
+        SupervisorRestartOutcome::PendingRestart { reason, failure_phase } => {
+            warn!(
+                supervisor_id = current_supervisor_id,
+                reason, failure_phase, "Requested previous supervisor restoration after application quiescence failed"
+            );
+        }
+    }
 }
 
 #[cfg(test)]
@@ -618,24 +669,7 @@ mod tests {
         std::fs::write(&app_path, "#!/bin/sh\ncd /\nread _\n").unwrap();
         make_executable(&app_path);
 
-        let supervisor_path = active_app_dir.join(crate::platform::process::supervisor_binary_name());
-        std::fs::write(
-            &supervisor_path,
-            r#"#!/bin/sh
-id=""
-dir=""
-while [ "$#" -gt 0 ]; do
-  case "$1" in
-    --id) id="$2"; shift 2 ;;
-    --dir) dir="$2"; shift 2 ;;
-    *) shift ;;
-  esac
-done
-echo $$ > "$dir/.surge-supervisor-$id.pid"
-"#,
-        )
-        .unwrap();
-        make_executable(&supervisor_path);
+        write_test_supervisor(&active_app_dir);
 
         let spawn_deadline = std::time::Instant::now() + Duration::from_secs(1);
         let mut child = loop {
@@ -684,6 +718,77 @@ echo $$ > "$dir/.surge-supervisor-$id.pid"
             crate::supervisor::state::read_supervisor_exe_path(install_dir, "demo-supervisor").as_deref(),
             Some(app_path.as_path())
         );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn previous_swap_identity_failure_restores_current_supervisor() {
+        let tmp = tempfile::tempdir().unwrap();
+        let install_dir = tmp.path().join("install");
+        let store_dir = tmp.path().join("store");
+        let active_app_dir = install_dir.join("app");
+        let previous_swap_dir = install_dir.join(".surge-app-prev");
+        std::fs::create_dir_all(&active_app_dir).unwrap();
+        std::fs::create_dir_all(&previous_swap_dir).unwrap();
+        std::fs::create_dir_all(&store_dir).unwrap();
+
+        let app_path = active_app_dir.join("current-app");
+        std::fs::write(&app_path, "#!/bin/sh\nexit 0\n").unwrap();
+        make_executable(&app_path);
+        write_test_supervisor(&active_app_dir);
+
+        let ctx = std::sync::Arc::new(crate::context::Context::new());
+        ctx.set_storage(
+            crate::context::StorageProvider::Filesystem,
+            store_dir.to_str().unwrap(),
+            "",
+            "",
+            "",
+            "",
+        );
+        let manager = UpdateManager::new(ctx, "test-app", "1.0.0", "stable", install_dir.to_str().unwrap()).unwrap();
+
+        let error = prepare_and_quiesce_previous_swap_before_reuse(
+            &manager,
+            &previous_swap_dir,
+            Some(&active_app_dir),
+            "1.0.0",
+            "current-app",
+            "demo-supervisor",
+            true,
+        )
+        .await
+        .err()
+        .unwrap();
+
+        assert!(error.to_string().contains("no persisted process identity"));
+        assert!(supervisor_pid_file(&install_dir, "demo-supervisor").is_file());
+        assert_eq!(
+            crate::supervisor::state::read_supervisor_exe_path(&install_dir, "demo-supervisor").as_deref(),
+            Some(app_path.as_path())
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    fn write_test_supervisor(active_app_dir: &Path) {
+        let supervisor_path = active_app_dir.join(crate::platform::process::supervisor_binary_name());
+        std::fs::write(
+            &supervisor_path,
+            r#"#!/bin/sh
+id=""
+dir=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --id) id="$2"; shift 2 ;;
+    --dir) dir="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+echo $$ > "$dir/.surge-supervisor-$id.pid"
+"#,
+        )
+        .unwrap();
+        make_executable(&supervisor_path);
     }
 
     #[cfg(target_os = "linux")]

--- a/crates/surge-core/src/update/manager/finalize_quiescence.rs
+++ b/crates/surge-core/src/update/manager/finalize_quiescence.rs
@@ -1,0 +1,348 @@
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use tracing::warn;
+
+use crate::error::{Result, SurgeError};
+
+use super::UpdateManager;
+use super::lifecycle::{self, SupervisorRestartOutcome};
+
+#[allow(clippy::too_many_arguments)]
+pub(super) fn prepare_and_quiesce_active_app_before_swap(
+    install_dir: &Path,
+    current_app_dir: &Path,
+    current_version: &str,
+    current_main_exe: &str,
+    current_supervisor_id: &str,
+    current_environment: Option<&BTreeMap<String, String>>,
+    supervisor_requires_restoration: bool,
+    supervised_child_pid: Option<u32>,
+    allow_in_process_swap: bool,
+) -> Result<Option<lifecycle::PreparedAppQuiescence>> {
+    let result = (|| {
+        let prepared = lifecycle::prepare_app_quiescence(current_app_dir, current_main_exe, allow_in_process_swap)?;
+        if let Some(prepared) = &prepared {
+            lifecycle::terminate_prepared_app_processes(prepared)?;
+        }
+        Ok(prepared)
+    })();
+    let Err(error) = result else {
+        return result;
+    };
+
+    Err(restore_previous_supervisor_after_quiescence_failure(
+        install_dir,
+        Some(current_app_dir),
+        current_version,
+        current_main_exe,
+        current_supervisor_id,
+        current_environment,
+        supervisor_requires_restoration,
+        supervised_child_pid,
+        error,
+    ))
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(super) fn restore_previous_supervisor_after_quiescence_failure(
+    install_dir: &Path,
+    current_app_dir: Option<&Path>,
+    current_version: &str,
+    current_main_exe: &str,
+    current_supervisor_id: &str,
+    current_environment: Option<&BTreeMap<String, String>>,
+    supervisor_requires_restoration: bool,
+    supervised_child_pid: Option<u32>,
+    error: SurgeError,
+) -> SurgeError {
+    if supervisor_requires_restoration
+        && let Some(current_app_dir) = current_app_dir
+        && let Some(current_environment) = current_environment
+    {
+        request_previous_supervisor_restoration(
+            install_dir,
+            current_app_dir,
+            current_version,
+            current_main_exe,
+            current_supervisor_id,
+            current_environment,
+            supervised_child_pid,
+        );
+    }
+
+    error
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(super) async fn prepare_and_quiesce_previous_swap_before_reuse(
+    manager: &UpdateManager,
+    previous_swap_dir: &Path,
+    current_app_dir: Option<&Path>,
+    current_version: &str,
+    current_main_exe: &str,
+    current_supervisor_id: &str,
+    current_environment: Option<&BTreeMap<String, String>>,
+    supervisor_requires_restoration: bool,
+    supervised_child_pid: Option<u32>,
+) -> Result<Option<(lifecycle::PreparedAppQuiescence, String)>> {
+    let result: Result<Option<(lifecycle::PreparedAppQuiescence, String)>> = async {
+        let previous_swap_identity = super::current_install::load_previous_swap(manager, previous_swap_dir)?
+            .ok_or_else(|| {
+                SurgeError::Update(
+                    "Previous swap directory has no persisted process identity; refusing to delete or reuse it"
+                        .to_string(),
+                )
+            })?;
+        let _ =
+            lifecycle::request_supervisor_shutdown(&manager.install_dir, &previous_swap_identity.supervisor_id).await?;
+        let prepared = lifecycle::prepare_app_quiescence(
+            previous_swap_dir,
+            &previous_swap_identity.main_exe,
+            manager.allow_in_process_swap,
+        )?
+        .ok_or_else(|| {
+            SurgeError::Update(
+                "Previous swap application entrypoint disappeared before it could be quiesced".to_string(),
+            )
+        })?;
+        lifecycle::terminate_prepared_app_processes(&prepared)?;
+        Ok(Some((prepared, previous_swap_identity.main_exe)))
+    }
+    .await;
+
+    let Err(error) = result else {
+        return result;
+    };
+    Err(restore_previous_supervisor_after_quiescence_failure(
+        &manager.install_dir,
+        current_app_dir,
+        current_version,
+        current_main_exe,
+        current_supervisor_id,
+        current_environment,
+        supervisor_requires_restoration,
+        supervised_child_pid,
+        error,
+    ))
+}
+
+fn request_previous_supervisor_restoration(
+    install_dir: &Path,
+    current_app_dir: &Path,
+    current_version: &str,
+    current_main_exe: &str,
+    current_supervisor_id: &str,
+    current_environment: &BTreeMap<String, String>,
+    supervised_child_pid: Option<u32>,
+) {
+    let Some(supervised_child_pid) = supervised_child_pid else {
+        warn!(
+            supervisor_id = current_supervisor_id,
+            "Cannot safely restore the previous supervisor because it did not provide its surviving child PID"
+        );
+        return;
+    };
+    let restore_outcome = lifecycle::restore_previous_supervisor_after_failed_quiescence(
+        install_dir,
+        current_app_dir,
+        current_version,
+        current_main_exe,
+        current_supervisor_id,
+        current_environment,
+        supervised_child_pid,
+    );
+    match restore_outcome {
+        SupervisorRestartOutcome::NotApplicable => {
+            warn!(
+                supervisor_id = current_supervisor_id,
+                "Previous supervisor could not be restored after application quiescence failed"
+            );
+        }
+        SupervisorRestartOutcome::PendingRestart { reason, failure_phase } => {
+            warn!(
+                supervisor_id = current_supervisor_id,
+                reason, failure_phase, "Requested previous supervisor restoration after application quiescence failed"
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::os::unix::fs::PermissionsExt;
+    use std::path::PathBuf;
+    use std::process::{Command, Stdio};
+    use std::time::Duration;
+
+    use crate::supervisor::state::supervisor_pid_file;
+
+    use super::*;
+
+    #[test]
+    fn quiescence_failure_restores_previous_supervisor_and_preserves_error() {
+        let tmp = tempfile::tempdir().unwrap();
+        let install_dir = tmp.path();
+        let active_app_dir = install_dir.join("app");
+        std::fs::create_dir_all(&active_app_dir).unwrap();
+
+        let app_path = active_app_dir.join("cwd-changing-demo-script");
+        std::fs::write(&app_path, "#!/bin/sh\ncd /\nread _\n").unwrap();
+        make_executable(&app_path);
+        write_test_supervisor(&active_app_dir);
+
+        let spawn_deadline = std::time::Instant::now() + Duration::from_secs(1);
+        let mut child = loop {
+            match Command::new("./cwd-changing-demo-script")
+                .current_dir(&active_app_dir)
+                .stdin(Stdio::piped())
+                .spawn()
+            {
+                Ok(child) => break child,
+                Err(error)
+                    if error.raw_os_error() == Some(nix::errno::Errno::ETXTBSY as i32)
+                        && std::time::Instant::now() < spawn_deadline =>
+                {
+                    std::thread::sleep(Duration::from_millis(10));
+                }
+                Err(error) => panic!("failed to launch changed-cwd app fixture: {error}"),
+            }
+        };
+        let cwd_path = PathBuf::from(format!("/proc/{}/cwd", child.id()));
+        let deadline = std::time::Instant::now() + Duration::from_secs(2);
+        while std::fs::read_link(&cwd_path).ok().as_deref() != Some(Path::new("/")) {
+            assert!(std::time::Instant::now() < deadline, "test child did not change cwd");
+            std::thread::sleep(Duration::from_millis(10));
+        }
+
+        let current_environment = BTreeMap::from([("SURGE_TEST_MODE".to_string(), "preserved".to_string())]);
+        let child_pid = child.id();
+        let result = prepare_and_quiesce_active_app_before_swap(
+            install_dir,
+            &active_app_dir,
+            "1.0.0",
+            "cwd-changing-demo-script",
+            "demo-supervisor",
+            Some(&current_environment),
+            true,
+            Some(child_pid),
+            false,
+        );
+        let child_still_running = child.try_wait().unwrap().is_none();
+        if child_still_running {
+            child.kill().unwrap();
+        }
+        let _ = child.wait();
+
+        let error = result.err().unwrap();
+        assert!(error.to_string().contains("process identity is ambiguous"));
+        assert!(child_still_running);
+        assert!(supervisor_pid_file(install_dir, "demo-supervisor").is_file());
+        assert_eq!(
+            crate::supervisor::state::read_supervisor_exe_path(install_dir, "demo-supervisor").as_deref(),
+            Some(app_path.as_path())
+        );
+        assert_eq!(
+            std::fs::read_to_string(install_dir.join("restored-environment")).unwrap(),
+            "preserved"
+        );
+        assert_eq!(
+            std::fs::read_to_string(install_dir.join("restored-watched.pid"))
+                .unwrap()
+                .trim(),
+            child_pid.to_string()
+        );
+    }
+
+    #[tokio::test]
+    async fn previous_swap_identity_failure_restores_current_supervisor() {
+        let tmp = tempfile::tempdir().unwrap();
+        let install_dir = tmp.path().join("install");
+        let store_dir = tmp.path().join("store");
+        let active_app_dir = install_dir.join("app");
+        let previous_swap_dir = install_dir.join(".surge-app-prev");
+        std::fs::create_dir_all(&active_app_dir).unwrap();
+        std::fs::create_dir_all(&previous_swap_dir).unwrap();
+        std::fs::create_dir_all(&store_dir).unwrap();
+
+        let app_path = active_app_dir.join("current-app");
+        std::fs::write(&app_path, "#!/bin/sh\nexit 0\n").unwrap();
+        make_executable(&app_path);
+        write_test_supervisor(&active_app_dir);
+
+        let ctx = std::sync::Arc::new(crate::context::Context::new());
+        ctx.set_storage(
+            crate::context::StorageProvider::Filesystem,
+            store_dir.to_str().unwrap(),
+            "",
+            "",
+            "",
+            "",
+        );
+        let manager = UpdateManager::new(ctx, "test-app", "1.0.0", "stable", install_dir.to_str().unwrap()).unwrap();
+
+        let current_environment = BTreeMap::from([("SURGE_TEST_MODE".to_string(), "preserved".to_string())]);
+        let error = prepare_and_quiesce_previous_swap_before_reuse(
+            &manager,
+            &previous_swap_dir,
+            Some(&active_app_dir),
+            "1.0.0",
+            "current-app",
+            "demo-supervisor",
+            Some(&current_environment),
+            true,
+            Some(4242),
+        )
+        .await
+        .err()
+        .unwrap();
+
+        assert!(error.to_string().contains("no persisted process identity"));
+        assert!(supervisor_pid_file(&install_dir, "demo-supervisor").is_file());
+        assert_eq!(
+            crate::supervisor::state::read_supervisor_exe_path(&install_dir, "demo-supervisor").as_deref(),
+            Some(app_path.as_path())
+        );
+        assert_eq!(
+            std::fs::read_to_string(install_dir.join("restored-environment")).unwrap(),
+            "preserved"
+        );
+        assert_eq!(
+            std::fs::read_to_string(install_dir.join("restored-watched.pid"))
+                .unwrap()
+                .trim(),
+            "4242"
+        );
+    }
+
+    fn write_test_supervisor(active_app_dir: &Path) {
+        let supervisor_path = active_app_dir.join(crate::platform::process::supervisor_binary_name());
+        std::fs::write(
+            &supervisor_path,
+            r#"#!/bin/sh
+id=""
+dir=""
+pid=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --id) id="$2"; shift 2 ;;
+    --dir) dir="$2"; shift 2 ;;
+    --pid) pid="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+printf '%s' "$SURGE_TEST_MODE" > "$dir/restored-environment"
+printf '%s' "$pid" > "$dir/restored-watched.pid"
+echo $$ > "$dir/.surge-supervisor-$id.pid"
+"#,
+        )
+        .unwrap();
+        make_executable(&supervisor_path);
+    }
+
+    fn make_executable(path: &Path) {
+        let mut permissions = std::fs::metadata(path).unwrap().permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(path, permissions).unwrap();
+    }
+}

--- a/crates/surge-core/src/update/manager/lifecycle.rs
+++ b/crates/surge-core/src/update/manager/lifecycle.rs
@@ -23,7 +23,9 @@ mod process_quiescence;
 pub(super) use self::process_quiescence::terminate_active_app_processes_before_swap;
 pub(super) use self::process_quiescence::terminate_superseded_app_processes;
 #[cfg(unix)]
-pub(super) use self::process_quiescence::{prepare_app_quiescence, terminate_prepared_app_processes};
+pub(super) use self::process_quiescence::{
+    PreparedAppQuiescence, prepare_app_quiescence, terminate_prepared_app_processes,
+};
 #[cfg(all(test, any(target_os = "linux", target_os = "macos")))]
 pub(in crate::update::manager) use self::process_quiescence::{spawn_native_test_app, wait_for_native_test_app};
 
@@ -163,6 +165,32 @@ pub(super) fn restart_supervisor_after_update(
     restart_supervisor_after_update_with_pid(install_dir, active_app_dir, latest, current_pid())
 }
 
+#[cfg(unix)]
+pub(super) fn restore_previous_supervisor_after_failed_quiescence(
+    install_dir: &Path,
+    active_app_dir: &Path,
+    version: &str,
+    main_exe: &str,
+    supervisor_id: &str,
+) -> SupervisorRestartOutcome {
+    let previous = ReleaseEntry {
+        version: version.to_string(),
+        main_exe: main_exe.to_string(),
+        supervisor_id: supervisor_id.to_string(),
+        ..ReleaseEntry::default()
+    };
+    restart_supervisor_after_update_with_config(
+        install_dir,
+        active_app_dir,
+        &previous,
+        current_pid(),
+        None,
+        SUPERVISOR_RESTART_CONFIRM_TIMEOUT,
+        SUPERVISOR_RESTART_MAX_ATTEMPTS,
+        SUPERVISOR_RESTART_RETRY_DELAY,
+    )
+}
+
 pub(super) fn restart_supervisor_after_update_with_pid(
     install_dir: &Path,
     active_app_dir: &Path,
@@ -174,6 +202,7 @@ pub(super) fn restart_supervisor_after_update_with_pid(
         active_app_dir,
         latest,
         watched_pid,
+        Some(&latest.version),
         SUPERVISOR_RESTART_CONFIRM_TIMEOUT,
         SUPERVISOR_RESTART_MAX_ATTEMPTS,
         SUPERVISOR_RESTART_RETRY_DELAY,
@@ -185,6 +214,7 @@ fn restart_supervisor_after_update_with_config(
     active_app_dir: &Path,
     latest: &ReleaseEntry,
     watched_pid: u32,
+    handoff_version: Option<&str>,
     confirm_timeout: Duration,
     max_attempts: u32,
     retry_delay: Duration,
@@ -242,7 +272,7 @@ fn restart_supervisor_after_update_with_config(
         }
     };
 
-    let args = supervisor_watch_args(supervisor_id, install_dir, watched_pid, &latest.version, &restart_args);
+    let args = supervisor_watch_args(supervisor_id, install_dir, watched_pid, handoff_version, &restart_args);
     let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
 
     let mut last_failure: Option<(String, &'static str)> = None;
@@ -254,11 +284,20 @@ fn restart_supervisor_after_update_with_config(
                     supervisor_id, attempt, "Restarted supervisor after update"
                 );
                 if confirm_supervisor_restart(install_dir, supervisor_id, confirm_timeout) {
+                    let reason = handoff_version.map_or_else(
+                        || {
+                            format!(
+                                "previous supervisor restoration accepted; waiting for process pid {watched_pid} to exit"
+                            )
+                        },
+                        |version| {
+                            format!(
+                                "supervisor handoff accepted; waiting for previous child pid {watched_pid} to exit and target version {version} to start"
+                            )
+                        },
+                    );
                     return SupervisorRestartOutcome::PendingRestart {
-                        reason: format!(
-                            "supervisor handoff accepted; waiting for previous child pid {watched_pid} to exit and target version {} to start",
-                            latest.version
-                        ),
+                        reason,
                         failure_phase: RESTART_HANDOFF_WAITING_FOR_OLD_CHILD_PHASE,
                     };
                 }
@@ -302,7 +341,7 @@ fn supervisor_watch_args(
     supervisor_id: &str,
     install_dir: &Path,
     watched_pid: u32,
-    handoff_version: &str,
+    handoff_version: Option<&str>,
     restart_args: &[String],
 ) -> Vec<String> {
     let mut args = vec![
@@ -313,9 +352,11 @@ fn supervisor_watch_args(
         install_dir.to_string_lossy().into_owned(),
         "--pid".to_string(),
         watched_pid.to_string(),
-        "--handoff-version".to_string(),
-        handoff_version.to_string(),
     ];
+    if let Some(handoff_version) = handoff_version {
+        args.push("--handoff-version".to_string());
+        args.push(handoff_version.to_string());
+    }
     if !restart_args.is_empty() {
         args.push("--".to_string());
         args.extend(restart_args.iter().cloned());
@@ -333,7 +374,13 @@ mod tests {
     fn supervisor_watch_args_include_handoff_version_before_child_args() {
         let restart_args = vec!["--app-mode".to_string(), "service".to_string()];
 
-        let args = supervisor_watch_args("demo-supervisor", Path::new("/opt/demo"), 42, "2.0.0", &restart_args);
+        let args = supervisor_watch_args(
+            "demo-supervisor",
+            Path::new("/opt/demo"),
+            42,
+            Some("2.0.0"),
+            &restart_args,
+        );
 
         assert_eq!(
             args,
@@ -356,6 +403,13 @@ mod tests {
             !args.iter().any(|arg| arg == "--exe"),
             "supervisor argv must not carry the app exe path so external pkill -f <app-path> cannot match it"
         );
+    }
+
+    #[test]
+    fn previous_supervisor_restoration_omits_update_handoff_version() {
+        let args = supervisor_watch_args("demo-supervisor", Path::new("/opt/demo"), 42, None, &[]);
+
+        assert!(!args.iter().any(|argument| argument == "--handoff-version"));
     }
 
     #[cfg(unix)]
@@ -397,6 +451,7 @@ mod tests {
             &active_app_dir,
             &latest,
             std::process::id(),
+            Some(&latest.version),
             Duration::from_millis(200),
             2,
             Duration::from_millis(10),

--- a/crates/surge-core/src/update/manager/lifecycle.rs
+++ b/crates/surge-core/src/update/manager/lifecycle.rs
@@ -6,6 +6,8 @@ use tracing::{debug, info, warn};
 use crate::error::{Result, SurgeError};
 use crate::platform::process::{ProcessHandle, current_pid, spawn_detached, spawn_process, supervisor_binary_name};
 use crate::releases::manifest::ReleaseEntry;
+#[cfg(unix)]
+use crate::supervisor::state::{clear_supervisor_takeover_pid, take_supervisor_takeover_pid};
 use crate::supervisor::state::{
     read_restart_args, supervisor_pid_file, supervisor_stop_file, write_supervisor_exe_path,
 };
@@ -43,7 +45,7 @@ pub(super) enum SupervisorRestartOutcome {
     },
 }
 
-pub(super) async fn request_supervisor_shutdown(install_dir: &Path, supervisor_id: &str) -> Result<()> {
+pub(super) async fn request_supervisor_shutdown(install_dir: &Path, supervisor_id: &str) -> Result<Option<u32>> {
     request_supervisor_shutdown_with_timeout(
         install_dir,
         supervisor_id,
@@ -58,16 +60,21 @@ pub(super) async fn request_supervisor_shutdown_with_timeout(
     supervisor_id: &str,
     timeout: Duration,
     poll_interval: Duration,
-) -> Result<()> {
+) -> Result<Option<u32>> {
     let supervisor_id = supervisor_id.trim();
     if supervisor_id.is_empty() {
-        return Ok(());
+        return Ok(None);
     }
 
     let pid_file = supervisor_pid_file(install_dir, supervisor_id);
     if !pid_file.is_file() {
-        return Ok(());
+        #[cfg(unix)]
+        return Ok(take_supervisor_takeover_pid(install_dir, supervisor_id));
+        #[cfg(not(unix))]
+        return Ok(None);
     }
+    #[cfg(unix)]
+    clear_supervisor_takeover_pid(install_dir, supervisor_id);
 
     let stop_file = supervisor_stop_file(install_dir, supervisor_id);
     tokio::fs::write(&stop_file, b"surge-update").await?;
@@ -83,7 +90,11 @@ pub(super) async fn request_supervisor_shutdown_with_timeout(
     }
 
     let _ = tokio::fs::remove_file(&stop_file).await;
-    Ok(())
+    #[cfg(unix)]
+    let takeover_pid = take_supervisor_takeover_pid(install_dir, supervisor_id);
+    #[cfg(not(unix))]
+    let takeover_pid = None;
+    Ok(takeover_pid)
 }
 
 pub(super) fn invoke_post_update_hook(install_dir: &Path, active_app_dir: &Path, latest: &ReleaseEntry) {
@@ -172,18 +183,21 @@ pub(super) fn restore_previous_supervisor_after_failed_quiescence(
     version: &str,
     main_exe: &str,
     supervisor_id: &str,
+    environment: &std::collections::BTreeMap<String, String>,
+    watched_pid: u32,
 ) -> SupervisorRestartOutcome {
     let previous = ReleaseEntry {
         version: version.to_string(),
         main_exe: main_exe.to_string(),
         supervisor_id: supervisor_id.to_string(),
+        environment: environment.clone(),
         ..ReleaseEntry::default()
     };
     restart_supervisor_after_update_with_config(
         install_dir,
         active_app_dir,
         &previous,
-        current_pid(),
+        watched_pid,
         None,
         SUPERVISOR_RESTART_CONFIRM_TIMEOUT,
         SUPERVISOR_RESTART_MAX_ATTEMPTS,

--- a/crates/surge-core/src/update/manager/lifecycle/process_quiescence.rs
+++ b/crates/surge-core/src/update/manager/lifecycle/process_quiescence.rs
@@ -690,6 +690,36 @@ mod tests {
 
     #[cfg(any(target_os = "linux", target_os = "macos"))]
     #[test]
+    fn missing_active_entrypoint_refuses_swap_without_signalling_running_process() {
+        use std::os::unix::fs::symlink;
+        use std::process::Command;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let active_app_dir = tmp.path().join("app");
+        std::fs::create_dir_all(&active_app_dir).unwrap();
+        let app_path = active_app_dir.join("demo");
+        symlink("/bin/sleep", &app_path).unwrap();
+
+        let mut child = Command::new(&app_path).arg("30").spawn().unwrap();
+        std::fs::remove_file(&app_path).unwrap();
+
+        let error = terminate_active_app_processes_except(&active_app_dir, "demo", u32::MAX).unwrap_err();
+        let child_still_running = child.try_wait().unwrap().is_none();
+        if child_still_running {
+            child.kill().unwrap();
+        }
+        let _ = child.wait();
+
+        assert!(
+            error
+                .to_string()
+                .contains("Failed to resolve active application executable before swap")
+        );
+        assert!(child_still_running);
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    #[test]
     fn symlinked_active_entrypoint_does_not_terminate_other_processes_using_shared_target() {
         use std::os::unix::fs::symlink;
         use std::process::Command;
@@ -875,7 +905,7 @@ mod tests {
     #[cfg(any(target_os = "linux", target_os = "macos"))]
     #[test]
     fn interpreted_active_app_with_multiple_interpreter_options_is_terminated_before_swap() {
-        assert_interpreted_active_app_process_is_terminated_before_swap("#!/usr/bin/env -S /bin/sh -e -u");
+        assert_interpreted_active_app_process_is_terminated_before_swap("#!/usr/bin/env -S -i /bin/sh -e -u");
     }
 
     #[cfg(any(target_os = "linux", target_os = "macos"))]

--- a/crates/surge-core/src/update/manager/lifecycle/process_quiescence.rs
+++ b/crates/surge-core/src/update/manager/lifecycle/process_quiescence.rs
@@ -68,9 +68,7 @@ fn prepare_app_quiescence_except(
         return Ok(None);
     }
 
-    let active_entrypoint = active_entrypoint::Identity::resolve(active_app_dir, main_exe)?.ok_or_else(|| {
-        SurgeError::Platform("Failed to resolve active application executable before swap".to_string())
-    })?;
+    let active_entrypoint = active_entrypoint::Identity::resolve(active_app_dir, main_exe)?;
     let interpreted_main = interpreted_main::resolve(&active_entrypoint.resolved)?;
     if allow_in_process_swap {
         info!("In-process swap explicitly allowed, quiescing other active application processes only");
@@ -327,9 +325,7 @@ pub(in crate::update::manager) fn spawn_native_test_app(app_path: &Path) -> std:
 pub(in crate::update::manager) fn wait_for_native_test_app(app_path: &Path, child_pid: u32) {
     let active_app_dir = app_path.parent().unwrap();
     let main_exe = app_path.file_name().unwrap().to_str().unwrap();
-    let active_entrypoint = active_entrypoint::Identity::resolve(active_app_dir, main_exe)
-        .unwrap()
-        .unwrap();
+    let active_entrypoint = active_entrypoint::Identity::resolve(active_app_dir, main_exe).unwrap();
     let deadline = std::time::Instant::now() + Duration::from_secs(5);
     while !app_process_pids(u32::MAX, &|process| {
         is_active_app_process(&active_entrypoint, None, process)
@@ -369,7 +365,6 @@ fn is_active_app_process(
             return Ok(true);
         }
     }
-
     let Some(identity) = interpreted_main else {
         return Ok(false);
     };
@@ -529,9 +524,7 @@ mod tests {
         std::fs::create_dir_all(&active_app_dir).unwrap();
         let app_path = active_app_dir.join("demo-script");
         std::fs::write(&app_path, "#!/bin/sh\n").unwrap();
-        let active_entrypoint = active_entrypoint::Identity::resolve(&active_app_dir, "demo-script")
-            .unwrap()
-            .unwrap();
+        let active_entrypoint = active_entrypoint::Identity::resolve(&active_app_dir, "demo-script").unwrap();
         let interpreted_main = interpreted_main::resolve(&active_entrypoint.resolved).unwrap().unwrap();
         let process = AppProcess {
             exe: std::fs::canonicalize("/bin/sh").unwrap(),
@@ -553,9 +546,7 @@ mod tests {
         std::fs::create_dir_all(&active_app_dir).unwrap();
         let app_path = active_app_dir.join("demo");
         std::fs::write(&app_path, "fixture").unwrap();
-        let active_entrypoint = active_entrypoint::Identity::resolve(&active_app_dir, "demo")
-            .unwrap()
-            .unwrap();
+        let active_entrypoint = active_entrypoint::Identity::resolve(&active_app_dir, "demo").unwrap();
         let process = AppProcess {
             exe: std::fs::canonicalize("/bin/sleep").unwrap(),
             command: vec![app_path.into_os_string()],
@@ -574,9 +565,7 @@ mod tests {
         std::fs::create_dir_all(&active_app_dir).unwrap();
         let app_path = active_app_dir.join("demo-script");
         std::fs::write(&app_path, "#!/bin/sh\n").unwrap();
-        let active_entrypoint = active_entrypoint::Identity::resolve(&active_app_dir, "demo-script")
-            .unwrap()
-            .unwrap();
+        let active_entrypoint = active_entrypoint::Identity::resolve(&active_app_dir, "demo-script").unwrap();
         let interpreted_main = interpreted_main::resolve(&active_entrypoint.resolved).unwrap().unwrap();
         let process = AppProcess {
             exe: std::fs::canonicalize("/bin/sleep").unwrap(),
@@ -596,9 +585,7 @@ mod tests {
         std::fs::create_dir_all(&active_app_dir).unwrap();
         let app_path = active_app_dir.join("demo-script");
         std::fs::write(&app_path, "#!/bin/sh\n").unwrap();
-        let active_entrypoint = active_entrypoint::Identity::resolve(&active_app_dir, "demo-script")
-            .unwrap()
-            .unwrap();
+        let active_entrypoint = active_entrypoint::Identity::resolve(&active_app_dir, "demo-script").unwrap();
         let interpreted_main = interpreted_main::resolve(&active_entrypoint.resolved).unwrap().unwrap();
         let process = AppProcess {
             exe: std::fs::canonicalize("/bin/sh").unwrap(),
@@ -620,9 +607,7 @@ mod tests {
         std::fs::create_dir_all(&active_app_dir).unwrap();
         let app_path = active_app_dir.join("demo-script");
         std::fs::write(&app_path, "#!/bin/sh\n").unwrap();
-        let active_entrypoint = active_entrypoint::Identity::resolve(&active_app_dir, "demo-script")
-            .unwrap()
-            .unwrap();
+        let active_entrypoint = active_entrypoint::Identity::resolve(&active_app_dir, "demo-script").unwrap();
         let interpreted_main = interpreted_main::resolve(&active_entrypoint.resolved).unwrap().unwrap();
         let process = AppProcess {
             exe: std::fs::canonicalize("/bin/sh").unwrap(),
@@ -644,9 +629,7 @@ mod tests {
         std::fs::create_dir_all(&active_app_dir).unwrap();
         let app_path = active_app_dir.join("demo-script");
         std::fs::write(&app_path, "#!/bin/sh\n").unwrap();
-        let active_entrypoint = active_entrypoint::Identity::resolve(&active_app_dir, "demo-script")
-            .unwrap()
-            .unwrap();
+        let active_entrypoint = active_entrypoint::Identity::resolve(&active_app_dir, "demo-script").unwrap();
         let interpreted_main = interpreted_main::resolve(&active_entrypoint.resolved).unwrap().unwrap();
         let process = AppProcess {
             exe: std::fs::canonicalize("/bin/sh").unwrap(),
@@ -669,9 +652,7 @@ mod tests {
         let active_app_dir = tmp.path().join("app");
         std::fs::create_dir_all(&active_app_dir).unwrap();
         symlink("/bin/sleep", active_app_dir.join("demo")).unwrap();
-        let active_entrypoint = active_entrypoint::Identity::resolve(&active_app_dir, "demo")
-            .unwrap()
-            .unwrap();
+        let active_entrypoint = active_entrypoint::Identity::resolve(&active_app_dir, "demo").unwrap();
         let process = AppProcess {
             exe: std::fs::canonicalize("/bin/sleep").unwrap(),
             command: vec![OsString::new()],
@@ -692,9 +673,7 @@ mod tests {
         std::fs::create_dir_all(&active_app_dir).unwrap();
         let app_path = active_app_dir.join("demo-script");
         std::fs::write(&app_path, "#!/bin/sh\n").unwrap();
-        let active_entrypoint = active_entrypoint::Identity::resolve(&active_app_dir, "demo-script")
-            .unwrap()
-            .unwrap();
+        let active_entrypoint = active_entrypoint::Identity::resolve(&active_app_dir, "demo-script").unwrap();
         let interpreted_main = interpreted_main::resolve(&active_entrypoint.resolved).unwrap().unwrap();
         let process = AppProcess {
             exe: std::fs::canonicalize("/bin/sh").unwrap(),
@@ -720,9 +699,7 @@ mod tests {
         std::fs::create_dir_all(&active_app_dir).unwrap();
         let app_path = active_app_dir.join("demo");
         symlink("/bin/sleep", &app_path).unwrap();
-        let active_entrypoint = active_entrypoint::Identity::resolve(&active_app_dir, "demo")
-            .unwrap()
-            .unwrap();
+        let active_entrypoint = active_entrypoint::Identity::resolve(&active_app_dir, "demo").unwrap();
         assert!(active_entrypoint.requires_argument());
 
         let mut app_child = Command::new(&app_path).arg("30").spawn().unwrap();
@@ -773,9 +750,7 @@ mod tests {
         let mut permissions = std::fs::metadata(&app_path).unwrap().permissions();
         permissions.set_mode(0o755);
         std::fs::set_permissions(&app_path, permissions).unwrap();
-        let active_entrypoint = active_entrypoint::Identity::resolve(&active_app_dir, "demo-script")
-            .unwrap()
-            .unwrap();
+        let active_entrypoint = active_entrypoint::Identity::resolve(&active_app_dir, "demo-script").unwrap();
         let interpreted_main = interpreted_main::resolve(&active_entrypoint.resolved).unwrap().unwrap();
 
         let spawn_deadline = std::time::Instant::now() + Duration::from_secs(1);
@@ -818,24 +793,31 @@ mod tests {
 
     #[cfg(any(target_os = "linux", target_os = "macos"))]
     #[test]
-    fn missing_active_entrypoint_refuses_swap() {
-        let tmp = tempfile::tempdir().unwrap();
-        let active_app_dir = tmp.path().join("app");
-        std::fs::create_dir_all(&active_app_dir).unwrap();
-
-        let error = terminate_active_app_processes_except(&active_app_dir, "missing", u32::MAX, false).unwrap_err();
-
-        assert!(
-            error
-                .to_string()
-                .contains("Failed to resolve active application executable before swap")
-        );
+    fn interpreted_active_app_process_is_terminated_before_swap() {
+        assert_interpreted_active_app_process_is_terminated_before_swap("#!/bin/sh");
     }
 
     #[cfg(any(target_os = "linux", target_os = "macos"))]
     #[test]
-    fn interpreted_active_app_process_is_terminated_before_swap() {
-        assert_interpreted_active_app_process_is_terminated_before_swap("#!/bin/sh");
+    fn interpreted_relative_entrypoint_with_changed_cwd_refuses_swap() {
+        let tmp = tempfile::tempdir().unwrap();
+        let active_app_dir = tmp.path().join("app");
+        std::fs::create_dir_all(&active_app_dir).unwrap();
+        let app_path = active_app_dir.join("demo-script");
+        std::fs::write(&app_path, "#!/bin/sh\n").unwrap();
+        let active_entrypoint = active_entrypoint::Identity::resolve(&active_app_dir, "demo-script").unwrap();
+        let interpreted_main = interpreted_main::resolve(&active_entrypoint.resolved).unwrap().unwrap();
+        let process = AppProcess {
+            exe: std::fs::canonicalize("/bin/sh").unwrap(),
+            command: vec![OsString::from("/bin/sh"), OsString::from("./demo-script")],
+            command_inspected: true,
+            cwd: Some(std::path::PathBuf::from("/")),
+        };
+
+        let error = is_active_app_process(&active_entrypoint, Some(&interpreted_main), &process).unwrap_err();
+
+        assert!(error.to_string().contains("launch directory"));
+        assert!(error.to_string().contains("process identity is ambiguous"));
     }
 
     #[cfg(any(target_os = "linux", target_os = "macos"))]
@@ -905,9 +887,7 @@ mod tests {
         let interpreter_name = "surge-test-unresolvable-env-interpreter";
         let app_path = active_app_dir.join("demo-script");
         std::fs::write(&app_path, format!("#!/usr/bin/env {interpreter_name}\n")).unwrap();
-        let active_entrypoint = active_entrypoint::Identity::resolve(&active_app_dir, "demo-script")
-            .unwrap()
-            .unwrap();
+        let active_entrypoint = active_entrypoint::Identity::resolve(&active_app_dir, "demo-script").unwrap();
         let interpreted_main = interpreted_main::resolve(&active_entrypoint.resolved).unwrap().unwrap();
         let process = AppProcess {
             exe: std::fs::canonicalize("/bin/sh").unwrap(),
@@ -934,9 +914,7 @@ mod tests {
         let app_path = active_app_dir.join("demo-script");
         let interpreter_name = "surge-test-unresolvable-env-interpreter";
         std::fs::write(&app_path, format!("#!/usr/bin/env {interpreter_name}\n")).unwrap();
-        let active_entrypoint = active_entrypoint::Identity::resolve(&active_app_dir, "demo-script")
-            .unwrap()
-            .unwrap();
+        let active_entrypoint = active_entrypoint::Identity::resolve(&active_app_dir, "demo-script").unwrap();
         let interpreted_main = interpreted_main::resolve(&active_entrypoint.resolved).unwrap().unwrap();
         let process = AppProcess {
             exe: std::fs::canonicalize("/bin/sh").unwrap(),
@@ -968,9 +946,7 @@ mod tests {
         std::fs::create_dir_all(&active_app_dir).unwrap();
         let app_path = active_app_dir.join("demo");
         symlink("/bin/sleep", &app_path).unwrap();
-        let active_entrypoint = active_entrypoint::Identity::resolve(&active_app_dir, "demo")
-            .unwrap()
-            .unwrap();
+        let active_entrypoint = active_entrypoint::Identity::resolve(&active_app_dir, "demo").unwrap();
         let mut command = vec![0];
         command.extend_from_slice(app_path.as_os_str().as_encoded_bytes());
         command.push(0);

--- a/crates/surge-core/src/update/manager/lifecycle/process_quiescence.rs
+++ b/crates/surge-core/src/update/manager/lifecycle/process_quiescence.rs
@@ -703,7 +703,7 @@ mod tests {
         let mut child = Command::new(&app_path).arg("30").spawn().unwrap();
         std::fs::remove_file(&app_path).unwrap();
 
-        let error = terminate_active_app_processes_except(&active_app_dir, "demo", u32::MAX).unwrap_err();
+        let error = terminate_active_app_processes_except(&active_app_dir, "demo", u32::MAX, false).unwrap_err();
         let child_still_running = child.try_wait().unwrap().is_none();
         if child_still_running {
             child.kill().unwrap();

--- a/crates/surge-core/src/update/manager/lifecycle/process_quiescence/active_entrypoint.rs
+++ b/crates/surge-core/src/update/manager/lifecycle/process_quiescence/active_entrypoint.rs
@@ -11,38 +11,30 @@ pub(super) struct Identity {
 }
 
 impl Identity {
-    pub(super) fn resolve(active_app_dir: &Path, main_exe: &str) -> Result<Option<Self>> {
+    pub(super) fn resolve(active_app_dir: &Path, main_exe: &str) -> Result<Self> {
         let configured_launch_path = std::path::absolute(active_app_dir.join(main_exe)).map_err(|e| {
             SurgeError::Platform(format!(
                 "Failed to resolve configured active application path before swap: {e}"
             ))
         })?;
-        let active_app_root = match std::fs::canonicalize(active_app_dir) {
-            Ok(path) => path,
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
-            Err(e) => {
-                return Err(SurgeError::Platform(format!(
-                    "Failed to resolve active application directory before swap: {e}"
-                )));
-            }
-        };
+        let active_app_root = std::fs::canonicalize(active_app_dir).map_err(|e| {
+            SurgeError::Platform(format!(
+                "Failed to resolve active application directory before swap: {e}"
+            ))
+        })?;
         let configured_path = active_app_root.join(main_exe);
-        let resolved = match std::fs::canonicalize(&configured_path) {
-            Ok(path) => path,
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
-            Err(e) => {
-                return Err(SurgeError::Platform(format!(
-                    "Failed to resolve active application executable before swap: {e}"
-                )));
-            }
-        };
+        let resolved = std::fs::canonicalize(&configured_path).map_err(|e| {
+            SurgeError::Platform(format!(
+                "Failed to resolve active application executable before swap: {e}"
+            ))
+        })?;
 
-        Ok(Some(Self {
+        Ok(Self {
             configured_launch_path,
             require_entrypoint_argument: configured_path != resolved,
             path: configured_path,
             resolved,
-        }))
+        })
     }
 
     pub(super) fn matches_executable(&self, executable: &Path) -> bool {
@@ -150,7 +142,7 @@ mod tests {
         std::fs::write(shared_dir.join("demo"), "fixture").unwrap();
         symlink(&shared_dir, active_app_dir.join("bin")).unwrap();
 
-        let identity = Identity::resolve(&active_app_dir, "bin/demo").unwrap().unwrap();
+        let identity = Identity::resolve(&active_app_dir, "bin/demo").unwrap();
 
         assert!(identity.requires_argument());
         assert!(
@@ -174,7 +166,7 @@ mod tests {
         std::fs::write(shared_dir.join("demo"), "fixture").unwrap();
         symlink("shared/demo", active_app_dir.join("demo")).unwrap();
 
-        let identity = Identity::resolve(&active_app_dir, "demo").unwrap().unwrap();
+        let identity = Identity::resolve(&active_app_dir, "demo").unwrap();
 
         assert!(identity.requires_argument());
         assert!(
@@ -200,7 +192,7 @@ mod tests {
         symlink("shared/demo", active_app_dir.join("demo")).unwrap();
         symlink(&active_app_dir, &active_app_alias).unwrap();
 
-        let identity = Identity::resolve(&active_app_alias, "demo").unwrap().unwrap();
+        let identity = Identity::resolve(&active_app_alias, "demo").unwrap();
 
         assert!(identity.requires_argument());
         assert!(

--- a/crates/surge-core/src/update/manager/lifecycle/process_quiescence/interpreted_main.rs
+++ b/crates/surge-core/src/update/manager/lifecycle/process_quiescence/interpreted_main.rs
@@ -244,7 +244,6 @@ fn parse_env_command(argument: &str) -> Result<EnvCommand> {
             "Active application env shebang with multiple arguments must use -S".to_string(),
         ));
     }
-
     let (command_index, search_path) = env_command_index(&words)?;
     Ok(EnvCommand {
         program: OsString::from(&words[command_index]),
@@ -497,7 +496,6 @@ mod tests {
         permissions.set_mode(0o755);
         std::fs::set_permissions(path, permissions).unwrap();
     }
-
     #[test]
     fn macos_direct_interpreter_arguments_are_counted_literally() {
         assert_eq!(

--- a/crates/surge-core/src/update/manager/lifecycle/process_quiescence/interpreted_main.rs
+++ b/crates/surge-core/src/update/manager/lifecycle/process_quiescence/interpreted_main.rs
@@ -496,6 +496,7 @@ mod tests {
         permissions.set_mode(0o755);
         std::fs::set_permissions(path, permissions).unwrap();
     }
+
     #[test]
     fn macos_direct_interpreter_arguments_are_counted_literally() {
         assert_eq!(

--- a/crates/surge-supervisor/src/main.rs
+++ b/crates/surge-supervisor/src/main.rs
@@ -599,19 +599,31 @@ mod tests {
         let exe_path_for_thread = exe_path.clone();
         let (tx, rx) = std::sync::mpsc::channel();
         let supervisor = std::thread::spawn(move || {
-            let result = run_supervisor(
-                "demo-supervisor",
-                &install_dir_for_thread,
-                &exe_path_for_thread,
-                &[
-                    "--app-mode".to_string(),
-                    "service".to_string(),
-                    "--surge-first-run".to_string(),
-                    "2.0.0".to_string(),
-                ],
-                None,
-                None,
-            );
+            let spawn_deadline = std::time::Instant::now() + std::time::Duration::from_secs(1);
+            let result = loop {
+                let result = run_supervisor(
+                    "demo-supervisor",
+                    &install_dir_for_thread,
+                    &exe_path_for_thread,
+                    &[
+                        "--app-mode".to_string(),
+                        "service".to_string(),
+                        "--surge-first-run".to_string(),
+                        "2.0.0".to_string(),
+                    ],
+                    None,
+                    None,
+                );
+                match &result {
+                    Err(SupervisorError::Io(error))
+                        if error.raw_os_error() == Some(nix::errno::Errno::ETXTBSY as i32)
+                            && std::time::Instant::now() < spawn_deadline =>
+                    {
+                        std::thread::sleep(std::time::Duration::from_millis(10));
+                    }
+                    _ => break result,
+                }
+            };
             tx.send(result).unwrap();
         });
 

--- a/crates/surge-supervisor/src/main.rs
+++ b/crates/surge-supervisor/src/main.rs
@@ -5,6 +5,8 @@ use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
 use clap::{Parser, Subcommand};
+#[cfg(unix)]
+use surge_core::supervisor::state::{clear_supervisor_takeover_pid, write_supervisor_takeover_pid};
 use surge_core::supervisor::state::{read_supervisor_exe_path, supervisor_pid_file, supervisor_stop_file};
 use thiserror::Error;
 
@@ -15,7 +17,7 @@ mod ownership;
 use child::{
     WaitOutcome, spawn_supervised_child, wait_before_restart, wait_for_pid_or_stop, wait_for_supervised_child,
 };
-#[cfg(all(test, unix))]
+#[cfg(unix)]
 use ownership::current_supervisor_owns_pid_file;
 use ownership::{remove_owned_supervisor_state, supervisor_was_superseded};
 
@@ -221,6 +223,8 @@ fn run_supervisor(
     let pid_file = supervisor_pid_file(install_dir, supervisor_id);
     let stop_file = supervisor_stop_file(install_dir, supervisor_id);
 
+    #[cfg(unix)]
+    clear_supervisor_takeover_pid(install_dir, supervisor_id);
     if stop_file.exists() {
         let _ = std::fs::remove_file(&stop_file);
     }
@@ -239,8 +243,16 @@ fn run_supervisor(
     let mut watched_pid = watched_pid;
 
     loop {
-        if shutdown.load(std::sync::atomic::Ordering::Acquire) || stop_file.exists() {
+        if shutdown.load(std::sync::atomic::Ordering::Acquire) {
             tracing::info!("Shutdown signal received, exiting supervisor loop");
+            break;
+        }
+        if stop_file.exists() {
+            #[cfg(unix)]
+            if let Some(pid) = watched_pid {
+                record_supervisor_takeover_pid_if_owned(install_dir, supervisor_id, &pid_file, own_pid, pid);
+            }
+            tracing::info!("Stop requested, exiting supervisor loop");
             break;
         }
 
@@ -258,6 +270,8 @@ fn run_supervisor(
                     tracing::info!("Observed process PID {pid} exited, starting replacement child");
                 }
                 WaitOutcome::StopRequested => {
+                    #[cfg(unix)]
+                    record_supervisor_takeover_pid_if_owned(install_dir, supervisor_id, &pid_file, own_pid, pid);
                     tracing::info!("Stop requested, exiting supervisor loop and leaving watched process running");
                     break;
                 }
@@ -278,6 +292,8 @@ fn run_supervisor(
 
         let child_args = next_child_args.take().unwrap_or_else(|| restart_args.clone());
         let mut child = spawn_supervised_child(exe_path, install_dir, &child_args)?;
+        #[cfg(unix)]
+        let child_pid = child.id();
 
         let Some(status) = wait_for_supervised_child(
             &mut child,
@@ -289,6 +305,10 @@ fn run_supervisor(
             &mut pending_handoff_version,
         )?
         else {
+            #[cfg(unix)]
+            if stop_file.exists() {
+                record_supervisor_takeover_pid_if_owned(install_dir, supervisor_id, &pid_file, own_pid, child_pid);
+            }
             break;
         };
 
@@ -322,6 +342,22 @@ fn run_supervisor(
 
     tracing::info!("Supervisor '{supervisor_id}' exiting");
     Ok(())
+}
+
+#[cfg(unix)]
+fn record_supervisor_takeover_pid_if_owned(
+    install_dir: &Path,
+    supervisor_id: &str,
+    supervisor_pid_file: &Path,
+    own_pid: u32,
+    child_pid: u32,
+) {
+    if !current_supervisor_owns_pid_file(supervisor_pid_file, own_pid) {
+        return;
+    }
+    if let Err(error) = write_supervisor_takeover_pid(install_dir, supervisor_id, child_pid) {
+        tracing::warn!(pid = child_pid, supervisor_id, %error, "Failed to persist child PID for supervisor takeover");
+    }
 }
 
 fn write_pid_file(path: &Path, own_pid: u32) -> Result<(), SupervisorError> {
@@ -640,6 +676,83 @@ mod tests {
 
         assert!(first_child_ran, "first child should have recorded its argv");
         assert_eq!(args.unwrap(), "--app-mode\nservice\n--surge-first-run\n2.0.0\n");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn stop_request_persists_running_child_pid_for_takeover() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = TestInstallDir::new("surge-supervisor-takeover-pid");
+        let install_dir = tmp.path();
+        let child_pid_path = install_dir.join("child.pid");
+        let exe_path = install_dir.join("target-child");
+        std::fs::write(
+            &exe_path,
+            format!("#!/bin/sh\necho $$ > '{}'\nexec sleep 30\n", child_pid_path.display()),
+        )
+        .unwrap();
+        let mut permissions = std::fs::metadata(&exe_path).unwrap().permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&exe_path, permissions).unwrap();
+
+        let install_dir_for_thread = install_dir.to_path_buf();
+        let exe_path_for_thread = exe_path.clone();
+        let (tx, rx) = std::sync::mpsc::channel();
+        let supervisor = std::thread::spawn(move || {
+            tx.send(run_supervisor(
+                "demo-supervisor",
+                &install_dir_for_thread,
+                &exe_path_for_thread,
+                &[],
+                None,
+                None,
+            ))
+            .unwrap();
+        });
+
+        assert!(
+            wait_until(std::time::Duration::from_secs(5), || child_pid_path.is_file()),
+            "supervised child did not start"
+        );
+        let child_pid = std::fs::read_to_string(&child_pid_path)
+            .unwrap()
+            .trim()
+            .parse::<u32>()
+            .unwrap();
+        std::fs::write(supervisor_stop_file(install_dir, "demo-supervisor"), "surge-update").unwrap();
+
+        let supervisor_result = rx.recv_timeout(std::time::Duration::from_secs(5));
+        supervisor.join().unwrap();
+        let takeover_pid = surge_core::supervisor::state::take_supervisor_takeover_pid(install_dir, "demo-supervisor");
+        let _ = nix::sys::signal::kill(
+            nix::unistd::Pid::from_raw(i32::try_from(child_pid).unwrap()),
+            nix::sys::signal::Signal::SIGKILL,
+        );
+
+        supervisor_result
+            .expect("supervisor did not exit after stop file")
+            .unwrap();
+        assert_eq!(takeover_pid, Some(child_pid));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn superseded_supervisor_does_not_persist_takeover_pid() {
+        let tmp = TestInstallDir::new("surge-supervisor-superseded-takeover");
+        let install_dir = tmp.path();
+        let supervisor_id = "demo-supervisor";
+        let pid_file = supervisor_pid_file(install_dir, supervisor_id);
+        let own_pid = std::process::id();
+        let replacement_pid = if own_pid == 1 { 2 } else { 1 };
+
+        std::fs::write(&pid_file, replacement_pid.to_string()).unwrap();
+        record_supervisor_takeover_pid_if_owned(install_dir, supervisor_id, &pid_file, own_pid, 4242);
+
+        assert_eq!(
+            surge_core::supervisor::state::take_supervisor_takeover_pid(install_dir, supervisor_id),
+            None
+        );
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
## Summary

- route pre-swap quiescence failures through structured finalize recovery
- restore previous application supervision after pre-swap and previous-swap failures
- preserve supervisor handoff state instead of losing the surviving child on recovery

## Why

Failing closed is safe only if an interrupted update also restores supervision. A quiescence error must not leave the prior application running without its supervisor.

This is stack 2 of 16.

- Base: #258
- Next: #260

Relates to fintermobilityas/youpark#1310.

## Validation

- exact layer `2db6745` passed quiescence-failure and supervision-restoration regressions, rustfmt, blocking Clippy, and maintainability
- complete stack `c48f19f` passed 681 Rust workspace tests, both blocking Clippy tiers, vendor/version/format/maintainability checks, .NET formatting, and all 58 .NET tests

No migration is required.
