### PR TITLE
Preserve supervision across finalize failures

### DIFF
--- a/crates/surge-core/src/update/manager.rs
+++ b/crates/surge-core/src/update/manager.rs
@@ -6,6 +6,8 @@ mod current_install;
 mod finalize;
 #[cfg(unix)]
 mod finalize_quiescence;
+#[cfg(unix)]
+mod finalize_recovery;
 mod lifecycle;
 mod progress;
 mod progress_substep;
@@ -26,7 +28,7 @@ use crate::update::status::{self, FailureContext, UpdateStatusRecord, UpdateWork
 
 use self::apply::materialize_update_payload;
 use self::artifacts::prepare_update_artifacts;
-use self::finalize::finalize_update;
+use self::finalize::{FinalizeFailure, finalize_update};
 use self::lifecycle::SupervisorRestartOutcome;
 pub use self::progress::ProgressInfo;
 use self::progress::emit_progress;
@@ -77,6 +79,37 @@ pub struct UpdateCheckState {
 const DEFAULT_RELEASE_RETENTION_LIMIT: usize = 1;
 pub(super) const RELEASE_GRAPH_CHECKPOINT_FULLS: usize = 3;
 const ABANDONED_IN_PROGRESS_TIMEOUT: Duration = Duration::from_mins(5);
+
+#[derive(Debug)]
+struct UpdateAttemptFailure {
+    error: SurgeError,
+    installed_version: Option<String>,
+}
+
+impl From<SurgeError> for UpdateAttemptFailure {
+    fn from(error: SurgeError) -> Self {
+        Self {
+            error,
+            installed_version: None,
+        }
+    }
+}
+
+impl From<std::io::Error> for UpdateAttemptFailure {
+    fn from(error: std::io::Error) -> Self {
+        SurgeError::from(error).into()
+    }
+}
+
+impl From<FinalizeFailure> for UpdateAttemptFailure {
+    fn from(failure: FinalizeFailure) -> Self {
+        let (error, installed_version) = failure.into_parts();
+        Self {
+            error,
+            installed_version,
+        }
+    }
+}
 
 fn bind_install_dir(install_dir: &str) -> Result<PathBuf> {
     let absolute = std::path::absolute(install_dir)?;
@@ -410,20 +443,25 @@ impl UpdateManager {
                 }
                 Ok(())
             }
-            Err(e) => {
+            Err(failure) => {
+                let UpdateAttemptFailure {
+                    error,
+                    installed_version,
+                } = failure;
                 let status_context = status::read_update_status(&self.install_dir).ok().flatten();
+                let installed_version = installed_version.as_deref().unwrap_or(&pre_attempt_version);
                 let mut record = UpdateStatusRecord::failed_with_context(
                     &self.app_id,
-                    &pre_attempt_version,
+                    installed_version,
                     &target_version,
                     &self.channel,
                     attempted_at_utc,
-                    &e.to_string(),
+                    &error.to_string(),
                     FailureContext::from_record(status_context.as_ref(), true),
                 );
                 // A user-initiated cancellation is not a failure to back off
                 // from; the next attempt may start immediately.
-                if !matches!(e, SurgeError::Cancelled) {
+                if !matches!(error, SurgeError::Cancelled) {
                     let schedule = status::retry_schedule(previous_attempt_status.as_ref(), &target_version);
                     record = record
                         .with_retry_schedule_at(&schedule, status::next_retry_timestamp(chrono::Utc::now(), &schedule));
@@ -431,7 +469,7 @@ impl UpdateManager {
                 if let Err(write_err) = status::write_update_status(&self.install_dir, &record) {
                     warn!(error = %write_err, "Failed to persist failed-update status (continuing)");
                 }
-                Err(e)
+                Err(error)
             }
         }
     }
@@ -441,7 +479,7 @@ impl UpdateManager {
         info: &UpdateInfo,
         progress: Option<Arc<F>>,
         in_progress_template: UpdateStatusRecord,
-    ) -> Result<SupervisorRestartOutcome>
+    ) -> std::result::Result<SupervisorRestartOutcome, UpdateAttemptFailure>
     where
         F: Fn(ProgressInfo) + Send + Sync,
     {
@@ -464,7 +502,7 @@ impl UpdateManager {
         progress_emitter.emit_substep(1, update_phase::RELEASE_RESOLVED, 1);
 
         if info.apply_releases.is_empty() {
-            return Err(SurgeError::Update("No releases to apply".to_string()));
+            return Err(SurgeError::Update("No releases to apply".to_string()).into());
         }
 
         let staging_dir = self.install_dir.join(".surge-staging");

--- a/crates/surge-core/src/update/manager/finalize.rs
+++ b/crates/surge-core/src/update/manager/finalize.rs
@@ -42,6 +42,41 @@ use super::{RELEASE_GRAPH_CHECKPOINT_FULLS, SupervisorRestartOutcome, UpdateInfo
 /// backend must not stall the rest of finalize indefinitely.
 const PRUNE_INDEX_FETCH_TIMEOUT: Duration = Duration::from_secs(30);
 
+#[derive(Debug)]
+pub(super) struct FinalizeFailure {
+    error: SurgeError,
+    active_version: Option<String>,
+}
+
+impl FinalizeFailure {
+    #[cfg(unix)]
+    fn with_active_target(error: SurgeError, version: &str) -> Self {
+        Self {
+            error,
+            active_version: Some(version.to_string()),
+        }
+    }
+
+    pub(super) fn into_parts(self) -> (SurgeError, Option<String>) {
+        (self.error, self.active_version)
+    }
+}
+
+impl From<SurgeError> for FinalizeFailure {
+    fn from(error: SurgeError) -> Self {
+        Self {
+            error,
+            active_version: None,
+        }
+    }
+}
+
+impl From<std::io::Error> for FinalizeFailure {
+    fn from(error: std::io::Error) -> Self {
+        SurgeError::from(error).into()
+    }
+}
+
 #[cfg(unix)]
 const PREVIOUS_SWAP_QUARANTINE_DIR: &str = ".surge-app-prev-quiescing";
 
@@ -82,7 +117,7 @@ pub(super) async fn finalize_update<F>(
     staging_dir: &Path,
     artifact_cache_dir: &Path,
     progress_emitter: &PhaseProgressEmitter<'_, F>,
-) -> Result<SupervisorRestartOutcome>
+) -> std::result::Result<SupervisorRestartOutcome, FinalizeFailure>
 where
     F: Fn(ProgressInfo) + Send + Sync,
 {
@@ -121,7 +156,8 @@ where
         return Err(SurgeError::Update(
             "Installed application directory disappeared after the update check; refusing to swap the active application"
                 .to_string(),
-        ));
+        )
+        .into());
     }
     #[cfg(unix)]
     let (current_version, current_main_exe, current_supervisor_id, current_environment) = if current_app_dir.is_some() {
@@ -130,7 +166,8 @@ where
             return Err(SurgeError::Update(
                 "Installed application identity changed after the update check; refusing to swap the active application"
                     .to_string(),
-            ));
+            )
+            .into());
         }
         let current = manager.current_release_identity.as_ref().ok_or_else(|| {
             SurgeError::Update(format!(
@@ -250,7 +287,8 @@ where
                 supervisor_requires_restoration,
                 supervised_child_pid,
                 error,
-            ));
+            )
+            .into());
         }
         if let Err(error) = tokio::fs::remove_dir_all(&previous_swap_quarantine_dir).await {
             let error =
@@ -265,7 +303,8 @@ where
                 supervisor_requires_restoration,
                 supervised_child_pid,
                 error,
-            ));
+            )
+            .into());
         }
     }
     #[cfg(not(unix))]
@@ -273,118 +312,126 @@ where
         tokio::fs::remove_dir_all(&previous_swap_dir).await?;
     }
 
-    progress_emitter.emit_substep(6, finalize_phase::SWAPPING_APP_DIRECTORY, 93);
-    atomic_rename(extracted_final_dir, &next_app_dir)?;
-
-    if active_app_was_present {
-        atomic_rename(&active_app_dir, &previous_swap_dir)?;
-        #[cfg(unix)]
-        if let Err(error) = (|| {
-            if let Some(current_quiescence) = &current_quiescence {
-                lifecycle::terminate_prepared_app_processes(current_quiescence)?;
-            }
-            lifecycle::terminate_superseded_app_processes(&manager.install_dir, &active_app_dir, current_main_exe)?;
-            Ok::<(), SurgeError>(())
-        })() {
-            let _ = atomic_rename(&previous_swap_dir, &active_app_dir);
-            return Err(restore_previous_supervisor_after_quiescence_failure(
-                &manager.install_dir,
-                Some(&active_app_dir),
-                current_version,
-                current_main_exe,
-                current_supervisor_id,
-                current_environment,
-                supervisor_requires_restoration,
-                supervised_child_pid,
-                error,
-            ));
-        }
-    }
     #[cfg(unix)]
-    if !active_app_was_present
-        && let Err(error) = (|| {
-            if let Some(current_quiescence) = &current_quiescence {
-                lifecycle::terminate_prepared_app_processes(current_quiescence)?;
+    let mut finalize_recovery = super::finalize_recovery::Guard::new(
+        &manager.install_dir,
+        current_app_dir,
+        &active_app_dir,
+        &next_app_dir,
+        &previous_swap_dir,
+        current_version,
+        current_main_exe,
+        current_supervisor_id,
+        current_environment,
+        latest,
+    );
+
+    let swap_result: Result<SupervisorRestartOutcome> = (|| {
+        progress_emitter.emit_substep(6, finalize_phase::SWAPPING_APP_DIRECTORY, 93);
+        atomic_rename(extracted_final_dir, &next_app_dir)?;
+        #[cfg(unix)]
+        finalize_recovery.mark_target_staged();
+
+        if active_app_was_present {
+            atomic_rename(&active_app_dir, &previous_swap_dir)?;
+            #[cfg(unix)]
+            finalize_recovery.mark_previous_moved();
+            #[cfg(unix)]
+            (|| {
+                if let Some(current_quiescence) = &current_quiescence {
+                    lifecycle::terminate_prepared_app_processes(current_quiescence)?;
+                }
+                lifecycle::terminate_superseded_app_processes(&manager.install_dir, &active_app_dir, current_main_exe)?;
+                Ok::<(), SurgeError>(())
+            })()?;
+        }
+        #[cfg(unix)]
+        if !active_app_was_present {
+            (|| {
+                if let Some(current_quiescence) = &current_quiescence {
+                    lifecycle::terminate_prepared_app_processes(current_quiescence)?;
+                }
+                lifecycle::terminate_superseded_app_processes(&manager.install_dir, &active_app_dir, current_main_exe)?;
+                Ok::<(), SurgeError>(())
+            })()?;
+        }
+        atomic_rename(&next_app_dir, &active_app_dir)?;
+        #[cfg(unix)]
+        finalize_recovery.mark_target_active();
+
+        let previous_app_dir_for_assets = if previous_swap_dir.is_dir() {
+            Some(previous_swap_dir.as_path())
+        } else {
+            fallback_previous_app_dir.as_deref()
+        };
+
+        if !latest.persistent_assets.is_empty() && previous_app_dir_for_assets.is_some() {
+            progress_emitter.emit_substep(6, finalize_phase::COPYING_PERSISTENT_ASSETS, 94);
+            if let Some(previous) = previous_app_dir_for_assets {
+                copy_persistent_assets(previous, &active_app_dir, &latest.persistent_assets)?;
             }
-            lifecycle::terminate_superseded_app_processes(&manager.install_dir, &active_app_dir, current_main_exe)?;
-            Ok::<(), SurgeError>(())
-        })()
-    {
-        return Err(restore_previous_supervisor_after_quiescence_failure(
-            &manager.install_dir,
-            current_app_dir,
-            current_version,
-            current_main_exe,
-            current_supervisor_id,
-            current_environment,
-            supervisor_requires_restoration,
-            supervised_child_pid,
-            error,
-        ));
-    }
-    if let Err(err) = atomic_rename(&next_app_dir, &active_app_dir) {
-        // Best effort rollback to previous active content.
-        if previous_swap_dir.is_dir() && !active_app_dir.exists() {
-            let _ = atomic_rename(&previous_swap_dir, &active_app_dir);
+        } else if !latest.persistent_assets.is_empty() {
+            debug!(
+                version = %latest.version,
+                "No previous app directory found; skipping persistent asset carry-over"
+            );
         }
-        return Err(err);
-    }
 
-    let previous_app_dir_for_assets = if previous_swap_dir.is_dir() {
-        Some(previous_swap_dir.as_path())
-    } else {
-        fallback_previous_app_dir.as_deref()
-    };
-
-    if !latest.persistent_assets.is_empty() && previous_app_dir_for_assets.is_some() {
-        progress_emitter.emit_substep(6, finalize_phase::COPYING_PERSISTENT_ASSETS, 94);
-        if let Some(previous) = previous_app_dir_for_assets {
-            copy_persistent_assets(previous, &active_app_dir, &latest.persistent_assets)?;
-        }
-    } else if !latest.persistent_assets.is_empty() {
-        debug!(
-            version = %latest.version,
-            "No previous app directory found; skipping persistent asset carry-over"
+        progress_emitter.emit_substep(6, finalize_phase::WRITING_RUNTIME_MANIFEST, 95);
+        let storage_cfg = manager.ctx.storage_config();
+        let runtime_manifest_profile = InstallProfile::new(
+            &manager.app_id,
+            latest.display_name(&manager.app_id),
+            &latest.main_exe,
+            &latest.install_directory,
+            &latest.supervisor_id,
+            &latest.icon,
+            &latest.shortcuts,
+            &latest.persistent_assets,
+            &latest.environment,
         );
-    }
+        let runtime_manifest_metadata = RuntimeManifestMetadata::new(
+            &latest.version,
+            &manager.channel,
+            storage_provider_manifest_name(storage_cfg.provider),
+            &storage_cfg.bucket,
+            &storage_cfg.region,
+            &storage_cfg.endpoint,
+        );
+        write_runtime_manifest(&active_app_dir, &runtime_manifest_profile, &runtime_manifest_metadata)?;
 
-    progress_emitter.emit_substep(6, finalize_phase::WRITING_RUNTIME_MANIFEST, 95);
-    let storage_cfg = manager.ctx.storage_config();
-    let runtime_manifest_profile = InstallProfile::new(
-        &manager.app_id,
-        latest.display_name(&manager.app_id),
-        &latest.main_exe,
-        &latest.install_directory,
-        &latest.supervisor_id,
-        &latest.icon,
-        &latest.shortcuts,
-        &latest.persistent_assets,
-        &latest.environment,
-    );
-    let runtime_manifest_metadata = RuntimeManifestMetadata::new(
-        &latest.version,
-        &manager.channel,
-        storage_provider_manifest_name(storage_cfg.provider),
-        &storage_cfg.bucket,
-        &storage_cfg.region,
-        &storage_cfg.endpoint,
-    );
-    write_runtime_manifest(&active_app_dir, &runtime_manifest_profile, &runtime_manifest_metadata)?;
+        // Start the replacement watch-supervisor as soon as the swapped app is
+        // usable (directory swapped, persistent assets carried over, runtime
+        // manifest written), before the best-effort shortcut/prune/hook steps that
+        // can block for many seconds. This shrinks the window in which no
+        // supervisor is watching the app. The start no longer depends on a
+        // supervisor having been running before the update: if the release
+        // configures supervision, a fresh watch supervisor is always started so a
+        // supervisor that died before the update is recovered here.
+        let restart_outcome = if latest.supervisor_id.trim().is_empty() {
+            SupervisorRestartOutcome::NotApplicable
+        } else {
+            progress_emitter.emit_substep(6, finalize_phase::RESTARTING_SUPERVISOR, 96);
+            lifecycle::restart_supervisor_after_update(&manager.install_dir, &active_app_dir, latest)
+        };
+        Ok(restart_outcome)
+    })();
 
-    // Start the replacement watch-supervisor as soon as the swapped app is
-    // usable (directory swapped, persistent assets carried over, runtime
-    // manifest written), before the best-effort shortcut/prune/hook steps that
-    // can block for many seconds. This shrinks the window in which no
-    // supervisor is watching the app. The start no longer depends on a
-    // supervisor having been running before the update: if the release
-    // configures supervision, a fresh watch supervisor is always started so a
-    // supervisor that died before the update is recovered here.
-    let restart_outcome = if latest.supervisor_id.trim().is_empty() {
-        SupervisorRestartOutcome::NotApplicable
-    } else {
-        progress_emitter.emit_substep(6, finalize_phase::RESTARTING_SUPERVISOR, 96);
-        lifecycle::restart_supervisor_after_update(&manager.install_dir, &active_app_dir, latest)
+    #[cfg(unix)]
+    let restart_outcome = match swap_result {
+        Ok(restart_outcome) => {
+            finalize_recovery.complete_supervisor_restart();
+            restart_outcome
+        }
+        Err(error) => match finalize_recovery.recover() {
+            Some(super::finalize_recovery::RecoveredGeneration::Target) => {
+                return Err(FinalizeFailure::with_active_target(error, &latest.version));
+            }
+            Some(super::finalize_recovery::RecoveredGeneration::Previous) | None => return Err(error.into()),
+        },
     };
+    #[cfg(not(unix))]
+    let restart_outcome = swap_result?;
 
     if !latest.shortcuts.is_empty() {
         progress_emitter.emit_substep(6, finalize_phase::INSTALLING_SHORTCUTS, 97);
@@ -459,9 +506,18 @@ where
         )
         .await
         {
-            Ok(Ok(data)) => Some(decompress_release_index(&data)?),
+            Ok(Ok(data)) => match decompress_release_index(&data) {
+                Ok(index) => Some(index),
+                Err(error) => {
+                    warn!(%error, "Failed to decode release index for artifact pruning; skipping prune step");
+                    None
+                }
+            },
             Ok(Err(SurgeError::NotFound(_))) => None,
-            Ok(Err(e)) => return Err(e),
+            Ok(Err(error)) => {
+                warn!(%error, "Failed to fetch release index for artifact pruning; skipping prune step");
+                None
+            }
             Err(_) => {
                 warn!(
                     timeout_secs = PRUNE_INDEX_FETCH_TIMEOUT.as_secs(),
@@ -509,7 +565,9 @@ where
                 "Terminated stale app processes from superseded install directories"
             );
         }
-        Err(e) => return Err(e),
+        Err(error) => {
+            warn!(%error, "Failed to finish superseded application cleanup after the target became active");
+        }
     }
 
     emit_progress(

--- a/crates/surge-core/src/update/manager/finalize_quiescence.rs
+++ b/crates/surge-core/src/update/manager/finalize_quiescence.rs
@@ -86,16 +86,35 @@ pub(super) async fn prepare_and_quiesce_previous_swap_before_reuse(
     supervisor_requires_restoration: bool,
     supervised_child_pid: Option<u32>,
 ) -> Result<Option<(lifecycle::PreparedAppQuiescence, String)>> {
-    let result: Result<Option<(lifecycle::PreparedAppQuiescence, String)>> = async {
-        let previous_swap_identity = super::current_install::load_previous_swap(manager, previous_swap_dir)?
-            .ok_or_else(|| {
-                SurgeError::Update(
-                    "Previous swap directory has no persisted process identity; refusing to delete or reuse it"
-                        .to_string(),
-                )
-            })?;
-        let _ =
-            lifecycle::request_supervisor_shutdown(&manager.install_dir, &previous_swap_identity.supervisor_id).await?;
+    let restore_current = |error| {
+        restore_previous_supervisor_after_quiescence_failure(
+            &manager.install_dir,
+            current_app_dir,
+            current_version,
+            current_main_exe,
+            current_supervisor_id,
+            current_environment,
+            supervisor_requires_restoration,
+            supervised_child_pid,
+            error,
+        )
+    };
+    let previous_swap_identity = match super::current_install::load_previous_swap(manager, previous_swap_dir) {
+        Ok(Some(identity)) => identity,
+        Ok(None) => {
+            return Err(restore_current(SurgeError::Update(
+                "Previous swap directory has no persisted process identity; refusing to delete or reuse it".to_string(),
+            )));
+        }
+        Err(error) => return Err(restore_current(error)),
+    };
+    let previous_supervised_child_pid =
+        match lifecycle::request_supervisor_shutdown(&manager.install_dir, &previous_swap_identity.supervisor_id).await
+        {
+            Ok(pid) => pid,
+            Err(error) => return Err(restore_current(error)),
+        };
+    let result = (|| {
         let prepared = lifecycle::prepare_app_quiescence(
             previous_swap_dir,
             &previous_swap_identity.main_exe,
@@ -107,24 +126,33 @@ pub(super) async fn prepare_and_quiesce_previous_swap_before_reuse(
             )
         })?;
         lifecycle::terminate_prepared_app_processes(&prepared)?;
-        Ok(Some((prepared, previous_swap_identity.main_exe)))
-    }
-    .await;
+        Ok::<_, SurgeError>(prepared)
+    })();
 
-    let Err(error) = result else {
-        return result;
-    };
-    Err(restore_previous_supervisor_after_quiescence_failure(
-        &manager.install_dir,
-        current_app_dir,
-        current_version,
-        current_main_exe,
-        current_supervisor_id,
-        current_environment,
-        supervisor_requires_restoration,
-        supervised_child_pid,
-        error,
-    ))
+    match result {
+        Ok(prepared) => Ok(Some((prepared, previous_swap_identity.main_exe))),
+        Err(error) => {
+            if previous_supervised_child_pid.is_some()
+                && (!supervisor_requires_restoration || previous_swap_identity.supervisor_id != current_supervisor_id)
+            {
+                request_previous_supervisor_restoration(
+                    &manager.install_dir,
+                    previous_swap_dir,
+                    &previous_swap_identity.version,
+                    &previous_swap_identity.main_exe,
+                    &previous_swap_identity.supervisor_id,
+                    &previous_swap_identity.environment,
+                    previous_supervised_child_pid,
+                );
+            } else if previous_supervised_child_pid.is_some() {
+                warn!(
+                    supervisor_id = current_supervisor_id,
+                    "Cannot restore both current and previous-swap children through the same supervisor identity"
+                );
+            }
+            Err(restore_current(error))
+        }
+    }
 }
 
 fn request_previous_supervisor_restoration(
@@ -175,7 +203,7 @@ mod tests {
     use std::process::{Command, Stdio};
     use std::time::Duration;
 
-    use crate::supervisor::state::supervisor_pid_file;
+    use crate::supervisor::state::{supervisor_pid_file, write_supervisor_takeover_pid};
 
     use super::*;
 
@@ -312,6 +340,100 @@ mod tests {
                 .unwrap()
                 .trim(),
             "4242"
+        );
+    }
+
+    #[tokio::test]
+    async fn previous_swap_quiescence_failure_restores_its_supervisor_handoff() {
+        let tmp = tempfile::tempdir().unwrap();
+        let install_dir = tmp.path().join("install");
+        let store_dir = tmp.path().join("store");
+        let previous_swap_dir = install_dir.join(".surge-app-prev");
+        std::fs::create_dir_all(previous_swap_dir.join(".surge")).unwrap();
+        std::fs::create_dir_all(&store_dir).unwrap();
+
+        let app_path = previous_swap_dir.join("cwd-changing-demo-script");
+        std::fs::write(&app_path, "#!/bin/sh\ncd /\nread _\n").unwrap();
+        make_executable(&app_path);
+        write_test_supervisor(&previous_swap_dir);
+        std::fs::write(
+            previous_swap_dir.join(crate::install::RUNTIME_MANIFEST_RELATIVE_PATH),
+            "id: test-app\nversion: 0.9.0\nmainExe: cwd-changing-demo-script\nsupervisorId: previous-supervisor\nenvironment:\n  SURGE_TEST_MODE: previous-preserved\n",
+        )
+        .unwrap();
+
+        let spawn_deadline = std::time::Instant::now() + Duration::from_secs(1);
+        let mut child = loop {
+            match Command::new("./cwd-changing-demo-script")
+                .current_dir(&previous_swap_dir)
+                .stdin(Stdio::piped())
+                .spawn()
+            {
+                Ok(child) => break child,
+                Err(error)
+                    if error.raw_os_error() == Some(nix::errno::Errno::ETXTBSY as i32)
+                        && std::time::Instant::now() < spawn_deadline =>
+                {
+                    std::thread::sleep(Duration::from_millis(10));
+                }
+                Err(error) => panic!("failed to launch previous-swap fixture: {error}"),
+            }
+        };
+        let cwd_path = PathBuf::from(format!("/proc/{}/cwd", child.id()));
+        let deadline = std::time::Instant::now() + Duration::from_secs(2);
+        while std::fs::read_link(&cwd_path).ok().as_deref() != Some(Path::new("/")) {
+            assert!(std::time::Instant::now() < deadline, "test child did not change cwd");
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        write_supervisor_takeover_pid(&install_dir, "previous-supervisor", child.id()).unwrap();
+
+        let ctx = std::sync::Arc::new(crate::context::Context::new());
+        ctx.set_storage(
+            crate::context::StorageProvider::Filesystem,
+            store_dir.to_str().unwrap(),
+            "",
+            "",
+            "",
+            "",
+        );
+        let manager = UpdateManager::new(ctx, "test-app", "1.0.0", "stable", install_dir.to_str().unwrap()).unwrap();
+
+        let child_pid = child.id();
+        let result = prepare_and_quiesce_previous_swap_before_reuse(
+            &manager,
+            &previous_swap_dir,
+            None,
+            "",
+            "",
+            "",
+            None,
+            false,
+            None,
+        )
+        .await;
+        let child_still_running = child.try_wait().unwrap().is_none();
+        if child_still_running {
+            child.kill().unwrap();
+        }
+        let _ = child.wait();
+
+        let error = result.err().unwrap();
+        assert!(error.to_string().contains("process identity is ambiguous"));
+        assert!(child_still_running);
+        assert!(supervisor_pid_file(&install_dir, "previous-supervisor").is_file());
+        assert_eq!(
+            crate::supervisor::state::read_supervisor_exe_path(&install_dir, "previous-supervisor").as_deref(),
+            Some(app_path.as_path())
+        );
+        assert_eq!(
+            std::fs::read_to_string(install_dir.join("restored-environment")).unwrap(),
+            "previous-preserved"
+        );
+        assert_eq!(
+            std::fs::read_to_string(install_dir.join("restored-watched.pid"))
+                .unwrap()
+                .trim(),
+            child_pid.to_string()
         );
     }
 

--- a/crates/surge-core/src/update/manager/finalize_recovery.rs
+++ b/crates/surge-core/src/update/manager/finalize_recovery.rs
@@ -1,0 +1,446 @@
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use tracing::warn;
+
+use crate::platform::fs::atomic_rename;
+use crate::releases::manifest::ReleaseEntry;
+
+use super::lifecycle::{self, SupervisorRestartOutcome};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum RecoveredGeneration {
+    Previous,
+    Target,
+}
+
+pub(super) struct Guard {
+    install_dir: PathBuf,
+    current_app_dir: Option<PathBuf>,
+    active_app_dir: PathBuf,
+    next_app_dir: PathBuf,
+    previous_swap_dir: PathBuf,
+    previous: ReleaseEntry,
+    target: ReleaseEntry,
+    previous_moved: bool,
+    target_staged: bool,
+    target_active: bool,
+    armed: bool,
+}
+
+impl Guard {
+    #[allow(clippy::too_many_arguments)]
+    pub(super) fn new(
+        install_dir: &Path,
+        current_app_dir: Option<&Path>,
+        active_app_dir: &Path,
+        next_app_dir: &Path,
+        previous_swap_dir: &Path,
+        current_version: &str,
+        current_main_exe: &str,
+        current_supervisor_id: &str,
+        current_environment: Option<&BTreeMap<String, String>>,
+        target: &ReleaseEntry,
+    ) -> Self {
+        Self {
+            install_dir: install_dir.to_path_buf(),
+            current_app_dir: current_app_dir.map(Path::to_path_buf),
+            active_app_dir: active_app_dir.to_path_buf(),
+            next_app_dir: next_app_dir.to_path_buf(),
+            previous_swap_dir: previous_swap_dir.to_path_buf(),
+            previous: ReleaseEntry {
+                version: current_version.to_string(),
+                main_exe: current_main_exe.to_string(),
+                supervisor_id: current_supervisor_id.to_string(),
+                environment: current_environment.cloned().unwrap_or_default(),
+                ..ReleaseEntry::default()
+            },
+            target: target.clone(),
+            previous_moved: false,
+            target_staged: false,
+            target_active: false,
+            armed: true,
+        }
+    }
+
+    pub(super) fn mark_target_staged(&mut self) {
+        self.target_staged = true;
+    }
+
+    pub(super) fn mark_previous_moved(&mut self) {
+        self.previous_moved = true;
+    }
+
+    pub(super) fn mark_target_active(&mut self) {
+        self.target_staged = false;
+        self.target_active = true;
+    }
+
+    pub(super) fn complete_supervisor_restart(&mut self) {
+        self.armed = false;
+    }
+
+    pub(super) fn recover(&mut self) -> Option<RecoveredGeneration> {
+        if !self.armed {
+            return None;
+        }
+        self.armed = false;
+
+        warn!("Finalize failed after application quiescence; recovering application supervision");
+        let Some(start) = self.recovery_start() else {
+            warn!("Finalize recovery could not find a usable previous or target application directory");
+            return None;
+        };
+        let release = match start.generation {
+            RecoveredGeneration::Previous => &self.previous,
+            RecoveredGeneration::Target => &self.target,
+        };
+        let supervisor_outcome = lifecycle::restart_supervisor_immediately(&self.install_dir, &start.app_dir, release);
+        match &supervisor_outcome {
+            SupervisorRestartOutcome::NotApplicable => {
+                warn!(app = %start.app_dir.display(), "Finalize recovery has no configured supervisor to restart");
+            }
+            SupervisorRestartOutcome::PendingRestart { reason, failure_phase } => {
+                warn!(
+                    app = %start.app_dir.display(),
+                    target = matches!(start.generation, RecoveredGeneration::Target),
+                    reason,
+                    failure_phase,
+                    "Finalize recovery requested application supervision"
+                );
+            }
+        }
+        Some(start.generation)
+    }
+
+    fn recovery_start(&mut self) -> Option<RecoveryStart> {
+        if self.target_active && self.active_app_dir.is_dir() && !self.move_target_aside() {
+            return Some(RecoveryStart::target(self.active_app_dir.clone()));
+        }
+
+        if self.previous_moved && self.previous_swap_dir.is_dir() {
+            if !self.active_app_dir.exists() {
+                match atomic_rename(&self.previous_swap_dir, &self.active_app_dir) {
+                    Ok(()) => return Some(RecoveryStart::previous(self.active_app_dir.clone())),
+                    Err(error) => {
+                        warn!(
+                            previous = %self.previous_swap_dir.display(),
+                            active = %self.active_app_dir.display(),
+                            %error,
+                            "Failed to restore the previous application directory after finalize failed"
+                        );
+                        if let Some(target) = self.restore_target_to_canonical_path() {
+                            return Some(target);
+                        }
+                    }
+                }
+            }
+            return Some(RecoveryStart::previous(self.previous_swap_dir.clone()));
+        }
+
+        if let Some(current_app_dir) = &self.current_app_dir
+            && current_app_dir.is_dir()
+        {
+            return Some(RecoveryStart::previous(current_app_dir.clone()));
+        }
+
+        if self.target_staged || self.next_app_dir.is_dir() {
+            return self.restore_target_to_canonical_path().or_else(|| {
+                self.next_app_dir
+                    .is_dir()
+                    .then(|| RecoveryStart::target(self.next_app_dir.clone()))
+            });
+        }
+
+        if self.target_active && self.active_app_dir.is_dir() {
+            return Some(RecoveryStart::target(self.active_app_dir.clone()));
+        }
+        None
+    }
+
+    fn move_target_aside(&mut self) -> bool {
+        if self.next_app_dir.exists() {
+            warn!(
+                target = %self.active_app_dir.display(),
+                next = %self.next_app_dir.display(),
+                "Cannot move the failed target application aside because the next directory already exists"
+            );
+            return false;
+        }
+        match atomic_rename(&self.active_app_dir, &self.next_app_dir) {
+            Ok(()) => {
+                self.target_active = false;
+                self.target_staged = true;
+                true
+            }
+            Err(error) => {
+                warn!(
+                    target = %self.active_app_dir.display(),
+                    next = %self.next_app_dir.display(),
+                    %error,
+                    "Failed to move the target application aside during finalize recovery"
+                );
+                false
+            }
+        }
+    }
+
+    fn restore_target_to_canonical_path(&mut self) -> Option<RecoveryStart> {
+        if self.active_app_dir.is_dir() {
+            return self
+                .target_active
+                .then(|| RecoveryStart::target(self.active_app_dir.clone()));
+        }
+        if !self.next_app_dir.is_dir() {
+            return None;
+        }
+        match atomic_rename(&self.next_app_dir, &self.active_app_dir) {
+            Ok(()) => {
+                self.target_staged = false;
+                self.target_active = true;
+                Some(RecoveryStart::target(self.active_app_dir.clone()))
+            }
+            Err(error) => {
+                warn!(
+                    target = %self.next_app_dir.display(),
+                    active = %self.active_app_dir.display(),
+                    %error,
+                    "Failed to restore the target application to the canonical directory during finalize recovery"
+                );
+                None
+            }
+        }
+    }
+}
+
+impl Drop for Guard {
+    fn drop(&mut self) {
+        let _ = self.recover();
+    }
+}
+
+struct RecoveryStart {
+    app_dir: PathBuf,
+    generation: RecoveredGeneration,
+}
+
+impl RecoveryStart {
+    fn previous(app_dir: PathBuf) -> Self {
+        Self {
+            app_dir,
+            generation: RecoveredGeneration::Previous,
+        }
+    }
+
+    fn target(app_dir: PathBuf) -> Self {
+        Self {
+            app_dir,
+            generation: RecoveredGeneration::Target,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::os::unix::fs::PermissionsExt;
+
+    use super::*;
+
+    #[test]
+    fn pre_swap_failure_restarts_previous_supervisor_with_environment() {
+        let fixture = RecoveryFixture::new();
+        write_supervised_app(fixture.install_dir(), &fixture.active_app_dir, "old-app", "old");
+        let previous_environment = BTreeMap::from([("RECOVERY_MARKER".to_string(), "preserved".to_string())]);
+        let mut guard = fixture.guard(Some(&previous_environment));
+
+        let recovery = guard.recover().unwrap();
+
+        assert_eq!(recovery, RecoveredGeneration::Previous);
+        assert_eq!(fixture.recovery_command(), "run\n");
+        assert_eq!(fixture.recovery_environment(), "preserved\n");
+    }
+
+    #[test]
+    fn post_swap_failure_rolls_back_and_restarts_previous_supervisor() {
+        let fixture = RecoveryFixture::new();
+        write_supervised_app(fixture.install_dir(), &fixture.active_app_dir, "target-app", "target");
+        write_supervised_app(fixture.install_dir(), &fixture.previous_swap_dir, "old-app", "previous");
+        let mut guard = fixture.guard(None);
+        guard.mark_target_staged();
+        guard.mark_previous_moved();
+        guard.mark_target_active();
+
+        let recovery = guard.recover().unwrap();
+
+        assert_eq!(recovery, RecoveredGeneration::Previous);
+        assert_eq!(
+            std::fs::read_to_string(fixture.active_app_dir.join("generation")).unwrap(),
+            "previous"
+        );
+        assert_eq!(
+            std::fs::read_to_string(fixture.next_app_dir.join("generation")).unwrap(),
+            "target"
+        );
+        assert_eq!(fixture.recovery_command(), "run\n");
+    }
+
+    #[test]
+    fn first_install_failure_restores_staged_target_to_canonical_path() {
+        let fixture = RecoveryFixture::new_without_current();
+        write_supervised_app(fixture.install_dir(), &fixture.next_app_dir, "target-app", "target");
+        let mut guard = fixture.guard(None);
+        guard.mark_target_staged();
+
+        let recovery = guard.recover().unwrap();
+
+        assert_eq!(recovery, RecoveredGeneration::Target);
+        assert_eq!(
+            std::fs::read_to_string(fixture.active_app_dir.join("generation")).unwrap(),
+            "target"
+        );
+        assert!(!fixture.next_app_dir.exists());
+    }
+
+    #[test]
+    fn unexpected_active_directory_does_not_override_known_previous_swap() {
+        let fixture = RecoveryFixture::new();
+        write_supervised_app(fixture.install_dir(), &fixture.active_app_dir, "unknown-app", "unknown");
+        write_supervised_app(fixture.install_dir(), &fixture.previous_swap_dir, "old-app", "previous");
+        let mut guard = fixture.guard(None);
+        guard.mark_previous_moved();
+
+        let recovery = guard.recover().unwrap();
+
+        assert_eq!(recovery, RecoveredGeneration::Previous);
+        assert_eq!(
+            crate::supervisor::state::read_supervisor_exe_path(fixture.install_dir(), "demo-supervisor").as_deref(),
+            Some(fixture.previous_swap_dir.join("old-app").as_path())
+        );
+    }
+
+    #[test]
+    fn completed_target_restart_does_not_roll_back_pending_handoff() {
+        let fixture = RecoveryFixture::new();
+        write_supervised_app(fixture.install_dir(), &fixture.active_app_dir, "target-app", "target");
+        write_supervised_app(fixture.install_dir(), &fixture.previous_swap_dir, "old-app", "previous");
+        let mut guard = fixture.guard(None);
+        guard.mark_previous_moved();
+        guard.mark_target_active();
+        guard.complete_supervisor_restart();
+
+        drop(guard);
+
+        assert_eq!(
+            std::fs::read_to_string(fixture.active_app_dir.join("generation")).unwrap(),
+            "target"
+        );
+        assert!(!fixture.next_app_dir.exists());
+    }
+
+    struct RecoveryFixture {
+        temp: tempfile::TempDir,
+        current_app_dir: Option<PathBuf>,
+        active_app_dir: PathBuf,
+        next_app_dir: PathBuf,
+        previous_swap_dir: PathBuf,
+    }
+
+    impl RecoveryFixture {
+        fn new() -> Self {
+            Self::new_with_current(true)
+        }
+
+        fn new_without_current() -> Self {
+            Self::new_with_current(false)
+        }
+
+        fn new_with_current(has_current: bool) -> Self {
+            let temp = tempfile::tempdir().unwrap();
+            let active_app_dir = temp.path().join("app");
+            Self {
+                current_app_dir: has_current.then(|| active_app_dir.clone()),
+                next_app_dir: temp.path().join(".surge-app-next"),
+                previous_swap_dir: temp.path().join(".surge-app-prev"),
+                active_app_dir,
+                temp,
+            }
+        }
+
+        fn install_dir(&self) -> &Path {
+            self.temp.path()
+        }
+
+        fn guard(&self, environment: Option<&BTreeMap<String, String>>) -> Guard {
+            Guard::new(
+                self.install_dir(),
+                self.current_app_dir.as_deref(),
+                &self.active_app_dir,
+                &self.next_app_dir,
+                &self.previous_swap_dir,
+                "1.0.0",
+                "old-app",
+                "demo-supervisor",
+                environment,
+                &release("2.0.0", "target-app"),
+            )
+        }
+
+        fn recovery_command(&self) -> String {
+            std::fs::read_to_string(self.install_dir().join("recovery-command")).unwrap()
+        }
+
+        fn recovery_environment(&self) -> String {
+            std::fs::read_to_string(self.install_dir().join("recovery-environment")).unwrap()
+        }
+    }
+
+    fn release(version: &str, main_exe: &str) -> ReleaseEntry {
+        ReleaseEntry {
+            version: version.to_string(),
+            main_exe: main_exe.to_string(),
+            supervisor_id: "demo-supervisor".to_string(),
+            ..ReleaseEntry::default()
+        }
+    }
+
+    fn write_supervised_app(install_dir: &Path, app_dir: &Path, main_exe: &str, generation: &str) {
+        std::fs::create_dir_all(app_dir).unwrap();
+        std::fs::write(app_dir.join("generation"), generation).unwrap();
+        let main_exe_path = app_dir.join(main_exe);
+        std::fs::write(&main_exe_path, "#!/bin/sh\nexit 0\n").unwrap();
+        make_executable(&main_exe_path);
+
+        let supervisor_path = app_dir.join(crate::platform::process::supervisor_binary_name());
+        std::fs::write(
+            &supervisor_path,
+            format!(
+                r#"#!/bin/sh
+command="$1"
+shift
+id=""
+dir=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --id) id="$2"; shift 2 ;;
+    --dir) dir="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+echo "$command" > '{}'
+echo "${{RECOVERY_MARKER:-missing}}" > '{}'
+echo $$ > "$dir/.surge-supervisor-$id.pid"
+"#,
+                install_dir.join("recovery-command").display(),
+                install_dir.join("recovery-environment").display()
+            ),
+        )
+        .unwrap();
+        make_executable(&supervisor_path);
+    }
+
+    fn make_executable(path: &Path) {
+        let mut permissions = std::fs::metadata(path).unwrap().permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(path, permissions).unwrap();
+    }
+}

--- a/crates/surge-core/src/update/manager/lifecycle.rs
+++ b/crates/surge-core/src/update/manager/lifecycle.rs
@@ -33,8 +33,8 @@ pub(in crate::update::manager) use self::process_quiescence::{spawn_native_test_
 
 #[derive(Debug, Clone)]
 pub(super) enum SupervisorRestartOutcome {
-    /// No supervisor was configured for this release (or wasn't running before
-    /// the update) so there is no post-update restart to confirm.
+    /// No supervisor was configured for this release, so there is no
+    /// post-update restart to confirm.
     NotApplicable,
     /// The target package is installed, but restart handoff is still pending.
     /// The supervisor writes the converged record only after the old child exits
@@ -197,7 +197,7 @@ pub(super) fn restore_previous_supervisor_after_failed_quiescence(
         install_dir,
         active_app_dir,
         &previous,
-        watched_pid,
+        Some(watched_pid),
         None,
         SUPERVISOR_RESTART_CONFIRM_TIMEOUT,
         SUPERVISOR_RESTART_MAX_ATTEMPTS,
@@ -215,8 +215,26 @@ pub(super) fn restart_supervisor_after_update_with_pid(
         install_dir,
         active_app_dir,
         latest,
-        watched_pid,
+        Some(watched_pid),
         Some(&latest.version),
+        SUPERVISOR_RESTART_CONFIRM_TIMEOUT,
+        SUPERVISOR_RESTART_MAX_ATTEMPTS,
+        SUPERVISOR_RESTART_RETRY_DELAY,
+    )
+}
+
+#[cfg(unix)]
+pub(super) fn restart_supervisor_immediately(
+    install_dir: &Path,
+    active_app_dir: &Path,
+    release: &ReleaseEntry,
+) -> SupervisorRestartOutcome {
+    restart_supervisor_after_update_with_config(
+        install_dir,
+        active_app_dir,
+        release,
+        None,
+        None,
         SUPERVISOR_RESTART_CONFIRM_TIMEOUT,
         SUPERVISOR_RESTART_MAX_ATTEMPTS,
         SUPERVISOR_RESTART_RETRY_DELAY,
@@ -227,7 +245,7 @@ fn restart_supervisor_after_update_with_config(
     install_dir: &Path,
     active_app_dir: &Path,
     latest: &ReleaseEntry,
-    watched_pid: u32,
+    watched_pid: Option<u32>,
     handoff_version: Option<&str>,
     confirm_timeout: Duration,
     max_attempts: u32,
@@ -286,7 +304,7 @@ fn restart_supervisor_after_update_with_config(
         }
     };
 
-    let args = supervisor_watch_args(supervisor_id, install_dir, watched_pid, handoff_version, &restart_args);
+    let args = supervisor_restart_args(supervisor_id, install_dir, watched_pid, handoff_version, &restart_args);
     let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
 
     let mut last_failure: Option<(String, &'static str)> = None;
@@ -300,13 +318,23 @@ fn restart_supervisor_after_update_with_config(
                 if confirm_supervisor_restart(install_dir, supervisor_id, confirm_timeout) {
                     let reason = handoff_version.map_or_else(
                         || {
-                            format!(
-                                "previous supervisor restoration accepted; waiting for process pid {watched_pid} to exit"
+                            watched_pid.map_or_else(
+                                || "previous supervisor restoration accepted".to_string(),
+                                |watched_pid| {
+                                    format!(
+                                        "previous supervisor restoration accepted; waiting for process pid {watched_pid} to exit"
+                                    )
+                                },
                             )
                         },
                         |version| {
-                            format!(
-                                "supervisor handoff accepted; waiting for previous child pid {watched_pid} to exit and target version {version} to start"
+                            watched_pid.map_or_else(
+                                || format!("supervisor restart accepted; waiting for target version {version} to start"),
+                                |watched_pid| {
+                                    format!(
+                                        "supervisor handoff accepted; waiting for previous child pid {watched_pid} to exit and target version {version} to start"
+                                    )
+                                },
                             )
                         },
                     );
@@ -351,23 +379,27 @@ fn restart_supervisor_after_update_with_config(
     SupervisorRestartOutcome::PendingRestart { reason, failure_phase }
 }
 
-fn supervisor_watch_args(
+fn supervisor_restart_args(
     supervisor_id: &str,
     install_dir: &Path,
-    watched_pid: u32,
+    watched_pid: Option<u32>,
     handoff_version: Option<&str>,
     restart_args: &[String],
 ) -> Vec<String> {
     let mut args = vec![
-        "watch".to_string(),
+        if watched_pid.is_some() { "watch" } else { "run" }.to_string(),
         "--id".to_string(),
         supervisor_id.to_string(),
         "--dir".to_string(),
         install_dir.to_string_lossy().into_owned(),
-        "--pid".to_string(),
-        watched_pid.to_string(),
     ];
-    if let Some(handoff_version) = handoff_version {
+    if let Some(watched_pid) = watched_pid {
+        args.push("--pid".to_string());
+        args.push(watched_pid.to_string());
+    }
+    if watched_pid.is_some()
+        && let Some(handoff_version) = handoff_version
+    {
         args.push("--handoff-version".to_string());
         args.push(handoff_version.to_string());
     }
@@ -388,10 +420,10 @@ mod tests {
     fn supervisor_watch_args_include_handoff_version_before_child_args() {
         let restart_args = vec!["--app-mode".to_string(), "service".to_string()];
 
-        let args = supervisor_watch_args(
+        let args = supervisor_restart_args(
             "demo-supervisor",
             Path::new("/opt/demo"),
-            42,
+            Some(42),
             Some("2.0.0"),
             &restart_args,
         );
@@ -421,9 +453,17 @@ mod tests {
 
     #[test]
     fn previous_supervisor_restoration_omits_update_handoff_version() {
-        let args = supervisor_watch_args("demo-supervisor", Path::new("/opt/demo"), 42, None, &[]);
+        let args = supervisor_restart_args("demo-supervisor", Path::new("/opt/demo"), Some(42), None, &[]);
 
         assert!(!args.iter().any(|argument| argument == "--handoff-version"));
+    }
+
+    #[test]
+    fn previous_supervisor_without_surviving_child_starts_immediately() {
+        let args = supervisor_restart_args("demo-supervisor", Path::new("/opt/demo"), None, None, &[]);
+
+        assert_eq!(args[0], "run");
+        assert!(!args.iter().any(|argument| argument == "--pid"));
     }
 
     #[cfg(unix)]
@@ -464,7 +504,7 @@ mod tests {
             install_dir,
             &active_app_dir,
             &latest,
-            std::process::id(),
+            Some(std::process::id()),
             Some(&latest.version),
             Duration::from_millis(200),
             2,

--- a/crates/surge-core/src/update/status.rs
+++ b/crates/surge-core/src/update/status.rs
@@ -9,8 +9,8 @@
 //!   restart could not be confirmed within the post-update window. The runtime
 //!   process may still be running an older binary even though `installed_version`
 //!   already reflects the new release.
-//! - **`Failed`** — the most recent attempt failed before the install swap could
-//!   complete. The `installed_version` field reflects the pre-attempt state.
+//! - **`Failed`** — the most recent attempt failed. The `installed_version`
+//!   field reflects the generation retained in the active app directory.
 //!
 //! This record is persisted at `{install_dir}/.surge-update-status.json` so it
 //! survives the active app directory swap that happens on every successful update.
@@ -70,8 +70,9 @@ impl std::fmt::Display for UpdateConvergenceState {
 /// directory at the time the record was written. `target_version` is the
 /// version the most recent update attempt was trying to reach. For `Converged`
 /// records the two are equal; for `Failed` records `installed_version` is the
-/// pre-attempt version; for `PendingRestart` records `installed_version` is
-/// already the new release even though the runtime process may not yet be.
+/// generation retained after recovery; for `PendingRestart` records
+/// `installed_version` is already the new release even though the runtime
+/// process may not yet be.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct UpdateStatusRecord {
     pub state: UpdateConvergenceState,


### PR DESCRIPTION
## Summary

- restore supervision when quiescing a retained previous-swap generation fails
- add a finalize recovery guard that selects the known previous or target generation
- roll back directory transitions and restart the matching supervisor after finalize errors

## Why

Once application directories begin moving, recovery must be generation-aware. This layer makes every finalize failure converge on a known runnable and supervised generation.

This is stack 3 of 16.

- Base: #259
- Next: #279

Relates to fintermobilityas/youpark#1310.

## Validation

- exact layer `0899230` passed previous-swap and finalize-generation recovery regressions, rustfmt, blocking Clippy, and maintainability
- complete stack `c48f19f` passed 681 Rust workspace tests, both blocking Clippy tiers, vendor/version/format/maintainability checks, .NET formatting, and all 58 .NET tests

No migration is required.
