### PR TITLE
Close process identity matching gaps

### DIFF
--- a/crates/surge-core/src/platform/process/identity.rs
+++ b/crates/surge-core/src/platform/process/identity.rs
@@ -118,12 +118,25 @@ fn process_identity_impl(pid: u32) -> io::Result<Option<ProcessIdentity>> {
         Err(error) if process_disappeared(&error) => return Ok(None),
         Err(error) => return Err(error),
     };
-    parse_linux_process_stat(pid, &stat)
-        .map(|generation| generation.map(|generation| ProcessIdentity { pid, generation }))
+    let stat = parse_linux_process_stat(pid, &stat)?;
+    if stat.is_zombie && !linux_thread_group_has_live_member(pid)? {
+        return Ok(None);
+    }
+    Ok(Some(ProcessIdentity {
+        pid,
+        generation: stat.generation,
+    }))
 }
 
 #[cfg(target_os = "linux")]
-fn parse_linux_process_stat(pid: u32, stat: &str) -> io::Result<Option<u64>> {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct LinuxProcessStat {
+    generation: u64,
+    is_zombie: bool,
+}
+
+#[cfg(target_os = "linux")]
+fn parse_linux_process_stat(pid: u32, stat: &str) -> io::Result<LinuxProcessStat> {
     let Some((_, fields)) = stat.rsplit_once(") ") else {
         return Err(io::Error::new(
             io::ErrorKind::InvalidData,
@@ -134,9 +147,6 @@ fn parse_linux_process_stat(pid: u32, stat: &str) -> io::Result<Option<u64>> {
     let state = fields
         .next()
         .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, format!("process {pid} stat has no state")))?;
-    if matches!(state.as_bytes(), [b'Z' | b'X']) {
-        return Ok(None);
-    }
     let generation = fields
         .nth(18)
         .and_then(|value| value.parse::<u64>().ok())
@@ -146,7 +156,53 @@ fn parse_linux_process_stat(pid: u32, stat: &str) -> io::Result<Option<u64>> {
                 format!("process {pid} stat has no valid start time"),
             )
         })?;
-    Ok(Some(generation))
+    Ok(LinuxProcessStat {
+        generation,
+        is_zombie: matches!(state.as_bytes(), [b'Z' | b'X']),
+    })
+}
+
+#[cfg(target_os = "linux")]
+fn linux_thread_group_has_live_member(pid: u32) -> io::Result<bool> {
+    let tasks = match std::fs::read_dir(format!("/proc/{pid}/task")) {
+        Ok(tasks) => tasks,
+        Err(error) if process_disappeared(&error) => return Ok(false),
+        Err(error) => return Err(error),
+    };
+    for task in tasks {
+        let task = match task {
+            Ok(task) => task,
+            Err(error) if process_disappeared(&error) => continue,
+            Err(error) => return Err(error),
+        };
+        let Some(tid) = task.file_name().to_string_lossy().parse::<u32>().ok() else {
+            continue;
+        };
+        let stat = match std::fs::read_to_string(format!("/proc/{pid}/task/{tid}/stat")) {
+            Ok(stat) => stat,
+            Err(error) if process_disappeared(&error) => continue,
+            Err(error) => return Err(error),
+        };
+        if !linux_process_stat_is_zombie(tid, &stat)? {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+#[cfg(target_os = "linux")]
+fn linux_process_stat_is_zombie(pid: u32, stat: &str) -> io::Result<bool> {
+    let Some((_, fields)) = stat.rsplit_once(") ") else {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("process {pid} stat has no command boundary"),
+        ));
+    };
+    let state = fields
+        .split_whitespace()
+        .next()
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, format!("process {pid} stat has no state")))?;
+    Ok(matches!(state.as_bytes(), [b'Z' | b'X']))
 }
 
 #[cfg(target_os = "linux")]
@@ -183,13 +239,34 @@ mod tests {
     #[test]
     fn linux_stat_parser_uses_start_time_after_complex_command_name() {
         let stat = "42 (worker ) name) S 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 123456 20";
-        assert_eq!(parse_linux_process_stat(42, stat).unwrap(), Some(123_456));
+        assert_eq!(
+            parse_linux_process_stat(42, stat).unwrap(),
+            LinuxProcessStat {
+                generation: 123_456,
+                is_zombie: false,
+            }
+        );
     }
 
     #[cfg(target_os = "linux")]
     #[test]
-    fn linux_stat_parser_treats_zombies_as_absent() {
-        assert_eq!(parse_linux_process_stat(42, "42 (worker) Z").unwrap(), None);
+    fn linux_stat_parser_retains_zombie_generation_for_thread_group_check() {
+        let stat = "42 (worker) Z 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 123456 20";
+        assert_eq!(
+            parse_linux_process_stat(42, stat).unwrap(),
+            LinuxProcessStat {
+                generation: 123_456,
+                is_zombie: true,
+            }
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn linux_thread_state_distinguishes_live_workers_from_zombies() {
+        assert!(!linux_process_stat_is_zombie(43, "43 (worker) S 1").unwrap());
+        assert!(linux_process_stat_is_zombie(43, "43 (worker) Z 1").unwrap());
+        assert!(linux_process_stat_is_zombie(43, "43 (worker) X 1").unwrap());
     }
 
     #[cfg(target_os = "linux")]

--- a/crates/surge-core/src/update/manager/lifecycle/process_quiescence.rs
+++ b/crates/surge-core/src/update/manager/lifecycle/process_quiescence.rs
@@ -96,14 +96,21 @@ fn terminate_superseded_app_processes_except(
     main_exe: &str,
     protected_pid: u32,
 ) -> Result<usize> {
-    terminate_matching_app_processes(main_exe, protected_pid, "superseded", |process| {
-        Ok(is_superseded_app_exe(
-            install_dir,
-            active_app_dir,
-            main_exe,
-            &process.exe,
-        ))
-    })
+    terminate_matching_app_processes(
+        main_exe,
+        protected_pid,
+        "superseded",
+        |process| {
+            Ok(is_superseded_app_exe(
+                install_dir,
+                active_app_dir,
+                main_exe,
+                &process.exe,
+            ))
+        },
+        |exe| Ok(is_superseded_app_exe(install_dir, active_app_dir, main_exe, exe)),
+        |command, cwd| Ok(superseded_app_command_may_match(install_dir, main_exe, command, cwd)),
+    )
 }
 
 #[cfg(all(unix, test))]
@@ -123,9 +130,21 @@ fn terminate_active_app_processes_except(
 
 #[cfg(unix)]
 fn terminate_prepared_app_processes_except(prepared: &PreparedAppQuiescence, protected_pid: u32) -> Result<usize> {
-    terminate_matching_app_processes(&prepared.main_exe, protected_pid, "active", |process| {
-        is_active_app_process(&prepared.active_entrypoint, prepared.interpreted_main.as_ref(), process)
-    })
+    terminate_matching_app_processes(
+        &prepared.main_exe,
+        protected_pid,
+        "active",
+        |process| is_active_app_process(&prepared.active_entrypoint, prepared.interpreted_main.as_ref(), process),
+        |exe| active_app_executable_may_match(&prepared.active_entrypoint, prepared.interpreted_main.as_ref(), exe),
+        |command, cwd| {
+            active_app_command_may_match(
+                &prepared.active_entrypoint,
+                prepared.interpreted_main.as_ref(),
+                command,
+                cwd,
+            )
+        },
+    )
 }
 
 #[cfg(unix)]
@@ -186,14 +205,18 @@ fn refuse_process_in_swap(
 }
 
 #[cfg(unix)]
-fn terminate_matching_app_processes<F>(
+fn terminate_matching_app_processes<F, E, C>(
     main_exe: &str,
     protected_pid: u32,
     process_scope: &'static str,
-    matches_exe: F,
+    matches_process: F,
+    executable_may_match: E,
+    command_may_match: C,
 ) -> Result<usize>
 where
     F: Fn(&AppProcess) -> Result<bool>,
+    E: Fn(&Path) -> Result<bool>,
+    C: Fn(&[OsString], Option<&Path>) -> Result<bool>,
 {
     use nix::errno::Errno;
     use nix::sys::signal::Signal;
@@ -203,7 +226,12 @@ where
         return Ok(0);
     }
 
-    let identities = app_process_identities(protected_pid, &matches_exe)?;
+    let identities = app_process_identities(
+        protected_pid,
+        &matches_process,
+        &executable_may_match,
+        &command_may_match,
+    )?;
     if identities.is_empty() {
         return Ok(0);
     }
@@ -215,12 +243,23 @@ where
         }
     }
 
-    if wait_until_app_processes_exit(protected_pid, &matches_exe, Duration::from_secs(5))? {
+    if wait_until_app_processes_exit(
+        protected_pid,
+        &matches_process,
+        &executable_may_match,
+        &command_may_match,
+        Duration::from_secs(5),
+    )? {
         info!(count = identities.len(), process_scope, "Terminated app processes");
         return Ok(identities.len());
     }
 
-    let remaining = app_process_identities(protected_pid, &matches_exe)?;
+    let remaining = app_process_identities(
+        protected_pid,
+        &matches_process,
+        &executable_may_match,
+        &command_may_match,
+    )?;
     for identity in &remaining {
         match signal_pid(identity.pid, Signal::SIGKILL) {
             Ok(()) | Err(Errno::ESRCH) => {}
@@ -231,7 +270,13 @@ where
         }
     }
 
-    if wait_until_app_processes_exit(protected_pid, &matches_exe, Duration::from_secs(2))? {
+    if wait_until_app_processes_exit(
+        protected_pid,
+        &matches_process,
+        &executable_may_match,
+        &command_may_match,
+        Duration::from_secs(2),
+    )? {
         info!(
             count = identities.len(),
             forced = remaining.len(),
@@ -278,13 +323,21 @@ fn terminate_active_app_processes_except(
 }
 
 #[cfg(unix)]
-fn wait_until_app_processes_exit<F>(protected_pid: u32, matches_exe: &F, timeout: Duration) -> Result<bool>
+fn wait_until_app_processes_exit<F, E, C>(
+    protected_pid: u32,
+    matches_process: &F,
+    executable_may_match: &E,
+    command_may_match: &C,
+    timeout: Duration,
+) -> Result<bool>
 where
     F: Fn(&AppProcess) -> Result<bool>,
+    E: Fn(&Path) -> Result<bool>,
+    C: Fn(&[OsString], Option<&Path>) -> Result<bool>,
 {
     let deadline = std::time::Instant::now() + timeout;
     loop {
-        if app_process_identities(protected_pid, matches_exe)?.is_empty() {
+        if app_process_identities(protected_pid, matches_process, executable_may_match, command_may_match)?.is_empty() {
             return Ok(true);
         }
         if std::time::Instant::now() >= deadline {
@@ -343,6 +396,61 @@ pub(in crate::update::manager) fn wait_for_native_test_app(app_path: &Path, chil
         );
         std::thread::sleep(Duration::from_millis(10));
     }
+}
+
+#[cfg(unix)]
+fn active_app_executable_may_match(
+    active_entrypoint: &active_entrypoint::Identity,
+    interpreted_main: Option<&interpreted_main::Identity>,
+    executable: &Path,
+) -> Result<bool> {
+    if active_entrypoint.matches_resolved_executable(executable) {
+        return Ok(true);
+    }
+    match interpreted_main {
+        Some(identity) => identity.executable_may_match(executable),
+        None => Ok(false),
+    }
+}
+
+#[cfg(unix)]
+fn active_app_command_may_match(
+    active_entrypoint: &active_entrypoint::Identity,
+    interpreted_main: Option<&interpreted_main::Identity>,
+    command: &[OsString],
+    cwd: Option<&Path>,
+) -> Result<bool> {
+    if command.iter().all(|argument| argument.is_empty()) {
+        return Ok(true);
+    }
+    let Some(first_argument) = command.first() else {
+        return Ok(true);
+    };
+    if active_entrypoint.matches_argument(first_argument, cwd)? {
+        return Ok(true);
+    }
+    let Some(script_argument) = interpreted_main.and_then(|identity| command.get(identity.script_argument_index))
+    else {
+        return Ok(false);
+    };
+    active_entrypoint.matches_argument(script_argument, cwd)
+}
+
+#[cfg(unix)]
+fn superseded_app_command_may_match(
+    install_dir: &Path,
+    main_exe: &str,
+    command: &[OsString],
+    _cwd: Option<&Path>,
+) -> bool {
+    let Some(argument) = command.first() else {
+        return true;
+    };
+    let argument = Path::new(argument);
+    if argument.file_name().and_then(|name| name.to_str()) != Some(main_exe) {
+        return false;
+    }
+    argument.is_relative() || argument.starts_with(install_dir)
 }
 
 #[cfg(unix)]

--- a/crates/surge-core/src/update/manager/lifecycle/process_quiescence.rs
+++ b/crates/surge-core/src/update/manager/lifecycle/process_quiescence.rs
@@ -12,6 +12,8 @@ mod discovery;
 #[cfg(unix)]
 use self::discovery::AppProcess;
 #[cfg(unix)]
+use self::discovery::app_process_identities;
+#[cfg(all(unix, test))]
 use self::discovery::app_process_pids;
 use crate::error::Result;
 #[cfg(unix)]
@@ -201,27 +203,29 @@ where
         return Ok(0);
     }
 
-    let pids = app_process_pids(protected_pid, &matches_exe)?;
-    if pids.is_empty() {
+    let identities = app_process_identities(protected_pid, &matches_exe)?;
+    if identities.is_empty() {
         return Ok(0);
     }
 
-    for pid in &pids {
-        if let Err(e) = signal_pid(*pid, Signal::SIGTERM) {
+    for identity in &identities {
+        if let Err(e) = signal_pid(identity.pid, Signal::SIGTERM) {
+            let pid = identity.pid;
             warn!(pid, error = %e, process_scope, "Failed to request app process termination");
         }
     }
 
     if wait_until_app_processes_exit(protected_pid, &matches_exe, Duration::from_secs(5))? {
-        info!(count = pids.len(), process_scope, "Terminated app processes");
-        return Ok(pids.len());
+        info!(count = identities.len(), process_scope, "Terminated app processes");
+        return Ok(identities.len());
     }
 
-    let remaining = app_process_pids(protected_pid, &matches_exe)?;
-    for pid in &remaining {
-        match signal_pid(*pid, Signal::SIGKILL) {
+    let remaining = app_process_identities(protected_pid, &matches_exe)?;
+    for identity in &remaining {
+        match signal_pid(identity.pid, Signal::SIGKILL) {
             Ok(()) | Err(Errno::ESRCH) => {}
             Err(e) => {
+                let pid = identity.pid;
                 warn!(pid, error = %e, process_scope, "Failed to force-kill app process");
             }
         }
@@ -229,12 +233,12 @@ where
 
     if wait_until_app_processes_exit(protected_pid, &matches_exe, Duration::from_secs(2))? {
         info!(
-            count = pids.len(),
+            count = identities.len(),
             forced = remaining.len(),
             process_scope,
             "Force-killed app processes"
         );
-        return Ok(pids.len());
+        return Ok(identities.len());
     }
 
     Err(SurgeError::Platform(format!(
@@ -280,7 +284,7 @@ where
 {
     let deadline = std::time::Instant::now() + timeout;
     loop {
-        if app_process_pids(protected_pid, matches_exe)?.is_empty() {
+        if app_process_identities(protected_pid, matches_exe)?.is_empty() {
             return Ok(true);
         }
         if std::time::Instant::now() >= deadline {

--- a/crates/surge-core/src/update/manager/lifecycle/process_quiescence/discovery.rs
+++ b/crates/surge-core/src/update/manager/lifecycle/process_quiescence/discovery.rs
@@ -15,6 +15,8 @@ use std::path::Path;
 use crate::error::Result;
 #[cfg(target_os = "linux")]
 use crate::error::SurgeError;
+#[cfg(unix)]
+use crate::platform::process::{ProcessIdentity, process_identity, process_identity_matches};
 
 #[cfg(unix)]
 pub(super) struct AppProcess {
@@ -24,15 +26,24 @@ pub(super) struct AppProcess {
     pub(super) cwd: Option<PathBuf>,
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(all(unix, test))]
 pub(super) fn app_process_pids<F>(protected_pid: u32, matches_exe: &F) -> Result<Vec<u32>>
+where
+    F: Fn(&AppProcess) -> Result<bool>,
+{
+    app_process_identities(protected_pid, matches_exe)
+        .map(|identities| identities.into_iter().map(|identity| identity.pid).collect())
+}
+
+#[cfg(target_os = "linux")]
+pub(super) fn app_process_identities<F>(protected_pid: u32, matches_exe: &F) -> Result<Vec<ProcessIdentity>>
 where
     F: Fn(&AppProcess) -> Result<bool>,
 {
     let entries = std::fs::read_dir("/proc")
         .map_err(|e| SurgeError::Platform(format!("Failed to enumerate processes from /proc: {e}")))?;
 
-    let mut pids = Vec::new();
+    let mut identities = Vec::new();
     for entry in entries.filter_map(std::result::Result::ok) {
         let Some(pid) = entry.file_name().to_string_lossy().parse::<u32>().ok() else {
             continue;
@@ -40,6 +51,9 @@ where
         if pid == protected_pid {
             continue;
         }
+        let Some(identity) = inspected_process_identity(pid)? else {
+            continue;
+        };
         let Ok(mut exe) = std::fs::read_link(format!("/proc/{pid}/exe")).map(normalize_proc_exe_path) else {
             continue;
         };
@@ -52,16 +66,16 @@ where
             command_inspected,
             cwd: std::fs::read_link(format!("/proc/{pid}/cwd")).ok(),
         };
-        if matches_exe(&process)? {
-            pids.push(pid);
+        if matches_exe(&process)? && inspected_identity_still_matches(identity)? {
+            identities.push(identity);
         }
     }
 
-    Ok(pids)
+    Ok(identities)
 }
 
 #[cfg(target_os = "macos")]
-pub(super) fn app_process_pids<F>(protected_pid: u32, matches_exe: &F) -> Result<Vec<u32>>
+pub(super) fn app_process_identities<F>(protected_pid: u32, matches_exe: &F) -> Result<Vec<ProcessIdentity>>
 where
     F: Fn(&AppProcess) -> Result<bool>,
 {
@@ -69,12 +83,15 @@ where
 
     let mut system = System::new();
     let _ = system.refresh_processes(ProcessesToUpdate::All, true);
-    let mut pids = Vec::new();
+    let mut identities = Vec::new();
     for (pid, process) in system.processes() {
         let pid = pid.as_u32();
         if pid == protected_pid {
             continue;
         }
+        let Some(identity) = inspected_process_identity(pid)? else {
+            continue;
+        };
         let Some(exe) = process.exe() else {
             continue;
         };
@@ -84,12 +101,12 @@ where
             command_inspected: !process.cmd().is_empty(),
             cwd: process.cwd().map(Path::to_path_buf),
         };
-        if matches_exe(&app_process)? {
-            pids.push(pid);
+        if matches_exe(&app_process)? && inspected_identity_still_matches(identity)? {
+            identities.push(identity);
         }
     }
 
-    Ok(pids)
+    Ok(identities)
 }
 
 #[cfg(target_os = "linux")]
@@ -167,7 +184,7 @@ fn proc_stat_is_zombie(stat: &str) -> Option<bool> {
 }
 
 #[cfg(all(unix, not(any(target_os = "linux", target_os = "macos"))))]
-pub(super) fn app_process_pids<F>(_protected_pid: u32, _matches_exe: &F) -> Result<Vec<u32>>
+pub(super) fn app_process_identities<F>(_protected_pid: u32, _matches_exe: &F) -> Result<Vec<ProcessIdentity>>
 where
     F: Fn(&AppProcess) -> Result<bool>,
 {
@@ -176,6 +193,25 @@ where
     Err(SurgeError::Platform(
         "Active application process discovery is unsupported on this Unix platform".to_string(),
     ))
+}
+
+#[cfg(unix)]
+fn inspected_process_identity(pid: u32) -> Result<Option<ProcessIdentity>> {
+    process_identity(pid).map_err(|error| {
+        crate::error::SurgeError::Platform(format!(
+            "Failed to inspect process {pid} generation before application swap: {error}"
+        ))
+    })
+}
+
+#[cfg(unix)]
+fn inspected_identity_still_matches(identity: ProcessIdentity) -> Result<bool> {
+    process_identity_matches(identity).map_err(|error| {
+        crate::error::SurgeError::Platform(format!(
+            "Failed to revalidate process {} generation before application swap: {error}",
+            identity.pid
+        ))
+    })
 }
 
 #[cfg(target_os = "linux")]

--- a/crates/surge-core/src/update/manager/lifecycle/process_quiescence/discovery.rs
+++ b/crates/surge-core/src/update/manager/lifecycle/process_quiescence/discovery.rs
@@ -4,12 +4,9 @@
 #[cfg(unix)]
 use std::ffi::OsString;
 #[cfg(unix)]
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 #[cfg(target_os = "linux")]
 use std::time::Duration;
-
-#[cfg(target_os = "macos")]
-use std::path::Path;
 
 #[cfg(unix)]
 use crate::error::Result;
@@ -31,12 +28,27 @@ pub(super) fn app_process_pids<F>(protected_pid: u32, matches_exe: &F) -> Result
 where
     F: Fn(&AppProcess) -> Result<bool>,
 {
-    app_process_identities(protected_pid, matches_exe)
+    app_process_identities(protected_pid, matches_exe, &|_| Ok(true), &|_, _| Ok(true))
         .map(|identities| identities.into_iter().map(|identity| identity.pid).collect())
 }
 
+#[cfg(unix)]
+pub(super) fn app_process_identities<F, E, C>(
+    protected_pid: u32,
+    matches_process: &F,
+    _executable_may_match: &E,
+    _command_may_match: &C,
+) -> Result<Vec<ProcessIdentity>>
+where
+    F: Fn(&AppProcess) -> Result<bool>,
+    E: Fn(&Path) -> Result<bool>,
+    C: Fn(&[OsString], Option<&Path>) -> Result<bool>,
+{
+    app_process_identities_impl(protected_pid, matches_process)
+}
+
 #[cfg(target_os = "linux")]
-pub(super) fn app_process_identities<F>(protected_pid: u32, matches_exe: &F) -> Result<Vec<ProcessIdentity>>
+fn app_process_identities_impl<F>(protected_pid: u32, matches_exe: &F) -> Result<Vec<ProcessIdentity>>
 where
     F: Fn(&AppProcess) -> Result<bool>,
 {
@@ -75,7 +87,7 @@ where
 }
 
 #[cfg(target_os = "macos")]
-pub(super) fn app_process_identities<F>(protected_pid: u32, matches_exe: &F) -> Result<Vec<ProcessIdentity>>
+fn app_process_identities_impl<F>(protected_pid: u32, matches_exe: &F) -> Result<Vec<ProcessIdentity>>
 where
     F: Fn(&AppProcess) -> Result<bool>,
 {
@@ -184,7 +196,7 @@ fn proc_stat_is_zombie(stat: &str) -> Option<bool> {
 }
 
 #[cfg(all(unix, not(any(target_os = "linux", target_os = "macos"))))]
-pub(super) fn app_process_identities<F>(_protected_pid: u32, _matches_exe: &F) -> Result<Vec<ProcessIdentity>>
+fn app_process_identities_impl<F>(_protected_pid: u32, _matches_exe: &F) -> Result<Vec<ProcessIdentity>>
 where
     F: Fn(&AppProcess) -> Result<bool>,
 {


### PR DESCRIPTION
## Summary

- keep live Linux thread groups addressable across leader exit
- bind every discovered process candidate to its observed generation
- separate strict executable matching from explicitly allowed interpreter aliases

## Why

Process discovery must preserve the identity it inspected and make alias policy explicit. Re-resolving a bare PID or applying broad aliases later can target a different process.

This is stack 9 of 16.

- Base: #282
- Next: #283

Relates to fintermobilityas/youpark#1310.

## Validation

- exact layer `63a390f` passed thread-group, generation-binding, and process-match-policy regressions, rustfmt, blocking Clippy, and maintainability
- complete stack `c48f19f` passed 681 Rust workspace tests, both blocking Clippy tiers, vendor/version/format/maintainability checks, .NET formatting, and all 58 .NET tests

No migration is required.
