### PR TITLE
Validate recovery paths before supervisor shutdown

### DIFF
--- a/crates/surge-core/src/update/manager.rs
+++ b/crates/surge-core/src/update/manager.rs
@@ -4712,6 +4712,101 @@ echo started > new-child-started
 
     #[cfg(any(target_os = "linux", target_os = "macos"))]
     #[tokio::test]
+    async fn test_download_and_apply_preflights_entrypoint_before_consuming_supervisor_takeover() {
+        use std::os::unix::fs::PermissionsExt;
+
+        use crate::platform::process::ProcessIdentity;
+        use crate::supervisor::state::{
+            SupervisorTakeoverAcknowledgement, SupervisorTakeoverCommit, SupervisorTakeoverInstance,
+            SupervisorTakeoverRequest, accept_supervisor_takeover_request, read_accepted_supervisor_takeover,
+            write_supervisor_takeover_acknowledgement, write_supervisor_takeover_commit,
+            write_supervisor_takeover_request,
+        };
+
+        let tmp = tempfile::tempdir().unwrap();
+        let store_root = tmp.path().join("store");
+        let install_root = tmp.path().join("install");
+        let active_app_dir = install_root.join("app");
+        let app_id = "test-app";
+        let supervisor_id = "current-supervisor";
+        std::fs::create_dir_all(&store_root).unwrap();
+        std::fs::create_dir_all(&active_app_dir).unwrap();
+        write_runtime_identity(&active_app_dir, app_id, "1.0.0", "missing-app", supervisor_id);
+
+        let supervisor_path = active_app_dir.join(crate::platform::process::supervisor_binary_name());
+        std::fs::write(&supervisor_path, "#!/bin/sh\nexit 0\n").unwrap();
+        let mut permissions = std::fs::metadata(&supervisor_path).unwrap().permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&supervisor_path, permissions).unwrap();
+
+        let instance = SupervisorTakeoverInstance::new(42);
+        let request = SupervisorTakeoverRequest::new(&instance, Duration::from_secs(5));
+        let acknowledgement =
+            SupervisorTakeoverAcknowledgement::new(&request, Some(ProcessIdentity { pid: 84, generation: 7 }));
+        let commit = SupervisorTakeoverCommit::new(&acknowledgement);
+        write_supervisor_takeover_request(&install_root, supervisor_id, &request).unwrap();
+        write_supervisor_takeover_acknowledgement(&install_root, supervisor_id, &acknowledgement).unwrap();
+        write_supervisor_takeover_commit(&install_root, supervisor_id, &commit).unwrap();
+        assert!(accept_supervisor_takeover_request(&install_root, supervisor_id, &request).unwrap());
+
+        let rid = current_rid();
+        let full_filename = format!("{app_id}-1.1.0-{rid}-full.tar.zst");
+        let full_path = app_scoped_store_root(&store_root, app_id).join(&full_filename);
+        let mut packer = ArchivePacker::new(3).unwrap();
+        packer.add_buffer("new-app", b"#!/bin/sh\nexit 0\n", 0o755).unwrap();
+        packer.finalize_to_file(&full_path).unwrap();
+
+        let mut latest = make_entry("1.1.0", "stable", &current_os_label_for_tests(), &rid);
+        latest.is_genesis = true;
+        latest.main_exe = "new-app".to_string();
+        latest.full_filename = full_filename;
+        latest.full_size = std::fs::metadata(&full_path).unwrap().len() as i64;
+        latest.full_sha256 = sha256_hex_file(&full_path).unwrap();
+        latest.deltas.clear();
+        latest.preferred_delta_id.clear();
+        write_app_scoped_release_index(
+            &store_root,
+            app_id,
+            &ReleaseIndex {
+                app_id: app_id.to_string(),
+                releases: vec![latest],
+                ..ReleaseIndex::default()
+            },
+        );
+
+        let ctx = Arc::new(Context::new());
+        ctx.set_storage(
+            StorageProvider::Filesystem,
+            store_root.to_str().unwrap(),
+            "",
+            "",
+            "",
+            "",
+        );
+        let mut manager = UpdateManager::new(ctx, app_id, "1.0.0", "stable", install_root.to_str().unwrap()).unwrap();
+        let info = manager.check_for_updates().await.unwrap().unwrap();
+
+        let error = manager
+            .download_and_apply(&info, None::<fn(ProgressInfo)>)
+            .await
+            .unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("Failed to resolve active application executable before swap")
+        );
+        assert!(
+            read_accepted_supervisor_takeover(&install_root, supervisor_id)
+                .unwrap()
+                .is_some(),
+            "entrypoint preflight must fail before the accepted supervisor takeover is consumed"
+        );
+        assert!(!active_app_dir.join("new-app").exists());
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    #[tokio::test]
     async fn test_download_and_apply_quiesces_installed_executable_when_target_name_changes() {
         let tmp = tempfile::tempdir().unwrap();
         let store_root = tmp.path().join("store");

--- a/crates/surge-core/src/update/manager/finalize.rs
+++ b/crates/surge-core/src/update/manager/finalize.rs
@@ -31,8 +31,8 @@ use crate::supervisor::state::supervisor_pid_file;
 use super::current_install::ensure_captured_install_still_has_app_dir;
 #[cfg(unix)]
 use super::finalize_quiescence::{
-    prepare_and_quiesce_active_app_before_swap, prepare_and_quiesce_previous_swap_before_reuse,
-    restore_previous_supervisor_after_quiescence_failure,
+    prepare_active_app_before_supervisor_shutdown, prepare_and_quiesce_previous_swap_before_reuse,
+    quiesce_prepared_active_app_before_swap, restore_previous_supervisor_after_quiescence_failure,
 };
 use super::progress::{ProgressInfo, emit_progress};
 use super::progress_substep::{HEARTBEAT_INTERVAL, PhaseProgressEmitter, labels as finalize_phase};
@@ -186,6 +186,18 @@ where
     let supervisor_was_running = !current_supervisor_id.trim().is_empty()
         && supervisor_pid_file(&manager.install_dir, current_supervisor_id).is_file();
 
+    #[cfg(unix)]
+    let prepared_current_app = if let Some(current_app_dir) = current_app_dir {
+        prepare_active_app_before_supervisor_shutdown(
+            current_app_dir,
+            current_main_exe,
+            current_supervisor_id,
+            manager.allow_in_process_swap,
+        )?
+    } else {
+        None
+    };
+
     let supervised_child_identity = if supervisor_was_running {
         progress_emitter
             .run_with_heartbeat(
@@ -205,7 +217,7 @@ where
     progress_emitter.emit_substep(6, finalize_phase::QUIESCING_ACTIVE_APP, 92);
     #[cfg(unix)]
     let current_quiescence = if let Some(current_app_dir) = current_app_dir {
-        prepare_and_quiesce_active_app_before_swap(
+        quiesce_prepared_active_app_before_swap(
             &manager.install_dir,
             current_app_dir,
             current_version,
@@ -214,7 +226,7 @@ where
             current_environment,
             supervisor_requires_restoration,
             supervised_child_identity,
-            manager.allow_in_process_swap,
+            prepared_current_app,
         )?
     } else {
         None

--- a/crates/surge-core/src/update/manager/finalize_quiescence.rs
+++ b/crates/surge-core/src/update/manager/finalize_quiescence.rs
@@ -9,8 +9,19 @@ use crate::platform::process::ProcessIdentity;
 use super::UpdateManager;
 use super::lifecycle::{self, SupervisorRestartOutcome};
 
+pub(super) fn prepare_active_app_before_supervisor_shutdown(
+    current_app_dir: &Path,
+    current_main_exe: &str,
+    current_supervisor_id: &str,
+    allow_in_process_swap: bool,
+) -> Result<Option<lifecycle::PreparedAppQuiescence>> {
+    let prepared = lifecycle::prepare_app_quiescence(current_app_dir, current_main_exe, None, allow_in_process_swap)?;
+    lifecycle::preflight_supervisor_recovery_paths(current_app_dir, current_main_exe, current_supervisor_id)?;
+    Ok(prepared)
+}
+
 #[allow(clippy::too_many_arguments)]
-pub(super) fn prepare_and_quiesce_active_app_before_swap(
+pub(super) fn quiesce_prepared_active_app_before_swap(
     install_dir: &Path,
     current_app_dir: &Path,
     current_version: &str,
@@ -19,15 +30,11 @@ pub(super) fn prepare_and_quiesce_active_app_before_swap(
     current_environment: Option<&BTreeMap<String, String>>,
     supervisor_requires_restoration: bool,
     supervised_child_identity: Option<ProcessIdentity>,
-    allow_in_process_swap: bool,
+    prepared: Option<lifecycle::PreparedAppQuiescence>,
 ) -> Result<Option<lifecycle::PreparedAppQuiescence>> {
     let result = (|| {
-        let prepared = lifecycle::prepare_app_quiescence(
-            current_app_dir,
-            current_main_exe,
-            supervised_child_identity,
-            allow_in_process_swap,
-        )?;
+        let prepared =
+            prepared.map(|prepared| lifecycle::with_supervised_child_identity(prepared, supervised_child_identity));
         if let Some(prepared) = &prepared {
             lifecycle::terminate_prepared_app_processes(prepared)?;
         }
@@ -114,17 +121,11 @@ pub(super) async fn prepare_and_quiesce_previous_swap_before_reuse(
         }
         Err(error) => return Err(restore_current(error)),
     };
-    let previous_supervised_child_identity =
-        match lifecycle::request_supervisor_shutdown(&manager.install_dir, &previous_swap_identity.supervisor_id).await
-        {
-            Ok(pid) => pid,
-            Err(error) => return Err(restore_current(error)),
-        };
-    let result = (|| {
+    let prepared = match (|| {
         let prepared = lifecycle::prepare_app_quiescence(
             previous_swap_dir,
             &previous_swap_identity.main_exe,
-            previous_supervised_child_identity,
+            None,
             manager.allow_in_process_swap,
         )?
         .ok_or_else(|| {
@@ -132,6 +133,24 @@ pub(super) async fn prepare_and_quiesce_previous_swap_before_reuse(
                 "Previous swap application entrypoint disappeared before it could be quiesced".to_string(),
             )
         })?;
+        lifecycle::preflight_supervisor_recovery_paths(
+            previous_swap_dir,
+            &previous_swap_identity.main_exe,
+            &previous_swap_identity.supervisor_id,
+        )?;
+        Ok::<_, SurgeError>(prepared)
+    })() {
+        Ok(prepared) => prepared,
+        Err(error) => return Err(restore_current(error)),
+    };
+    let previous_supervised_child_identity =
+        match lifecycle::request_supervisor_shutdown(&manager.install_dir, &previous_swap_identity.supervisor_id).await
+        {
+            Ok(pid) => pid,
+            Err(error) => return Err(restore_current(error)),
+        };
+    let result = (|| {
+        let prepared = lifecycle::with_supervised_child_identity(prepared, previous_supervised_child_identity);
         lifecycle::terminate_prepared_app_processes(&prepared)?;
         Ok::<_, SurgeError>(prepared)
     })();
@@ -257,7 +276,14 @@ mod tests {
         let current_environment = BTreeMap::from([("SURGE_TEST_MODE".to_string(), "preserved".to_string())]);
         let child_pid = child.id();
         let child_identity = crate::platform::process::process_identity(child_pid).unwrap().unwrap();
-        let result = prepare_and_quiesce_active_app_before_swap(
+        let prepared = prepare_active_app_before_supervisor_shutdown(
+            &active_app_dir,
+            "cwd-changing-demo-script",
+            "demo-supervisor",
+            false,
+        )
+        .unwrap();
+        let result = quiesce_prepared_active_app_before_swap(
             install_dir,
             &active_app_dir,
             "1.0.0",
@@ -266,7 +292,7 @@ mod tests {
             Some(&current_environment),
             true,
             Some(child_identity),
-            false,
+            prepared,
         );
         let child_still_running = child.try_wait().unwrap().is_none();
         if child_still_running {

--- a/crates/surge-core/src/update/manager/lifecycle.rs
+++ b/crates/surge-core/src/update/manager/lifecycle.rs
@@ -3,9 +3,7 @@ use std::time::Duration;
 
 use tracing::{debug, info, warn};
 
-use crate::error::Result;
-#[cfg(not(unix))]
-use crate::error::SurgeError;
+use crate::error::{Result, SurgeError};
 #[cfg(unix)]
 use crate::platform::process::process_identity;
 use crate::platform::process::{
@@ -77,7 +75,7 @@ pub(super) use self::process_quiescence::terminate_active_app_processes_before_s
 pub(super) use self::process_quiescence::terminate_superseded_app_processes;
 #[cfg(unix)]
 pub(super) use self::process_quiescence::{
-    PreparedAppQuiescence, prepare_app_quiescence, terminate_prepared_app_processes,
+    PreparedAppQuiescence, prepare_app_quiescence, terminate_prepared_app_processes, with_supervised_child_identity,
 };
 #[cfg(all(test, any(target_os = "linux", target_os = "macos")))]
 pub(in crate::update::manager) use self::process_quiescence::{spawn_native_test_app, wait_for_native_test_app};
@@ -107,6 +105,41 @@ pub(super) async fn request_supervisor_shutdown(
         Duration::from_millis(100),
     )
     .await
+}
+
+#[cfg(unix)]
+pub(super) fn preflight_supervisor_recovery_paths(
+    active_app_dir: &Path,
+    main_exe: &str,
+    supervisor_id: &str,
+) -> Result<()> {
+    if supervisor_id.trim().is_empty() {
+        return Ok(());
+    }
+
+    ensure_recovery_launch_path(
+        &active_app_dir.join(supervisor_binary_name()),
+        "bundled supervisor binary",
+    )?;
+    ensure_recovery_launch_path(&active_app_dir.join(main_exe), "application executable")
+}
+
+#[cfg(unix)]
+fn ensure_recovery_launch_path(path: &Path, description: &str) -> Result<()> {
+    use nix::unistd::{AccessFlags, access};
+
+    if !path.is_file() {
+        return Err(SurgeError::Update(format!(
+            "Cannot request supervisor shutdown because its recovery {description} is missing at {}",
+            path.display()
+        )));
+    }
+    access(path, AccessFlags::X_OK).map_err(|error| {
+        SurgeError::Update(format!(
+            "Cannot request supervisor shutdown because its recovery {description} is not executable at {}: {error}",
+            path.display()
+        ))
+    })
 }
 
 pub(super) async fn request_supervisor_shutdown_with_timeout(
@@ -640,6 +673,41 @@ mod tests {
         );
         assert!(!supervisor_takeover_request_file(dir.path(), supervisor_id).exists());
         assert!(supervisor_pid_file(dir.path(), supervisor_id).exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn supervisor_recovery_preflight_requires_every_launch_path() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let active_app_dir = dir.path().join("app");
+        std::fs::create_dir_all(&active_app_dir).unwrap();
+        let app_path = active_app_dir.join("demo-app");
+        std::fs::write(&app_path, "#!/bin/sh\nexit 0\n").unwrap();
+        let mut permissions = std::fs::metadata(&app_path).unwrap().permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&app_path, permissions).unwrap();
+
+        let error = preflight_supervisor_recovery_paths(&active_app_dir, "demo-app", "demo-supervisor").unwrap_err();
+        assert!(error.to_string().contains("bundled supervisor binary is missing"));
+
+        let supervisor_path = active_app_dir.join(supervisor_binary_name());
+        std::fs::write(&supervisor_path, "#!/bin/sh\nexit 0\n").unwrap();
+        let mut permissions = std::fs::metadata(&supervisor_path).unwrap().permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&supervisor_path, permissions).unwrap();
+        let mut permissions = std::fs::metadata(&app_path).unwrap().permissions();
+        permissions.set_mode(0o644);
+        std::fs::set_permissions(&app_path, permissions).unwrap();
+
+        let error = preflight_supervisor_recovery_paths(&active_app_dir, "demo-app", "demo-supervisor").unwrap_err();
+        assert!(error.to_string().contains("application executable is not executable"));
+
+        let mut permissions = std::fs::metadata(&app_path).unwrap().permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&app_path, permissions).unwrap();
+        preflight_supervisor_recovery_paths(&active_app_dir, "demo-app", "demo-supervisor").unwrap();
     }
 
     #[test]

--- a/crates/surge-core/src/update/manager/lifecycle/process_quiescence.rs
+++ b/crates/surge-core/src/update/manager/lifecycle/process_quiescence.rs
@@ -17,6 +17,7 @@ use self::discovery::AppProcess;
 use self::discovery::app_process_pids;
 #[cfg(unix)]
 use self::discovery::{app_process_identities, current_process_environment};
+pub(in crate::update::manager) use self::process_target::with_supervised_child_identity;
 #[cfg(unix)]
 use self::process_target::{ProcessTarget, add_process_targets, process_targets_are_running};
 use crate::error::Result;

--- a/crates/surge-core/src/update/manager/lifecycle/process_quiescence/process_target.rs
+++ b/crates/surge-core/src/update/manager/lifecycle/process_quiescence/process_target.rs
@@ -5,6 +5,8 @@ use crate::platform::process::StableProcessHandle;
 use crate::platform::process::process_identity_matches;
 use crate::platform::process::{ProcessIdentity, ProcessSignalOutcome};
 
+use super::PreparedAppQuiescence;
+
 #[derive(Debug)]
 pub(super) struct ProcessTarget {
     identity: ProcessIdentity,
@@ -34,6 +36,14 @@ pub(super) fn process_targets_are_running(targets: &[ProcessTarget]) -> Result<b
         }
     }
     Ok(false)
+}
+
+pub(in crate::update::manager) fn with_supervised_child_identity(
+    mut prepared: PreparedAppQuiescence,
+    supervised_child_identity: Option<ProcessIdentity>,
+) -> PreparedAppQuiescence {
+    prepared.supervised_child_identity = supervised_child_identity;
+    prepared
 }
 
 impl ProcessTarget {


### PR DESCRIPTION
## Summary

- capture the active entrypoint and both current and previous recovery launch paths before shutdown
- require bundled supervisors and application executables to exist and be executable before takeover
- attach the exact acknowledged child generation only after takeover succeeds

## Why

Resolving recovery paths after the current supervisor exits can leave no trustworthy process to restart. Every recovery input must be validated while the old application is still supervised.

This is stack 14 of 16.

- Base: #286
- Next: #263

Relates to fintermobilityas/youpark#1310.

## Validation

- exact layer `4017254` passed missing-entrypoint, missing-supervisor, non-executable-app, and accepted-takeover preservation regressions
- it resolves the actionable review feedback previously raised on this PR without consuming takeover state before preflight succeeds
- complete stack `c48f19f` passed 681 Rust workspace tests, both blocking Clippy tiers, vendor/version/format/maintainability checks, .NET formatting, and all 58 .NET tests

No migration is required.
