### PR TITLE
Close inherited descriptors before exec in spawned children

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3247,6 +3247,7 @@ dependencies = [
  "fs2",
  "futures-util",
  "hex",
+ "libc",
  "nix",
  "percent-encoding",
  "quick-xml 0.42.0",

--- a/crates/surge-core/Cargo.toml
+++ b/crates/surge-core/Cargo.toml
@@ -41,6 +41,7 @@ fs2 = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
 nix = { version = "0.31", features = ["signal", "process", "fs"] }
+libc = "0.2"
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_System_Threading", "Win32_Security", "Win32_Storage_FileSystem"] }

--- a/crates/surge-core/src/platform/process.rs
+++ b/crates/surge-core/src/platform/process.rs
@@ -4,6 +4,8 @@ use std::process::{Child, Command, Stdio};
 
 use crate::error::{Result, SurgeError};
 
+mod descriptors;
+
 pub struct ProcessHandle {
     child: Child,
 }
@@ -102,12 +104,27 @@ fn spawn_impl(
     }
 
     cmd.envs(envs);
+    close_inherited_descriptors(&mut cmd);
 
     let child = cmd
         .spawn()
         .map_err(|e| SurgeError::Platform(format!("Failed to spawn {}: {e}", exe.display())))?;
 
     Ok(ProcessHandle { child })
+}
+
+/// Configure `command` so the child starts with only stdin, stdout and stderr open.
+///
+/// A spawned child otherwise inherits every descriptor of the spawning process that
+/// is not marked close-on-exec. For Surge that spawning process is often the
+/// supervised application itself (starting its supervisor, or handing off an
+/// update), and the leaked descriptors keep kernel state alive that belongs to the
+/// application: an exclusive evdev grab, a listening socket, a lock file. The
+/// replacement application then finds its own resources "busy" until every
+/// process in the chain has exited. Closing the inherited descriptors in the child
+/// before `exec` removes that coupling. Unix only; a no-op elsewhere.
+pub fn close_inherited_descriptors(command: &mut Command) {
+    descriptors::close_inherited_before_exec(command);
 }
 
 #[must_use]
@@ -244,6 +261,50 @@ pub fn exec_replace(exe: &Path, args: &[&str]) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn spawned_child_does_not_inherit_open_descriptors() {
+        use super::spawn_process;
+        use std::collections::BTreeMap;
+        use std::os::fd::AsRawFd;
+
+        use nix::fcntl::{FcntlArg, FdFlag, fcntl};
+
+        // Rust opens files close-on-exec by default; clear the flag so the descriptor
+        // would be inherited by a child spawned without descriptor hygiene.
+        let tmp = tempfile::NamedTempFile::new().expect("temp file");
+        fcntl(tmp.as_file(), FcntlArg::F_SETFD(FdFlag::empty())).expect("clear close-on-exec");
+        let inherited = tmp.as_file().as_raw_fd();
+        let probe = format!("test ! -e /proc/self/fd/{inherited}");
+
+        let mut handle = spawn_process(std::path::Path::new("/bin/sh"), &["-c", &probe], None, &BTreeMap::new())
+            .expect("spawn probe shell");
+        let result = handle.wait().expect("wait probe shell");
+
+        assert_eq!(result.exit_code, 0, "descriptor {inherited} leaked into the child");
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn spawned_child_keeps_standard_streams() {
+        use super::spawn_process;
+        use std::collections::BTreeMap;
+
+        let mut handle = spawn_process(
+            std::path::Path::new("/bin/sh"),
+            &[
+                "-c",
+                "test -e /proc/self/fd/0 && test -e /proc/self/fd/1 && test -e /proc/self/fd/2",
+            ],
+            None,
+            &BTreeMap::new(),
+        )
+        .expect("spawn probe shell");
+        let result = handle.wait().expect("wait probe shell");
+
+        assert_eq!(result.exit_code, 0);
+    }
+
     use super::{PidLiveness, is_pid_alive, probe_pid_liveness};
     use std::time::{Duration, Instant};
 

--- a/crates/surge-core/src/platform/process.rs
+++ b/crates/surge-core/src/platform/process.rs
@@ -121,8 +121,9 @@ fn spawn_impl(
 /// update), and the leaked descriptors keep kernel state alive that belongs to the
 /// application: an exclusive evdev grab, a listening socket, a lock file. The
 /// replacement application then finds its own resources "busy" until every
-/// process in the chain has exited. Closing the inherited descriptors in the child
-/// before `exec` removes that coupling. Unix only; a no-op elsewhere.
+/// process in the chain has exited. Marking the inherited descriptors close-on-exec
+/// in the child before `exec` removes that coupling without disturbing the standard
+/// library's spawn-error reporting. Unix only; a no-op elsewhere.
 pub fn close_inherited_descriptors(command: &mut Command) {
     descriptors::close_inherited_before_exec(command);
 }
@@ -282,6 +283,25 @@ mod tests {
         let result = handle.wait().expect("wait probe shell");
 
         assert_eq!(result.exit_code, 0, "descriptor {inherited} leaked into the child");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn spawning_a_missing_executable_still_reports_the_error() {
+        use super::spawn_process;
+        use std::collections::BTreeMap;
+
+        let result = spawn_process(
+            std::path::Path::new("/nonexistent/surge-missing-executable"),
+            &[],
+            None,
+            &BTreeMap::new(),
+        );
+
+        assert!(
+            matches!(result, Err(crate::error::SurgeError::Platform(_))),
+            "exec failure must surface through spawn(), not vanish with the error pipe"
+        );
     }
 
     #[cfg(target_os = "linux")]

--- a/crates/surge-core/src/platform/process/descriptors.rs
+++ b/crates/surge-core/src/platform/process/descriptors.rs
@@ -1,0 +1,63 @@
+//! Descriptor hygiene for spawned children: an `unsafe` boundary around the
+//! post-fork, pre-exec hook that closes inherited descriptors.
+#![allow(unsafe_code)]
+
+use std::process::Command;
+
+#[cfg(unix)]
+const FIRST_INHERITABLE_DESCRIPTOR: libc::c_int = 3;
+
+#[cfg(unix)]
+const MAX_SCANNED_DESCRIPTOR: libc::c_int = 65_536;
+
+/// Install a pre-exec hook that closes every descriptor above stderr in the child.
+pub(super) fn close_inherited_before_exec(command: &mut Command) {
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+
+        // SAFETY: the closure runs in the forked child between `fork` and `exec` and
+        // only calls async-signal-safe functions (`close_range`, `sysconf`, `close`).
+        // It does not allocate, take locks, or touch state shared with the parent.
+        unsafe {
+            command.pre_exec(|| {
+                close_descriptors_from(FIRST_INHERITABLE_DESCRIPTOR);
+                Ok(())
+            });
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = command;
+    }
+}
+
+#[cfg(unix)]
+fn close_descriptors_from(first: libc::c_int) {
+    #[cfg(target_os = "linux")]
+    {
+        // SAFETY: a plain syscall with integer arguments; `close_range(2)` closes every
+        // descriptor in the inclusive range and has no memory-safety preconditions.
+        let first_unsigned = libc::c_uint::try_from(first).unwrap_or(0);
+        let closed = unsafe { libc::syscall(libc::SYS_close_range, first_unsigned, libc::c_uint::MAX, 0) };
+        if closed == 0 {
+            return;
+        }
+    }
+
+    // SAFETY: `sysconf` and `close` are async-signal-safe and take only integer
+    // arguments; closing an unused descriptor number merely fails with `EBADF`.
+    unsafe {
+        let limit = libc::sysconf(libc::_SC_OPEN_MAX);
+        let last = libc::c_int::try_from(limit).map_or(MAX_SCANNED_DESCRIPTOR, |open_max| {
+            if open_max > 0 {
+                open_max.min(MAX_SCANNED_DESCRIPTOR)
+            } else {
+                MAX_SCANNED_DESCRIPTOR
+            }
+        });
+        for descriptor in first..last {
+            libc::close(descriptor);
+        }
+    }
+}

--- a/crates/surge-core/src/platform/process/descriptors.rs
+++ b/crates/surge-core/src/platform/process/descriptors.rs
@@ -1,5 +1,5 @@
 //! Descriptor hygiene for spawned children: an `unsafe` boundary around the
-//! post-fork, pre-exec hook that closes inherited descriptors.
+//! post-fork, pre-exec hook that marks inherited descriptors close-on-exec.
 #![allow(unsafe_code)]
 
 use std::process::Command;
@@ -10,18 +10,28 @@ const FIRST_INHERITABLE_DESCRIPTOR: libc::c_int = 3;
 #[cfg(unix)]
 const MAX_SCANNED_DESCRIPTOR: libc::c_int = 65_536;
 
-/// Install a pre-exec hook that closes every descriptor above stderr in the child.
+/// `close_range(2)` flag: set `FD_CLOEXEC` on the range instead of closing it.
+#[cfg(target_os = "linux")]
+const CLOSE_RANGE_CLOEXEC: libc::c_int = 1 << 2;
+
+/// Install a pre-exec hook that marks every descriptor above stderr close-on-exec.
+///
+/// The descriptors are marked rather than closed: the standard library keeps a
+/// private close-on-exec pipe open in the child to report `chdir`, `pre_exec` and
+/// `execve` failures back to `spawn()`, and closing it would turn a missing
+/// executable into a successful spawn. Marked descriptors vanish at `exec`, while
+/// the error channel keeps working until then.
 pub(super) fn close_inherited_before_exec(command: &mut Command) {
     #[cfg(unix)]
     {
         use std::os::unix::process::CommandExt;
 
         // SAFETY: the closure runs in the forked child between `fork` and `exec` and
-        // only calls async-signal-safe functions (`close_range`, `sysconf`, `close`).
+        // only calls async-signal-safe functions (`close_range`, `sysconf`, `fcntl`).
         // It does not allocate, take locks, or touch state shared with the parent.
         unsafe {
             command.pre_exec(|| {
-                close_descriptors_from(FIRST_INHERITABLE_DESCRIPTOR);
+                mark_close_on_exec_from(FIRST_INHERITABLE_DESCRIPTOR);
                 Ok(())
             });
         }
@@ -33,20 +43,27 @@ pub(super) fn close_inherited_before_exec(command: &mut Command) {
 }
 
 #[cfg(unix)]
-fn close_descriptors_from(first: libc::c_int) {
+fn mark_close_on_exec_from(first: libc::c_int) {
     #[cfg(target_os = "linux")]
     {
-        // SAFETY: a plain syscall with integer arguments; `close_range(2)` closes every
-        // descriptor in the inclusive range and has no memory-safety preconditions.
+        // SAFETY: a plain syscall with integer arguments; with `CLOSE_RANGE_CLOEXEC`
+        // it only flips the close-on-exec flag on the descriptors in the range.
         let first_unsigned = libc::c_uint::try_from(first).unwrap_or(0);
-        let closed = unsafe { libc::syscall(libc::SYS_close_range, first_unsigned, libc::c_uint::MAX, 0) };
-        if closed == 0 {
+        let marked = unsafe {
+            libc::syscall(
+                libc::SYS_close_range,
+                first_unsigned,
+                libc::c_uint::MAX,
+                CLOSE_RANGE_CLOEXEC,
+            )
+        };
+        if marked == 0 {
             return;
         }
     }
 
-    // SAFETY: `sysconf` and `close` are async-signal-safe and take only integer
-    // arguments; closing an unused descriptor number merely fails with `EBADF`.
+    // SAFETY: `sysconf` and `fcntl` are async-signal-safe and take only integer
+    // arguments; an unused descriptor number merely fails with `EBADF` and is skipped.
     unsafe {
         let limit = libc::sysconf(libc::_SC_OPEN_MAX);
         let last = libc::c_int::try_from(limit).map_or(MAX_SCANNED_DESCRIPTOR, |open_max| {
@@ -57,7 +74,10 @@ fn close_descriptors_from(first: libc::c_int) {
             }
         });
         for descriptor in first..last {
-            libc::close(descriptor);
+            let flags = libc::fcntl(descriptor, libc::F_GETFD);
+            if flags >= 0 && flags & libc::FD_CLOEXEC == 0 {
+                libc::fcntl(descriptor, libc::F_SETFD, flags | libc::FD_CLOEXEC);
+            }
         }
     }
 }

--- a/crates/surge-core/tests/unsafe_boundaries.rs
+++ b/crates/surge-core/tests/unsafe_boundaries.rs
@@ -15,7 +15,7 @@ fn collect_rust_files(root: &Path, out: &mut Vec<PathBuf>) {
 }
 
 #[test]
-fn unsafe_is_confined_to_diff_modules() {
+fn unsafe_is_confined_to_boundary_modules() {
     let src_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
     let mut rust_files = Vec::new();
     collect_rust_files(&src_root, &mut rust_files);
@@ -29,7 +29,10 @@ fn unsafe_is_confined_to_diff_modules() {
 
         let allowed_unsafe_file = matches!(
             rel.as_str(),
-            "src/diff/bsdiff_sys.rs" | "src/diff/wrapper.rs" | "src/diff/mod.rs"
+            "src/diff/bsdiff_sys.rs"
+                | "src/diff/wrapper.rs"
+                | "src/diff/mod.rs"
+                | "src/platform/process/descriptors.rs"
         );
 
         let content = fs::read_to_string(&file).expect("failed to read rust source file");

--- a/crates/surge-supervisor/src/child.rs
+++ b/crates/surge-supervisor/src/child.rs
@@ -19,6 +19,7 @@ pub(crate) fn spawn_supervised_child(
 
     let mut command = Command::new(exe_path);
     command.current_dir(install_dir).args(child_args);
+    surge_core::platform::process::close_inherited_descriptors(&mut command);
 
     // Put the child in its own process group so a group-scoped signal or
     // `pkill -g` aimed at the supervisor cannot also take down the child.


### PR DESCRIPTION
## Summary

- add `platform::process::close_inherited_descriptors`, a pre-exec hook that closes every descriptor above stderr in the child (`close_range(2)` on Linux, bounded `close()` loop as fallback; no-op off Unix)
- apply it in `spawn_impl`, which backs the FFI `StartSupervisor`, the lifecycle hooks, install launch and the update handoff supervisor, and in the supervisor's `spawn_supervised_child`
- keep the `unsafe` in one boundary module (`platform/process/descriptors.rs`) and register it with the unsafe-confinement test
- regression test: a deliberately inheritable descriptor must not be visible in the child's `/proc/self/fd`, while stdin/stdout/stderr must be

## Why

The process that spawns a Surge child is frequently the supervised application itself. Its descriptors that are not close-on-exec — an exclusive evdev grab, a listening socket, a lock file — therefore leaked into the supervisor watcher and, through the handoff supervisor, into the replacement application. The kernel keeps that state alive while any copy exists, so after an in-place update the replacement found its own resources busy until the entire chain had exited.

Production case (the consuming application, 2026-08-31): the application grabs its touch screen's `/dev/input/eventN` exclusively; after the rollout a large share of the nodes with that input path logged `EVIOCGRAB` `EBUSY` in the new process, the `surge-supervisor watch` process was holding the inherited descriptor, and because a grabbed device only delivers events to the grab owner the touch screen was dead until reboot. The application side is hardened in the downstream repository; this change removes the leak at its source for every Surge-spawned process.

## Validation

- `cargo fmt --all -- --check`, `./scripts/sync-surge-core-vendor.sh --check`, `./scripts/check-version-sync.sh`
- `RUSTFLAGS="-D warnings" cargo test --workspace` (Rust 1.95.0): all suites green, including the new negative-checked descriptor test (fails with the hook disabled)
- `cargo clippy --all-targets --all-features -- -D warnings` and the `unwrap_used`/`expect_used` variant: clean
- pedantic variant: no findings in the changed files; pre-existing findings remain in `diff/chunked` (`format.rs:221,244`, `mod.rs:609`, `apply/delta.rs:142`)
- `dotnet format dotnet/Surge.slnx --verify-no-changes`, `dotnet test dotnet/Surge.slnx --configuration Release`: 57 passed