### PR TITLE
Write chunked patches in format 1 by default; format 2 is opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -629,6 +629,7 @@ pack:                             # optional; omitted uses built-in defaults
   delta:
     strategy: sparse-file-ops
     max_chain_length: 8
+    chunked_patch_format: 1       # 1 = readable by every client (default); 2 = identity-chunk bitset, needs clients that know format 2
   compression:
     format: zstd
     level: 3

--- a/crates/surge-bench/examples/diff_bench.rs
+++ b/crates/surge-bench/examples/diff_bench.rs
@@ -7,7 +7,7 @@
 use std::fs;
 use std::time::Instant;
 
-use surge_core::diff::chunked::{self, ChunkedDiffOptions};
+use surge_core::diff::chunked::{self, ChunkedDiffOptions, ChunkedPatchFormat};
 use surge_core::diff::wrapper;
 
 fn peak_rss_mb() -> f64 {
@@ -127,6 +127,7 @@ fn main() {
             let opts = ChunkedDiffOptions {
                 chunk_size,
                 max_threads: threads,
+                format: ChunkedPatchFormat::IdentityChunks,
             };
             let thread_label = if threads == 0 {
                 "auto".to_string()

--- a/crates/surge-bench/src/main.rs
+++ b/crates/surge-bench/src/main.rs
@@ -300,6 +300,7 @@ fn main() {
             let chunked_opts = surge_core::diff::chunked::ChunkedDiffOptions {
                 chunk_size: (args.chunk_mb.saturating_mul(1024 * 1024)).max(1) as usize,
                 max_threads: args.diff_threads,
+                format: surge_core::diff::chunked::ChunkedPatchFormat::IdentityChunks,
             };
             // Use the archives for diffing (more realistic than raw files)
             let mut packer_v2 = surge_core::archive::packer::ArchivePacker::new(3).expect("packer v2");

--- a/crates/surge-cli/src/commands/init.rs
+++ b/crates/surge-cli/src/commands/init.rs
@@ -130,6 +130,7 @@ fn default_pack_manifest_config() -> PackManifestConfig {
         delta: Some(PackDeltaManifestConfig {
             strategy: Some(PACK_DEFAULT_DELTA_STRATEGY.to_string()),
             max_chain_length: Some(PACK_DEFAULT_MAX_CHAIN_LENGTH),
+            chunked_patch_format: None,
         }),
         compression: Some(PackCompressionManifestConfig {
             format: Some(PACK_DEFAULT_COMPRESSION_FORMAT.to_string()),

--- a/crates/surge-core/src/config/manifest/lookup.rs
+++ b/crates/surge-core/src/config/manifest/lookup.rs
@@ -1,6 +1,6 @@
 use super::types::{
-    AppConfig, InstallArtifactCachePolicy, PackCompressionFormat, PackDeltaStrategy, PackPolicy, SurgeManifest,
-    TargetConfig,
+    AppConfig, InstallArtifactCachePolicy, PackChunkedPatchFormat, PackCompressionFormat, PackDeltaStrategy,
+    PackPolicy, SurgeManifest, TargetConfig,
 };
 use super::validate::canonicalize_installers;
 
@@ -16,6 +16,9 @@ impl SurgeManifest {
                 }
                 if let Some(max_chain_length) = delta.max_chain_length {
                     policy.max_chain_length = max_chain_length;
+                }
+                if let Some(format) = delta.chunked_patch_format.and_then(PackChunkedPatchFormat::parse) {
+                    policy.chunked_patch_format = format;
                 }
             }
 
@@ -153,5 +156,45 @@ impl AppConfig {
             resolved.environment = merged;
         }
         resolved
+    }
+}
+
+#[cfg(test)]
+mod chunked_patch_format_tests {
+    use super::super::types::{PackChunkedPatchFormat, SurgeManifest};
+
+    fn manifest(chunked_patch_format: Option<u8>) -> SurgeManifest {
+        let pack = chunked_patch_format.map_or(String::new(), |value| {
+            format!("pack:\n  delta:\n    chunked_patch_format: {value}\n")
+        });
+        let yaml = format!(
+            "schema: 1\nstorage:\n  provider: filesystem\n  bucket: /tmp/store\napps:\n  - id: demoapp\n    target:\n      rid: linux-x64\n{pack}"
+        );
+        SurgeManifest::parse(yaml.as_bytes()).expect("manifest should parse")
+    }
+
+    #[test]
+    fn chunked_patch_format_defaults_to_v1() {
+        let policy = manifest(None).effective_pack_policy();
+
+        assert_eq!(policy.chunked_patch_format, PackChunkedPatchFormat::V1);
+    }
+
+    #[test]
+    fn chunked_patch_format_two_opts_in_to_identity_chunks() {
+        let policy = manifest(Some(2)).effective_pack_policy();
+
+        assert_eq!(policy.chunked_patch_format, PackChunkedPatchFormat::V2);
+        assert_eq!(
+            crate::diff::chunked::ChunkedPatchFormat::from(policy.chunked_patch_format),
+            crate::diff::chunked::ChunkedPatchFormat::IdentityChunks
+        );
+    }
+
+    #[test]
+    fn unknown_chunked_patch_format_keeps_the_compatible_default() {
+        let policy = manifest(Some(3)).effective_pack_policy();
+
+        assert_eq!(policy.chunked_patch_format, PackChunkedPatchFormat::V1);
     }
 }

--- a/crates/surge-core/src/config/manifest/types.rs
+++ b/crates/surge-core/src/config/manifest/types.rs
@@ -43,6 +43,10 @@ pub struct PackDeltaManifestConfig {
     pub strategy: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub max_chain_length: Option<u32>,
+    /// Chunked patch format version to publish: `1` (default, readable by every client) or `2`
+    /// (identity-chunk bitset; requires clients that understand format version 2).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub chunked_patch_format: Option<u8>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -361,6 +365,36 @@ impl PackCompressionFormat {
     }
 }
 
+/// Chunked patch format version a publisher writes. Readers accept both versions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum PackChunkedPatchFormat {
+    /// Format version 1: readable by every client; every chunk carries a bsdiff payload.
+    #[default]
+    V1,
+    /// Format version 2: identity-chunk bitset; rejected by clients that predate it.
+    V2,
+}
+
+impl PackChunkedPatchFormat {
+    #[must_use]
+    pub fn parse(raw: u8) -> Option<Self> {
+        match raw {
+            1 => Some(Self::V1),
+            2 => Some(Self::V2),
+            _ => None,
+        }
+    }
+}
+
+impl From<PackChunkedPatchFormat> for crate::diff::chunked::ChunkedPatchFormat {
+    fn from(format: PackChunkedPatchFormat) -> Self {
+        match format {
+            PackChunkedPatchFormat::V1 => Self::Legacy,
+            PackChunkedPatchFormat::V2 => Self::IdentityChunks,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct PackPolicy {
     pub delta_strategy: PackDeltaStrategy,
@@ -369,6 +403,7 @@ pub struct PackPolicy {
     pub max_chain_length: u32,
     pub keep_latest_fulls: u32,
     pub checkpoint_every: u32,
+    pub chunked_patch_format: PackChunkedPatchFormat,
 }
 
 impl Default for PackPolicy {
@@ -380,6 +415,7 @@ impl Default for PackPolicy {
             max_chain_length: PACK_DEFAULT_MAX_CHAIN_LENGTH,
             keep_latest_fulls: PACK_DEFAULT_KEEP_LATEST_FULLS,
             checkpoint_every: PACK_DEFAULT_CHECKPOINT_EVERY,
+            chunked_patch_format: PackChunkedPatchFormat::default(),
         }
     }
 }

--- a/crates/surge-core/src/diff/chunked/format.rs
+++ b/crates/surge-core/src/diff/chunked/format.rs
@@ -16,6 +16,7 @@
 //!   For each chunk:
 //!     patch_len (8 bytes LE)
 //!     patch_data (patch_len bytes; empty for identity chunks)
+use super::ChunkedPatchFormat;
 use crate::error::{Result, SurgeError};
 
 /// Magic bytes identifying the chunked patch format.
@@ -68,11 +69,20 @@ pub(super) fn serialize_patch(
     new_size: usize,
     chunk_size: usize,
     chunks: &[(usize, Vec<u8>, bool)],
+    format: ChunkedPatchFormat,
 ) -> Result<Vec<u8>> {
     let num_chunks = chunks.len();
-    let mut bitset = vec![0u8; identity_bitset_len(num_chunks)];
+    let (version, mut bitset) = match format {
+        ChunkedPatchFormat::Legacy => (LEGACY_VERSION, Vec::new()),
+        ChunkedPatchFormat::IdentityChunks => (VERSION, vec![0u8; identity_bitset_len(num_chunks)]),
+    };
     for (idx, _, identity) in chunks {
         if *identity {
+            if format == ChunkedPatchFormat::Legacy {
+                return Err(SurgeError::Diff(
+                    "identity chunk cannot be encoded in the legacy chunked patch format".into(),
+                ));
+            }
             set_identity_bit(&mut bitset, *idx);
         }
     }
@@ -82,7 +92,7 @@ pub(super) fn serialize_patch(
     let mut buf = Vec::with_capacity(header_size + bitset.len() + data_size);
 
     buf.extend_from_slice(MAGIC);
-    buf.push(VERSION);
+    buf.push(version);
     buf.extend_from_slice(
         &u64::try_from(chunk_size)
             .map_err(|_| SurgeError::Diff("chunk size exceeds supported patch format".into()))?
@@ -216,7 +226,7 @@ mod tests {
 
     #[test]
     fn test_chunked_v2_identity_chunks_carry_no_payload() {
-        // 4 chunks, middle two identical to the old file.
+        // 4 chunks, middle two identical to the old file; identity chunks are opt-in.
         let chunk = 256usize;
         let old: Vec<u8> = (0..(4 * chunk)).map(|i| (i % 251) as u8).collect();
         let mut new = old.clone();
@@ -227,6 +237,7 @@ mod tests {
         let opts = ChunkedDiffOptions {
             chunk_size: chunk,
             max_threads: 2,
+            format: ChunkedPatchFormat::IdentityChunks,
         };
         let patch = chunked_bsdiff(&old, &new, &opts).expect("bsdiff");
 
@@ -282,9 +293,48 @@ mod tests {
         let opts = ChunkedDiffOptions {
             chunk_size: chunk,
             max_threads: 1,
+            format: ChunkedPatchFormat::Legacy,
         };
         let reconstructed = chunked_bspatch(&old, &patch, &opts).expect("bspatch v1");
         assert_eq!(reconstructed, new);
+    }
+
+    #[test]
+    fn test_chunked_default_format_is_legacy_and_carries_identity_payloads() {
+        // Default options must produce a patch every fielded reader accepts: version byte 1,
+        // no identity bitset, and a real bsdiff payload for the unchanged chunks.
+        let chunk = 256usize;
+        let old: Vec<u8> = (0..(4 * chunk))
+            .map(|i| u8::try_from(i % 251).unwrap_or_default())
+            .collect();
+        let mut new = old.clone();
+        new[10] ^= 0xff;
+        let opts = ChunkedDiffOptions {
+            chunk_size: chunk,
+            max_threads: 1,
+            ..ChunkedDiffOptions::default()
+        };
+        let patch = chunked_bsdiff(&old, &new, &opts).unwrap();
+
+        assert_eq!(patch[4], LEGACY_VERSION);
+        let decoded = deserialize_patch(&patch).unwrap();
+        assert_eq!(decoded.chunks.len(), 4);
+        assert!(
+            decoded.identity.iter().all(|flag| !flag),
+            "legacy patches never carry identity flags"
+        );
+        assert!(
+            decoded.chunks.iter().all(|c| !c.is_empty()),
+            "every legacy chunk carries a payload"
+        );
+        assert_eq!(chunked_bspatch(&old, &patch, &opts).unwrap(), new);
+    }
+
+    #[test]
+    fn test_chunked_legacy_format_rejects_identity_flags() {
+        let chunks = vec![(0usize, vec![1u8, 2, 3], true)];
+        let err = serialize_patch(3, 3, 3, &chunks, ChunkedPatchFormat::Legacy).unwrap_err();
+        assert!(err.to_string().contains("legacy chunked patch format"), "{err}");
     }
 
     #[test]
@@ -295,6 +345,7 @@ mod tests {
         let opts = ChunkedDiffOptions {
             chunk_size: chunk,
             max_threads: 1,
+            format: ChunkedPatchFormat::Legacy,
         };
         let mut patch = chunked_bsdiff(&old, &new, &opts).expect("bsdiff");
         patch[4] = 3;

--- a/crates/surge-core/src/diff/chunked/mod.rs
+++ b/crates/surge-core/src/diff/chunked/mod.rs
@@ -27,12 +27,31 @@ pub const DEFAULT_CHUNK_SIZE: usize = 64 * 1024 * 1024;
 /// Progress callback for file-backed patch application: (bytes_done, bytes_total).
 pub type ByteProgress<'a> = dyn Fn(u64, u64) + 'a;
 
+/// On-disk format written for a chunked patch.
+///
+/// Readers accept both; the choice only affects what publishers emit. `Legacy`
+/// (format version 1) is the default because every reader in the field can apply
+/// it. `IdentityChunks` (format version 2) skips the bsdiff payload for chunks that
+/// did not change, which is much cheaper to produce and apply for large files with
+/// small edits, but readers older than the version that introduced it reject the
+/// patch — publish it only once every client has been upgraded.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ChunkedPatchFormat {
+    /// Format version 1: every chunk carries a bsdiff payload.
+    #[default]
+    Legacy,
+    /// Format version 2: unchanged chunks are marked in an identity bitset and carry no payload.
+    IdentityChunks,
+}
+
 /// Options for chunked diff/patch operations.
 pub struct ChunkedDiffOptions {
     /// Size of each chunk in bytes. Both files are split at these boundaries.
     pub chunk_size: usize,
     /// Maximum number of threads for parallel processing. 0 = auto (memory-aware).
     pub max_threads: usize,
+    /// Patch format to write. Ignored when applying a patch.
+    pub format: ChunkedPatchFormat,
 }
 
 impl Default for ChunkedDiffOptions {
@@ -40,6 +59,7 @@ impl Default for ChunkedDiffOptions {
         Self {
             chunk_size: DEFAULT_CHUNK_SIZE,
             max_threads: 0,
+            format: ChunkedPatchFormat::default(),
         }
     }
 }
@@ -156,7 +176,7 @@ pub fn chunked_bsdiff(older: &[u8], newer: &[u8], opts: &ChunkedDiffOptions) -> 
                         (new_chunk.to_vec(), false)
                     } else if new_chunk.is_empty() {
                         (Vec::new(), false)
-                    } else if old_chunk == new_chunk {
+                    } else if old_chunk == new_chunk && opts.format == ChunkedPatchFormat::IdentityChunks {
                         // Unchanged chunk: record the identity marker instead
                         // of paying for a whole-chunk bsdiff.
                         (Vec::new(), true)
@@ -183,7 +203,7 @@ pub fn chunked_bsdiff(older: &[u8], newer: &[u8], opts: &ChunkedDiffOptions) -> 
     let mut chunks = into_inner(results);
     chunks.sort_by_key(|(idx, _, _)| *idx);
 
-    serialize_patch(older.len(), newer.len(), chunk_size, &chunks)
+    serialize_patch(older.len(), newer.len(), chunk_size, &chunks, opts.format)
 }
 
 /// Apply a chunked patch to reconstruct the newer file.
@@ -208,6 +228,7 @@ pub fn chunked_bspatch(older: &[u8], patch: &[u8], opts: &ChunkedDiffOptions) ->
     let thread_opts = ChunkedDiffOptions {
         chunk_size,
         max_threads: opts.max_threads,
+        format: opts.format,
     };
     let num_threads = thread_opts.effective_threads();
 
@@ -355,7 +376,7 @@ pub fn chunked_bsdiff_files(older_path: &Path, newer_path: &Path, opts: &Chunked
                         (new_chunk, false)
                     } else if new_chunk.is_empty() {
                         (Vec::new(), false)
-                    } else if old_chunk == new_chunk {
+                    } else if old_chunk == new_chunk && opts.format == ChunkedPatchFormat::IdentityChunks {
                         // Unchanged chunk: record the identity marker instead
                         // of paying for a whole-chunk bsdiff.
                         (Vec::new(), true)
@@ -379,7 +400,7 @@ pub fn chunked_bsdiff_files(older_path: &Path, newer_path: &Path, opts: &Chunked
     }
     let mut chunks = into_inner(results);
     chunks.sort_by_key(|(idx, _, _)| *idx);
-    serialize_patch(old_size, new_size, chunk_size, &chunks)
+    serialize_patch(old_size, new_size, chunk_size, &chunks, opts.format)
 }
 
 /// Apply a chunked binary diff patch directly against a file, writing the
@@ -495,6 +516,7 @@ mod tests {
         let opts = ChunkedDiffOptions {
             chunk_size: 256,
             max_threads: 1,
+            format: ChunkedPatchFormat::Legacy,
         };
         let patch = chunked_bsdiff(&data, &data, &opts).expect("bsdiff");
         let reconstructed = chunked_bspatch(&data, &patch, &opts).expect("bspatch");
@@ -511,6 +533,7 @@ mod tests {
         let opts = ChunkedDiffOptions {
             chunk_size: 512,
             max_threads: 2,
+            format: ChunkedPatchFormat::Legacy,
         };
         let patch = chunked_bsdiff(&old, &new, &opts).expect("bsdiff");
         let reconstructed = chunked_bspatch(&old, &patch, &opts).expect("bspatch");
@@ -526,6 +549,7 @@ mod tests {
         let opts = ChunkedDiffOptions {
             chunk_size: 512,
             max_threads: 1,
+            format: ChunkedPatchFormat::Legacy,
         };
         let patch = chunked_bsdiff(&old, &new, &opts).expect("bsdiff");
         let reconstructed = chunked_bspatch(&old, &patch, &opts).expect("bspatch");
@@ -540,6 +564,7 @@ mod tests {
         let opts = ChunkedDiffOptions {
             chunk_size: 512,
             max_threads: 1,
+            format: ChunkedPatchFormat::Legacy,
         };
         let patch = chunked_bsdiff(&old, &new, &opts).expect("bsdiff");
         let reconstructed = chunked_bspatch(&old, &patch, &opts).expect("bspatch");
@@ -557,6 +582,7 @@ mod tests {
         let opts = ChunkedDiffOptions {
             chunk_size: 512,
             max_threads: 4,
+            format: ChunkedPatchFormat::Legacy,
         };
         let patch = chunked_bsdiff(&old, &new, &opts).expect("bsdiff");
         let reconstructed = chunked_bspatch(&old, &patch, &opts).expect("bspatch");
@@ -583,6 +609,7 @@ mod tests {
             &ChunkedDiffOptions {
                 chunk_size: 256 * 1024,
                 max_threads: 1,
+                format: ChunkedPatchFormat::Legacy,
             },
         )
         .expect("build patch");
@@ -601,6 +628,7 @@ mod tests {
         let opts = ChunkedDiffOptions {
             chunk_size: chunk,
             max_threads: 1,
+            format: ChunkedPatchFormat::IdentityChunks,
         };
         let patch = chunked_bsdiff(&old, &new, &opts).expect("bsdiff");
         let header = 4 + 1 + 8 + 8 + 8 + 4;

--- a/crates/surge-core/src/pack/builder/delta.rs
+++ b/crates/surge-core/src/pack/builder/delta.rs
@@ -2,7 +2,7 @@ use crate::config::constants::RELEASES_FILE_COMPRESSED;
 use crate::config::manifest::PackDeltaStrategy;
 use crate::context::ResourceBudget;
 use crate::crypto::sha256::sha256_hex;
-use crate::diff::chunked::{ChunkedDiffOptions, DEFAULT_CHUNK_SIZE};
+use crate::diff::chunked::{ChunkedDiffOptions, ChunkedPatchFormat, DEFAULT_CHUNK_SIZE};
 use crate::error::{Result, SurgeError};
 use crate::releases::delta::{build_archive_bsdiff_patch, build_archive_chunked_patch, build_sparse_file_patch};
 use crate::releases::manifest::{
@@ -54,7 +54,12 @@ impl PackBuilder {
             );
         }
         let n_workers = budget.effective_zstd_workers();
-        let diff_options = chunked_diff_options(&budget, prev_data.len(), new_data.len());
+        let diff_options = chunked_diff_options(
+            &budget,
+            prev_data.len(),
+            new_data.len(),
+            self.pack_policy.chunked_patch_format.into(),
+        );
 
         let (patch, patch_format) = match self.pack_policy.delta_strategy {
             PackDeltaStrategy::SparseFileOps => (
@@ -143,7 +148,12 @@ fn should_fallback_to_full(delta_size: i64, full_size: i64) -> bool {
     delta_size >= full_size
 }
 
-fn chunked_diff_options(budget: &ResourceBudget, older_len: usize, newer_len: usize) -> ChunkedDiffOptions {
+fn chunked_diff_options(
+    budget: &ResourceBudget,
+    older_len: usize,
+    newer_len: usize,
+    format: ChunkedPatchFormat,
+) -> ChunkedDiffOptions {
     const MIN_CHUNK_SIZE: usize = 4 * 1024 * 1024;
     const BYTES_PER_THREAD_FACTOR: usize = 12;
 
@@ -174,6 +184,7 @@ fn chunked_diff_options(budget: &ResourceBudget, older_len: usize, newer_len: us
         } else {
             requested_threads.min(chunk_count)
         },
+        format,
     }
 }
 

--- a/crates/surge-core/src/releases/delta/tests.rs
+++ b/crates/surge-core/src/releases/delta/tests.rs
@@ -7,7 +7,7 @@ use super::*;
 use crate::archive::extractor::extract_to;
 use crate::archive::packer::ArchivePacker;
 use crate::crypto::sha256::sha256_hex;
-use crate::diff::chunked::ChunkedDiffOptions;
+use crate::diff::chunked::{ChunkedDiffOptions, ChunkedPatchFormat};
 use crate::releases::manifest::{
     DeltaArtifact, PATCH_FORMAT_BSDIFF4_ARCHIVE_V3, PATCH_FORMAT_CHUNKED_BSDIFF_ARCHIVE_V3,
 };
@@ -183,6 +183,7 @@ fn test_sparse_file_patch_roundtrip_rebuilds_full_archive_bytes() {
         &ChunkedDiffOptions {
             chunk_size: 128 * 1024,
             max_threads: 1,
+            format: ChunkedPatchFormat::Legacy,
         },
     )
     .unwrap();
@@ -233,6 +234,7 @@ fn test_sparse_file_patch_reports_incremental_apply_progress() {
         &ChunkedDiffOptions {
             chunk_size: 128 * 1024,
             max_threads: 1,
+            format: ChunkedPatchFormat::Legacy,
         },
     )
     .unwrap();
@@ -376,6 +378,7 @@ fn test_in_place_chain_steps_match_single_shot_apply() {
     let opts = ChunkedDiffOptions {
         chunk_size: 128 * 1024,
         max_threads: 1,
+        format: ChunkedPatchFormat::Legacy,
     };
     let patch_12 = build_sparse_file_patch(&full_v1, &full_v2, 7, 0, &opts).unwrap();
     let patch_23 = build_sparse_file_patch(&full_v2, &full_v3, 7, 0, &opts).unwrap();
@@ -434,6 +437,7 @@ fn test_in_place_chain_with_verified_cache_detects_external_modification() {
     let opts = ChunkedDiffOptions {
         chunk_size: 128 * 1024,
         max_threads: 1,
+        format: ChunkedPatchFormat::Legacy,
     };
     let patch_12 = build_sparse_file_patch(&full_v1, &full_v2, 7, 0, &opts).unwrap();
     let patch_23 = build_sparse_file_patch(&full_v2, &full_v3, 7, 0, &opts).unwrap();

--- a/crates/surge-core/src/update/manager.rs
+++ b/crates/surge-core/src/update/manager.rs
@@ -535,7 +535,7 @@ mod tests {
     use crate::config::manifest::ShortcutLocation;
     use crate::context::StorageProvider;
     use crate::crypto::sha256::{sha256_hex, sha256_hex_file};
-    use crate::diff::chunked::ChunkedDiffOptions;
+    use crate::diff::chunked::{ChunkedDiffOptions, ChunkedPatchFormat};
     use crate::diff::wrapper::bsdiff_buffers;
     use crate::platform::detect::current_rid;
     #[cfg(target_os = "linux")]
@@ -2637,6 +2637,7 @@ echo started > new-child-started
             &ChunkedDiffOptions {
                 chunk_size: 128 * 1024,
                 max_threads: 1,
+                format: ChunkedPatchFormat::Legacy,
             },
         )
         .unwrap();

--- a/docs/performance/pack-policy.md
+++ b/docs/performance/pack-policy.md
@@ -80,6 +80,7 @@ Accepted but not yet auto-tuned:
 
 - `pack.delta.max_chain_length`
 - `pack.retention.keep_latest_fulls`
+- `pack.delta.chunked_patch_format` — `1` (default) writes chunked patches every fielded client can read; `2` enables the identity-chunk bitset (unchanged chunks carry no payload — far cheaper for large files with small edits) but clients older than the reader that introduced it reject such patches, so switch only after the whole fleet runs a client that understands version 2.
 - `pack.retention.checkpoint_every`
 
 Not allowed in the manifest:


### PR DESCRIPTION
## Summary

- add `pack.delta.chunked_patch_format` (`1` default, `2` opt-in) to the manifest and `PackPolicy`, mapped to a new `ChunkedDiffOptions::format` (`Legacy` / `IdentityChunks`)
- format 1 writes the legacy header and a real bsdiff payload for unchanged chunks (both the in-memory and the file-backed diff paths); format 2 keeps the identity-chunk bitset from #256
- readers are unchanged and accept both versions; `promote` builds cross-channel deltas with the default (format 1)
- bench keeps measuring format 2 explicitly so the autoresearch numbers are unaffected
- tests: default writes version 1 without bitset and round-trips through `chunked_bspatch`; identity flags in a legacy patch are rejected; manifest parsing for `1`, `2` and an unknown value; existing format-2 tests opt in explicitly
- docs: README manifest example and `docs/performance/pack-policy.md`

## Why

Format 2 is rejected by every reader older than beta.56 ("unsupported chunked patch version: 2"). A publisher that upgrades to beta.56 therefore breaks in-place updates for its entire fielded fleet in one push — observed today on the the consuming application's test channel (three downstream nodes on the previous client), where the nodes also could not fall back to the full package because the publisher had skipped uploading it (#266). The publisher default must stay readable by the clients that exist; the cheaper format is enabled per manifest once a fleet has been upgraded.

## Validation

- `cargo fmt --all -- --check`, `./scripts/sync-surge-core-vendor.sh --check`, `./scripts/check-version-sync.sh`
- `RUSTFLAGS="-D warnings" cargo test --workspace` (1.95.0): green, including the new format/manifest tests
- `cargo clippy --all-targets --all-features -- -D warnings` and the `unwrap_used`/`expect_used` variant: clean; pedantic: no new findings in changed non-test code (the pre-existing test casts in `format.rs`/`mod.rs` remain)
- `dotnet format dotnet/Surge.slnx --verify-no-changes`, `dotnet test dotnet/Surge.slnx --configuration Release`: 58 passed

Fixes the rollout blocker for the downstream repository; the the consuming application manifest keeps the default (format 1) until the fleet is on ≥ beta.56.