### PR TITLE
Require acknowledged supervisor takeover

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3309,6 +3309,7 @@ dependencies = [
  "signal-hook",
  "surge-core",
  "sysinfo",
+ "tempfile",
  "thiserror 2.0.20",
  "tracing",
  "tracing-subscriber",

--- a/crates/surge-core/src/supervisor/state.rs
+++ b/crates/surge-core/src/supervisor/state.rs
@@ -11,9 +11,9 @@ pub use takeover::{
     accept_supervisor_takeover_request, cancel_supervisor_takeover_request, clear_supervisor_takeover_exchange,
     clear_supervisor_takeover_instance_if_owned, clear_supervisor_takeover_request, read_accepted_supervisor_takeover,
     read_supervisor_takeover_acknowledgement, read_supervisor_takeover_commit, read_supervisor_takeover_instance,
-    read_supervisor_takeover_request, supervisor_takeover_request_file, take_accepted_supervisor_takeover,
-    write_supervisor_takeover_acknowledgement, write_supervisor_takeover_commit, write_supervisor_takeover_instance,
-    write_supervisor_takeover_request,
+    read_supervisor_takeover_request, supervisor_takeover_acknowledgement_file, supervisor_takeover_request_file,
+    take_accepted_supervisor_takeover, write_supervisor_takeover_acknowledgement, write_supervisor_takeover_commit,
+    write_supervisor_takeover_instance, write_supervisor_takeover_request,
 };
 
 fn normalized_supervisor_id(supervisor_id: &str) -> &str {
@@ -76,7 +76,18 @@ pub fn take_supervisor_takeover_pid(install_dir: &Path, supervisor_id: &str) -> 
 
 #[cfg(unix)]
 pub fn clear_supervisor_takeover_pid(install_dir: &Path, supervisor_id: &str) {
-    let _ = std::fs::remove_file(supervisor_takeover_pid_file(install_dir, supervisor_id));
+    if let Err(error) = try_clear_supervisor_takeover_pid(install_dir, supervisor_id) {
+        tracing::warn!(supervisor_id, %error, "Failed to clean up legacy supervisor takeover PID");
+    }
+}
+
+#[cfg(unix)]
+pub fn try_clear_supervisor_takeover_pid(install_dir: &Path, supervisor_id: &str) -> Result<()> {
+    match std::fs::remove_file(supervisor_takeover_pid_file(install_dir, supervisor_id)) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error.into()),
+    }
 }
 
 /// Persist the supervised executable path so the spawning side can omit it from
@@ -193,5 +204,14 @@ mod tests {
 
         assert_eq!(take_supervisor_takeover_pid(dir.path(), "demo-supervisor"), Some(42));
         assert_eq!(take_supervisor_takeover_pid(dir.path(), "demo-supervisor"), None);
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn supervisor_takeover_pid_cleanup_reports_failures() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir(supervisor_takeover_pid_file(dir.path(), "demo-supervisor")).unwrap();
+
+        assert!(try_clear_supervisor_takeover_pid(dir.path(), "demo-supervisor").is_err());
     }
 }

--- a/crates/surge-core/src/supervisor/state/takeover.rs
+++ b/crates/surge-core/src/supervisor/state/takeover.rs
@@ -186,6 +186,11 @@ pub fn supervisor_takeover_request_file(install_dir: &Path, supervisor_id: &str)
     takeover_request_file(install_dir, supervisor_id)
 }
 
+#[must_use]
+pub fn supervisor_takeover_acknowledgement_file(install_dir: &Path, supervisor_id: &str) -> PathBuf {
+    takeover_acknowledgement_file(install_dir, supervisor_id)
+}
+
 pub fn write_supervisor_takeover_instance(
     install_dir: &Path,
     supervisor_id: &str,

--- a/crates/surge-supervisor/Cargo.toml
+++ b/crates/surge-supervisor/Cargo.toml
@@ -22,5 +22,8 @@ signal-hook = "0.4.4"
 [target.'cfg(unix)'.dependencies]
 nix = { version = "0.31", features = ["signal", "process"] }
 
+[dev-dependencies]
+tempfile = { workspace = true }
+
 [lints]
 workspace = true

--- a/crates/surge-supervisor/src/child.rs
+++ b/crates/surge-supervisor/src/child.rs
@@ -42,7 +42,7 @@ pub(crate) fn wait_for_supervised_child(
     own_pid: u32,
     install_dir: &Path,
     pending_handoff_version: &mut Option<String>,
-) -> Result<Option<ExitStatus>, SupervisorError> {
+) -> Result<SupervisedChildOutcome, SupervisorError> {
     let Some(version) = pending_handoff_version.clone() else {
         return wait_for_child_exit_status(child, shutdown, stop_file, pid_file, own_pid);
     };
@@ -62,17 +62,17 @@ pub(crate) fn wait_for_supervised_child(
         }
         StartupOutcome::Exited(status) => {
             handoff::record_restart_handoff_child_exited(install_dir, &version, status);
-            Ok(Some(status))
+            Ok(SupervisedChildOutcome::Exited(status))
         }
         StartupOutcome::StopRequested => {
             tracing::info!("Stop requested, exiting supervisor loop and leaving child running");
-            Ok(None)
+            Ok(SupervisedChildOutcome::StopRequested)
         }
         StartupOutcome::ShutdownRequested => {
             tracing::info!("Shutdown signal received, child terminated and supervisor loop is exiting");
-            Ok(None)
+            Ok(SupervisedChildOutcome::ShutdownRequested)
         }
-        StartupOutcome::Superseded => Ok(None),
+        StartupOutcome::Superseded => Ok(SupervisedChildOutcome::Superseded),
     }
 }
 
@@ -82,25 +82,41 @@ fn wait_for_child_exit_status(
     stop_file: &Path,
     pid_file: &Path,
     own_pid: u32,
-) -> Result<Option<ExitStatus>, SupervisorError> {
+) -> Result<SupervisedChildOutcome, SupervisorError> {
     match wait_for_child_or_stop(child, shutdown, stop_file, pid_file, own_pid)? {
-        WaitOutcome::Exited(status) => Ok(Some(status)),
+        WaitOutcome::Exited(status) => Ok(SupervisedChildOutcome::Exited(status)),
         WaitOutcome::ObservedProcessExited => unreachable!(),
         WaitOutcome::StopRequested => {
             tracing::info!("Stop requested, exiting supervisor loop and leaving child running");
-            Ok(None)
+            Ok(SupervisedChildOutcome::StopRequested)
         }
         WaitOutcome::ShutdownRequested => {
             tracing::info!("Shutdown signal received, child terminated and supervisor loop is exiting");
-            Ok(None)
+            Ok(SupervisedChildOutcome::ShutdownRequested)
         }
-        WaitOutcome::Superseded => Ok(None),
+        WaitOutcome::Superseded => Ok(SupervisedChildOutcome::Superseded),
     }
+}
+
+#[derive(Debug)]
+pub(crate) enum SupervisedChildOutcome {
+    Exited(ExitStatus),
+    StopRequested,
+    ShutdownRequested,
+    Superseded,
 }
 
 pub(crate) enum WaitOutcome {
     Exited(std::process::ExitStatus),
     ObservedProcessExited,
+    StopRequested,
+    ShutdownRequested,
+    Superseded,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RestartWaitOutcome {
+    DelayElapsed,
     StopRequested,
     ShutdownRequested,
     Superseded,
@@ -212,32 +228,32 @@ pub(crate) fn wait_before_restart(
     pid_file: &Path,
     own_pid: u32,
     delay: std::time::Duration,
-) -> bool {
+) -> RestartWaitOutcome {
     let deadline = std::time::Instant::now() + delay;
     loop {
         if shutdown.load(std::sync::atomic::Ordering::Acquire) {
             tracing::info!("Shutdown signal received during restart delay, not restarting");
-            return false;
+            return RestartWaitOutcome::ShutdownRequested;
         }
 
         if supervisor_was_superseded(pid_file, own_pid) {
-            return false;
+            return RestartWaitOutcome::Superseded;
         }
 
         if stop_file.exists() {
             tracing::info!("Stop requested during restart delay, not restarting");
-            return false;
+            return RestartWaitOutcome::StopRequested;
         }
 
         if std::time::Instant::now() >= deadline {
-            return true;
+            return RestartWaitOutcome::DelayElapsed;
         }
 
         std::thread::sleep(std::time::Duration::from_millis(100));
     }
 }
 
-fn terminate_child_process(child: &mut Child) -> Result<(), SupervisorError> {
+pub(crate) fn terminate_child_process(child: &mut Child) -> Result<(), SupervisorError> {
     if child.try_wait()?.is_some() {
         return Ok(());
     }
@@ -267,6 +283,59 @@ fn terminate_child_process(child: &mut Child) -> Result<(), SupervisorError> {
     let _ = child.kill();
     let _ = child.wait();
     Ok(())
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn shutdown_wins_when_stop_and_shutdown_are_simultaneous() {
+        let dir = tempfile::tempdir().unwrap();
+        let stop_file = dir.path().join("stop");
+        let pid_file = dir.path().join("pid");
+        let own_pid = std::process::id();
+        std::fs::write(&stop_file, "stop").unwrap();
+        std::fs::write(&pid_file, own_pid.to_string()).unwrap();
+        let shutdown = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true));
+        let mut child = Command::new("sleep").arg("30").spawn().unwrap();
+        let mut pending_handoff = None;
+
+        let outcome = wait_for_supervised_child(
+            &mut child,
+            &shutdown,
+            &stop_file,
+            &pid_file,
+            own_pid,
+            dir.path(),
+            &mut pending_handoff,
+        )
+        .unwrap();
+
+        assert!(matches!(outcome, SupervisedChildOutcome::ShutdownRequested));
+        assert!(child.try_wait().unwrap().is_some());
+    }
+
+    #[test]
+    fn restart_delay_reports_stop_request() {
+        let dir = tempfile::tempdir().unwrap();
+        let stop_file = dir.path().join("stop");
+        let pid_file = dir.path().join("pid");
+        let own_pid = std::process::id();
+        std::fs::write(&stop_file, "stop").unwrap();
+        std::fs::write(&pid_file, own_pid.to_string()).unwrap();
+        let shutdown = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+
+        let outcome = wait_before_restart(
+            &shutdown,
+            &stop_file,
+            &pid_file,
+            own_pid,
+            std::time::Duration::from_secs(1),
+        );
+
+        assert_eq!(outcome, RestartWaitOutcome::StopRequested);
+    }
 }
 
 #[cfg(unix)]

--- a/crates/surge-supervisor/src/child.rs
+++ b/crates/surge-supervisor/src/child.rs
@@ -10,6 +10,32 @@ use crate::ownership::supervisor_was_superseded;
 
 const RESTART_HANDOFF_STABILITY_WINDOW: std::time::Duration = std::time::Duration::from_secs(4);
 
+pub(crate) struct StopTriggers<'a> {
+    legacy_stop_file: &'a Path,
+    takeover_request_file: Option<&'a Path>,
+}
+
+impl<'a> StopTriggers<'a> {
+    pub(crate) fn new(legacy_stop_file: &'a Path, takeover_request_file: Option<&'a Path>) -> Self {
+        Self {
+            legacy_stop_file,
+            takeover_request_file,
+        }
+    }
+
+    pub(crate) fn requested(&self) -> bool {
+        self.legacy_requested() || self.takeover_requested()
+    }
+
+    pub(crate) fn legacy_requested(&self) -> bool {
+        self.legacy_stop_file.exists()
+    }
+
+    pub(crate) fn takeover_requested(&self) -> bool {
+        self.takeover_request_file.is_some_and(Path::exists)
+    }
+}
+
 pub(crate) fn spawn_supervised_child(
     exe_path: &Path,
     install_dir: &Path,
@@ -37,20 +63,20 @@ pub(crate) fn spawn_supervised_child(
 pub(crate) fn wait_for_supervised_child(
     child: &mut Child,
     shutdown: &std::sync::Arc<std::sync::atomic::AtomicBool>,
-    stop_file: &Path,
+    stop_triggers: &StopTriggers<'_>,
     pid_file: &Path,
     own_pid: u32,
     install_dir: &Path,
     pending_handoff_version: &mut Option<String>,
 ) -> Result<SupervisedChildOutcome, SupervisorError> {
     let Some(version) = pending_handoff_version.clone() else {
-        return wait_for_child_exit_status(child, shutdown, stop_file, pid_file, own_pid);
+        return wait_for_child_exit_status(child, shutdown, stop_triggers, pid_file, own_pid);
     };
 
     match wait_for_child_startup_or_stop(
         child,
         shutdown,
-        stop_file,
+        stop_triggers,
         pid_file,
         own_pid,
         RESTART_HANDOFF_STABILITY_WINDOW,
@@ -58,7 +84,7 @@ pub(crate) fn wait_for_supervised_child(
         StartupOutcome::Running => {
             handoff::record_restart_handoff_converged(install_dir, &version);
             *pending_handoff_version = None;
-            wait_for_child_exit_status(child, shutdown, stop_file, pid_file, own_pid)
+            wait_for_child_exit_status(child, shutdown, stop_triggers, pid_file, own_pid)
         }
         StartupOutcome::Exited(status) => {
             handoff::record_restart_handoff_child_exited(install_dir, &version, status);
@@ -79,11 +105,11 @@ pub(crate) fn wait_for_supervised_child(
 fn wait_for_child_exit_status(
     child: &mut Child,
     shutdown: &std::sync::Arc<std::sync::atomic::AtomicBool>,
-    stop_file: &Path,
+    stop_triggers: &StopTriggers<'_>,
     pid_file: &Path,
     own_pid: u32,
 ) -> Result<SupervisedChildOutcome, SupervisorError> {
-    match wait_for_child_or_stop(child, shutdown, stop_file, pid_file, own_pid)? {
+    match wait_for_child_or_stop(child, shutdown, stop_triggers, pid_file, own_pid)? {
         WaitOutcome::Exited(status) => Ok(SupervisedChildOutcome::Exited(status)),
         WaitOutcome::ObservedProcessExited => unreachable!(),
         WaitOutcome::StopRequested => {
@@ -133,7 +159,7 @@ enum StartupOutcome {
 fn wait_for_child_startup_or_stop(
     child: &mut Child,
     shutdown: &std::sync::Arc<std::sync::atomic::AtomicBool>,
-    stop_file: &Path,
+    stop_triggers: &StopTriggers<'_>,
     pid_file: &Path,
     own_pid: u32,
     stable_for: std::time::Duration,
@@ -149,7 +175,7 @@ fn wait_for_child_startup_or_stop(
             return Ok(StartupOutcome::Superseded);
         }
 
-        if stop_file.exists() {
+        if stop_triggers.requested() {
             return Ok(StartupOutcome::StopRequested);
         }
 
@@ -168,7 +194,7 @@ fn wait_for_child_startup_or_stop(
 pub(crate) fn wait_for_pid_or_stop(
     pid: u32,
     shutdown: &std::sync::Arc<std::sync::atomic::AtomicBool>,
-    stop_file: &Path,
+    stop_triggers: &StopTriggers<'_>,
     pid_file: &Path,
     own_pid: u32,
 ) -> WaitOutcome {
@@ -181,7 +207,7 @@ pub(crate) fn wait_for_pid_or_stop(
             return WaitOutcome::Superseded;
         }
 
-        if stop_file.exists() {
+        if stop_triggers.requested() {
             return WaitOutcome::StopRequested;
         }
 
@@ -196,7 +222,7 @@ pub(crate) fn wait_for_pid_or_stop(
 fn wait_for_child_or_stop(
     child: &mut Child,
     shutdown: &std::sync::Arc<std::sync::atomic::AtomicBool>,
-    stop_file: &Path,
+    stop_triggers: &StopTriggers<'_>,
     pid_file: &Path,
     own_pid: u32,
 ) -> Result<WaitOutcome, SupervisorError> {
@@ -210,7 +236,7 @@ fn wait_for_child_or_stop(
             return Ok(WaitOutcome::Superseded);
         }
 
-        if stop_file.exists() {
+        if stop_triggers.requested() {
             return Ok(WaitOutcome::StopRequested);
         }
 
@@ -224,7 +250,7 @@ fn wait_for_child_or_stop(
 
 pub(crate) fn wait_before_restart(
     shutdown: &std::sync::Arc<std::sync::atomic::AtomicBool>,
-    stop_file: &Path,
+    stop_triggers: &StopTriggers<'_>,
     pid_file: &Path,
     own_pid: u32,
     delay: std::time::Duration,
@@ -240,7 +266,7 @@ pub(crate) fn wait_before_restart(
             return RestartWaitOutcome::Superseded;
         }
 
-        if stop_file.exists() {
+        if stop_triggers.requested() {
             tracing::info!("Stop requested during restart delay, not restarting");
             return RestartWaitOutcome::StopRequested;
         }
@@ -300,11 +326,12 @@ mod tests {
         let shutdown = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true));
         let mut child = Command::new("sleep").arg("30").spawn().unwrap();
         let mut pending_handoff = None;
+        let stop_triggers = StopTriggers::new(&stop_file, None);
 
         let outcome = wait_for_supervised_child(
             &mut child,
             &shutdown,
-            &stop_file,
+            &stop_triggers,
             &pid_file,
             own_pid,
             dir.path(),
@@ -325,10 +352,11 @@ mod tests {
         std::fs::write(&stop_file, "stop").unwrap();
         std::fs::write(&pid_file, own_pid.to_string()).unwrap();
         let shutdown = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let stop_triggers = StopTriggers::new(&stop_file, None);
 
         let outcome = wait_before_restart(
             &shutdown,
-            &stop_file,
+            &stop_triggers,
             &pid_file,
             own_pid,
             std::time::Duration::from_secs(1),
@@ -339,7 +367,7 @@ mod tests {
 }
 
 #[cfg(unix)]
-fn is_process_running(pid: u32) -> bool {
+pub(crate) fn is_process_running(pid: u32) -> bool {
     use nix::errno::Errno;
     use nix::sys::signal::kill;
     use nix::unistd::Pid;
@@ -352,7 +380,7 @@ fn is_process_running(pid: u32) -> bool {
 }
 
 #[cfg(windows)]
-fn is_process_running(pid: u32) -> bool {
+pub(crate) fn is_process_running(pid: u32) -> bool {
     let watched_pid = Pid::from_u32(pid);
     let mut system = System::new();
     let _ = system.refresh_processes(ProcessesToUpdate::Some(&[watched_pid]), true);

--- a/crates/surge-supervisor/src/main.rs
+++ b/crates/surge-supervisor/src/main.rs
@@ -15,7 +15,8 @@ mod handoff;
 mod ownership;
 
 use child::{
-    WaitOutcome, spawn_supervised_child, wait_before_restart, wait_for_pid_or_stop, wait_for_supervised_child,
+    RestartWaitOutcome, SupervisedChildOutcome, WaitOutcome, spawn_supervised_child, wait_before_restart,
+    wait_for_pid_or_stop, wait_for_supervised_child,
 };
 #[cfg(unix)]
 use ownership::current_supervisor_owns_pid_file;
@@ -295,7 +296,7 @@ fn run_supervisor(
         #[cfg(unix)]
         let child_pid = child.id();
 
-        let Some(status) = wait_for_supervised_child(
+        let status = match wait_for_supervised_child(
             &mut child,
             &shutdown,
             &stop_file,
@@ -303,13 +304,14 @@ fn run_supervisor(
             own_pid,
             install_dir,
             &mut pending_handoff_version,
-        )?
-        else {
-            #[cfg(unix)]
-            if stop_file.exists() {
+        )? {
+            SupervisedChildOutcome::Exited(status) => status,
+            SupervisedChildOutcome::StopRequested => {
+                #[cfg(unix)]
                 record_supervisor_takeover_pid_if_owned(install_dir, supervisor_id, &pid_file, own_pid, child_pid);
+                break;
             }
-            break;
+            SupervisedChildOutcome::ShutdownRequested | SupervisedChildOutcome::Superseded => break,
         };
 
         if supervisor_was_superseded(&pid_file, own_pid) {
@@ -333,8 +335,11 @@ fn run_supervisor(
             );
         }
 
-        if !wait_before_restart(&shutdown, &stop_file, &pid_file, own_pid, CHILD_RESTART_BACKOFF) {
-            break;
+        match wait_before_restart(&shutdown, &stop_file, &pid_file, own_pid, CHILD_RESTART_BACKOFF) {
+            RestartWaitOutcome::DelayElapsed => {}
+            RestartWaitOutcome::StopRequested
+            | RestartWaitOutcome::ShutdownRequested
+            | RestartWaitOutcome::Superseded => break,
         }
     }
 

--- a/crates/surge-supervisor/src/main.rs
+++ b/crates/surge-supervisor/src/main.rs
@@ -6,21 +6,30 @@ use std::process::ExitCode;
 
 use clap::{Parser, Subcommand};
 #[cfg(unix)]
-use surge_core::supervisor::state::{clear_supervisor_takeover_pid, write_supervisor_takeover_pid};
+use surge_core::supervisor::state::{
+    SupervisorTakeoverInstance, clear_supervisor_takeover_instance_if_owned, supervisor_takeover_request_file,
+    try_clear_supervisor_takeover_pid, write_supervisor_takeover_instance, write_supervisor_takeover_pid,
+};
 use surge_core::supervisor::state::{read_supervisor_exe_path, supervisor_pid_file, supervisor_stop_file};
 use thiserror::Error;
 
 mod child;
 mod handoff;
 mod ownership;
+#[cfg(unix)]
+mod takeover;
 
 use child::{
-    RestartWaitOutcome, SupervisedChildOutcome, WaitOutcome, spawn_supervised_child, wait_before_restart,
+    RestartWaitOutcome, StopTriggers, SupervisedChildOutcome, WaitOutcome, spawn_supervised_child, wait_before_restart,
     wait_for_pid_or_stop, wait_for_supervised_child,
 };
 #[cfg(unix)]
+use child::{is_process_running, terminate_child_process};
+#[cfg(unix)]
 use ownership::current_supervisor_owns_pid_file;
 use ownership::{remove_owned_supervisor_state, supervisor_was_superseded};
+#[cfg(unix)]
+use takeover::{TakeoverResolution, complete_supervisor_takeover};
 
 /// Delay before relaunching a supervised child that has exited. Applied to both
 /// crash exits and clean (code 0) exits so a child that exits immediately cannot
@@ -114,6 +123,10 @@ enum SupervisorError {
 
     #[error("I/O error: {0}")]
     Io(#[from] std::io::Error),
+
+    #[cfg(unix)]
+    #[error("Surge state error: {0}")]
+    Surge(#[from] surge_core::error::SurgeError),
 }
 
 fn resolve_exe_path(
@@ -225,12 +238,27 @@ fn run_supervisor(
     let stop_file = supervisor_stop_file(install_dir, supervisor_id);
 
     #[cfg(unix)]
-    clear_supervisor_takeover_pid(install_dir, supervisor_id);
+    try_clear_supervisor_takeover_pid(install_dir, supervisor_id)?;
     if stop_file.exists() {
         let _ = std::fs::remove_file(&stop_file);
     }
     let own_pid = std::process::id();
     write_pid_file(&pid_file, own_pid)?;
+    #[cfg(unix)]
+    let takeover_instance = {
+        let takeover_instance = SupervisorTakeoverInstance::new(own_pid);
+        if let Err(error) = write_supervisor_takeover_instance(install_dir, supervisor_id, &takeover_instance) {
+            remove_owned_supervisor_state(&pid_file, &stop_file, own_pid);
+            return Err(error.into());
+        }
+        takeover_instance
+    };
+    #[cfg(unix)]
+    let takeover_request_file = supervisor_takeover_request_file(install_dir, supervisor_id);
+    #[cfg(unix)]
+    let stop_triggers = StopTriggers::new(&stop_file, Some(&takeover_request_file));
+    #[cfg(not(unix))]
+    let stop_triggers = StopTriggers::new(&stop_file, None);
 
     let shutdown = install_signal_handlers();
 
@@ -243,17 +271,9 @@ fn run_supervisor(
     let mut pending_handoff_version = handoff::pending_restart_handoff_version(watched_pid, handoff_version, args);
     let mut watched_pid = watched_pid;
 
-    loop {
+    'supervision: loop {
         if shutdown.load(std::sync::atomic::Ordering::Acquire) {
             tracing::info!("Shutdown signal received, exiting supervisor loop");
-            break;
-        }
-        if stop_file.exists() {
-            #[cfg(unix)]
-            if let Some(pid) = watched_pid {
-                record_supervisor_takeover_pid_if_owned(install_dir, supervisor_id, &pid_file, own_pid, pid);
-            }
-            tracing::info!("Stop requested, exiting supervisor loop");
             break;
         }
 
@@ -261,29 +281,90 @@ fn run_supervisor(
             break;
         }
 
+        if stop_triggers.requested() {
+            #[cfg(unix)]
+            match complete_supervisor_takeover(
+                install_dir,
+                supervisor_id,
+                &takeover_instance,
+                &stop_triggers,
+                &shutdown,
+                &pid_file,
+                own_pid,
+                || Ok(watched_pid.filter(|pid| is_process_running(*pid))),
+            )? {
+                TakeoverResolution::Cancelled => continue,
+                TakeoverResolution::LegacyStop(child_pid) => {
+                    if let Some(child_pid) = child_pid {
+                        record_supervisor_takeover_pid_if_owned(
+                            install_dir,
+                            supervisor_id,
+                            &pid_file,
+                            own_pid,
+                            child_pid,
+                        );
+                    }
+                    break;
+                }
+                TakeoverResolution::Accepted
+                | TakeoverResolution::ShutdownRequested
+                | TakeoverResolution::Superseded => break,
+            }
+            #[cfg(not(unix))]
+            break;
+        }
+
         if let Some(pid) = watched_pid.take() {
             tracing::info!("Watching running process PID {pid} before relaunch");
-            match wait_for_pid_or_stop(pid, &shutdown, &stop_file, &pid_file, own_pid) {
-                WaitOutcome::ObservedProcessExited => {
-                    if supervisor_was_superseded(&pid_file, own_pid) {
+            loop {
+                match wait_for_pid_or_stop(pid, &shutdown, &stop_triggers, &pid_file, own_pid) {
+                    WaitOutcome::ObservedProcessExited => {
+                        if supervisor_was_superseded(&pid_file, own_pid) {
+                            break 'supervision;
+                        }
+                        tracing::info!("Observed process PID {pid} exited, starting replacement child");
                         break;
                     }
-                    tracing::info!("Observed process PID {pid} exited, starting replacement child");
+                    WaitOutcome::StopRequested => {
+                        #[cfg(unix)]
+                        match complete_supervisor_takeover(
+                            install_dir,
+                            supervisor_id,
+                            &takeover_instance,
+                            &stop_triggers,
+                            &shutdown,
+                            &pid_file,
+                            own_pid,
+                            || Ok(is_process_running(pid).then_some(pid)),
+                        )? {
+                            TakeoverResolution::Accepted => break 'supervision,
+                            TakeoverResolution::Cancelled => continue,
+                            TakeoverResolution::LegacyStop(child_pid) => {
+                                if let Some(child_pid) = child_pid {
+                                    record_supervisor_takeover_pid_if_owned(
+                                        install_dir,
+                                        supervisor_id,
+                                        &pid_file,
+                                        own_pid,
+                                        child_pid,
+                                    );
+                                }
+                                break 'supervision;
+                            }
+                            TakeoverResolution::ShutdownRequested | TakeoverResolution::Superseded => {
+                                break 'supervision;
+                            }
+                        }
+                        #[cfg(not(unix))]
+                        break 'supervision;
+                    }
+                    WaitOutcome::ShutdownRequested => {
+                        tracing::info!("Shutdown signal received, supervisor loop is exiting");
+                        break 'supervision;
+                    }
+                    WaitOutcome::Superseded => break 'supervision,
+                    WaitOutcome::Exited(_) => unreachable!(),
                 }
-                WaitOutcome::StopRequested => {
-                    #[cfg(unix)]
-                    record_supervisor_takeover_pid_if_owned(install_dir, supervisor_id, &pid_file, own_pid, pid);
-                    tracing::info!("Stop requested, exiting supervisor loop and leaving watched process running");
-                    break;
-                }
-                WaitOutcome::ShutdownRequested => {
-                    tracing::info!("Shutdown signal received, supervisor loop is exiting");
-                    break;
-                }
-                WaitOutcome::Superseded => {
-                    break;
-                }
-                WaitOutcome::Exited(_) => unreachable!(),
             }
         }
 
@@ -296,31 +377,67 @@ fn run_supervisor(
         #[cfg(unix)]
         let child_pid = child.id();
 
-        let status = match wait_for_supervised_child(
-            &mut child,
-            &shutdown,
-            &stop_file,
-            &pid_file,
-            own_pid,
-            install_dir,
-            &mut pending_handoff_version,
-        )? {
-            SupervisedChildOutcome::Exited(status) => status,
-            SupervisedChildOutcome::StopRequested => {
-                #[cfg(unix)]
-                record_supervisor_takeover_pid_if_owned(install_dir, supervisor_id, &pid_file, own_pid, child_pid);
-                break;
+        let status = loop {
+            match wait_for_supervised_child(
+                &mut child,
+                &shutdown,
+                &stop_triggers,
+                &pid_file,
+                own_pid,
+                install_dir,
+                &mut pending_handoff_version,
+            )? {
+                SupervisedChildOutcome::Exited(status) => break status,
+                SupervisedChildOutcome::StopRequested => {
+                    #[cfg(unix)]
+                    match complete_supervisor_takeover(
+                        install_dir,
+                        supervisor_id,
+                        &takeover_instance,
+                        &stop_triggers,
+                        &shutdown,
+                        &pid_file,
+                        own_pid,
+                        || Ok(child.try_wait()?.is_none().then_some(child_pid)),
+                    )? {
+                        TakeoverResolution::Cancelled => continue,
+                        TakeoverResolution::LegacyStop(running_child_pid) => {
+                            if let Some(running_child_pid) = running_child_pid {
+                                record_supervisor_takeover_pid_if_owned(
+                                    install_dir,
+                                    supervisor_id,
+                                    &pid_file,
+                                    own_pid,
+                                    running_child_pid,
+                                );
+                            }
+                            break 'supervision;
+                        }
+                        TakeoverResolution::ShutdownRequested => {
+                            terminate_child_process(&mut child)?;
+                            break 'supervision;
+                        }
+                        TakeoverResolution::Accepted | TakeoverResolution::Superseded => break 'supervision,
+                    }
+                    #[cfg(not(unix))]
+                    break 'supervision;
+                }
+                SupervisedChildOutcome::ShutdownRequested | SupervisedChildOutcome::Superseded => {
+                    break 'supervision;
+                }
             }
-            SupervisedChildOutcome::ShutdownRequested | SupervisedChildOutcome::Superseded => break,
         };
 
         if supervisor_was_superseded(&pid_file, own_pid) {
             break;
         }
 
-        if shutdown.load(std::sync::atomic::Ordering::Acquire) || stop_file.exists() {
+        if shutdown.load(std::sync::atomic::Ordering::Acquire) {
             tracing::info!("Child exited with {status} after shutdown signal, not restarting");
             break;
+        }
+        if stop_triggers.requested() {
+            continue;
         }
 
         if status.success() {
@@ -335,14 +452,39 @@ fn run_supervisor(
             );
         }
 
-        match wait_before_restart(&shutdown, &stop_file, &pid_file, own_pid, CHILD_RESTART_BACKOFF) {
-            RestartWaitOutcome::DelayElapsed => {}
-            RestartWaitOutcome::StopRequested
-            | RestartWaitOutcome::ShutdownRequested
-            | RestartWaitOutcome::Superseded => break,
+        loop {
+            match wait_before_restart(&shutdown, &stop_triggers, &pid_file, own_pid, CHILD_RESTART_BACKOFF) {
+                RestartWaitOutcome::DelayElapsed => break,
+                RestartWaitOutcome::StopRequested => {
+                    #[cfg(unix)]
+                    match complete_supervisor_takeover(
+                        install_dir,
+                        supervisor_id,
+                        &takeover_instance,
+                        &stop_triggers,
+                        &shutdown,
+                        &pid_file,
+                        own_pid,
+                        || Ok(None),
+                    )? {
+                        TakeoverResolution::Accepted | TakeoverResolution::LegacyStop(_) => break 'supervision,
+                        TakeoverResolution::Cancelled => continue,
+                        TakeoverResolution::ShutdownRequested | TakeoverResolution::Superseded => {
+                            break 'supervision;
+                        }
+                    }
+                    #[cfg(not(unix))]
+                    break 'supervision;
+                }
+                RestartWaitOutcome::ShutdownRequested | RestartWaitOutcome::Superseded => break 'supervision,
+            }
         }
     }
 
+    #[cfg(unix)]
+    if let Err(error) = clear_supervisor_takeover_instance_if_owned(install_dir, supervisor_id, &takeover_instance) {
+        tracing::warn!(supervisor_id, %error, "Failed to clean up supervisor takeover instance");
+    }
     remove_owned_supervisor_state(&pid_file, &stop_file, own_pid);
 
     tracing::info!("Supervisor '{supervisor_id}' exiting");
@@ -417,6 +559,13 @@ mod tests {
     use std::process::Command;
 
     use super::*;
+    #[cfg(unix)]
+    use surge_core::supervisor::state::{
+        SupervisorTakeoverAcknowledgement, SupervisorTakeoverCommit, SupervisorTakeoverRequest,
+        read_accepted_supervisor_takeover, read_supervisor_takeover_acknowledgement, read_supervisor_takeover_instance,
+        supervisor_takeover_acknowledgement_file, take_accepted_supervisor_takeover, write_supervisor_takeover_commit,
+        write_supervisor_takeover_request,
+    };
 
     #[cfg(unix)]
     struct TestInstallDir {
@@ -461,6 +610,27 @@ mod tests {
             std::thread::sleep(std::time::Duration::from_millis(20));
         }
         predicate()
+    }
+
+    #[cfg(unix)]
+    fn wait_for_takeover_acknowledgement(
+        install_dir: &Path,
+        supervisor_id: &str,
+        request: &SupervisorTakeoverRequest,
+    ) -> SupervisorTakeoverAcknowledgement {
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(3);
+        loop {
+            if let Some(acknowledgement) = read_supervisor_takeover_acknowledgement(install_dir, supervisor_id).unwrap()
+                && acknowledgement.matches_request(request)
+            {
+                return acknowledgement;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "takeover acknowledgement did not appear before the test deadline"
+            );
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
     }
 
     #[test]
@@ -739,6 +909,104 @@ mod tests {
             .expect("supervisor did not exit after stop file")
             .unwrap();
         assert_eq!(takeover_pid, Some(child_pid));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn takeover_acknowledgement_storage_failure_keeps_supervisor_and_child_running() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = TestInstallDir::new("surge-supervisor-ack-storage-retry");
+        let install_dir = tmp.path();
+        let supervisor_id = "demo-supervisor";
+        let child_pid_path = install_dir.join("child.pid");
+        let exe_path = install_dir.join("target-child");
+        std::fs::write(
+            &exe_path,
+            format!("#!/bin/sh\necho $$ > '{}'\nexec sleep 30\n", child_pid_path.display()),
+        )
+        .unwrap();
+        let mut permissions = std::fs::metadata(&exe_path).unwrap().permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&exe_path, permissions).unwrap();
+
+        let install_dir_for_thread = install_dir.to_path_buf();
+        let exe_path_for_thread = exe_path.clone();
+        let (tx, rx) = std::sync::mpsc::channel();
+        let supervisor = std::thread::spawn(move || {
+            tx.send(run_supervisor(
+                supervisor_id,
+                &install_dir_for_thread,
+                &exe_path_for_thread,
+                &[],
+                None,
+                None,
+            ))
+            .unwrap();
+        });
+
+        assert!(
+            wait_until(std::time::Duration::from_secs(5), || {
+                child_pid_path.is_file()
+                    && read_supervisor_takeover_instance(install_dir, supervisor_id)
+                        .unwrap()
+                        .is_some()
+            }),
+            "supervisor and child did not start"
+        );
+        let child_pid = std::fs::read_to_string(&child_pid_path)
+            .unwrap()
+            .trim()
+            .parse::<u32>()
+            .unwrap();
+        let instance = read_supervisor_takeover_instance(install_dir, supervisor_id)
+            .unwrap()
+            .unwrap();
+        let acknowledgement_path = supervisor_takeover_acknowledgement_file(install_dir, supervisor_id);
+        std::fs::create_dir(&acknowledgement_path).unwrap();
+        let request = SupervisorTakeoverRequest::new(&instance, std::time::Duration::from_secs(5));
+        write_supervisor_takeover_request(install_dir, supervisor_id, &request).unwrap();
+
+        std::thread::sleep(std::time::Duration::from_millis(250));
+        assert!(
+            matches!(rx.try_recv(), Err(std::sync::mpsc::TryRecvError::Empty)),
+            "supervisor must not exit when acknowledgement persistence fails"
+        );
+        assert!(is_process_running(child_pid), "supervised child must remain running");
+        assert!(supervisor_pid_file(install_dir, supervisor_id).exists());
+
+        std::fs::remove_dir(&acknowledgement_path).unwrap();
+        let acknowledgement = wait_for_takeover_acknowledgement(install_dir, supervisor_id, &request);
+        write_supervisor_takeover_commit(
+            install_dir,
+            supervisor_id,
+            &SupervisorTakeoverCommit::new(&acknowledgement),
+        )
+        .unwrap();
+        assert!(
+            wait_until(std::time::Duration::from_secs(5), || {
+                read_accepted_supervisor_takeover(install_dir, supervisor_id)
+                    .unwrap()
+                    .is_some()
+                    && !supervisor_pid_file(install_dir, supervisor_id).exists()
+            }),
+            "supervisor did not accept the recovered takeover handshake"
+        );
+
+        let supervisor_result = rx.recv_timeout(std::time::Duration::from_secs(5));
+        supervisor.join().unwrap();
+        let handoff = take_accepted_supervisor_takeover(install_dir, supervisor_id)
+            .unwrap()
+            .unwrap();
+        let _ = nix::sys::signal::kill(
+            nix::unistd::Pid::from_raw(i32::try_from(child_pid).unwrap()),
+            nix::sys::signal::Signal::SIGKILL,
+        );
+
+        supervisor_result
+            .expect("supervisor did not exit after acknowledged takeover")
+            .unwrap();
+        assert_eq!(handoff.child_pid, Some(child_pid));
     }
 
     #[cfg(unix)]

--- a/crates/surge-supervisor/src/takeover.rs
+++ b/crates/surge-supervisor/src/takeover.rs
@@ -1,0 +1,175 @@
+use std::path::Path;
+
+use surge_core::supervisor::state::{
+    SupervisorTakeoverAcknowledgement, SupervisorTakeoverCancellation, SupervisorTakeoverInstance,
+    accept_supervisor_takeover_request, cancel_supervisor_takeover_request, read_supervisor_takeover_commit,
+    read_supervisor_takeover_request, write_supervisor_takeover_acknowledgement,
+};
+
+use crate::SupervisorError;
+use crate::child::StopTriggers;
+use crate::ownership::supervisor_was_superseded;
+
+const TAKEOVER_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(50);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TakeoverResolution {
+    Accepted,
+    Cancelled,
+    LegacyStop(Option<u32>),
+    ShutdownRequested,
+    Superseded,
+}
+
+pub(crate) fn complete_supervisor_takeover(
+    install_dir: &Path,
+    supervisor_id: &str,
+    instance: &SupervisorTakeoverInstance,
+    stop_triggers: &StopTriggers<'_>,
+    shutdown: &std::sync::Arc<std::sync::atomic::AtomicBool>,
+    supervisor_pid_file: &Path,
+    own_pid: u32,
+    mut current_child_pid: impl FnMut() -> Result<Option<u32>, SupervisorError>,
+) -> Result<TakeoverResolution, SupervisorError> {
+    let mut acknowledgement: Option<SupervisorTakeoverAcknowledgement> = None;
+
+    loop {
+        if shutdown.load(std::sync::atomic::Ordering::Acquire) {
+            return Ok(TakeoverResolution::ShutdownRequested);
+        }
+        if supervisor_was_superseded(supervisor_pid_file, own_pid) {
+            return Ok(TakeoverResolution::Superseded);
+        }
+
+        let request = match read_supervisor_takeover_request(install_dir, supervisor_id) {
+            Ok(Some(request)) => request,
+            Ok(None) => return legacy_stop_or_cancelled(stop_triggers, &mut current_child_pid),
+            Err(error) => {
+                tracing::warn!(
+                    supervisor_id,
+                    %error,
+                    "Cannot read supervisor takeover request; continuing supervision"
+                );
+                std::thread::sleep(TAKEOVER_POLL_INTERVAL);
+                continue;
+            }
+        };
+
+        if !request.matches_instance(instance) || request.is_expired() {
+            match cancel_supervisor_takeover_request(install_dir, supervisor_id, &request) {
+                Ok(SupervisorTakeoverCancellation::Cancelled | SupervisorTakeoverCancellation::Missing) => {
+                    return legacy_stop_or_cancelled(stop_triggers, &mut current_child_pid);
+                }
+                Ok(SupervisorTakeoverCancellation::Replaced) => {
+                    acknowledgement = None;
+                    continue;
+                }
+                Ok(SupervisorTakeoverCancellation::Accepted) if request.matches_instance(instance) => {
+                    return Ok(TakeoverResolution::Accepted);
+                }
+                Ok(SupervisorTakeoverCancellation::Accepted) => {
+                    tracing::warn!(
+                        supervisor_id,
+                        "Ignoring an accepted takeover request for a different supervisor instance"
+                    );
+                    return legacy_stop_or_cancelled(stop_triggers, &mut current_child_pid);
+                }
+                Err(error) => {
+                    tracing::warn!(
+                        supervisor_id,
+                        %error,
+                        "Cannot cancel unusable supervisor takeover request; continuing supervision"
+                    );
+                    std::thread::sleep(TAKEOVER_POLL_INTERVAL);
+                    continue;
+                }
+            }
+        }
+
+        let observed_child_pid = current_child_pid()?;
+        let acknowledgement_matches_observation = acknowledgement.as_ref().is_some_and(|acknowledgement| {
+            acknowledgement.matches_request(&request) && acknowledgement.child_pid == observed_child_pid
+        });
+        if !acknowledgement_matches_observation {
+            let next_acknowledgement = SupervisorTakeoverAcknowledgement::new(&request, observed_child_pid);
+            match write_supervisor_takeover_acknowledgement(install_dir, supervisor_id, &next_acknowledgement) {
+                Ok(()) => acknowledgement = Some(next_acknowledgement),
+                Err(error) => {
+                    tracing::warn!(
+                        supervisor_id,
+                        %error,
+                        "Cannot persist supervisor takeover acknowledgement; continuing supervision"
+                    );
+                    std::thread::sleep(TAKEOVER_POLL_INTERVAL);
+                    continue;
+                }
+            }
+        }
+
+        let Some(current_acknowledgement) = acknowledgement.as_ref() else {
+            continue;
+        };
+        let commit = match read_supervisor_takeover_commit(install_dir, supervisor_id) {
+            Ok(commit) => commit,
+            Err(error) => {
+                tracing::warn!(
+                    supervisor_id,
+                    %error,
+                    "Cannot read supervisor takeover commit; continuing supervision"
+                );
+                std::thread::sleep(TAKEOVER_POLL_INTERVAL);
+                continue;
+            }
+        };
+        let Some(commit) = commit else {
+            std::thread::sleep(TAKEOVER_POLL_INTERVAL);
+            continue;
+        };
+        if !commit.matches_acknowledgement(current_acknowledgement) {
+            std::thread::sleep(TAKEOVER_POLL_INTERVAL);
+            continue;
+        }
+
+        if shutdown.load(std::sync::atomic::Ordering::Acquire) {
+            return Ok(TakeoverResolution::ShutdownRequested);
+        }
+        if supervisor_was_superseded(supervisor_pid_file, own_pid) {
+            return Ok(TakeoverResolution::Superseded);
+        }
+        if request.is_expired() {
+            continue;
+        }
+
+        let refreshed_child_pid = current_child_pid()?;
+        if refreshed_child_pid != current_acknowledgement.child_pid {
+            acknowledgement = None;
+            continue;
+        }
+
+        match accept_supervisor_takeover_request(install_dir, supervisor_id, &request) {
+            Ok(true) => return Ok(TakeoverResolution::Accepted),
+            Ok(false) => {
+                acknowledgement = None;
+            }
+            Err(error) => {
+                tracing::warn!(
+                    supervisor_id,
+                    %error,
+                    "Cannot accept supervisor takeover request; continuing supervision"
+                );
+                std::thread::sleep(TAKEOVER_POLL_INTERVAL);
+            }
+        }
+    }
+}
+
+fn legacy_stop_or_cancelled(
+    stop_triggers: &StopTriggers<'_>,
+    current_child_pid: &mut impl FnMut() -> Result<Option<u32>, SupervisorError>,
+) -> Result<TakeoverResolution, SupervisorError> {
+    if stop_triggers.legacy_requested() {
+        Ok(TakeoverResolution::LegacyStop(current_child_pid()?))
+    } else {
+        Ok(TakeoverResolution::Cancelled)
+    }
+}


### PR DESCRIPTION
## Summary

- preserve explicit stop, shutdown, and restart outcomes in the supervisor loop
- require a matching acknowledgement and commit before the old supervisor exits
- keep the supervisor and child alive when acknowledgement persistence or protocol validation fails

## Why

Stopping the supervisor is a state transfer, not a best-effort signal. The current owner must retain supervision until the updater proves it accepted the exact handoff.

This is stack 5 of 16.

- Base: #279
- Next: #280

Relates to fintermobilityas/youpark#1310.

## Validation

- exact layer `9a45fdb` passed stop-outcome, takeover-acknowledgement, persistence-failure, and supervisor lifecycle regressions
- complete stack `c48f19f` passed 681 Rust workspace tests, both blocking Clippy tiers, vendor/version/format/maintainability checks, .NET formatting, and all 58 .NET tests

No migration is required.
