### PR TITLE
update: rebuild a missing full package from the release graph

### DIFF
--- a/crates/surge-core/src/update/manager.rs
+++ b/crates/surge-core/src/update/manager.rs
@@ -3212,6 +3212,116 @@ echo started > new-child-started
     }
 
     #[tokio::test]
+    async fn test_download_and_apply_full_strategy_rebuilds_missing_full_from_release_graph() {
+        // The publisher skipped the newest release's full upload (non-checkpoint release). A client
+        // that has to take the full-package path must rebuild that full from the newest available
+        // full plus the delta chain instead of failing with "blob not found".
+        let tmp = tempfile::tempdir().unwrap();
+        let store_root = tmp.path().join("store");
+        let install_root = tmp.path().join("install");
+        let app_id = "test-app";
+        std::fs::create_dir_all(&store_root).unwrap();
+        std::fs::create_dir_all(&install_root).unwrap();
+        let app_store = app_scoped_store_root(&store_root, app_id);
+
+        let rid = current_rid();
+        let os = current_os_label_for_tests();
+
+        let mut packer_v2 = ArchivePacker::new(3).unwrap();
+        packer_v2.add_buffer("payload.txt", b"v2 payload", 0o644).unwrap();
+        let full_v2 = packer_v2.finalize().unwrap();
+
+        let mut packer_v3 = ArchivePacker::new(3).unwrap();
+        packer_v3.add_buffer("payload.txt", b"v3 payload", 0o644).unwrap();
+        let full_v3 = packer_v3.finalize().unwrap();
+
+        let delta_v3 = zstd::encode_all(bsdiff_buffers(&full_v2, &full_v3).unwrap().as_slice(), 3).unwrap();
+
+        let full_v1_name = format!("{app_id}-1.0.0-{rid}-full.tar.zst");
+        let full_v2_name = format!("{app_id}-1.1.0-{rid}-full.tar.zst");
+        let full_v3_name = format!("{app_id}-1.2.0-{rid}-full.tar.zst");
+        let delta_v3_name = format!("{app_id}-1.2.0-{rid}-delta.tar.zst");
+
+        // v1 has no artifacts at all (the installed version), v2's full and v3's delta exist,
+        // v3's full was never uploaded.
+        std::fs::write(app_store.join(&full_v2_name), &full_v2).unwrap();
+        std::fs::write(app_store.join(&delta_v3_name), &delta_v3).unwrap();
+
+        let base_release = |version: &str, full_name: &str, full: &[u8]| ReleaseEntry {
+            version: version.to_string(),
+            channels: vec!["stable".to_string()],
+            os: os.clone(),
+            rid: rid.clone(),
+            is_genesis: false,
+            full_filename: full_name.to_string(),
+            full_size: full.len() as i64,
+            full_sha256: sha256_hex(full),
+            full_compression_level: 0,
+            full_zstd_workers: 0,
+            deltas: Vec::new(),
+            preferred_delta_id: String::new(),
+            created_utc: chrono::Utc::now().to_rfc3339(),
+            release_notes: String::new(),
+            name: String::new(),
+            main_exe: app_id.to_string(),
+            install_directory: app_id.to_string(),
+            supervisor_id: String::new(),
+            icon: String::new(),
+            shortcuts: Vec::new(),
+            persistent_assets: Vec::new(),
+            installers: Vec::new(),
+            environment: std::collections::BTreeMap::new(),
+        };
+        let mut v1 = base_release("1.0.0", &full_v1_name, b"v1 payload archive never uploaded");
+        v1.is_genesis = true;
+        let v2 = base_release("1.1.0", &full_v2_name, &full_v2);
+        let mut v3 = base_release("1.2.0", &full_v3_name, &full_v3);
+        v3.deltas = vec![DeltaArtifact::bsdiff_zstd(
+            "primary",
+            "1.1.0",
+            &delta_v3_name,
+            delta_v3.len() as i64,
+            &sha256_hex(&delta_v3),
+        )];
+        v3.preferred_delta_id = "primary".to_string();
+
+        let index = ReleaseIndex {
+            app_id: app_id.to_string(),
+            releases: vec![v1, v2, v3],
+            ..ReleaseIndex::default()
+        };
+        write_app_scoped_release_index(&store_root, app_id, &index);
+
+        let ctx = Arc::new(Context::new());
+        ctx.set_storage(
+            StorageProvider::Filesystem,
+            store_root.to_str().unwrap(),
+            "",
+            "",
+            "",
+            "",
+        );
+
+        let mut manager = UpdateManager::new(ctx, app_id, "1.0.0", "stable", install_root.to_str().unwrap()).unwrap();
+        let info = manager.check_for_updates().await.unwrap().unwrap();
+        assert_eq!(
+            info.apply_strategy,
+            ApplyStrategy::Full,
+            "no delta path exists from 1.0.0"
+        );
+        manager
+            .download_and_apply(&info, None::<fn(ProgressInfo)>)
+            .await
+            .expect("the missing full must be rebuilt from v2 full + v3 delta");
+
+        let installed = std::fs::read_to_string(install_root.join("app").join("payload.txt")).unwrap();
+        assert_eq!(installed, "v3 payload");
+        let status = status::read_update_status(&install_root).unwrap().unwrap();
+        assert_eq!(status.state, status::UpdateConvergenceState::Converged);
+        assert_eq!(status.installed_version, "1.2.0");
+    }
+
+    #[tokio::test]
     async fn test_download_and_apply_delta_rebuilds_current_full_from_installed_app_when_cache_chain_is_missing() {
         let tmp = tempfile::tempdir().unwrap();
         let store_root = tmp.path().join("store");

--- a/crates/surge-core/src/update/manager/apply.rs
+++ b/crates/surge-core/src/update/manager/apply.rs
@@ -18,6 +18,7 @@ use super::{ApplyStrategy, UpdateInfo, UpdateManager};
 
 mod base;
 mod delta;
+pub(in crate::update::manager) mod full_fallback;
 mod installed_app;
 
 use self::base::{BaseFullArchiveSource, restore_base_full_archive, restore_release_graph_base_full_archive};
@@ -266,15 +267,37 @@ where
         );
     };
 
-    fetch_or_reuse_file(
+    let fetched = fetch_or_reuse_file(
         manager.storage.as_ref(),
         &latest.full_filename,
         &cache_path,
         &latest.full_sha256,
         Some(&download_progress),
     )
-    .await
-    .map_err(|fallback_error| {
+    .await;
+    // Publishers skip the full upload for non-checkpoint releases (see checkpoint retention), so the
+    // release's own full object may legitimately be absent. Rebuild it from the newest available full
+    // and the delta chain instead of failing the update.
+    let fetched = match fetched {
+        Err(SurgeError::NotFound(missing)) => {
+            warn!(
+                version = %latest.version,
+                key = %latest.full_filename,
+                "Full package is not in storage ({missing}); rebuilding it from the release graph"
+            );
+            full_fallback::restore_full_into_cache(manager, latest, &cache_path)
+                .await
+                .map(|()| ())
+                .map_err(|restore_error| {
+                    SurgeError::Update(format!(
+                        "Delta materialization failed: {delta_error}; full package fallback failed: {missing}; \
+                         rebuilding the full package from the release graph failed: {restore_error}"
+                    ))
+                })
+        }
+        other => other.map(|_| ()),
+    };
+    fetched.map_err(|fallback_error| {
         if is_verification_failure(&fallback_error) {
             // Terminal path: if this verification failure exhausts the
             // budget, surface the bounded-abort error instead of the raw

--- a/crates/surge-core/src/update/manager/apply.rs
+++ b/crates/surge-core/src/update/manager/apply.rs
@@ -287,7 +287,6 @@ where
             );
             full_fallback::restore_full_into_cache(manager, latest, &cache_path)
                 .await
-                .map(|()| ())
                 .map_err(|restore_error| {
                     SurgeError::Update(format!(
                         "Delta materialization failed: {delta_error}; full package fallback failed: {missing}; \

--- a/crates/surge-core/src/update/manager/apply/full_fallback.rs
+++ b/crates/surge-core/src/update/manager/apply/full_fallback.rs
@@ -1,0 +1,151 @@
+//! Rebuild a release's full package from the release graph when the publisher never uploaded it.
+
+use std::path::Path;
+
+use crate::crypto::sha256::sha256_hex;
+use crate::error::{Result, SurgeError};
+use crate::releases::manifest::{ReleaseEntry, ReleaseIndex};
+use crate::releases::restore::restore_full_archive_for_version;
+use crate::storage::StorageBackend;
+
+use super::UpdateManager;
+
+/// Restore `release`'s full archive through the newest available full plus the delta chain, verify
+/// it against the release's recorded SHA-256 and place it at `cache_path`.
+pub(in crate::update::manager) async fn restore_full_into_cache(
+    manager: &UpdateManager,
+    release: &ReleaseEntry,
+    cache_path: &Path,
+) -> Result<()> {
+    let index = manager
+        .cached_index
+        .as_ref()
+        .ok_or_else(|| SurgeError::Update("release index is not loaded".to_string()))?;
+    let archive = restore_verified_full_archive(manager.storage.as_ref(), index, release).await?;
+    write_atomically(cache_path, &archive).await
+}
+
+/// Restore and verify the full archive for `release` without touching the cache.
+pub(in crate::update::manager) async fn restore_verified_full_archive(
+    storage: &dyn StorageBackend,
+    index: &ReleaseIndex,
+    release: &ReleaseEntry,
+) -> Result<Vec<u8>> {
+    let archive = restore_full_archive_for_version(storage, index, &release.rid, &release.version).await?;
+    let expected = release.full_sha256.trim();
+    if !expected.is_empty() {
+        let actual = sha256_hex(&archive);
+        if actual != expected {
+            return Err(SurgeError::Integrity(format!(
+                "Rebuilt full archive for {} ({}) has SHA-256 {actual}, release manifest expects {expected}",
+                release.version, release.rid
+            )));
+        }
+    }
+    Ok(archive)
+}
+
+async fn write_atomically(path: &Path, bytes: &[u8]) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        tokio::fs::create_dir_all(parent).await?;
+    }
+    let temp = path.with_extension("rebuilding");
+    tokio::fs::write(&temp, bytes).await?;
+    tokio::fs::rename(&temp, path).await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::diff::wrapper::bsdiff_buffers;
+    use crate::releases::manifest::DeltaArtifact;
+    use crate::storage::filesystem::FilesystemBackend;
+
+    fn release(version: &str, rid: &str, full: &[u8]) -> ReleaseEntry {
+        ReleaseEntry {
+            version: version.to_string(),
+            channels: vec!["production".to_string()],
+            os: "linux".to_string(),
+            rid: rid.to_string(),
+            is_genesis: false,
+            full_filename: format!("demo-{version}-{rid}-full.tar.zst"),
+            full_size: i64::try_from(full.len()).unwrap(),
+            full_sha256: sha256_hex(full),
+            full_compression_level: 0,
+            full_zstd_workers: 0,
+            deltas: Vec::new(),
+            preferred_delta_id: String::new(),
+            created_utc: chrono::Utc::now().to_rfc3339(),
+            release_notes: String::new(),
+            name: String::new(),
+            main_exe: "demoapp".to_string(),
+            install_directory: "demoapp".to_string(),
+            supervisor_id: String::new(),
+            icon: String::new(),
+            shortcuts: Vec::new(),
+            persistent_assets: Vec::new(),
+            installers: Vec::new(),
+            environment: Default::default(),
+            ..Default::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn rebuilds_a_missing_full_from_the_previous_full_and_the_delta_and_verifies_it() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = tmp.path().join("store");
+        std::fs::create_dir_all(&store).unwrap();
+        let rid = "linux-x64";
+
+        let full_v1 = b"release-1-full".to_vec();
+        let full_v2 = b"release-2-content".to_vec();
+        let delta_v2 = zstd::encode_all(bsdiff_buffers(&full_v1, &full_v2).unwrap().as_slice(), 3).unwrap();
+
+        let v1 = release("1.1.0", rid, &full_v1);
+        let mut v2 = release("1.2.0", rid, &full_v2);
+        let delta_key = format!("demo-1.2.0-{rid}-delta.tar.zst");
+        v2.set_primary_delta(Some(DeltaArtifact::bsdiff_zstd(
+            "primary",
+            "1.1.0",
+            &delta_key,
+            i64::try_from(delta_v2.len()).unwrap(),
+            &sha256_hex(&delta_v2),
+        )));
+        // The publisher skipped v2's full upload: only v1's full and v2's delta exist.
+        std::fs::write(store.join(&v1.full_filename), &full_v1).unwrap();
+        std::fs::write(store.join(&delta_key), &delta_v2).unwrap();
+        let index = ReleaseIndex {
+            app_id: "demo".to_string(),
+            releases: vec![v1, v2.clone()],
+            ..ReleaseIndex::default()
+        };
+        let backend = FilesystemBackend::new(store.to_str().unwrap(), "");
+
+        let restored = restore_verified_full_archive(&backend, &index, &v2).await.unwrap();
+
+        assert_eq!(restored, full_v2);
+    }
+
+    #[tokio::test]
+    async fn rejects_a_rebuilt_full_whose_hash_does_not_match_the_manifest() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = tmp.path().join("store");
+        std::fs::create_dir_all(&store).unwrap();
+        let rid = "linux-x64";
+        let full_v1 = b"release-1-full".to_vec();
+        let mut v1 = release("1.1.0", rid, &full_v1);
+        v1.full_sha256 = "deadbeef".to_string();
+        std::fs::write(store.join(&v1.full_filename), &full_v1).unwrap();
+        let index = ReleaseIndex {
+            app_id: "demo".to_string(),
+            releases: vec![v1.clone()],
+            ..ReleaseIndex::default()
+        };
+        let backend = FilesystemBackend::new(store.to_str().unwrap(), "");
+
+        let err = restore_verified_full_archive(&backend, &index, &v1).await.unwrap_err();
+
+        assert!(matches!(err, SurgeError::Integrity(_)), "{err}");
+    }
+}

--- a/crates/surge-core/src/update/manager/apply/full_fallback.rs
+++ b/crates/surge-core/src/update/manager/apply/full_fallback.rs
@@ -86,8 +86,7 @@ mod tests {
             shortcuts: Vec::new(),
             persistent_assets: Vec::new(),
             installers: Vec::new(),
-            environment: Default::default(),
-            ..Default::default()
+            environment: std::collections::BTreeMap::new(),
         }
     }
 

--- a/crates/surge-core/src/update/manager/artifacts.rs
+++ b/crates/surge-core/src/update/manager/artifacts.rs
@@ -2,13 +2,14 @@ use std::path::Path;
 use std::sync::{Arc, Mutex};
 
 use futures_util::stream::{self, StreamExt};
-use tracing::debug;
+use tracing::{debug, warn};
 
 use crate::crypto::sha256::sha256_hex_file;
 use crate::error::{Result, SurgeError};
 use crate::releases::artifact_cache::{CacheFetchOutcome, cache_path_for_key, fetch_or_reuse_file};
 use crate::releases::manifest::ReleaseEntry;
 
+use super::apply::full_fallback;
 use super::progress::{
     ArtifactDownload, DownloadProgressState, ProgressInfo, average_speed_bytes_per_sec, emit_progress,
 };
@@ -64,14 +65,43 @@ where
                     };
                     emit_progress(progress.as_ref(), snapshot);
                 };
-                let outcome = fetch_or_reuse_file(
+                let outcome = match fetch_or_reuse_file(
                     storage,
                     &artifact.key,
                     &cache_path,
                     &artifact.sha256,
                     Some(&progress_callback),
                 )
-                .await?;
+                .await
+                {
+                    Ok(outcome) => outcome,
+                    // Publishers skip the full upload for non-checkpoint releases, so a release's full
+                    // object can legitimately be absent: rebuild it from the release graph instead.
+                    Err(SurgeError::NotFound(missing)) => {
+                        let Some(release) = info
+                            .apply_releases
+                            .iter()
+                            .find(|release| release.full_filename.trim() == artifact.key.trim())
+                        else {
+                            return Err(SurgeError::NotFound(missing));
+                        };
+                        warn!(
+                            version = %release.version,
+                            key = %artifact.key,
+                            "Full package is not in storage ({missing}); rebuilding it from the release graph"
+                        );
+                        full_fallback::restore_full_into_cache(manager, release, &cache_path)
+                            .await
+                            .map_err(|restore_error| {
+                                SurgeError::Update(format!(
+                                    "Full package {} is missing ({missing}) and could not be rebuilt from the release graph: {restore_error}",
+                                    artifact.key
+                                ))
+                            })?;
+                        CacheFetchOutcome::DownloadedFresh
+                    }
+                    Err(other) => return Err(other),
+                };
 
                 let stage_path = staging_dir.join(&artifact.key);
                 if let Some(parent) = stage_path.parent() {


### PR DESCRIPTION
## Summary

- new `apply::full_fallback` (`restore_full_into_cache` / `restore_verified_full_archive`): restore the target release's full archive through the newest available full and the delta chain, verify it against the release's `full_sha256`, and place it in the artifact cache atomically
- the general artifact download (`ApplyStrategy::Full`) and the post-delta-failure full fallback both use it when the release's full object is `NotFound`; every other error keeps its current handling, and a rebuilt archive whose hash does not match is rejected as an integrity failure
- tests: unit tests for the rebuild and the hash check; manager-level regression where the newest release's full was never uploaded and the client has no delta path from its installed version — it now rebuilds the full from the previous full plus the delta and converges

## Why

Fixes #266. Publishers legitimately skip the full upload for non-checkpoint releases (`Skipping full package upload: existing full baseline found`), yet the client's full-package path fetched exactly that object. Today's outage sequence hit it twice: after the unreadable format-2 delta, and again when the direct delta did not apply and the release-graph retry failed — both times the node ended with `full package fallback failed: Not found`, even though the archive was reconstructable from artifacts that were present.

## Validation

- `cargo fmt --all -- --check`, `./scripts/sync-surge-core-vendor.sh --check`, `./scripts/check-version-sync.sh`
- `RUSTFLAGS="-D warnings" cargo test --workspace` (1.95.0): green
- `cargo clippy --all-targets --all-features -- -D warnings` and the `unwrap_used`/`expect_used` variant: clean; pedantic: no findings in changed non-test code
- `dotnet test dotnet/Surge.slnx --configuration Release`: 58 passed
