### PR TITLE
update: allow an explicit in-process directory swap for self-hosted apps

### DIFF
--- a/crates/surge-core/src/update/manager.rs
+++ b/crates/surge-core/src/update/manager.rs
@@ -121,6 +121,7 @@ pub struct UpdateManager {
     pub(super) release_retention_limit: usize,
     pub(super) artifact_retention_policy: InstallArtifactCachePolicy,
     pub(super) install_dir: PathBuf,
+    pub(super) allow_in_process_swap: bool,
     pub(super) storage: Box<dyn StorageBackend>,
     pub(super) cached_index: Option<ReleaseIndex>,
     pub(in crate::update::manager) current_release_identity: Option<current_install::ReleaseIdentity>,
@@ -164,6 +165,7 @@ impl UpdateManager {
             release_retention_limit: DEFAULT_RELEASE_RETENTION_LIMIT,
             artifact_retention_policy: InstallArtifactCachePolicy::default(),
             install_dir,
+            allow_in_process_swap: false,
             storage,
             cached_index: None,
             current_release_identity: None,
@@ -260,6 +262,18 @@ impl UpdateManager {
     /// Update the number of old app snapshots retained after successful updates.
     pub fn set_release_retention_limit(&mut self, limit: usize) {
         self.release_retention_limit = limit;
+    }
+
+    /// Allow the running application to swap its own active directory during apply.
+    ///
+    /// Defaults to `false`, matching the fail-closed pre-swap quiescence contract: an
+    /// updater running from the active application executable refuses the swap and
+    /// expects an external Surge updater. A self-hosted application that updates
+    /// in-process can opt back in to the legacy in-place swap; other processes running
+    /// the active executable are still quiesced before the swap, and the
+    /// interpreted-entrypoint and shared-executable checks remain fail-closed.
+    pub fn set_allow_in_process_swap(&mut self, allow: bool) {
+        self.allow_in_process_swap = allow;
     }
 
     /// Update the local artifact cache retention policy applied after successful updates.

--- a/crates/surge-core/src/update/manager/finalize.rs
+++ b/crates/surge-core/src/update/manager/finalize.rs
@@ -124,7 +124,11 @@ where
 
     progress_emitter.emit_substep(6, finalize_phase::QUIESCING_ACTIVE_APP, 92);
     if let Some(current_app_dir) = current_app_dir {
-        lifecycle::terminate_active_app_processes_before_swap(current_app_dir, current_main_exe)?;
+        lifecycle::terminate_active_app_processes_before_swap(
+            current_app_dir,
+            current_main_exe,
+            manager.allow_in_process_swap,
+        )?;
     }
     #[cfg(unix)]
     if previous_swap_dir.is_dir() {
@@ -136,7 +140,11 @@ where
                 )
             })?;
         lifecycle::request_supervisor_shutdown(&manager.install_dir, &previous_swap_identity.supervisor_id).await?;
-        lifecycle::terminate_active_app_processes_before_swap(&previous_swap_dir, &previous_swap_identity.main_exe)?;
+        lifecycle::terminate_active_app_processes_before_swap(
+            &previous_swap_dir,
+            &previous_swap_identity.main_exe,
+            manager.allow_in_process_swap,
+        )?;
     }
 
     progress_emitter.emit_substep(6, finalize_phase::PREPARING_SWAP, 92);

--- a/crates/surge-core/src/update/manager/lifecycle/process_quiescence.rs
+++ b/crates/surge-core/src/update/manager/lifecycle/process_quiescence.rs
@@ -1,27 +1,22 @@
 #[cfg(unix)]
-use std::ffi::OsString;
-#[cfg(unix)]
 use std::io::Read;
 use std::path::Path;
-#[cfg(unix)]
-use std::path::PathBuf;
 #[cfg(unix)]
 use std::time::Duration;
 
 #[cfg(unix)]
 use tracing::{info, warn};
 
+mod discovery;
+
+#[cfg(unix)]
+use self::discovery::AppProcess;
+#[cfg(unix)]
+use self::discovery::app_process_pids;
 use crate::error::Result;
 #[cfg(unix)]
 use crate::error::SurgeError;
 use crate::platform::process::current_pid;
-
-#[cfg(unix)]
-struct AppProcess {
-    exe: PathBuf,
-    command: Vec<OsString>,
-    cwd: Option<PathBuf>,
-}
 
 pub(in crate::update::manager) fn terminate_superseded_app_processes(
     install_dir: &Path,
@@ -232,96 +227,6 @@ where
         }
         std::thread::sleep(Duration::from_millis(100));
     }
-}
-
-#[cfg(target_os = "linux")]
-fn app_process_pids<F>(protected_pid: u32, matches_exe: &F) -> Result<Vec<u32>>
-where
-    F: Fn(&AppProcess) -> bool,
-{
-    use std::os::unix::ffi::OsStringExt;
-
-    let entries = std::fs::read_dir("/proc")
-        .map_err(|e| SurgeError::Platform(format!("Failed to enumerate processes from /proc: {e}")))?;
-
-    Ok(entries
-        .filter_map(std::result::Result::ok)
-        .filter_map(|entry| entry.file_name().to_string_lossy().parse::<u32>().ok())
-        .filter(|pid| *pid != protected_pid)
-        .filter_map(|pid| {
-            let exe = std::fs::read_link(format!("/proc/{pid}/exe"))
-                .map(normalize_proc_exe_path)
-                .ok()?;
-            let command = std::fs::read(format!("/proc/{pid}/cmdline")).map_or_else(
-                |_| Vec::new(),
-                |bytes| {
-                    bytes
-                        .split(|byte| *byte == 0)
-                        .filter(|argument| !argument.is_empty())
-                        .map(|argument| OsString::from_vec(argument.to_vec()))
-                        .collect()
-                },
-            );
-            let process = AppProcess {
-                exe,
-                command,
-                cwd: std::fs::read_link(format!("/proc/{pid}/cwd")).ok(),
-            };
-            matches_exe(&process).then_some(pid)
-        })
-        .collect())
-}
-
-#[cfg(target_os = "macos")]
-fn app_process_pids<F>(protected_pid: u32, matches_exe: &F) -> Result<Vec<u32>>
-where
-    F: Fn(&AppProcess) -> bool,
-{
-    use sysinfo::{ProcessesToUpdate, System};
-
-    let mut system = System::new();
-    let _ = system.refresh_processes(ProcessesToUpdate::All, true);
-    Ok(system
-        .processes()
-        .iter()
-        .filter_map(|(pid, process)| {
-            let pid = pid.as_u32();
-            if pid == protected_pid {
-                return None;
-            }
-            let app_process = AppProcess {
-                exe: process.exe()?.to_path_buf(),
-                command: process.cmd().to_vec(),
-                cwd: process.cwd().map(Path::to_path_buf),
-            };
-            matches_exe(&app_process).then_some(pid)
-        })
-        .collect())
-}
-
-#[cfg(all(unix, not(any(target_os = "linux", target_os = "macos"))))]
-fn app_process_pids<F>(_protected_pid: u32, _matches_exe: &F) -> Result<Vec<u32>>
-where
-    F: Fn(&AppProcess) -> bool,
-{
-    Err(SurgeError::Platform(
-        "Active application process discovery is unsupported on this Unix platform".to_string(),
-    ))
-}
-
-#[cfg(target_os = "linux")]
-fn normalize_proc_exe_path(path: PathBuf) -> PathBuf {
-    use std::os::unix::ffi::{OsStrExt, OsStringExt};
-
-    match path.try_exists() {
-        Ok(false) => {}
-        Ok(true) | Err(_) => return path,
-    }
-
-    let Some(path_bytes) = path.as_os_str().as_bytes().strip_suffix(b" (deleted)") else {
-        return path;
-    };
-    PathBuf::from(OsString::from_vec(path_bytes.to_vec()))
 }
 
 #[cfg(all(unix, not(target_os = "macos")))]
@@ -600,24 +505,5 @@ mod tests {
                 .contains("resolves outside the active application directory")
         );
         assert!(unrelated_still_running);
-    }
-
-    #[cfg(target_os = "linux")]
-    #[test]
-    fn proc_exe_deleted_suffix_is_ignored_for_matching() {
-        assert_eq!(
-            normalize_proc_exe_path(PathBuf::from("/opt/demo/app-1.0.0/demo (deleted)")),
-            PathBuf::from("/opt/demo/app-1.0.0/demo")
-        );
-    }
-
-    #[cfg(target_os = "linux")]
-    #[test]
-    fn proc_exe_path_preserves_existing_filename_with_deleted_suffix() {
-        let tmp = tempfile::tempdir().unwrap();
-        let executable = tmp.path().join("demo (deleted)");
-        std::fs::write(&executable, "fixture").unwrap();
-
-        assert_eq!(normalize_proc_exe_path(executable.clone()), executable);
     }
 }

--- a/crates/surge-core/src/update/manager/lifecycle/process_quiescence.rs
+++ b/crates/surge-core/src/update/manager/lifecycle/process_quiescence.rs
@@ -34,8 +34,9 @@ pub(in crate::update::manager) fn terminate_superseded_app_processes(
 pub(in crate::update::manager) fn terminate_active_app_processes_before_swap(
     active_app_dir: &Path,
     main_exe: &str,
+    allow_in_process_swap: bool,
 ) -> Result<usize> {
-    terminate_active_app_processes_except(active_app_dir, main_exe, current_pid())
+    terminate_active_app_processes_except(active_app_dir, main_exe, current_pid(), allow_in_process_swap)
 }
 
 #[cfg(unix)]
@@ -51,7 +52,12 @@ fn terminate_superseded_app_processes_except(
 }
 
 #[cfg(unix)]
-fn terminate_active_app_processes_except(active_app_dir: &Path, main_exe: &str, protected_pid: u32) -> Result<usize> {
+fn terminate_active_app_processes_except(
+    active_app_dir: &Path,
+    main_exe: &str,
+    protected_pid: u32,
+    allow_in_process_swap: bool,
+) -> Result<usize> {
     let main_exe = main_exe.trim();
     if main_exe.is_empty() {
         return Ok(0);
@@ -73,7 +79,17 @@ fn terminate_active_app_processes_except(active_app_dir: &Path, main_exe: &str, 
             active_app_root.join(main_exe).display()
         )));
     }
-    refuse_in_process_swap(&active_exe, protected_pid)?;
+    if updater_runs_from_active_exe(&active_exe, protected_pid)? {
+        if !allow_in_process_swap {
+            return Err(SurgeError::Platform(
+                "The updater is running from the active application executable; refusing an in-process directory swap. Apply the update from an external Surge updater."
+                    .to_string(),
+            ));
+        }
+        info!(
+            "The updater is running from the active application executable; in-process swap explicitly allowed, quiescing other active application processes only"
+        );
+    }
     let interpreted_main = is_interpreted_main(&active_exe)?;
     if interpreted_main {
         return Err(SurgeError::Platform(
@@ -86,11 +102,11 @@ fn terminate_active_app_processes_except(active_app_dir: &Path, main_exe: &str, 
 }
 
 #[cfg(unix)]
-fn refuse_in_process_swap(active_exe: &Path, protected_pid: u32) -> Result<()> {
+fn updater_runs_from_active_exe(active_exe: &Path, protected_pid: u32) -> Result<bool> {
     use std::os::unix::fs::MetadataExt;
 
     if protected_pid != current_pid() {
-        return Ok(());
+        return Ok(false);
     }
 
     let updater_exe = std::env::current_exe().map_err(|e| {
@@ -108,14 +124,7 @@ fn refuse_in_process_swap(active_exe: &Path, protected_pid: u32) -> Result<()> {
             "Failed to inspect updater process identity before application swap: {e}"
         ))
     })?;
-    if active_metadata.dev() == updater_metadata.dev() && active_metadata.ino() == updater_metadata.ino() {
-        return Err(SurgeError::Platform(
-            "The updater is running from the active application executable; refusing an in-process directory swap. Apply the update from an external Surge updater."
-                .to_string(),
-        ));
-    }
-
-    Ok(())
+    Ok(active_metadata.dev() == updater_metadata.dev() && active_metadata.ino() == updater_metadata.ino())
 }
 
 #[cfg(unix)]
@@ -203,6 +212,7 @@ fn terminate_active_app_processes_except(
     _active_app_dir: &Path,
     _main_exe: &str,
     _protected_pid: u32,
+    _allow_in_process_swap: bool,
 ) -> Result<usize> {
     Ok(0)
 }
@@ -497,7 +507,8 @@ mod tests {
         let child_pid = child.id();
         wait_for_native_test_app(&app_path, child_pid);
 
-        let terminated = terminate_active_app_processes_except(&linked_active_app_dir, "demo", u32::MAX).unwrap();
+        let terminated =
+            terminate_active_app_processes_except(&linked_active_app_dir, "demo", u32::MAX, false).unwrap();
         let status = child.wait().unwrap();
 
         assert_eq!(terminated, 1);
@@ -520,9 +531,22 @@ mod tests {
         std::fs::create_dir_all(&active_app_dir).unwrap();
         std::fs::hard_link(std::env::current_exe().unwrap(), active_app_dir.join("demo")).unwrap();
 
-        let error = terminate_active_app_processes_except(&active_app_dir, "demo", current_pid()).unwrap_err();
+        let error = terminate_active_app_processes_except(&active_app_dir, "demo", current_pid(), false).unwrap_err();
 
         assert!(error.to_string().contains("refusing an in-process directory swap"));
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    #[test]
+    fn in_process_updater_swaps_without_signalling_itself_when_explicitly_allowed() {
+        let tmp = tempfile::tempdir().unwrap();
+        let active_app_dir = tmp.path().join("app");
+        std::fs::create_dir_all(&active_app_dir).unwrap();
+        std::fs::hard_link(std::env::current_exe().unwrap(), active_app_dir.join("demo")).unwrap();
+
+        let terminated = terminate_active_app_processes_except(&active_app_dir, "demo", current_pid(), true).unwrap();
+
+        assert_eq!(terminated, 0);
     }
 
     #[cfg(any(target_os = "linux", target_os = "macos"))]
@@ -540,7 +564,7 @@ mod tests {
         permissions.set_mode(0o755);
         std::fs::set_permissions(&app_path, permissions).unwrap();
         let mut child = Command::new(&app_path).spawn().unwrap();
-        let error = terminate_active_app_processes_except(&active_app_dir, "demo-script", u32::MAX).unwrap_err();
+        let error = terminate_active_app_processes_except(&active_app_dir, "demo-script", u32::MAX, false).unwrap_err();
         let child_still_running = child.try_wait().unwrap().is_none();
         if child_still_running {
             child.kill().unwrap();
@@ -563,7 +587,7 @@ mod tests {
         symlink("/bin/sleep", active_app_dir.join("demo")).unwrap();
 
         let mut unrelated_child = Command::new("/bin/sleep").arg("30").spawn().unwrap();
-        let error = terminate_active_app_processes_except(&active_app_dir, "demo", u32::MAX).unwrap_err();
+        let error = terminate_active_app_processes_except(&active_app_dir, "demo", u32::MAX, false).unwrap_err();
         let unrelated_still_running = unrelated_child.try_wait().unwrap().is_none();
         if unrelated_still_running {
             unrelated_child.kill().unwrap();

--- a/crates/surge-core/src/update/manager/lifecycle/process_quiescence/discovery.rs
+++ b/crates/surge-core/src/update/manager/lifecycle/process_quiescence/discovery.rs
@@ -1,0 +1,131 @@
+//! OS-specific discovery of processes that run a given application
+//! executable, used by the pre-swap quiescence step.
+
+#[cfg(unix)]
+use std::ffi::OsString;
+#[cfg(unix)]
+use std::path::PathBuf;
+
+#[cfg(unix)]
+use crate::error::{Result, SurgeError};
+
+#[cfg(unix)]
+pub(super) struct AppProcess {
+    pub(super) exe: PathBuf,
+    pub(super) command: Vec<OsString>,
+    pub(super) cwd: Option<PathBuf>,
+}
+
+#[cfg(target_os = "linux")]
+pub(super) fn app_process_pids<F>(protected_pid: u32, matches_exe: &F) -> Result<Vec<u32>>
+where
+    F: Fn(&AppProcess) -> bool,
+{
+    use std::os::unix::ffi::OsStringExt;
+
+    let entries = std::fs::read_dir("/proc")
+        .map_err(|e| SurgeError::Platform(format!("Failed to enumerate processes from /proc: {e}")))?;
+
+    Ok(entries
+        .filter_map(std::result::Result::ok)
+        .filter_map(|entry| entry.file_name().to_string_lossy().parse::<u32>().ok())
+        .filter(|pid| *pid != protected_pid)
+        .filter_map(|pid| {
+            let exe = std::fs::read_link(format!("/proc/{pid}/exe"))
+                .map(normalize_proc_exe_path)
+                .ok()?;
+            let command = std::fs::read(format!("/proc/{pid}/cmdline")).map_or_else(
+                |_| Vec::new(),
+                |bytes| {
+                    bytes
+                        .split(|byte| *byte == 0)
+                        .filter(|argument| !argument.is_empty())
+                        .map(|argument| OsString::from_vec(argument.to_vec()))
+                        .collect()
+                },
+            );
+            let process = AppProcess {
+                exe,
+                command,
+                cwd: std::fs::read_link(format!("/proc/{pid}/cwd")).ok(),
+            };
+            matches_exe(&process).then_some(pid)
+        })
+        .collect())
+}
+
+#[cfg(target_os = "macos")]
+pub(super) fn app_process_pids<F>(protected_pid: u32, matches_exe: &F) -> Result<Vec<u32>>
+where
+    F: Fn(&AppProcess) -> bool,
+{
+    use sysinfo::{ProcessesToUpdate, System};
+
+    let mut system = System::new();
+    let _ = system.refresh_processes(ProcessesToUpdate::All, true);
+    Ok(system
+        .processes()
+        .iter()
+        .filter_map(|(pid, process)| {
+            let pid = pid.as_u32();
+            if pid == protected_pid {
+                return None;
+            }
+            let app_process = AppProcess {
+                exe: process.exe()?.to_path_buf(),
+                command: process.cmd().to_vec(),
+                cwd: process.cwd().map(Path::to_path_buf),
+            };
+            matches_exe(&app_process).then_some(pid)
+        })
+        .collect())
+}
+
+#[cfg(all(unix, not(any(target_os = "linux", target_os = "macos"))))]
+pub(super) fn app_process_pids<F>(_protected_pid: u32, _matches_exe: &F) -> Result<Vec<u32>>
+where
+    F: Fn(&AppProcess) -> bool,
+{
+    Err(SurgeError::Platform(
+        "Active application process discovery is unsupported on this Unix platform".to_string(),
+    ))
+}
+
+#[cfg(target_os = "linux")]
+fn normalize_proc_exe_path(path: PathBuf) -> PathBuf {
+    use std::os::unix::ffi::{OsStrExt, OsStringExt};
+
+    match path.try_exists() {
+        Ok(false) => {}
+        Ok(true) | Err(_) => return path,
+    }
+
+    let Some(path_bytes) = path.as_os_str().as_bytes().strip_suffix(b" (deleted)") else {
+        return path;
+    };
+    PathBuf::from(OsString::from_vec(path_bytes.to_vec()))
+}
+
+#[cfg(all(test, target_os = "linux"))]
+mod tests {
+    use super::*;
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn proc_exe_deleted_suffix_is_ignored_for_matching() {
+        assert_eq!(
+            normalize_proc_exe_path(PathBuf::from("/opt/demo/app-1.0.0/demo (deleted)")),
+            PathBuf::from("/opt/demo/app-1.0.0/demo")
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn proc_exe_path_preserves_existing_filename_with_deleted_suffix() {
+        let tmp = tempfile::tempdir().unwrap();
+        let executable = tmp.path().join("demo (deleted)");
+        std::fs::write(&executable, "fixture").unwrap();
+
+        assert_eq!(normalize_proc_exe_path(executable.clone()), executable);
+    }
+}

--- a/crates/surge-core/src/update/manager/lifecycle/process_quiescence/discovery.rs
+++ b/crates/surge-core/src/update/manager/lifecycle/process_quiescence/discovery.rs
@@ -6,8 +6,11 @@ use std::ffi::OsString;
 #[cfg(unix)]
 use std::path::PathBuf;
 
+#[cfg(target_os = "macos")]
+use std::path::Path;
+
 #[cfg(unix)]
-use crate::error::{Result, SurgeError};
+use crate::error::Result;
 
 #[cfg(unix)]
 pub(super) struct AppProcess {
@@ -22,6 +25,8 @@ where
     F: Fn(&AppProcess) -> bool,
 {
     use std::os::unix::ffi::OsStringExt;
+
+    use crate::error::SurgeError;
 
     let entries = std::fs::read_dir("/proc")
         .map_err(|e| SurgeError::Platform(format!("Failed to enumerate processes from /proc: {e}")))?;
@@ -86,6 +91,8 @@ pub(super) fn app_process_pids<F>(_protected_pid: u32, _matches_exe: &F) -> Resu
 where
     F: Fn(&AppProcess) -> bool,
 {
+    use crate::error::SurgeError;
+
     Err(SurgeError::Platform(
         "Active application process discovery is unsupported on this Unix platform".to_string(),
     ))

--- a/crates/surge-ffi/src/handles.rs
+++ b/crates/surge-ffi/src/handles.rs
@@ -117,6 +117,7 @@ pub struct SurgeUpdateManagerHandle {
     pub channel: String,
     pub release_retention_limit: usize,
     pub artifact_retention_policy: InstallArtifactCachePolicy,
+    pub allow_in_process_swap: bool,
     pub install_dir: String,
 }
 

--- a/crates/surge-ffi/src/lib.rs
+++ b/crates/surge-ffi/src/lib.rs
@@ -51,9 +51,9 @@ use crate::shared::{
 };
 pub use crate::update::{
     surge_update_check, surge_update_download_and_apply, surge_update_manager_create, surge_update_manager_destroy,
-    surge_update_manager_set_artifact_retention_policy, surge_update_manager_set_channel,
-    surge_update_manager_set_current_version, surge_update_manager_set_release_retention_limit,
-    surge_update_status_read_json,
+    surge_update_manager_set_allow_in_process_swap, surge_update_manager_set_artifact_retention_policy,
+    surge_update_manager_set_channel, surge_update_manager_set_current_version,
+    surge_update_manager_set_release_retention_limit, surge_update_status_read_json,
 };
 use crate::utils::to_lossy_cstring;
 

--- a/crates/surge-ffi/src/update.rs
+++ b/crates/surge-ffi/src/update.rs
@@ -67,6 +67,7 @@ pub unsafe extern "C" fn surge_update_manager_create(
             channel: channel_s,
             release_retention_limit: 1,
             artifact_retention_policy: InstallArtifactCachePolicy::default(),
+            allow_in_process_swap: false,
             install_dir: install_s,
         });
 
@@ -172,6 +173,38 @@ pub unsafe extern "C" fn surge_update_manager_set_release_retention_limit(
     }))
 }
 
+/// Allow the running application to swap its own active directory during apply.
+///
+/// `allow` is treated as a boolean: zero disables (the default), non-zero
+/// enables. When disabled, an updater running from the active application
+/// executable refuses the swap and expects an external Surge updater. A
+/// self-hosted application that updates in-process (calling
+/// `surge_update_download_and_apply` from inside the installed app) must
+/// enable this to keep self-updating; other processes running the active
+/// executable are still quiesced before the swap.
+///
+/// # Safety
+///
+/// `mgr` must be a valid update manager handle or NULL.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn surge_update_manager_set_allow_in_process_swap(
+    mgr: *mut SurgeUpdateManagerHandle,
+    allow: c_int,
+) -> i32 {
+    if mgr.is_null() {
+        return SURGE_ERROR;
+    }
+
+    catch_ffi(std::panic::AssertUnwindSafe(|| {
+        // SAFETY: `mgr` is checked non-null above.
+        let mgr_ref = unsafe { &mut *mgr };
+        clear_shared_error(&mgr_ref.ctx, &mgr_ref.last_error);
+
+        mgr_ref.allow_in_process_swap = allow != 0;
+        SURGE_OK
+    }))
+}
+
 /// Change local artifact cache retention applied after successful updates.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn surge_update_manager_set_artifact_retention_policy(
@@ -261,6 +294,7 @@ pub unsafe extern "C" fn surge_update_check(
             Err(e) => return set_shared_error(&mgr_ref.ctx, &mgr_ref.last_error, &e),
         };
         update_mgr.set_release_retention_limit(mgr_ref.release_retention_limit);
+        update_mgr.set_allow_in_process_swap(mgr_ref.allow_in_process_swap);
         if let Err(e) = update_mgr.set_artifact_retention_policy(mgr_ref.artifact_retention_policy) {
             return set_shared_error(&mgr_ref.ctx, &mgr_ref.last_error, &e);
         }
@@ -372,6 +406,7 @@ pub unsafe extern "C" fn surge_update_download_and_apply(
             Err(e) => return set_shared_error(&mgr_ref.ctx, &mgr_ref.last_error, &e),
         };
         update_mgr.set_release_retention_limit(mgr_ref.release_retention_limit);
+        update_mgr.set_allow_in_process_swap(mgr_ref.allow_in_process_swap);
         if let Err(e) = update_mgr.set_artifact_retention_policy(mgr_ref.artifact_retention_policy) {
             return set_shared_error(&mgr_ref.ctx, &mgr_ref.last_error, &e);
         }

--- a/dotnet/Surge.NET/NativeMethods.cs
+++ b/dotnet/Surge.NET/NativeMethods.cs
@@ -114,6 +114,9 @@ namespace Surge
         [LibraryImport(LibName, EntryPoint = "surge_update_manager_set_artifact_retention_policy")]
         internal static partial int UpdateManagerSetArtifactRetentionPolicy(IntPtr mgr, int retention, int keepFullCount);
 
+        [LibraryImport(LibName, EntryPoint = "surge_update_manager_set_allow_in_process_swap")]
+        internal static partial int UpdateManagerSetAllowInProcessSwap(IntPtr mgr, int allow);
+
         [LibraryImport(LibName, EntryPoint = "surge_update_check")]
         internal static partial int UpdateCheck(IntPtr mgr, out IntPtr info);
 
@@ -287,6 +290,9 @@ namespace Surge
 
         [DllImport(LibName, EntryPoint = "surge_update_manager_set_artifact_retention_policy", CallingConvention = CallingConvention.Cdecl)]
         internal static extern int UpdateManagerSetArtifactRetentionPolicy(IntPtr mgr, int retention, int keepFullCount);
+
+        [DllImport(LibName, EntryPoint = "surge_update_manager_set_allow_in_process_swap", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern int UpdateManagerSetAllowInProcessSwap(IntPtr mgr, int allow);
 
         [DllImport(LibName, EntryPoint = "surge_update_check", CallingConvention = CallingConvention.Cdecl)]
         internal static extern int UpdateCheck(IntPtr mgr, out IntPtr info);

--- a/dotnet/Surge.NET/SurgeUpdateManager.cs
+++ b/dotnet/Surge.NET/SurgeUpdateManager.cs
@@ -63,9 +63,6 @@ namespace Surge
         private int _updateOperationActive;
 
         /// <summary>
-        /// Maximum number of old installed versions to retain on disk after updating.
-        /// </summary>
-        /// <summary>
         /// Allow this process to swap its own active application directory during an update.
         /// Defaults to <c>false</c>, in which case an updater running from the active application
         /// executable refuses the swap and expects an external Surge updater. A self-hosted
@@ -74,6 +71,9 @@ namespace Surge
         /// </summary>
         public bool AllowInProcessSwap { get; set; }
 
+        /// <summary>
+        /// Maximum number of old installed versions to retain on disk after updating.
+        /// </summary>
         public int ReleaseRetentionLimit
         {
             get => _releaseRetentionLimit;

--- a/dotnet/Surge.NET/SurgeUpdateManager.cs
+++ b/dotnet/Surge.NET/SurgeUpdateManager.cs
@@ -65,6 +65,15 @@ namespace Surge
         /// <summary>
         /// Maximum number of old installed versions to retain on disk after updating.
         /// </summary>
+        /// <summary>
+        /// Allow this process to swap its own active application directory during an update.
+        /// Defaults to <c>false</c>, in which case an updater running from the active application
+        /// executable refuses the swap and expects an external Surge updater. A self-hosted
+        /// application that updates in-process must enable this to keep self-updating; other
+        /// processes running the active executable are still stopped before the swap.
+        /// </summary>
+        public bool AllowInProcessSwap { get; set; }
+
         public int ReleaseRetentionLimit
         {
             get => _releaseRetentionLimit;
@@ -523,7 +532,14 @@ namespace Surge
 
         private void ApplyRetentionSettings()
         {
-            int result = NativeMethods.UpdateManagerSetReleaseRetentionLimit(_nativeMgr, _releaseRetentionLimit);
+            int result = NativeMethods.UpdateManagerSetAllowInProcessSwap(_nativeMgr, AllowInProcessSwap ? 1 : 0);
+            if (result != 0)
+            {
+                var errorMsg = GetLastError();
+                throw new SurgeException(result, errorMsg ?? "Failed to set the in-process swap policy.");
+            }
+
+            result = NativeMethods.UpdateManagerSetReleaseRetentionLimit(_nativeMgr, _releaseRetentionLimit);
             if (result != 0)
             {
                 var errorMsg = GetLastError();

--- a/include/surge/surge_api.h
+++ b/include/surge/surge_api.h
@@ -275,6 +275,21 @@ SURGE_API surge_result SURGE_CALL surge_update_manager_set_release_retention_lim
                                                                                    int32_t release_retention_limit);
 
 /**
+ * Allow the running application to swap its own active directory during apply.
+ *
+ * `allow` is treated as a boolean: zero disables (the default), non-zero
+ * enables. When disabled, an updater running from the active application
+ * executable refuses the swap and expects an external Surge updater. A
+ * self-hosted application that updates in-process (calling
+ * `surge_update_download_and_apply` from inside the installed app) must
+ * enable this to keep self-updating; other processes running the active
+ * executable are still quiesced before the swap.
+ *
+ * `mgr` must be a valid update manager handle or NULL.
+ */
+SURGE_API surge_result SURGE_CALL surge_update_manager_set_allow_in_process_swap(surge_update_manager* mgr, int32_t allow);
+
+/**
  * Change local package-artifact cache retention after successful updates.
  * @param mgr             Manager handle.
  * @param retention       Cache retention policy.


### PR DESCRIPTION
Fixes #276.

## Summary

- add `UpdateManager::set_allow_in_process_swap` (default `false`): an explicit opt-in for applications that drive their own update from inside the installed app
- when enabled and the updater is the active application executable, skip only the self-refusal introduced with #255's pre-swap quiescence: other processes running the active executable are still terminated (the updater process itself is already excluded via `protected_pid`), and the interpreted-entrypoint and shared-executable checks remain fail-closed
- rename `refuse_in_process_swap` to `updater_runs_from_active_exe` and move the refusal decision to the caller; the error message is unchanged
- thread the flag through both finalize call sites (active app dir and persisted previous-swap identity)
- FFI: `surge_update_manager_set_allow_in_process_swap(mgr, allow)` stored on the manager handle and applied in `surge_update_download_and_apply`
- Surge.NET: `SurgeUpdateManager.AllowInProcessSwap` property wired to the new native setter (modern `LibraryImport` and legacy `DllImport` declarations)

## Why

beta.58 shipped #255's guard, which rejects the directory swap whenever the process applying the update runs from the active application executable. For a self-hosted application that updates in-process through the documented FFI flow, that is every update: the fleet checks, downloads, and refuses at finalize on every cycle, and recovery to any later client requires an out-of-band reinstall per node (#276). The external-updater flow #255 expects does not exist yet (#258–#263 are still open). This opt-in restores the pre-beta.58 contract for applications that accept the documented mixed-version window during the swap, and can be revisited once the external updater lands.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test -p surge-core process_quiescence`: 9 passed, including the new `in_process_updater_swaps_without_signalling_itself_when_explicitly_allowed` regression and the unchanged default-refusal test
- unsafe-boundaries check: no new unsafe modules (the FFI setter follows the existing handle-setter pattern)
- `dotnet build dotnet/Surge.NET -c Release`
- full workspace suite running; CI is authoritative
