### PR TITLE
Use leased supervisor takeover requests

### DIFF
--- a/crates/surge-core/src/update/manager.rs
+++ b/crates/surge-core/src/update/manager.rs
@@ -1164,6 +1164,7 @@ mod tests {
         );
     }
 
+    #[cfg(not(unix))]
     #[tokio::test]
     async fn test_request_supervisor_shutdown_waits_for_pid_file_to_disappear() {
         let tmp = tempfile::tempdir().unwrap();
@@ -1220,6 +1221,7 @@ mod tests {
         );
     }
 
+    #[cfg(not(unix))]
     #[tokio::test]
     async fn test_request_supervisor_shutdown_times_out_when_supervisor_does_not_exit() {
         let tmp = tempfile::tempdir().unwrap();

--- a/crates/surge-core/src/update/manager/lifecycle.rs
+++ b/crates/surge-core/src/update/manager/lifecycle.rs
@@ -3,14 +3,14 @@ use std::time::Duration;
 
 use tracing::{debug, info, warn};
 
-use crate::error::{Result, SurgeError};
+use crate::error::Result;
+#[cfg(not(unix))]
+use crate::error::SurgeError;
 use crate::platform::process::{ProcessHandle, current_pid, spawn_detached, spawn_process, supervisor_binary_name};
 use crate::releases::manifest::ReleaseEntry;
-#[cfg(unix)]
-use crate::supervisor::state::{clear_supervisor_takeover_pid, take_supervisor_takeover_pid};
-use crate::supervisor::state::{
-    read_restart_args, supervisor_pid_file, supervisor_stop_file, write_supervisor_exe_path,
-};
+use crate::supervisor::state::{read_restart_args, write_supervisor_exe_path};
+#[cfg(not(unix))]
+use crate::supervisor::state::{supervisor_pid_file, supervisor_stop_file};
 use crate::update::status::{
     RESTART_HANDOFF_FAILED_PHASE, RESTART_HANDOFF_WAITING_FOR_OLD_CHILD_PHASE, confirm_supervisor_restart,
 };
@@ -18,8 +18,9 @@ use crate::update::status::{
 const SUPERVISOR_RESTART_CONFIRM_TIMEOUT: Duration = Duration::from_secs(5);
 const SUPERVISOR_RESTART_MAX_ATTEMPTS: u32 = 2;
 const SUPERVISOR_RESTART_RETRY_DELAY: Duration = Duration::from_millis(500);
-
 mod process_quiescence;
+#[cfg(unix)]
+mod supervisor_takeover;
 
 #[cfg(not(unix))]
 pub(super) use self::process_quiescence::terminate_active_app_processes_before_swap;
@@ -66,15 +67,26 @@ pub(super) async fn request_supervisor_shutdown_with_timeout(
         return Ok(None);
     }
 
+    #[cfg(unix)]
+    return supervisor_takeover::request_shutdown(install_dir, supervisor_id, timeout, poll_interval).await;
+
+    #[cfg(not(unix))]
+    {
+        request_legacy_supervisor_shutdown(install_dir, supervisor_id, timeout, poll_interval).await
+    }
+}
+
+#[cfg(not(unix))]
+async fn request_legacy_supervisor_shutdown(
+    install_dir: &Path,
+    supervisor_id: &str,
+    timeout: Duration,
+    poll_interval: Duration,
+) -> Result<Option<u32>> {
     let pid_file = supervisor_pid_file(install_dir, supervisor_id);
     if !pid_file.is_file() {
-        #[cfg(unix)]
-        return Ok(take_supervisor_takeover_pid(install_dir, supervisor_id));
-        #[cfg(not(unix))]
         return Ok(None);
     }
-    #[cfg(unix)]
-    clear_supervisor_takeover_pid(install_dir, supervisor_id);
 
     let stop_file = supervisor_stop_file(install_dir, supervisor_id);
     tokio::fs::write(&stop_file, b"surge-update").await?;
@@ -90,11 +102,7 @@ pub(super) async fn request_supervisor_shutdown_with_timeout(
     }
 
     let _ = tokio::fs::remove_file(&stop_file).await;
-    #[cfg(unix)]
-    let takeover_pid = take_supervisor_takeover_pid(install_dir, supervisor_id);
-    #[cfg(not(unix))]
-    let takeover_pid = None;
-    Ok(takeover_pid)
+    Ok(None)
 }
 
 pub(super) fn invoke_post_update_hook(install_dir: &Path, active_app_dir: &Path, latest: &ReleaseEntry) {
@@ -415,6 +423,146 @@ mod tests {
     use std::path::Path;
 
     use super::*;
+    #[cfg(unix)]
+    use crate::supervisor::state::{
+        SupervisorTakeoverAcknowledgement, SupervisorTakeoverInstance, SupervisorTakeoverRequest,
+        accept_supervisor_takeover_request, read_accepted_supervisor_takeover, read_supervisor_takeover_commit,
+        read_supervisor_takeover_request, supervisor_pid_file, supervisor_stop_file, supervisor_takeover_request_file,
+        write_supervisor_takeover_acknowledgement, write_supervisor_takeover_instance,
+    };
+
+    #[cfg(unix)]
+    fn wait_for_takeover_request(install_dir: &Path, supervisor_id: &str) -> SupervisorTakeoverRequest {
+        let deadline = std::time::Instant::now() + Duration::from_secs(2);
+        loop {
+            if let Some(request) = read_supervisor_takeover_request(install_dir, supervisor_id).unwrap() {
+                return request;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "takeover request did not appear before the test deadline"
+            );
+            std::thread::sleep(Duration::from_millis(5));
+        }
+    }
+
+    #[cfg(unix)]
+    fn prepare_supervisor_instance(
+        install_dir: &Path,
+        supervisor_id: &str,
+        supervisor_pid: u32,
+    ) -> SupervisorTakeoverInstance {
+        std::fs::write(
+            supervisor_pid_file(install_dir, supervisor_id),
+            supervisor_pid.to_string(),
+        )
+        .unwrap();
+        let instance = SupervisorTakeoverInstance::new(supervisor_pid);
+        write_supervisor_takeover_instance(install_dir, supervisor_id, &instance).unwrap();
+        instance
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn acknowledged_supervisor_handoff_returns_the_refreshed_child_pid() {
+        let dir = tempfile::tempdir().unwrap();
+        let supervisor_id = "demo-supervisor";
+        let supervisor_pid = 42;
+        prepare_supervisor_instance(dir.path(), supervisor_id, supervisor_pid);
+        let install_dir = dir.path().to_path_buf();
+        let responder = std::thread::spawn(move || {
+            let request = wait_for_takeover_request(&install_dir, supervisor_id);
+            let acknowledgement = SupervisorTakeoverAcknowledgement::new(&request, Some(84));
+            write_supervisor_takeover_acknowledgement(&install_dir, supervisor_id, &acknowledgement).unwrap();
+
+            let deadline = std::time::Instant::now() + Duration::from_secs(2);
+            loop {
+                if read_supervisor_takeover_commit(&install_dir, supervisor_id)
+                    .unwrap()
+                    .is_some_and(|commit| commit.matches_acknowledgement(&acknowledgement))
+                {
+                    break;
+                }
+                assert!(
+                    std::time::Instant::now() < deadline,
+                    "takeover commit did not appear before the test deadline"
+                );
+                std::thread::sleep(Duration::from_millis(5));
+            }
+
+            assert!(accept_supervisor_takeover_request(&install_dir, supervisor_id, &request).unwrap());
+            std::fs::remove_file(supervisor_pid_file(&install_dir, supervisor_id)).unwrap();
+        });
+
+        let child_pid = request_supervisor_shutdown_with_timeout(
+            dir.path(),
+            supervisor_id,
+            Duration::from_secs(1),
+            Duration::from_millis(5),
+        )
+        .await
+        .unwrap();
+        responder.join().unwrap();
+
+        assert_eq!(child_pid, Some(84));
+        assert!(
+            read_accepted_supervisor_takeover(dir.path(), supervisor_id)
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn legacy_supervisor_is_not_stopped_without_acknowledgement_support() {
+        let dir = tempfile::tempdir().unwrap();
+        let supervisor_id = "demo-supervisor";
+        std::fs::write(supervisor_pid_file(dir.path(), supervisor_id), "42").unwrap();
+
+        let error = request_supervisor_shutdown_with_timeout(
+            dir.path(),
+            supervisor_id,
+            Duration::from_millis(50),
+            Duration::from_millis(5),
+        )
+        .await
+        .unwrap_err();
+
+        assert!(error.to_string().contains("does not advertise acknowledged takeover"));
+        assert!(!supervisor_stop_file(dir.path(), supervisor_id).exists());
+        assert!(!supervisor_takeover_request_file(dir.path(), supervisor_id).exists());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn timed_out_takeover_is_cancelled_before_a_late_acceptance() {
+        let dir = tempfile::tempdir().unwrap();
+        let supervisor_id = "demo-supervisor";
+        prepare_supervisor_instance(dir.path(), supervisor_id, 42);
+        let install_dir = dir.path().to_path_buf();
+        let late_responder = std::thread::spawn(move || {
+            let request = wait_for_takeover_request(&install_dir, supervisor_id);
+            std::thread::sleep(Duration::from_millis(150));
+            accept_supervisor_takeover_request(&install_dir, supervisor_id, &request).unwrap()
+        });
+
+        let error = request_supervisor_shutdown_with_timeout(
+            dir.path(),
+            supervisor_id,
+            Duration::from_millis(50),
+            Duration::from_millis(5),
+        )
+        .await
+        .unwrap_err();
+
+        assert!(error.to_string().contains("Timed out waiting"));
+        assert!(
+            !late_responder.join().unwrap(),
+            "a cancelled request must not be accepted later"
+        );
+        assert!(!supervisor_takeover_request_file(dir.path(), supervisor_id).exists());
+        assert!(supervisor_pid_file(dir.path(), supervisor_id).exists());
+    }
 
     #[test]
     fn supervisor_watch_args_include_handoff_version_before_child_args() {

--- a/crates/surge-core/src/update/manager/lifecycle/supervisor_takeover.rs
+++ b/crates/surge-core/src/update/manager/lifecycle/supervisor_takeover.rs
@@ -1,0 +1,283 @@
+use std::path::Path;
+use std::time::Duration;
+
+use crate::error::{Result, SurgeError};
+use crate::supervisor::state::{
+    SupervisorTakeoverCancellation, SupervisorTakeoverCommit, SupervisorTakeoverHandoff, SupervisorTakeoverInstance,
+    SupervisorTakeoverRequest, cancel_supervisor_takeover_request, clear_supervisor_takeover_exchange,
+    read_accepted_supervisor_takeover, read_supervisor_takeover_acknowledgement, read_supervisor_takeover_instance,
+    supervisor_pid_file, take_accepted_supervisor_takeover, take_supervisor_takeover_pid,
+    try_clear_supervisor_takeover_pid, write_supervisor_takeover_commit, write_supervisor_takeover_request,
+};
+
+const SUPERVISOR_TAKEOVER_EXIT_GRACE: Duration = Duration::from_secs(2);
+
+pub(super) async fn request_shutdown(
+    install_dir: &Path,
+    supervisor_id: &str,
+    timeout: Duration,
+    poll_interval: Duration,
+) -> Result<Option<u32>> {
+    let pid_file = supervisor_pid_file(install_dir, supervisor_id);
+    let Some(supervisor_pid) = read_supervisor_pid_owner(&pid_file)? else {
+        if let Some(handoff) = take_accepted_supervisor_takeover(install_dir, supervisor_id)? {
+            return Ok(handoff.child_pid);
+        }
+        return Ok(take_supervisor_takeover_pid(install_dir, supervisor_id));
+    };
+
+    let instance = read_supervisor_takeover_instance(install_dir, supervisor_id)?.ok_or_else(|| {
+        SurgeError::Update(format!(
+            "Supervisor '{supervisor_id}' does not advertise acknowledged takeover support"
+        ))
+    })?;
+    if instance.supervisor_pid != supervisor_pid {
+        return Err(SurgeError::Update(format!(
+            "Supervisor '{supervisor_id}' takeover instance belongs to PID {}, but its pid file belongs to PID {supervisor_pid}",
+            instance.supervisor_pid
+        )));
+    }
+
+    if let Some(handoff) = read_accepted_supervisor_takeover(install_dir, supervisor_id)? {
+        ensure_handoff_matches_instance(supervisor_id, &handoff, &instance)?;
+        return finish_accepted_takeover(install_dir, supervisor_id, &pid_file, &instance, None, poll_interval).await;
+    }
+
+    clear_supervisor_takeover_exchange(install_dir, supervisor_id)?;
+    try_clear_supervisor_takeover_pid(install_dir, supervisor_id)?;
+
+    let request = SupervisorTakeoverRequest::new(&instance, timeout.saturating_add(poll_interval));
+    write_supervisor_takeover_request(install_dir, supervisor_id, &request)?;
+    let deadline = tokio::time::Instant::now() + timeout;
+
+    loop {
+        if let Some(handoff) = read_accepted_supervisor_takeover(install_dir, supervisor_id)? {
+            ensure_handoff_matches_request(supervisor_id, &handoff, &request)?;
+            return finish_accepted_takeover(
+                install_dir,
+                supervisor_id,
+                &pid_file,
+                &instance,
+                Some(&request),
+                poll_interval,
+            )
+            .await;
+        }
+
+        if let Some(acknowledgement) = read_supervisor_takeover_acknowledgement(install_dir, supervisor_id)? {
+            if !acknowledgement.matches_request(&request) {
+                if cancel_after_protocol_error(install_dir, supervisor_id, &request)?
+                    == SupervisorTakeoverCancellation::Accepted
+                {
+                    return finish_accepted_takeover(
+                        install_dir,
+                        supervisor_id,
+                        &pid_file,
+                        &instance,
+                        Some(&request),
+                        poll_interval,
+                    )
+                    .await;
+                }
+                return Err(SurgeError::Update(format!(
+                    "Supervisor '{supervisor_id}' wrote an acknowledgement for a different takeover request"
+                )));
+            }
+            write_supervisor_takeover_commit(
+                install_dir,
+                supervisor_id,
+                &SupervisorTakeoverCommit::new(&acknowledgement),
+            )?;
+        }
+
+        if read_supervisor_pid_owner(&pid_file)? != Some(supervisor_pid) {
+            if let Some(handoff) = read_accepted_supervisor_takeover(install_dir, supervisor_id)? {
+                ensure_handoff_matches_request(supervisor_id, &handoff, &request)?;
+                return take_matching_accepted_handoff(install_dir, supervisor_id, &request);
+            }
+            if cancel_after_protocol_error(install_dir, supervisor_id, &request)?
+                == SupervisorTakeoverCancellation::Accepted
+            {
+                return finish_accepted_takeover(
+                    install_dir,
+                    supervisor_id,
+                    &pid_file,
+                    &instance,
+                    Some(&request),
+                    poll_interval,
+                )
+                .await;
+            }
+            return Err(SurgeError::Update(format!(
+                "Supervisor '{supervisor_id}' exited without accepting the takeover request"
+            )));
+        }
+
+        if tokio::time::Instant::now() >= deadline {
+            return finish_timed_out_takeover(
+                install_dir,
+                supervisor_id,
+                &pid_file,
+                &instance,
+                &request,
+                poll_interval,
+            )
+            .await;
+        }
+        tokio::time::sleep(poll_interval).await;
+    }
+}
+
+fn read_supervisor_pid_owner(pid_file: &Path) -> Result<Option<u32>> {
+    let contents = match std::fs::read_to_string(pid_file) {
+        Ok(contents) => contents,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error.into()),
+    };
+    let pid = contents.trim().parse::<u32>().map_err(|_| {
+        SurgeError::Update(format!(
+            "Supervisor pid file '{}' does not contain a valid process id",
+            pid_file.display()
+        ))
+    })?;
+    if pid == 0 {
+        return Err(SurgeError::Update(format!(
+            "Supervisor pid file '{}' contains process id 0",
+            pid_file.display()
+        )));
+    }
+    Ok(Some(pid))
+}
+
+fn ensure_handoff_matches_instance(
+    supervisor_id: &str,
+    handoff: &SupervisorTakeoverHandoff,
+    instance: &SupervisorTakeoverInstance,
+) -> Result<()> {
+    if handoff.supervisor_pid == instance.supervisor_pid && handoff.instance_token == instance.instance_token {
+        return Ok(());
+    }
+    Err(SurgeError::Update(format!(
+        "Supervisor '{supervisor_id}' has an accepted takeover from a different supervisor instance"
+    )))
+}
+
+fn ensure_handoff_matches_request(
+    supervisor_id: &str,
+    handoff: &SupervisorTakeoverHandoff,
+    request: &SupervisorTakeoverRequest,
+) -> Result<()> {
+    if handoff.supervisor_pid == request.supervisor_pid
+        && handoff.instance_token == request.instance_token
+        && handoff.request_token == request.request_token
+    {
+        return Ok(());
+    }
+    Err(SurgeError::Update(format!(
+        "Supervisor '{supervisor_id}' accepted a different takeover request"
+    )))
+}
+
+fn cancel_after_protocol_error(
+    install_dir: &Path,
+    supervisor_id: &str,
+    request: &SupervisorTakeoverRequest,
+) -> Result<SupervisorTakeoverCancellation> {
+    let cancellation = cancel_supervisor_takeover_request(install_dir, supervisor_id, request)?;
+    if cancellation == SupervisorTakeoverCancellation::Cancelled {
+        clear_supervisor_takeover_exchange(install_dir, supervisor_id)?;
+    }
+    Ok(cancellation)
+}
+
+async fn finish_timed_out_takeover(
+    install_dir: &Path,
+    supervisor_id: &str,
+    pid_file: &Path,
+    instance: &SupervisorTakeoverInstance,
+    request: &SupervisorTakeoverRequest,
+    poll_interval: Duration,
+) -> Result<Option<u32>> {
+    match cancel_supervisor_takeover_request(install_dir, supervisor_id, request)? {
+        SupervisorTakeoverCancellation::Cancelled => {
+            clear_supervisor_takeover_exchange(install_dir, supervisor_id)?;
+            Err(SurgeError::Update(format!(
+                "Timed out waiting for supervisor '{supervisor_id}' to acknowledge takeover before applying update"
+            )))
+        }
+        SupervisorTakeoverCancellation::Accepted => {
+            finish_accepted_takeover(
+                install_dir,
+                supervisor_id,
+                pid_file,
+                instance,
+                Some(request),
+                poll_interval,
+            )
+            .await
+        }
+        SupervisorTakeoverCancellation::Missing => Err(SurgeError::Update(format!(
+            "Supervisor '{supervisor_id}' removed the takeover request without accepting it"
+        ))),
+        SupervisorTakeoverCancellation::Replaced => Err(SurgeError::Update(format!(
+            "Supervisor '{supervisor_id}' takeover request was replaced before timeout"
+        ))),
+    }
+}
+
+async fn finish_accepted_takeover(
+    install_dir: &Path,
+    supervisor_id: &str,
+    pid_file: &Path,
+    instance: &SupervisorTakeoverInstance,
+    request: Option<&SupervisorTakeoverRequest>,
+    poll_interval: Duration,
+) -> Result<Option<u32>> {
+    let deadline = tokio::time::Instant::now() + SUPERVISOR_TAKEOVER_EXIT_GRACE;
+    while read_supervisor_pid_owner(pid_file)? == Some(instance.supervisor_pid) {
+        if tokio::time::Instant::now() >= deadline {
+            return Err(SurgeError::Update(format!(
+                "Supervisor '{supervisor_id}' accepted takeover but did not release its pid file"
+            )));
+        }
+        tokio::time::sleep(poll_interval).await;
+    }
+
+    if let Some(request) = request {
+        take_matching_accepted_handoff(install_dir, supervisor_id, request)
+    } else {
+        let handoff = read_accepted_supervisor_takeover(install_dir, supervisor_id)?.ok_or_else(|| {
+            SurgeError::Update(format!(
+                "Supervisor '{supervisor_id}' accepted takeover record disappeared before it was consumed"
+            ))
+        })?;
+        ensure_handoff_matches_instance(supervisor_id, &handoff, instance)?;
+        let consumed = take_accepted_supervisor_takeover(install_dir, supervisor_id)?.ok_or_else(|| {
+            SurgeError::Update(format!(
+                "Supervisor '{supervisor_id}' accepted takeover record disappeared before it was consumed"
+            ))
+        })?;
+        ensure_handoff_matches_instance(supervisor_id, &consumed, instance)?;
+        Ok(consumed.child_pid)
+    }
+}
+
+fn take_matching_accepted_handoff(
+    install_dir: &Path,
+    supervisor_id: &str,
+    request: &SupervisorTakeoverRequest,
+) -> Result<Option<u32>> {
+    let handoff = read_accepted_supervisor_takeover(install_dir, supervisor_id)?.ok_or_else(|| {
+        SurgeError::Update(format!(
+            "Supervisor '{supervisor_id}' accepted takeover record disappeared before it was consumed"
+        ))
+    })?;
+    ensure_handoff_matches_request(supervisor_id, &handoff, request)?;
+    let consumed = take_accepted_supervisor_takeover(install_dir, supervisor_id)?.ok_or_else(|| {
+        SurgeError::Update(format!(
+            "Supervisor '{supervisor_id}' accepted takeover record disappeared before it was consumed"
+        ))
+    })?;
+    ensure_handoff_matches_request(supervisor_id, &consumed, request)?;
+    Ok(consumed.child_pid)
+}


### PR DESCRIPTION
## Summary

- request supervisor shutdown through a bounded takeover lease
- cancel timed-out requests before a late acknowledgement can be accepted
- preserve an accepted handoff when cancellation loses the protocol race

## Why

An updater must know whether the supervisor accepted its exact request before it mutates the installation. Lease and cancellation semantics close the timeout race without relying on stale stop files.

This is stack 6 of 16.

- Base: #268
- Next: #281

Relates to fintermobilityas/youpark#1310.

## Validation

- exact layer `770df1c` passed focused takeover lifecycle tests, rustfmt, blocking Clippy, and maintainability
- complete stack `c48f19f` passed 681 Rust workspace tests, both blocking Clippy tiers, vendor/version/format/maintainability checks, .NET formatting, and all 58 .NET tests

No migration is required.
