### PR TITLE
Add stable process generation handles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3252,6 +3252,7 @@ dependencies = [
  "percent-encoding",
  "quick-xml 0.42.0",
  "reqwest",
+ "rustix 1.1.4",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/crates/surge-core/Cargo.toml
+++ b/crates/surge-core/Cargo.toml
@@ -44,6 +44,9 @@ fs2 = { workspace = true }
 nix = { version = "0.31", features = ["signal", "process", "fs"] }
 libc = "0.2"
 
+[target.'cfg(target_os = "linux")'.dependencies]
+rustix = { version = "1.1", features = ["process"] }
+
 [target.'cfg(target_os = "macos")'.dependencies]
 sysinfo = "0.39.3"
 

--- a/crates/surge-core/src/platform/process.rs
+++ b/crates/surge-core/src/platform/process.rs
@@ -5,6 +5,11 @@ use std::process::{Child, Command, Stdio};
 use crate::error::{Result, SurgeError};
 
 mod descriptors;
+mod identity;
+
+pub use identity::{
+    ProcessIdentity, ProcessSignalOutcome, StableProcessHandle, process_identity, process_identity_matches,
+};
 
 pub struct ProcessHandle {
     child: Child,

--- a/crates/surge-core/src/platform/process/identity.rs
+++ b/crates/surge-core/src/platform/process/identity.rs
@@ -1,0 +1,221 @@
+use std::io;
+
+use serde::{Deserialize, Serialize};
+
+#[cfg(target_os = "linux")]
+use std::os::fd::OwnedFd;
+
+#[cfg(target_os = "macos")]
+mod macos;
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ProcessIdentity {
+    pub pid: u32,
+    pub generation: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProcessSignalOutcome {
+    Delivered,
+    Exited,
+}
+
+#[derive(Debug)]
+pub struct StableProcessHandle {
+    identity: ProcessIdentity,
+    #[cfg(target_os = "linux")]
+    pidfd: OwnedFd,
+}
+
+impl StableProcessHandle {
+    pub fn open(expected: ProcessIdentity) -> io::Result<Option<Self>> {
+        #[cfg(target_os = "linux")]
+        {
+            let raw_pid = i32::try_from(expected.pid)
+                .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "process id exceeds platform limits"))?;
+            let pid = rustix::process::Pid::from_raw(raw_pid)
+                .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "process id must be positive"))?;
+            let pidfd = match rustix::process::pidfd_open(pid, rustix::process::PidfdFlags::empty()) {
+                Ok(pidfd) => pidfd,
+                Err(rustix::io::Errno::SRCH) => return Ok(None),
+                Err(error) => return Err(error.into()),
+            };
+
+            if process_identity(expected.pid)? != Some(expected) {
+                return Ok(None);
+            }
+
+            Ok(Some(Self {
+                identity: expected,
+                pidfd,
+            }))
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            let _ = expected;
+            Err(stable_handles_unsupported())
+        }
+    }
+
+    #[must_use]
+    pub fn identity(&self) -> ProcessIdentity {
+        self.identity
+    }
+
+    pub fn is_running(&self) -> io::Result<bool> {
+        process_identity_matches(self.identity)
+    }
+
+    pub fn terminate(&self) -> io::Result<ProcessSignalOutcome> {
+        self.send_signal(ProcessSignal::Terminate)
+    }
+
+    pub fn kill(&self) -> io::Result<ProcessSignalOutcome> {
+        self.send_signal(ProcessSignal::Kill)
+    }
+
+    #[cfg(target_os = "linux")]
+    fn send_signal(&self, signal: ProcessSignal) -> io::Result<ProcessSignalOutcome> {
+        let signal = match signal {
+            ProcessSignal::Terminate => rustix::process::Signal::TERM,
+            ProcessSignal::Kill => rustix::process::Signal::KILL,
+        };
+        match rustix::process::pidfd_send_signal(&self.pidfd, signal) {
+            Ok(()) => Ok(ProcessSignalOutcome::Delivered),
+            Err(rustix::io::Errno::SRCH) => Ok(ProcessSignalOutcome::Exited),
+            Err(error) => Err(error.into()),
+        }
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    fn send_signal(&self, _signal: ProcessSignal) -> io::Result<ProcessSignalOutcome> {
+        Err(stable_handles_unsupported())
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum ProcessSignal {
+    Terminate,
+    Kill,
+}
+
+pub fn process_identity(pid: u32) -> io::Result<Option<ProcessIdentity>> {
+    if pid == 0 {
+        return Ok(None);
+    }
+    process_identity_impl(pid)
+}
+
+pub fn process_identity_matches(expected: ProcessIdentity) -> io::Result<bool> {
+    process_identity(expected.pid).map(|current| current == Some(expected))
+}
+
+#[cfg(target_os = "linux")]
+fn process_identity_impl(pid: u32) -> io::Result<Option<ProcessIdentity>> {
+    let stat = match std::fs::read_to_string(format!("/proc/{pid}/stat")) {
+        Ok(stat) => stat,
+        Err(error) if process_disappeared(&error) => return Ok(None),
+        Err(error) => return Err(error),
+    };
+    parse_linux_process_stat(pid, &stat)
+        .map(|generation| generation.map(|generation| ProcessIdentity { pid, generation }))
+}
+
+#[cfg(target_os = "linux")]
+fn parse_linux_process_stat(pid: u32, stat: &str) -> io::Result<Option<u64>> {
+    let Some((_, fields)) = stat.rsplit_once(") ") else {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("process {pid} stat has no command boundary"),
+        ));
+    };
+    let mut fields = fields.split_whitespace();
+    let state = fields
+        .next()
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, format!("process {pid} stat has no state")))?;
+    if matches!(state.as_bytes(), [b'Z' | b'X']) {
+        return Ok(None);
+    }
+    let generation = fields
+        .nth(18)
+        .and_then(|value| value.parse::<u64>().ok())
+        .ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("process {pid} stat has no valid start time"),
+            )
+        })?;
+    Ok(Some(generation))
+}
+
+#[cfg(target_os = "linux")]
+fn process_disappeared(error: &io::Error) -> bool {
+    error.kind() == io::ErrorKind::NotFound || matches!(error.raw_os_error(), Some(libc::ESRCH))
+}
+
+#[cfg(target_os = "macos")]
+fn process_identity_impl(pid: u32) -> io::Result<Option<ProcessIdentity>> {
+    macos::process_identity(pid)
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+fn process_identity_impl(pid: u32) -> io::Result<Option<ProcessIdentity>> {
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        format!("process generation lookup is unsupported for PID {pid}"),
+    ))
+}
+
+#[cfg(not(target_os = "linux"))]
+fn stable_handles_unsupported() -> io::Error {
+    io::Error::new(
+        io::ErrorKind::Unsupported,
+        "stable process handles are unavailable on this platform",
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn linux_stat_parser_uses_start_time_after_complex_command_name() {
+        let stat = "42 (worker ) name) S 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 123456 20";
+        assert_eq!(parse_linux_process_stat(42, stat).unwrap(), Some(123_456));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn linux_stat_parser_treats_zombies_as_absent() {
+        assert_eq!(parse_linux_process_stat(42, "42 (worker) Z").unwrap(), None);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn stable_handle_rejects_a_different_generation() {
+        let identity = process_identity(std::process::id()).unwrap().unwrap();
+        let mismatched = ProcessIdentity {
+            generation: identity.generation.wrapping_add(1),
+            ..identity
+        };
+        assert!(StableProcessHandle::open(mismatched).unwrap().is_none());
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn stable_handle_signals_the_verified_process() {
+        let mut child = std::process::Command::new("sh")
+            .args(["-c", "exec sleep 30"])
+            .spawn()
+            .unwrap();
+        let identity = process_identity(child.id()).unwrap().unwrap();
+        let handle = StableProcessHandle::open(identity).unwrap().unwrap();
+
+        assert_eq!(handle.identity(), identity);
+        assert_eq!(handle.terminate().unwrap(), ProcessSignalOutcome::Delivered);
+        assert!(!child.wait().unwrap().success());
+        assert!(!handle.is_running().unwrap());
+    }
+}

--- a/crates/surge-core/src/platform/process/identity/macos.rs
+++ b/crates/surge-core/src/platform/process/identity/macos.rs
@@ -1,0 +1,57 @@
+//! macOS process-generation lookup through the narrow `proc_pidinfo` boundary.
+#![allow(unsafe_code)]
+
+use std::io;
+use std::mem::{MaybeUninit, size_of};
+
+use super::ProcessIdentity;
+
+pub(super) fn process_identity(pid: u32) -> io::Result<Option<ProcessIdentity>> {
+    let raw_pid = i32::try_from(pid)
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "process id exceeds platform limits"))?;
+    let mut info = MaybeUninit::<libc::proc_bsdinfo>::uninit();
+    let info_size = i32::try_from(size_of::<libc::proc_bsdinfo>())
+        .map_err(|_| io::Error::other("proc_bsdinfo size exceeds platform limits"))?;
+
+    // SAFETY: `info` points to writable storage of exactly `info_size` bytes.
+    // `proc_pidinfo` initializes that storage when it reports a full-size result.
+    let written =
+        unsafe { libc::proc_pidinfo(raw_pid, libc::PROC_PIDTBSDINFO, 0, info.as_mut_ptr().cast(), info_size) };
+    if written == 0 {
+        let error = io::Error::last_os_error();
+        return match error.raw_os_error() {
+            Some(libc::ESRCH | libc::ENOENT) => Ok(None),
+            _ => Err(error),
+        };
+    }
+    if written != info_size {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("proc_pidinfo returned {written} bytes, expected {info_size}"),
+        ));
+    }
+
+    // SAFETY: the full structure was initialized by the successful call above.
+    let info = unsafe { info.assume_init() };
+    if info.pbi_pid != pid {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("proc_pidinfo returned PID {} while querying PID {pid}", info.pbi_pid),
+        ));
+    }
+    if info.pbi_status == libc::SZOMB {
+        return Ok(None);
+    }
+
+    let generation = info
+        .pbi_start_tvsec
+        .checked_mul(1_000_000)
+        .and_then(|seconds| seconds.checked_add(info.pbi_start_tvusec))
+        .ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "process start time exceeds generation limits",
+            )
+        })?;
+    Ok(Some(ProcessIdentity { pid, generation }))
+}

--- a/crates/surge-core/tests/unsafe_boundaries.rs
+++ b/crates/surge-core/tests/unsafe_boundaries.rs
@@ -33,6 +33,7 @@ fn unsafe_is_confined_to_boundary_modules() {
                 | "src/diff/wrapper.rs"
                 | "src/diff/mod.rs"
                 | "src/platform/process/descriptors.rs"
+                | "src/platform/process/identity/macos.rs"
         );
 
         let content = fs::read_to_string(&file).expect("failed to read rust source file");


### PR DESCRIPTION
## Summary

- represent Unix process identity as PID plus a process-generation value
- provide stable generation handles that revalidate the target before signalling
- use native high-resolution identity support where platform APIs require it

## Why

A bare PID can be reused. Update safety checks need to bind discovery and later actions to the same process generation.

This PR replaces the reordered review in #269 and is stack 7 of 16.

- Base: #280
- Next: #282

Relates to fintermobilityas/youpark#1310.

## Validation

- exact layer `12e8a85` passed focused process-identity tests, unsafe-boundary checks, rustfmt, blocking Clippy, and maintainability
- complete stack `c48f19f` passed 681 Rust workspace tests, both blocking Clippy tiers, vendor/version/format/maintainability checks, .NET formatting, and all 58 .NET tests

No migration is required.
