### PR TITLE
Preserve process identity through supervisor handoff

### DIFF
--- a/crates/surge-core/src/supervisor/state.rs
+++ b/crates/surge-core/src/supervisor/state.rs
@@ -75,6 +75,23 @@ pub fn take_supervisor_takeover_pid(install_dir: &Path, supervisor_id: &str) -> 
 }
 
 #[cfg(unix)]
+pub fn read_supervisor_takeover_pid(install_dir: &Path, supervisor_id: &str) -> Result<Option<u32>> {
+    let path = supervisor_takeover_pid_file(install_dir, supervisor_id);
+    let contents = match std::fs::read_to_string(&path) {
+        Ok(contents) => contents,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error.into()),
+    };
+    let pid = contents
+        .trim()
+        .parse::<u32>()
+        .ok()
+        .filter(|pid| *pid != 0)
+        .ok_or_else(|| SurgeError::Update(format!("Invalid legacy supervisor takeover PID in {}", path.display())))?;
+    Ok(Some(pid))
+}
+
+#[cfg(unix)]
 pub fn clear_supervisor_takeover_pid(install_dir: &Path, supervisor_id: &str) {
     if let Err(error) = try_clear_supervisor_takeover_pid(install_dir, supervisor_id) {
         tracing::warn!(supervisor_id, %error, "Failed to clean up legacy supervisor takeover PID");
@@ -204,6 +221,20 @@ mod tests {
 
         assert_eq!(take_supervisor_takeover_pid(dir.path(), "demo-supervisor"), Some(42));
         assert_eq!(take_supervisor_takeover_pid(dir.path(), "demo-supervisor"), None);
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn supervisor_takeover_pid_can_be_inspected_without_consuming_it() {
+        let dir = tempfile::tempdir().unwrap();
+
+        write_supervisor_takeover_pid(dir.path(), "demo-supervisor", 42).unwrap();
+
+        assert_eq!(
+            read_supervisor_takeover_pid(dir.path(), "demo-supervisor").unwrap(),
+            Some(42)
+        );
+        assert_eq!(take_supervisor_takeover_pid(dir.path(), "demo-supervisor"), Some(42));
     }
 
     #[test]

--- a/crates/surge-core/src/supervisor/state/takeover.rs
+++ b/crates/surge-core/src/supervisor/state/takeover.rs
@@ -8,6 +8,7 @@ use uuid::Uuid;
 
 use crate::error::{Result, SurgeError};
 use crate::platform::fs::write_file_atomic;
+use crate::platform::process::ProcessIdentity;
 
 use super::supervisor_state_path;
 
@@ -90,18 +91,18 @@ pub struct SupervisorTakeoverAcknowledgement {
     pub instance_token: String,
     pub request_token: String,
     pub acknowledgement_token: String,
-    pub child_pid: Option<u32>,
+    pub child_identity: Option<ProcessIdentity>,
 }
 
 impl SupervisorTakeoverAcknowledgement {
     #[must_use]
-    pub fn new(request: &SupervisorTakeoverRequest, child_pid: Option<u32>) -> Self {
+    pub fn new(request: &SupervisorTakeoverRequest, child_identity: Option<ProcessIdentity>) -> Self {
         Self {
             supervisor_pid: request.supervisor_pid,
             instance_token: request.instance_token.clone(),
             request_token: request.request_token.clone(),
             acknowledgement_token: new_token(),
-            child_pid,
+            child_identity,
         }
     }
 
@@ -117,7 +118,7 @@ impl SupervisorTakeoverAcknowledgement {
             || self.instance_token.trim().is_empty()
             || self.request_token.trim().is_empty()
             || self.acknowledgement_token.trim().is_empty()
-            || self.child_pid == Some(0)
+            || self.child_identity.is_some_and(|identity| identity.pid == 0)
         {
             return Err(invalid_record("takeover acknowledgement"));
         }
@@ -170,7 +171,7 @@ pub struct SupervisorTakeoverHandoff {
     pub supervisor_pid: u32,
     pub instance_token: String,
     pub request_token: String,
-    pub child_pid: Option<u32>,
+    pub child_identity: Option<ProcessIdentity>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -383,7 +384,7 @@ pub fn read_accepted_supervisor_takeover(
         supervisor_pid: accepted.supervisor_pid,
         instance_token: accepted.instance_token,
         request_token: accepted.request_token,
-        child_pid: acknowledgement.child_pid,
+        child_identity: acknowledgement.child_identity,
     }))
 }
 
@@ -473,13 +474,15 @@ fn invalid_record(description: &str) -> SurgeError {
 mod tests {
     use super::*;
 
+    const CHILD_IDENTITY: ProcessIdentity = ProcessIdentity { pid: 84, generation: 7 };
+
     #[test]
     fn request_and_acknowledgement_tokens_are_unique_and_bound() {
         let first_instance = SupervisorTakeoverInstance::new(42);
         let second_instance = SupervisorTakeoverInstance::new(42);
         let first_request = SupervisorTakeoverRequest::new(&first_instance, Duration::from_secs(5));
         let second_request = SupervisorTakeoverRequest::new(&first_instance, Duration::from_secs(5));
-        let acknowledgement = SupervisorTakeoverAcknowledgement::new(&first_request, Some(84));
+        let acknowledgement = SupervisorTakeoverAcknowledgement::new(&first_request, Some(CHILD_IDENTITY));
         let commit = SupervisorTakeoverCommit::new(&acknowledgement);
 
         assert_ne!(first_instance.instance_token, second_instance.instance_token);
@@ -503,6 +506,17 @@ mod tests {
 
         assert!(!request.is_expired_at(999));
         assert!(request.is_expired_at(1_000));
+    }
+
+    #[test]
+    fn acknowledgement_rejects_an_invalid_child_identity() {
+        let dir = tempfile::tempdir().unwrap();
+        let instance = SupervisorTakeoverInstance::new(42);
+        let request = SupervisorTakeoverRequest::new(&instance, Duration::from_secs(5));
+        let acknowledgement =
+            SupervisorTakeoverAcknowledgement::new(&request, Some(ProcessIdentity { pid: 0, generation: 7 }));
+
+        assert!(write_supervisor_takeover_acknowledgement(dir.path(), "demo", &acknowledgement).is_err());
     }
 
     #[test]
@@ -538,7 +552,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let instance = SupervisorTakeoverInstance::new(42);
         let request = SupervisorTakeoverRequest::new(&instance, Duration::from_secs(5));
-        let acknowledgement = SupervisorTakeoverAcknowledgement::new(&request, Some(84));
+        let acknowledgement = SupervisorTakeoverAcknowledgement::new(&request, Some(CHILD_IDENTITY));
         let commit = SupervisorTakeoverCommit::new(&acknowledgement);
         write_supervisor_takeover_request(dir.path(), "demo", &request).unwrap();
         write_supervisor_takeover_acknowledgement(dir.path(), "demo", &acknowledgement).unwrap();
@@ -548,7 +562,7 @@ mod tests {
         let handoff = take_accepted_supervisor_takeover(dir.path(), "demo").unwrap().unwrap();
 
         assert_eq!(handoff.supervisor_pid, 42);
-        assert_eq!(handoff.child_pid, Some(84));
+        assert_eq!(handoff.child_identity, Some(CHILD_IDENTITY));
         assert!(read_accepted_supervisor_takeover(dir.path(), "demo").unwrap().is_none());
     }
 

--- a/crates/surge-core/src/update/manager.rs
+++ b/crates/surge-core/src/update/manager.rs
@@ -1205,19 +1205,18 @@ mod tests {
 
     #[cfg(unix)]
     #[tokio::test]
-    async fn test_request_supervisor_shutdown_consumes_existing_takeover_when_pid_file_is_missing() {
+    async fn test_request_supervisor_shutdown_rejects_legacy_takeover_without_generation() {
         let tmp = tempfile::tempdir().unwrap();
         crate::supervisor::state::write_supervisor_takeover_pid(tmp.path(), "test-supervisor", 42).unwrap();
 
-        assert_eq!(
-            lifecycle::request_supervisor_shutdown(tmp.path(), "test-supervisor")
-                .await
-                .unwrap(),
-            Some(42)
-        );
+        let error = lifecycle::request_supervisor_shutdown(tmp.path(), "test-supervisor")
+            .await
+            .unwrap_err();
+
+        assert!(error.to_string().contains("has no process generation"));
         assert_eq!(
             crate::supervisor::state::take_supervisor_takeover_pid(tmp.path(), "test-supervisor"),
-            None
+            Some(42)
         );
     }
 

--- a/crates/surge-core/src/update/manager/finalize.rs
+++ b/crates/surge-core/src/update/manager/finalize.rs
@@ -192,7 +192,7 @@ where
     let supervisor_was_running = !current_supervisor_id.trim().is_empty()
         && supervisor_pid_file(&manager.install_dir, current_supervisor_id).is_file();
 
-    let supervised_child_pid = if supervisor_was_running {
+    let supervised_child_identity = if supervisor_was_running {
         progress_emitter
             .run_with_heartbeat(
                 6,
@@ -206,7 +206,7 @@ where
         lifecycle::request_supervisor_shutdown(&manager.install_dir, current_supervisor_id).await?
     };
     #[cfg(unix)]
-    let supervisor_requires_restoration = supervisor_was_running || supervised_child_pid.is_some();
+    let supervisor_requires_restoration = supervisor_was_running || supervised_child_identity.is_some();
 
     progress_emitter.emit_substep(6, finalize_phase::QUIESCING_ACTIVE_APP, 92);
     #[cfg(unix)]
@@ -219,7 +219,7 @@ where
             current_supervisor_id,
             current_environment,
             supervisor_requires_restoration,
-            supervised_child_pid,
+            supervised_child_identity,
             manager.allow_in_process_swap,
         )?
     } else {
@@ -227,7 +227,7 @@ where
     };
     #[cfg(not(unix))]
     if let Some(current_app_dir) = current_app_dir {
-        let _ = supervised_child_pid;
+        let _ = supervised_child_identity;
         lifecycle::terminate_active_app_processes_before_swap(
             current_app_dir,
             current_main_exe,
@@ -245,7 +245,7 @@ where
             current_supervisor_id,
             current_environment,
             supervisor_requires_restoration,
-            supervised_child_pid,
+            supervised_child_identity,
         )
         .await?
     } else {
@@ -285,7 +285,7 @@ where
                 current_supervisor_id,
                 current_environment,
                 supervisor_requires_restoration,
-                supervised_child_pid,
+                supervised_child_identity,
                 error,
             )
             .into());
@@ -301,7 +301,7 @@ where
                 current_supervisor_id,
                 current_environment,
                 supervisor_requires_restoration,
-                supervised_child_pid,
+                supervised_child_identity,
                 error,
             )
             .into());

--- a/crates/surge-core/src/update/manager/finalize_quiescence.rs
+++ b/crates/surge-core/src/update/manager/finalize_quiescence.rs
@@ -4,6 +4,7 @@ use std::path::Path;
 use tracing::warn;
 
 use crate::error::{Result, SurgeError};
+use crate::platform::process::ProcessIdentity;
 
 use super::UpdateManager;
 use super::lifecycle::{self, SupervisorRestartOutcome};
@@ -17,7 +18,7 @@ pub(super) fn prepare_and_quiesce_active_app_before_swap(
     current_supervisor_id: &str,
     current_environment: Option<&BTreeMap<String, String>>,
     supervisor_requires_restoration: bool,
-    supervised_child_pid: Option<u32>,
+    supervised_child_identity: Option<ProcessIdentity>,
     allow_in_process_swap: bool,
 ) -> Result<Option<lifecycle::PreparedAppQuiescence>> {
     let result = (|| {
@@ -39,7 +40,7 @@ pub(super) fn prepare_and_quiesce_active_app_before_swap(
         current_supervisor_id,
         current_environment,
         supervisor_requires_restoration,
-        supervised_child_pid,
+        supervised_child_identity,
         error,
     ))
 }
@@ -53,7 +54,7 @@ pub(super) fn restore_previous_supervisor_after_quiescence_failure(
     current_supervisor_id: &str,
     current_environment: Option<&BTreeMap<String, String>>,
     supervisor_requires_restoration: bool,
-    supervised_child_pid: Option<u32>,
+    supervised_child_identity: Option<ProcessIdentity>,
     error: SurgeError,
 ) -> SurgeError {
     if supervisor_requires_restoration
@@ -67,7 +68,7 @@ pub(super) fn restore_previous_supervisor_after_quiescence_failure(
             current_main_exe,
             current_supervisor_id,
             current_environment,
-            supervised_child_pid,
+            supervised_child_identity,
         );
     }
 
@@ -84,7 +85,7 @@ pub(super) async fn prepare_and_quiesce_previous_swap_before_reuse(
     current_supervisor_id: &str,
     current_environment: Option<&BTreeMap<String, String>>,
     supervisor_requires_restoration: bool,
-    supervised_child_pid: Option<u32>,
+    supervised_child_identity: Option<ProcessIdentity>,
 ) -> Result<Option<(lifecycle::PreparedAppQuiescence, String)>> {
     let restore_current = |error| {
         restore_previous_supervisor_after_quiescence_failure(
@@ -95,7 +96,7 @@ pub(super) async fn prepare_and_quiesce_previous_swap_before_reuse(
             current_supervisor_id,
             current_environment,
             supervisor_requires_restoration,
-            supervised_child_pid,
+            supervised_child_identity,
             error,
         )
     };
@@ -108,7 +109,7 @@ pub(super) async fn prepare_and_quiesce_previous_swap_before_reuse(
         }
         Err(error) => return Err(restore_current(error)),
     };
-    let previous_supervised_child_pid =
+    let previous_supervised_child_identity =
         match lifecycle::request_supervisor_shutdown(&manager.install_dir, &previous_swap_identity.supervisor_id).await
         {
             Ok(pid) => pid,
@@ -132,7 +133,7 @@ pub(super) async fn prepare_and_quiesce_previous_swap_before_reuse(
     match result {
         Ok(prepared) => Ok(Some((prepared, previous_swap_identity.main_exe))),
         Err(error) => {
-            if previous_supervised_child_pid.is_some()
+            if previous_supervised_child_identity.is_some()
                 && (!supervisor_requires_restoration || previous_swap_identity.supervisor_id != current_supervisor_id)
             {
                 request_previous_supervisor_restoration(
@@ -142,9 +143,9 @@ pub(super) async fn prepare_and_quiesce_previous_swap_before_reuse(
                     &previous_swap_identity.main_exe,
                     &previous_swap_identity.supervisor_id,
                     &previous_swap_identity.environment,
-                    previous_supervised_child_pid,
+                    previous_supervised_child_identity,
                 );
-            } else if previous_supervised_child_pid.is_some() {
+            } else if previous_supervised_child_identity.is_some() {
                 warn!(
                     supervisor_id = current_supervisor_id,
                     "Cannot restore both current and previous-swap children through the same supervisor identity"
@@ -162,9 +163,9 @@ fn request_previous_supervisor_restoration(
     current_main_exe: &str,
     current_supervisor_id: &str,
     current_environment: &BTreeMap<String, String>,
-    supervised_child_pid: Option<u32>,
+    supervised_child_identity: Option<ProcessIdentity>,
 ) {
-    let Some(supervised_child_pid) = supervised_child_pid else {
+    let Some(supervised_child_identity) = supervised_child_identity else {
         warn!(
             supervisor_id = current_supervisor_id,
             "Cannot safely restore the previous supervisor because it did not provide its surviving child PID"
@@ -178,7 +179,7 @@ fn request_previous_supervisor_restoration(
         current_main_exe,
         current_supervisor_id,
         current_environment,
-        supervised_child_pid,
+        supervised_child_identity,
     );
     match restore_outcome {
         SupervisorRestartOutcome::NotApplicable => {
@@ -203,7 +204,11 @@ mod tests {
     use std::process::{Command, Stdio};
     use std::time::Duration;
 
-    use crate::supervisor::state::{supervisor_pid_file, write_supervisor_takeover_pid};
+    use crate::supervisor::state::{
+        SupervisorTakeoverAcknowledgement, SupervisorTakeoverCommit, SupervisorTakeoverInstance,
+        SupervisorTakeoverRequest, accept_supervisor_takeover_request, supervisor_pid_file,
+        write_supervisor_takeover_acknowledgement, write_supervisor_takeover_commit, write_supervisor_takeover_request,
+    };
 
     use super::*;
 
@@ -245,6 +250,7 @@ mod tests {
 
         let current_environment = BTreeMap::from([("SURGE_TEST_MODE".to_string(), "preserved".to_string())]);
         let child_pid = child.id();
+        let child_identity = crate::platform::process::process_identity(child_pid).unwrap().unwrap();
         let result = prepare_and_quiesce_active_app_before_swap(
             install_dir,
             &active_app_dir,
@@ -253,7 +259,7 @@ mod tests {
             "demo-supervisor",
             Some(&current_environment),
             true,
-            Some(child_pid),
+            Some(child_identity),
             false,
         );
         let child_still_running = child.try_wait().unwrap().is_none();
@@ -279,6 +285,12 @@ mod tests {
                 .unwrap()
                 .trim(),
             child_pid.to_string()
+        );
+        assert_eq!(
+            std::fs::read_to_string(install_dir.join("restored-watched.generation"))
+                .unwrap()
+                .trim(),
+            child_identity.generation.to_string()
         );
     }
 
@@ -319,7 +331,10 @@ mod tests {
             "demo-supervisor",
             Some(&current_environment),
             true,
-            Some(4242),
+            Some(ProcessIdentity {
+                pid: 4242,
+                generation: 7,
+            }),
         )
         .await
         .err()
@@ -340,6 +355,12 @@ mod tests {
                 .unwrap()
                 .trim(),
             "4242"
+        );
+        assert_eq!(
+            std::fs::read_to_string(install_dir.join("restored-watched.generation"))
+                .unwrap()
+                .trim(),
+            "7"
         );
     }
 
@@ -385,7 +406,8 @@ mod tests {
             assert!(std::time::Instant::now() < deadline, "test child did not change cwd");
             std::thread::sleep(Duration::from_millis(10));
         }
-        write_supervisor_takeover_pid(&install_dir, "previous-supervisor", child.id()).unwrap();
+        let child_identity = crate::platform::process::process_identity(child.id()).unwrap().unwrap();
+        write_accepted_takeover(&install_dir, "previous-supervisor", child_identity);
 
         let ctx = std::sync::Arc::new(crate::context::Context::new());
         ctx.set_storage(
@@ -435,6 +457,23 @@ mod tests {
                 .trim(),
             child_pid.to_string()
         );
+        assert_eq!(
+            std::fs::read_to_string(install_dir.join("restored-watched.generation"))
+                .unwrap()
+                .trim(),
+            child_identity.generation.to_string()
+        );
+    }
+
+    fn write_accepted_takeover(install_dir: &Path, supervisor_id: &str, child_identity: ProcessIdentity) {
+        let instance = SupervisorTakeoverInstance::new(42);
+        let request = SupervisorTakeoverRequest::new(&instance, Duration::from_secs(5));
+        let acknowledgement = SupervisorTakeoverAcknowledgement::new(&request, Some(child_identity));
+        let commit = SupervisorTakeoverCommit::new(&acknowledgement);
+        write_supervisor_takeover_request(install_dir, supervisor_id, &request).unwrap();
+        write_supervisor_takeover_acknowledgement(install_dir, supervisor_id, &acknowledgement).unwrap();
+        write_supervisor_takeover_commit(install_dir, supervisor_id, &commit).unwrap();
+        assert!(accept_supervisor_takeover_request(install_dir, supervisor_id, &request).unwrap());
     }
 
     fn write_test_supervisor(active_app_dir: &Path) {
@@ -445,16 +484,19 @@ mod tests {
 id=""
 dir=""
 pid=""
+generation=""
 while [ "$#" -gt 0 ]; do
   case "$1" in
     --id) id="$2"; shift 2 ;;
     --dir) dir="$2"; shift 2 ;;
     --pid) pid="$2"; shift 2 ;;
+    --generation) generation="$2"; shift 2 ;;
     *) shift ;;
   esac
 done
 printf '%s' "$SURGE_TEST_MODE" > "$dir/restored-environment"
 printf '%s' "$pid" > "$dir/restored-watched.pid"
+printf '%s' "$generation" > "$dir/restored-watched.generation"
 echo $$ > "$dir/.surge-supervisor-$id.pid"
 "#,
         )

--- a/crates/surge-core/src/update/manager/lifecycle.rs
+++ b/crates/surge-core/src/update/manager/lifecycle.rs
@@ -6,7 +6,11 @@ use tracing::{debug, info, warn};
 use crate::error::Result;
 #[cfg(not(unix))]
 use crate::error::SurgeError;
-use crate::platform::process::{ProcessHandle, current_pid, spawn_detached, spawn_process, supervisor_binary_name};
+#[cfg(unix)]
+use crate::platform::process::process_identity;
+use crate::platform::process::{
+    ProcessHandle, ProcessIdentity, current_pid, spawn_detached, spawn_process, supervisor_binary_name,
+};
 use crate::releases::manifest::ReleaseEntry;
 use crate::supervisor::state::{read_restart_args, write_supervisor_exe_path};
 #[cfg(not(unix))]
@@ -18,6 +22,52 @@ use crate::update::status::{
 const SUPERVISOR_RESTART_CONFIRM_TIMEOUT: Duration = Duration::from_secs(5);
 const SUPERVISOR_RESTART_MAX_ATTEMPTS: u32 = 2;
 const SUPERVISOR_RESTART_RETRY_DELAY: Duration = Duration::from_millis(500);
+
+#[derive(Debug, Clone, Copy)]
+struct SupervisorWatchTarget {
+    pid: u32,
+    generation: Option<u64>,
+}
+
+impl SupervisorWatchTarget {
+    fn capture(pid: u32) -> Result<Self> {
+        #[cfg(unix)]
+        {
+            let identity = match process_identity(pid) {
+                Ok(identity) => identity,
+                Err(error) if error.kind() == std::io::ErrorKind::Unsupported => {
+                    debug!(
+                        pid,
+                        "Process generations are unavailable; using the platform liveness fallback"
+                    );
+                    return Ok(Self { pid, generation: None });
+                }
+                Err(error) => {
+                    return Err(crate::error::SurgeError::Update(format!(
+                        "Failed to capture watched process generation for PID {pid}: {error}"
+                    )));
+                }
+            }
+            .ok_or_else(|| {
+                crate::error::SurgeError::Update(format!(
+                    "Watched process PID {pid} exited before its generation could be captured"
+                ))
+            })?;
+            Ok(Self::from_identity(identity))
+        }
+        #[cfg(not(unix))]
+        {
+            Ok(Self { pid, generation: None })
+        }
+    }
+
+    fn from_identity(identity: ProcessIdentity) -> Self {
+        Self {
+            pid: identity.pid,
+            generation: Some(identity.generation),
+        }
+    }
+}
 mod process_quiescence;
 #[cfg(unix)]
 mod supervisor_takeover;
@@ -46,7 +96,10 @@ pub(super) enum SupervisorRestartOutcome {
     },
 }
 
-pub(super) async fn request_supervisor_shutdown(install_dir: &Path, supervisor_id: &str) -> Result<Option<u32>> {
+pub(super) async fn request_supervisor_shutdown(
+    install_dir: &Path,
+    supervisor_id: &str,
+) -> Result<Option<ProcessIdentity>> {
     request_supervisor_shutdown_with_timeout(
         install_dir,
         supervisor_id,
@@ -61,7 +114,7 @@ pub(super) async fn request_supervisor_shutdown_with_timeout(
     supervisor_id: &str,
     timeout: Duration,
     poll_interval: Duration,
-) -> Result<Option<u32>> {
+) -> Result<Option<ProcessIdentity>> {
     let supervisor_id = supervisor_id.trim();
     if supervisor_id.is_empty() {
         return Ok(None);
@@ -82,7 +135,7 @@ async fn request_legacy_supervisor_shutdown(
     supervisor_id: &str,
     timeout: Duration,
     poll_interval: Duration,
-) -> Result<Option<u32>> {
+) -> Result<Option<ProcessIdentity>> {
     let pid_file = supervisor_pid_file(install_dir, supervisor_id);
     if !pid_file.is_file() {
         return Ok(None);
@@ -192,7 +245,7 @@ pub(super) fn restore_previous_supervisor_after_failed_quiescence(
     main_exe: &str,
     supervisor_id: &str,
     environment: &std::collections::BTreeMap<String, String>,
-    watched_pid: u32,
+    watched_identity: ProcessIdentity,
 ) -> SupervisorRestartOutcome {
     let previous = ReleaseEntry {
         version: version.to_string(),
@@ -205,7 +258,7 @@ pub(super) fn restore_previous_supervisor_after_failed_quiescence(
         install_dir,
         active_app_dir,
         &previous,
-        Some(watched_pid),
+        Some(SupervisorWatchTarget::from_identity(watched_identity)),
         None,
         SUPERVISOR_RESTART_CONFIRM_TIMEOUT,
         SUPERVISOR_RESTART_MAX_ATTEMPTS,
@@ -219,11 +272,21 @@ pub(super) fn restart_supervisor_after_update_with_pid(
     latest: &ReleaseEntry,
     watched_pid: u32,
 ) -> SupervisorRestartOutcome {
+    let watched_process = match SupervisorWatchTarget::capture(watched_pid) {
+        Ok(watched_process) => watched_process,
+        Err(error) => {
+            warn!(watched_pid, %error, "Cannot restart supervisor without a stable watch target");
+            return SupervisorRestartOutcome::PendingRestart {
+                reason: error.to_string(),
+                failure_phase: RESTART_HANDOFF_FAILED_PHASE,
+            };
+        }
+    };
     restart_supervisor_after_update_with_config(
         install_dir,
         active_app_dir,
         latest,
-        Some(watched_pid),
+        Some(watched_process),
         Some(&latest.version),
         SUPERVISOR_RESTART_CONFIRM_TIMEOUT,
         SUPERVISOR_RESTART_MAX_ATTEMPTS,
@@ -253,7 +316,7 @@ fn restart_supervisor_after_update_with_config(
     install_dir: &Path,
     active_app_dir: &Path,
     latest: &ReleaseEntry,
-    watched_pid: Option<u32>,
+    watched_process: Option<SupervisorWatchTarget>,
     handoff_version: Option<&str>,
     confirm_timeout: Duration,
     max_attempts: u32,
@@ -312,7 +375,13 @@ fn restart_supervisor_after_update_with_config(
         }
     };
 
-    let args = supervisor_restart_args(supervisor_id, install_dir, watched_pid, handoff_version, &restart_args);
+    let args = supervisor_restart_args(
+        supervisor_id,
+        install_dir,
+        watched_process,
+        handoff_version,
+        &restart_args,
+    );
     let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
 
     let mut last_failure: Option<(String, &'static str)> = None;
@@ -326,21 +395,23 @@ fn restart_supervisor_after_update_with_config(
                 if confirm_supervisor_restart(install_dir, supervisor_id, confirm_timeout) {
                     let reason = handoff_version.map_or_else(
                         || {
-                            watched_pid.map_or_else(
+                            watched_process.map_or_else(
                                 || "previous supervisor restoration accepted".to_string(),
-                                |watched_pid| {
+                                |watched_process| {
                                     format!(
-                                        "previous supervisor restoration accepted; waiting for process pid {watched_pid} to exit"
+                                        "previous supervisor restoration accepted; waiting for process pid {} to exit",
+                                        watched_process.pid
                                     )
                                 },
                             )
                         },
                         |version| {
-                            watched_pid.map_or_else(
+                            watched_process.map_or_else(
                                 || format!("supervisor restart accepted; waiting for target version {version} to start"),
-                                |watched_pid| {
+                                |watched_process| {
                                     format!(
-                                        "supervisor handoff accepted; waiting for previous child pid {watched_pid} to exit and target version {version} to start"
+                                        "supervisor handoff accepted; waiting for previous child pid {} to exit and target version {version} to start",
+                                        watched_process.pid
                                     )
                                 },
                             )
@@ -390,22 +461,26 @@ fn restart_supervisor_after_update_with_config(
 fn supervisor_restart_args(
     supervisor_id: &str,
     install_dir: &Path,
-    watched_pid: Option<u32>,
+    watched_process: Option<SupervisorWatchTarget>,
     handoff_version: Option<&str>,
     restart_args: &[String],
 ) -> Vec<String> {
     let mut args = vec![
-        if watched_pid.is_some() { "watch" } else { "run" }.to_string(),
+        if watched_process.is_some() { "watch" } else { "run" }.to_string(),
         "--id".to_string(),
         supervisor_id.to_string(),
         "--dir".to_string(),
         install_dir.to_string_lossy().into_owned(),
     ];
-    if let Some(watched_pid) = watched_pid {
+    if let Some(watched_process) = watched_process {
         args.push("--pid".to_string());
-        args.push(watched_pid.to_string());
+        args.push(watched_process.pid.to_string());
+        if let Some(generation) = watched_process.generation {
+            args.push("--generation".to_string());
+            args.push(generation.to_string());
+        }
     }
-    if watched_pid.is_some()
+    if watched_process.is_some()
         && let Some(handoff_version) = handoff_version
     {
         args.push("--handoff-version".to_string());
@@ -466,7 +541,7 @@ mod tests {
 
     #[cfg(unix)]
     #[tokio::test]
-    async fn acknowledged_supervisor_handoff_returns_the_refreshed_child_pid() {
+    async fn acknowledged_supervisor_handoff_returns_the_refreshed_child_identity() {
         let dir = tempfile::tempdir().unwrap();
         let supervisor_id = "demo-supervisor";
         let supervisor_pid = 42;
@@ -497,7 +572,7 @@ mod tests {
             std::fs::remove_file(supervisor_pid_file(&install_dir, supervisor_id)).unwrap();
         });
 
-        let child_pid = request_supervisor_shutdown_with_timeout(
+        let child_identity = request_supervisor_shutdown_with_timeout(
             dir.path(),
             supervisor_id,
             Duration::from_secs(1),
@@ -507,7 +582,7 @@ mod tests {
         .unwrap();
         responder.join().unwrap();
 
-        assert_eq!(child_pid, Some(84));
+        assert_eq!(child_identity, Some(ProcessIdentity { pid: 84, generation: 7 }));
         assert!(
             read_accepted_supervisor_takeover(dir.path(), supervisor_id)
                 .unwrap()
@@ -574,7 +649,10 @@ mod tests {
         let args = supervisor_restart_args(
             "demo-supervisor",
             Path::new("/opt/demo"),
-            Some(42),
+            Some(SupervisorWatchTarget {
+                pid: 42,
+                generation: Some(7),
+            }),
             Some("2.0.0"),
             &restart_args,
         );
@@ -589,6 +667,8 @@ mod tests {
                 "/opt/demo",
                 "--pid",
                 "42",
+                "--generation",
+                "7",
                 "--handoff-version",
                 "2.0.0",
                 "--",
@@ -604,9 +684,19 @@ mod tests {
 
     #[test]
     fn previous_supervisor_restoration_omits_update_handoff_version() {
-        let args = supervisor_restart_args("demo-supervisor", Path::new("/opt/demo"), Some(42), None, &[]);
+        let args = supervisor_restart_args(
+            "demo-supervisor",
+            Path::new("/opt/demo"),
+            Some(SupervisorWatchTarget {
+                pid: 42,
+                generation: Some(7),
+            }),
+            None,
+            &[],
+        );
 
         assert!(!args.iter().any(|argument| argument == "--handoff-version"));
+        assert!(args.windows(2).any(|pair| pair[0] == "--generation" && pair[1] == "7"));
     }
 
     #[test]
@@ -655,7 +745,7 @@ mod tests {
             install_dir,
             &active_app_dir,
             &latest,
-            Some(std::process::id()),
+            Some(SupervisorWatchTarget::capture(std::process::id()).unwrap()),
             Some(&latest.version),
             Duration::from_millis(200),
             2,

--- a/crates/surge-core/src/update/manager/lifecycle.rs
+++ b/crates/surge-core/src/update/manager/lifecycle.rs
@@ -424,6 +424,8 @@ mod tests {
 
     use super::*;
     #[cfg(unix)]
+    use crate::platform::process::ProcessIdentity;
+    #[cfg(unix)]
     use crate::supervisor::state::{
         SupervisorTakeoverAcknowledgement, SupervisorTakeoverInstance, SupervisorTakeoverRequest,
         accept_supervisor_takeover_request, read_accepted_supervisor_takeover, read_supervisor_takeover_commit,
@@ -472,7 +474,8 @@ mod tests {
         let install_dir = dir.path().to_path_buf();
         let responder = std::thread::spawn(move || {
             let request = wait_for_takeover_request(&install_dir, supervisor_id);
-            let acknowledgement = SupervisorTakeoverAcknowledgement::new(&request, Some(84));
+            let acknowledgement =
+                SupervisorTakeoverAcknowledgement::new(&request, Some(ProcessIdentity { pid: 84, generation: 7 }));
             write_supervisor_takeover_acknowledgement(&install_dir, supervisor_id, &acknowledgement).unwrap();
 
             let deadline = std::time::Instant::now() + Duration::from_secs(2);

--- a/crates/surge-core/src/update/manager/lifecycle/supervisor_takeover.rs
+++ b/crates/surge-core/src/update/manager/lifecycle/supervisor_takeover.rs
@@ -21,7 +21,7 @@ pub(super) async fn request_shutdown(
     let pid_file = supervisor_pid_file(install_dir, supervisor_id);
     let Some(supervisor_pid) = read_supervisor_pid_owner(&pid_file)? else {
         if let Some(handoff) = take_accepted_supervisor_takeover(install_dir, supervisor_id)? {
-            return Ok(handoff.child_pid);
+            return Ok(handoff.child_identity.map(|identity| identity.pid));
         }
         return Ok(take_supervisor_takeover_pid(install_dir, supervisor_id));
     };
@@ -258,7 +258,7 @@ async fn finish_accepted_takeover(
             ))
         })?;
         ensure_handoff_matches_instance(supervisor_id, &consumed, instance)?;
-        Ok(consumed.child_pid)
+        Ok(consumed.child_identity.map(|identity| identity.pid))
     }
 }
 
@@ -279,5 +279,5 @@ fn take_matching_accepted_handoff(
         ))
     })?;
     ensure_handoff_matches_request(supervisor_id, &consumed, request)?;
-    Ok(consumed.child_pid)
+    Ok(consumed.child_identity.map(|identity| identity.pid))
 }

--- a/crates/surge-core/src/update/manager/lifecycle/supervisor_takeover.rs
+++ b/crates/surge-core/src/update/manager/lifecycle/supervisor_takeover.rs
@@ -2,11 +2,12 @@ use std::path::Path;
 use std::time::Duration;
 
 use crate::error::{Result, SurgeError};
+use crate::platform::process::ProcessIdentity;
 use crate::supervisor::state::{
     SupervisorTakeoverCancellation, SupervisorTakeoverCommit, SupervisorTakeoverHandoff, SupervisorTakeoverInstance,
     SupervisorTakeoverRequest, cancel_supervisor_takeover_request, clear_supervisor_takeover_exchange,
     read_accepted_supervisor_takeover, read_supervisor_takeover_acknowledgement, read_supervisor_takeover_instance,
-    supervisor_pid_file, take_accepted_supervisor_takeover, take_supervisor_takeover_pid,
+    read_supervisor_takeover_pid, supervisor_pid_file, take_accepted_supervisor_takeover,
     try_clear_supervisor_takeover_pid, write_supervisor_takeover_commit, write_supervisor_takeover_request,
 };
 
@@ -17,13 +18,18 @@ pub(super) async fn request_shutdown(
     supervisor_id: &str,
     timeout: Duration,
     poll_interval: Duration,
-) -> Result<Option<u32>> {
+) -> Result<Option<ProcessIdentity>> {
     let pid_file = supervisor_pid_file(install_dir, supervisor_id);
     let Some(supervisor_pid) = read_supervisor_pid_owner(&pid_file)? else {
         if let Some(handoff) = take_accepted_supervisor_takeover(install_dir, supervisor_id)? {
-            return Ok(handoff.child_identity.map(|identity| identity.pid));
+            return Ok(handoff.child_identity);
         }
-        return Ok(take_supervisor_takeover_pid(install_dir, supervisor_id));
+        if let Some(pid) = read_supervisor_takeover_pid(install_dir, supervisor_id)? {
+            return Err(SurgeError::Update(format!(
+                "Legacy supervisor takeover state for PID {pid} has no process generation; refusing to continue the update"
+            )));
+        }
+        return Ok(None);
     };
 
     let instance = read_supervisor_takeover_instance(install_dir, supervisor_id)?.ok_or_else(|| {
@@ -197,7 +203,7 @@ async fn finish_timed_out_takeover(
     instance: &SupervisorTakeoverInstance,
     request: &SupervisorTakeoverRequest,
     poll_interval: Duration,
-) -> Result<Option<u32>> {
+) -> Result<Option<ProcessIdentity>> {
     match cancel_supervisor_takeover_request(install_dir, supervisor_id, request)? {
         SupervisorTakeoverCancellation::Cancelled => {
             clear_supervisor_takeover_exchange(install_dir, supervisor_id)?;
@@ -232,7 +238,7 @@ async fn finish_accepted_takeover(
     instance: &SupervisorTakeoverInstance,
     request: Option<&SupervisorTakeoverRequest>,
     poll_interval: Duration,
-) -> Result<Option<u32>> {
+) -> Result<Option<ProcessIdentity>> {
     let deadline = tokio::time::Instant::now() + SUPERVISOR_TAKEOVER_EXIT_GRACE;
     while read_supervisor_pid_owner(pid_file)? == Some(instance.supervisor_pid) {
         if tokio::time::Instant::now() >= deadline {
@@ -258,7 +264,7 @@ async fn finish_accepted_takeover(
             ))
         })?;
         ensure_handoff_matches_instance(supervisor_id, &consumed, instance)?;
-        Ok(consumed.child_identity.map(|identity| identity.pid))
+        Ok(consumed.child_identity)
     }
 }
 
@@ -266,7 +272,7 @@ fn take_matching_accepted_handoff(
     install_dir: &Path,
     supervisor_id: &str,
     request: &SupervisorTakeoverRequest,
-) -> Result<Option<u32>> {
+) -> Result<Option<ProcessIdentity>> {
     let handoff = read_accepted_supervisor_takeover(install_dir, supervisor_id)?.ok_or_else(|| {
         SurgeError::Update(format!(
             "Supervisor '{supervisor_id}' accepted takeover record disappeared before it was consumed"
@@ -279,5 +285,5 @@ fn take_matching_accepted_handoff(
         ))
     })?;
     ensure_handoff_matches_request(supervisor_id, &consumed, request)?;
-    Ok(consumed.child_identity.map(|identity| identity.pid))
+    Ok(consumed.child_identity)
 }

--- a/crates/surge-supervisor/src/child.rs
+++ b/crates/surge-supervisor/src/child.rs
@@ -192,27 +192,27 @@ fn wait_for_child_startup_or_stop(
 }
 
 pub(crate) fn wait_for_pid_or_stop(
-    pid: u32,
+    mut observed_process_is_running: impl FnMut() -> Result<bool, SupervisorError>,
     shutdown: &std::sync::Arc<std::sync::atomic::AtomicBool>,
     stop_triggers: &StopTriggers<'_>,
     pid_file: &Path,
     own_pid: u32,
-) -> WaitOutcome {
+) -> Result<WaitOutcome, SupervisorError> {
     loop {
         if shutdown.load(std::sync::atomic::Ordering::Acquire) {
-            return WaitOutcome::ShutdownRequested;
+            return Ok(WaitOutcome::ShutdownRequested);
         }
 
         if supervisor_was_superseded(pid_file, own_pid) {
-            return WaitOutcome::Superseded;
+            return Ok(WaitOutcome::Superseded);
         }
 
         if stop_triggers.requested() {
-            return WaitOutcome::StopRequested;
+            return Ok(WaitOutcome::StopRequested);
         }
 
-        if !is_process_running(pid) {
-            return WaitOutcome::ObservedProcessExited;
+        if !observed_process_is_running()? {
+            return Ok(WaitOutcome::ObservedProcessExited);
         }
 
         std::thread::sleep(std::time::Duration::from_millis(100));

--- a/crates/surge-supervisor/src/main.rs
+++ b/crates/surge-supervisor/src/main.rs
@@ -18,18 +18,22 @@ mod handoff;
 mod ownership;
 #[cfg(unix)]
 mod takeover;
+mod watched;
 
+#[cfg(unix)]
+use child::terminate_child_process;
 use child::{
     RestartWaitOutcome, StopTriggers, SupervisedChildOutcome, WaitOutcome, spawn_supervised_child, wait_before_restart,
     wait_for_pid_or_stop, wait_for_supervised_child,
 };
 #[cfg(unix)]
-use child::{is_process_running, terminate_child_process};
-#[cfg(unix)]
 use ownership::current_supervisor_owns_pid_file;
 use ownership::{remove_owned_supervisor_state, supervisor_was_superseded};
 #[cfg(unix)]
-use takeover::{TakeoverResolution, complete_supervisor_takeover};
+use takeover::{ChildObservation, TakeoverResolution, complete_supervisor_takeover};
+use watched::WatchedProcess;
+#[cfg(unix)]
+use watched::{capture_process_identity, observe_spawned_child};
 
 /// Delay before relaunching a supervised child that has exited. Applied to both
 /// crash exits and clean (code 0) exits so a child that exits immediately cannot
@@ -86,6 +90,10 @@ enum Commands {
         /// PID of the currently running application process
         #[arg(long)]
         pid: u32,
+
+        /// Process generation captured when the watched application was handed off
+        #[arg(long, requires = "pid")]
+        generation: Option<u64>,
 
         /// Target version whose update handoff should converge after replacement child startup
         #[arg(long)]
@@ -175,7 +183,7 @@ fn main() -> ExitCode {
                     return ExitCode::FAILURE;
                 }
             };
-            if let Err(e) = run_supervisor(&id, &dir, &exe_path, &args, None, None) {
+            if let Err(e) = run_supervisor(&id, &dir, &exe_path, &args, None, None, None) {
                 tracing::error!("{e}");
                 return ExitCode::FAILURE;
             }
@@ -185,6 +193,7 @@ fn main() -> ExitCode {
             id,
             dir,
             pid,
+            generation,
             handoff_version,
             exe,
             args,
@@ -198,7 +207,15 @@ fn main() -> ExitCode {
                     return ExitCode::FAILURE;
                 }
             };
-            if let Err(e) = run_supervisor(&id, &dir, &exe_path, &args, Some(pid), handoff_version.as_deref()) {
+            if let Err(e) = run_supervisor(
+                &id,
+                &dir,
+                &exe_path,
+                &args,
+                Some(pid),
+                generation,
+                handoff_version.as_deref(),
+            ) {
                 tracing::error!("{e}");
                 return ExitCode::FAILURE;
             }
@@ -223,6 +240,7 @@ fn run_supervisor(
     exe_path: &Path,
     args: &[String],
     watched_pid: Option<u32>,
+    watched_generation: Option<u64>,
     handoff_version: Option<&str>,
 ) -> Result<(), SupervisorError> {
     tracing::info!(
@@ -269,7 +287,7 @@ fn run_supervisor(
     let restart_args = handoff::without_lifecycle_args(args);
     let mut next_child_args = Some(first_child_args);
     let mut pending_handoff_version = handoff::pending_restart_handoff_version(watched_pid, handoff_version, args);
-    let mut watched_pid = watched_pid;
+    let mut watched_process = watched_pid.map(|pid| WatchedProcess::new(pid, watched_generation));
 
     'supervision: loop {
         if shutdown.load(std::sync::atomic::Ordering::Acquire) {
@@ -291,7 +309,7 @@ fn run_supervisor(
                 &shutdown,
                 &pid_file,
                 own_pid,
-                || Ok(watched_pid.filter(|pid| is_process_running(*pid))),
+                || watched_process.map_or(ChildObservation::Absent, WatchedProcess::observation),
             )? {
                 TakeoverResolution::Cancelled => continue,
                 TakeoverResolution::LegacyStop(child_pid) => {
@@ -314,10 +332,17 @@ fn run_supervisor(
             break;
         }
 
-        if let Some(pid) = watched_pid.take() {
+        if let Some(watched) = watched_process.take() {
+            let pid = watched.pid();
             tracing::info!("Watching running process PID {pid} before relaunch");
             loop {
-                match wait_for_pid_or_stop(pid, &shutdown, &stop_triggers, &pid_file, own_pid) {
+                match wait_for_pid_or_stop(
+                    || Ok(watched.is_running()),
+                    &shutdown,
+                    &stop_triggers,
+                    &pid_file,
+                    own_pid,
+                )? {
                     WaitOutcome::ObservedProcessExited => {
                         if supervisor_was_superseded(&pid_file, own_pid) {
                             break 'supervision;
@@ -335,7 +360,7 @@ fn run_supervisor(
                             &shutdown,
                             &pid_file,
                             own_pid,
-                            || Ok(is_process_running(pid).then_some(pid)),
+                            || watched.observation(),
                         )? {
                             TakeoverResolution::Accepted => break 'supervision,
                             TakeoverResolution::Cancelled => continue,
@@ -376,6 +401,8 @@ fn run_supervisor(
         let mut child = spawn_supervised_child(exe_path, install_dir, &child_args)?;
         #[cfg(unix)]
         let child_pid = child.id();
+        #[cfg(unix)]
+        let child_identity = capture_process_identity(child_pid);
 
         let status = loop {
             match wait_for_supervised_child(
@@ -398,7 +425,7 @@ fn run_supervisor(
                         &shutdown,
                         &pid_file,
                         own_pid,
-                        || Ok(child.try_wait()?.is_none().then_some(child_pid)),
+                        || observe_spawned_child(&mut child, child_pid, child_identity),
                     )? {
                         TakeoverResolution::Cancelled => continue,
                         TakeoverResolution::LegacyStop(running_child_pid) => {
@@ -465,7 +492,7 @@ fn run_supervisor(
                         &shutdown,
                         &pid_file,
                         own_pid,
-                        || Ok(None),
+                        || ChildObservation::Absent,
                     )? {
                         TakeoverResolution::Accepted | TakeoverResolution::LegacyStop(_) => break 'supervision,
                         TakeoverResolution::Cancelled => continue,
@@ -644,6 +671,8 @@ mod tests {
             "/tmp/demo",
             "--pid",
             "42",
+            "--generation",
+            "7",
             "--handoff-version",
             "2.0.0",
             "--exe",
@@ -654,12 +683,16 @@ mod tests {
         .unwrap();
 
         let Commands::Watch {
-            handoff_version, args, ..
+            generation,
+            handoff_version,
+            args,
+            ..
         } = cli.command
         else {
             panic!("expected watch command");
         };
 
+        assert_eq!(generation, Some(7));
         assert_eq!(handoff_version.as_deref(), Some("2.0.0"));
         assert_eq!(args, vec!["--app-mode"]);
     }
@@ -702,6 +735,7 @@ mod tests {
                 &exe_path_for_thread,
                 &[],
                 Some(watched_pid),
+                None,
                 None,
             );
             tx.send(result).unwrap();
@@ -824,6 +858,7 @@ mod tests {
                     ],
                     None,
                     None,
+                    None,
                 );
                 match &result {
                     Err(SupervisorError::Io(error))
@@ -880,6 +915,7 @@ mod tests {
                 &install_dir_for_thread,
                 &exe_path_for_thread,
                 &[],
+                None,
                 None,
                 None,
             ))
@@ -941,6 +977,7 @@ mod tests {
                 &[],
                 None,
                 None,
+                None,
             ))
             .unwrap();
         });
@@ -959,6 +996,9 @@ mod tests {
             .trim()
             .parse::<u32>()
             .unwrap();
+        let child_identity = surge_core::platform::process::process_identity(child_pid)
+            .unwrap()
+            .unwrap();
         let instance = read_supervisor_takeover_instance(install_dir, supervisor_id)
             .unwrap()
             .unwrap();
@@ -972,7 +1012,10 @@ mod tests {
             matches!(rx.try_recv(), Err(std::sync::mpsc::TryRecvError::Empty)),
             "supervisor must not exit when acknowledgement persistence fails"
         );
-        assert!(is_process_running(child_pid), "supervised child must remain running");
+        assert!(
+            child::is_process_running(child_pid),
+            "supervised child must remain running"
+        );
         assert!(supervisor_pid_file(install_dir, supervisor_id).exists());
 
         std::fs::remove_dir(&acknowledgement_path).unwrap();
@@ -1006,7 +1049,7 @@ mod tests {
         supervisor_result
             .expect("supervisor did not exit after acknowledged takeover")
             .unwrap();
-        assert_eq!(handoff.child_pid, Some(child_pid));
+        assert_eq!(handoff.child_identity, Some(child_identity));
     }
 
     #[cfg(unix)]
@@ -1077,6 +1120,7 @@ mod tests {
                 &exe_path_for_thread,
                 &[],
                 Some(watched_pid),
+                None,
                 Some("2.0.0"),
             );
             tx.send(result).unwrap();
@@ -1143,6 +1187,7 @@ mod tests {
                 &install_dir_for_thread,
                 &exe_path_for_thread,
                 &[],
+                None,
                 None,
                 None,
             );

--- a/crates/surge-supervisor/src/takeover.rs
+++ b/crates/surge-supervisor/src/takeover.rs
@@ -1,5 +1,6 @@
 use std::path::Path;
 
+use surge_core::platform::process::ProcessIdentity;
 use surge_core::supervisor::state::{
     SupervisorTakeoverAcknowledgement, SupervisorTakeoverCancellation, SupervisorTakeoverInstance,
     accept_supervisor_takeover_request, cancel_supervisor_takeover_request, read_supervisor_takeover_commit,
@@ -21,6 +22,30 @@ pub(crate) enum TakeoverResolution {
     Superseded,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ChildObservation {
+    Absent,
+    Verified(ProcessIdentity),
+    Unverified(u32),
+}
+
+impl ChildObservation {
+    fn pid(self) -> Option<u32> {
+        match self {
+            Self::Absent => None,
+            Self::Verified(identity) => Some(identity.pid),
+            Self::Unverified(pid) => Some(pid),
+        }
+    }
+
+    fn verified_identity(self) -> Option<ProcessIdentity> {
+        match self {
+            Self::Verified(identity) => Some(identity),
+            Self::Absent | Self::Unverified(_) => None,
+        }
+    }
+}
+
 pub(crate) fn complete_supervisor_takeover(
     install_dir: &Path,
     supervisor_id: &str,
@@ -29,9 +54,10 @@ pub(crate) fn complete_supervisor_takeover(
     shutdown: &std::sync::Arc<std::sync::atomic::AtomicBool>,
     supervisor_pid_file: &Path,
     own_pid: u32,
-    mut current_child_pid: impl FnMut() -> Result<Option<u32>, SupervisorError>,
+    mut current_child: impl FnMut() -> ChildObservation,
 ) -> Result<TakeoverResolution, SupervisorError> {
     let mut acknowledgement: Option<SupervisorTakeoverAcknowledgement> = None;
+    let mut warned_unverified_request: Option<String> = None;
 
     loop {
         if shutdown.load(std::sync::atomic::Ordering::Acquire) {
@@ -43,7 +69,7 @@ pub(crate) fn complete_supervisor_takeover(
 
         let request = match read_supervisor_takeover_request(install_dir, supervisor_id) {
             Ok(Some(request)) => request,
-            Ok(None) => return legacy_stop_or_cancelled(stop_triggers, &mut current_child_pid),
+            Ok(None) => return Ok(legacy_stop_or_cancelled(stop_triggers, &mut current_child)),
             Err(error) => {
                 tracing::warn!(
                     supervisor_id,
@@ -58,7 +84,7 @@ pub(crate) fn complete_supervisor_takeover(
         if !request.matches_instance(instance) || request.is_expired() {
             match cancel_supervisor_takeover_request(install_dir, supervisor_id, &request) {
                 Ok(SupervisorTakeoverCancellation::Cancelled | SupervisorTakeoverCancellation::Missing) => {
-                    return legacy_stop_or_cancelled(stop_triggers, &mut current_child_pid);
+                    return Ok(legacy_stop_or_cancelled(stop_triggers, &mut current_child));
                 }
                 Ok(SupervisorTakeoverCancellation::Replaced) => {
                     acknowledgement = None;
@@ -72,7 +98,7 @@ pub(crate) fn complete_supervisor_takeover(
                         supervisor_id,
                         "Ignoring an accepted takeover request for a different supervisor instance"
                     );
-                    return legacy_stop_or_cancelled(stop_triggers, &mut current_child_pid);
+                    return Ok(legacy_stop_or_cancelled(stop_triggers, &mut current_child));
                 }
                 Err(error) => {
                     tracing::warn!(
@@ -86,12 +112,25 @@ pub(crate) fn complete_supervisor_takeover(
             }
         }
 
-        let observed_child_pid = current_child_pid()?;
+        let observed_child = current_child();
+        if let ChildObservation::Unverified(pid) = observed_child {
+            if warned_unverified_request.as_deref() != Some(&request.request_token) {
+                tracing::warn!(
+                    pid,
+                    supervisor_id,
+                    "Cannot acknowledge takeover without a verified child process generation; continuing supervision"
+                );
+                warned_unverified_request = Some(request.request_token.clone());
+            }
+            std::thread::sleep(TAKEOVER_POLL_INTERVAL);
+            continue;
+        }
+        let observed_child_identity = observed_child.verified_identity();
         let acknowledgement_matches_observation = acknowledgement.as_ref().is_some_and(|acknowledgement| {
-            acknowledgement.matches_request(&request) && acknowledgement.child_pid == observed_child_pid
+            acknowledgement.matches_request(&request) && acknowledgement.child_identity == observed_child_identity
         });
         if !acknowledgement_matches_observation {
-            let next_acknowledgement = SupervisorTakeoverAcknowledgement::new(&request, observed_child_pid);
+            let next_acknowledgement = SupervisorTakeoverAcknowledgement::new(&request, observed_child_identity);
             match write_supervisor_takeover_acknowledgement(install_dir, supervisor_id, &next_acknowledgement) {
                 Ok(()) => acknowledgement = Some(next_acknowledgement),
                 Err(error) => {
@@ -140,8 +179,10 @@ pub(crate) fn complete_supervisor_takeover(
             continue;
         }
 
-        let refreshed_child_pid = current_child_pid()?;
-        if refreshed_child_pid != current_acknowledgement.child_pid {
+        let refreshed_child = current_child();
+        if matches!(refreshed_child, ChildObservation::Unverified(_))
+            || refreshed_child.verified_identity() != current_acknowledgement.child_identity
+        {
             acknowledgement = None;
             continue;
         }
@@ -165,11 +206,54 @@ pub(crate) fn complete_supervisor_takeover(
 
 fn legacy_stop_or_cancelled(
     stop_triggers: &StopTriggers<'_>,
-    current_child_pid: &mut impl FnMut() -> Result<Option<u32>, SupervisorError>,
-) -> Result<TakeoverResolution, SupervisorError> {
+    current_child: &mut impl FnMut() -> ChildObservation,
+) -> TakeoverResolution {
     if stop_triggers.legacy_requested() {
-        Ok(TakeoverResolution::LegacyStop(current_child_pid()?))
+        TakeoverResolution::LegacyStop(current_child().pid())
     } else {
-        Ok(TakeoverResolution::Cancelled)
+        TakeoverResolution::Cancelled
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unverified_child_keeps_supervision_until_request_is_cancelled() {
+        let dir = tempfile::tempdir().unwrap();
+        let supervisor_id = "demo-supervisor";
+        let instance = SupervisorTakeoverInstance::new(std::process::id());
+        let request = surge_core::supervisor::state::SupervisorTakeoverRequest::new(
+            &instance,
+            std::time::Duration::from_millis(25),
+        );
+        let request_file = surge_core::supervisor::state::supervisor_takeover_request_file(dir.path(), supervisor_id);
+        surge_core::supervisor::state::write_supervisor_takeover_request(dir.path(), supervisor_id, &request).unwrap();
+        let legacy_stop_file = dir.path().join("legacy.stop");
+        let pid_file = dir.path().join("supervisor.pid");
+        std::fs::write(&pid_file, std::process::id().to_string()).unwrap();
+        let stop_triggers = StopTriggers::new(&legacy_stop_file, Some(&request_file));
+        let shutdown = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+
+        let outcome = complete_supervisor_takeover(
+            dir.path(),
+            supervisor_id,
+            &instance,
+            &stop_triggers,
+            &shutdown,
+            &pid_file,
+            std::process::id(),
+            || ChildObservation::Unverified(84),
+        )
+        .unwrap();
+
+        assert_eq!(outcome, TakeoverResolution::Cancelled);
+        assert!(pid_file.exists());
+        assert!(
+            surge_core::supervisor::state::read_supervisor_takeover_acknowledgement(dir.path(), supervisor_id)
+                .unwrap()
+                .is_none()
+        );
     }
 }

--- a/crates/surge-supervisor/src/watched.rs
+++ b/crates/surge-supervisor/src/watched.rs
@@ -1,0 +1,127 @@
+use crate::child::is_process_running;
+#[cfg(unix)]
+use crate::takeover::ChildObservation;
+
+#[cfg(unix)]
+use std::process::Child;
+#[cfg(unix)]
+use surge_core::platform::process::{ProcessIdentity, process_identity, process_identity_matches};
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum WatchedProcess {
+    #[cfg(unix)]
+    Verified(ProcessIdentity),
+    Unverified(u32),
+    Exited(u32),
+}
+
+impl WatchedProcess {
+    pub(crate) fn new(pid: u32, generation: Option<u64>) -> Self {
+        #[cfg(unix)]
+        {
+            if let Some(generation) = generation {
+                return Self::Verified(ProcessIdentity { pid, generation });
+            }
+            match process_identity(pid) {
+                Ok(Some(identity)) => Self::Verified(identity),
+                Ok(None) => Self::Exited(pid),
+                Err(error) => {
+                    tracing::warn!(pid, %error, "Cannot capture watched process generation; using liveness-only fallback");
+                    Self::Unverified(pid)
+                }
+            }
+        }
+        #[cfg(not(unix))]
+        {
+            let _ = generation;
+            Self::Unverified(pid)
+        }
+    }
+
+    pub(crate) fn pid(self) -> u32 {
+        match self {
+            #[cfg(unix)]
+            Self::Verified(identity) => identity.pid,
+            Self::Unverified(pid) | Self::Exited(pid) => pid,
+        }
+    }
+
+    pub(crate) fn is_running(self) -> bool {
+        #[cfg(unix)]
+        {
+            !matches!(self.observation(), ChildObservation::Absent)
+        }
+        #[cfg(not(unix))]
+        {
+            match self {
+                Self::Unverified(pid) => is_process_running(pid),
+                Self::Exited(_) => false,
+            }
+        }
+    }
+
+    #[cfg(unix)]
+    pub(crate) fn observation(self) -> ChildObservation {
+        match self {
+            Self::Verified(identity) => match process_identity_matches(identity) {
+                Ok(true) => ChildObservation::Verified(identity),
+                Ok(false) => ChildObservation::Absent,
+                Err(error) => {
+                    tracing::warn!(pid = identity.pid, %error, "Cannot revalidate watched process generation");
+                    ChildObservation::Unverified(identity.pid)
+                }
+            },
+            Self::Unverified(pid) if is_process_running(pid) => ChildObservation::Unverified(pid),
+            Self::Unverified(_) | Self::Exited(_) => ChildObservation::Absent,
+        }
+    }
+}
+
+#[cfg(unix)]
+pub(crate) fn capture_process_identity(pid: u32) -> Option<ProcessIdentity> {
+    match process_identity(pid) {
+        Ok(identity) => identity,
+        Err(error) => {
+            tracing::warn!(pid, %error, "Cannot capture supervised child process generation");
+            None
+        }
+    }
+}
+
+#[cfg(unix)]
+pub(crate) fn observe_spawned_child(
+    child: &mut Child,
+    child_pid: u32,
+    child_identity: Option<ProcessIdentity>,
+) -> ChildObservation {
+    match child.try_wait() {
+        Ok(Some(_)) => ChildObservation::Absent,
+        Ok(None) => child_identity.map_or(ChildObservation::Unverified(child_pid), ChildObservation::Verified),
+        Err(error) => {
+            tracing::warn!(pid = child_pid, %error, "Cannot refresh supervised child state");
+            ChildObservation::Unverified(child_pid)
+        }
+    }
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn explicit_generation_does_not_follow_a_reused_pid() {
+        let current = process_identity(std::process::id()).unwrap().unwrap();
+        let watched = WatchedProcess::new(current.pid, Some(current.generation.wrapping_add(1)));
+
+        assert_eq!(watched.observation(), ChildObservation::Absent);
+        assert!(!watched.is_running());
+    }
+
+    #[test]
+    fn watch_start_captures_the_current_process_generation() {
+        let current = process_identity(std::process::id()).unwrap().unwrap();
+        let watched = WatchedProcess::new(current.pid, None);
+
+        assert_eq!(watched.observation(), ChildObservation::Verified(current));
+    }
+}


### PR DESCRIPTION
## Summary

- retain the supervised child identity from spawn or watch establishment
- persist that identity in acknowledged takeover state
- carry the same identity through finalize, recovery, and supervisor handoff paths

## Why

Capturing a generation only at shutdown can authenticate a replacement process after PID reuse. The original child identity must survive the full supervision lifecycle.

This is stack 8 of 16.

- Base: #281
- Next: #261

Relates to fintermobilityas/youpark#1310.

## Validation

- exact layer `fc5d94c` passed supervisor identity, handoff, and finalize recovery tests plus rustfmt, blocking Clippy, and maintainability
- complete stack `c48f19f` passed 681 Rust workspace tests, both blocking Clippy tiers, vendor/version/format/maintainability checks, .NET formatting, and all 58 .NET tests

No migration is required.
