### PR TITLE
Harden cross-platform process inspection

### DIFF
--- a/crates/surge-core/src/update/manager/lifecycle/process_quiescence/discovery.rs
+++ b/crates/surge-core/src/update/manager/lifecycle/process_quiescence/discovery.rs
@@ -4,36 +4,244 @@
 #[cfg(unix)]
 use std::ffi::OsString;
 #[cfg(unix)]
-use std::path::{Path, PathBuf};
+use std::path::Path;
 #[cfg(target_os = "linux")]
-use std::time::Duration;
+use std::path::PathBuf;
 
 #[cfg(unix)]
-use crate::error::Result;
-#[cfg(target_os = "linux")]
-use crate::error::SurgeError;
+use crate::error::{Result, SurgeError};
 #[cfg(unix)]
 use crate::platform::process::{ProcessIdentity, process_identity, process_identity_matches};
 
 #[cfg(unix)]
 pub(super) struct AppProcess {
-    pub(super) exe: PathBuf,
+    pub(super) exe: std::path::PathBuf,
     pub(super) command: Vec<OsString>,
     pub(super) command_inspected: bool,
-    pub(super) cwd: Option<PathBuf>,
-}
-
-#[cfg(all(unix, test))]
-pub(super) fn app_process_pids<F>(protected_pid: u32, matches_exe: &F) -> Result<Vec<u32>>
-where
-    F: Fn(&AppProcess) -> Result<bool>,
-{
-    app_process_identities(protected_pid, matches_exe, &|_| Ok(true), &|_, _| Ok(true))
-        .map(|identities| identities.into_iter().map(|identity| identity.pid).collect())
+    pub(super) cwd: Option<std::path::PathBuf>,
 }
 
 #[cfg(unix)]
 pub(super) fn app_process_identities<F, E, C>(
+    protected_pid: u32,
+    matches_process: &F,
+    executable_may_match: &E,
+    command_may_match: &C,
+) -> Result<Vec<ProcessIdentity>>
+where
+    F: Fn(&AppProcess) -> Result<bool>,
+    E: Fn(&Path) -> Result<bool>,
+    C: Fn(&[OsString], Option<&Path>) -> Result<bool>,
+{
+    app_process_identities_impl(protected_pid, matches_process, executable_may_match, command_may_match)
+}
+
+#[cfg(all(unix, test))]
+pub(super) fn app_process_pids<F>(protected_pid: u32, matches_process: &F) -> Result<Vec<u32>>
+where
+    F: Fn(&AppProcess) -> Result<bool>,
+{
+    app_process_identities(protected_pid, matches_process, &|_| Ok(true), &|_, _| Ok(true))
+        .map(|identities| identities.into_iter().map(|identity| identity.pid).collect())
+}
+
+#[cfg(target_os = "linux")]
+fn app_process_identities_impl<F, E, C>(
+    protected_pid: u32,
+    matches_process: &F,
+    executable_may_match: &E,
+    command_may_match: &C,
+) -> Result<Vec<ProcessIdentity>>
+where
+    F: Fn(&AppProcess) -> Result<bool>,
+    E: Fn(&Path) -> Result<bool>,
+    C: Fn(&[OsString], Option<&Path>) -> Result<bool>,
+{
+    let entries = std::fs::read_dir("/proc")
+        .map_err(|error| SurgeError::Platform(format!("Failed to enumerate processes from /proc: {error}")))?;
+    let current_uid = read_linux_effective_uid("self")
+        .map_err(|error| SurgeError::Platform(format!("Failed to inspect updater process ownership: {error}")))?;
+
+    let mut identities = Vec::new();
+    for entry in entries {
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(error) if process_exited_during_inspection(&error) => continue,
+            Err(error) => {
+                return Err(SurgeError::Platform(format!(
+                    "Failed while enumerating processes from /proc: {error}"
+                )));
+            }
+        };
+        let Some(pid) = entry.file_name().to_string_lossy().parse::<u32>().ok() else {
+            continue;
+        };
+        if pid == protected_pid {
+            continue;
+        }
+
+        let uid = match read_linux_effective_uid(&pid.to_string()) {
+            Ok(uid) => uid,
+            Err(error) if process_exited_during_inspection(&error) => continue,
+            Err(error) => return Err(process_inspection_error(pid, "ownership", &error)),
+        };
+        if uid != current_uid {
+            continue;
+        }
+        let Some(identity) = inspected_process_identity(pid)? else {
+            continue;
+        };
+
+        let mut executable = std::fs::read_link(format!("/proc/{pid}/exe")).map(normalize_proc_exe_path);
+        let command = match inspect_proc_command(pid, executable.as_mut().ok()) {
+            Ok(Some(command)) => Ok(command),
+            Ok(None) => continue,
+            Err(error) => Err(error),
+        };
+        if executable.as_ref().is_err_and(process_exited_during_inspection)
+            || command.as_ref().is_err_and(process_exited_during_inspection)
+        {
+            continue;
+        }
+
+        let cwd = match std::fs::read_link(format!("/proc/{pid}/cwd")) {
+            Ok(cwd) => Some(cwd),
+            Err(_) if inspected_identity_still_matches(identity)? => None,
+            Err(_) => continue,
+        };
+        let (executable, command) = match (executable, command) {
+            (Ok(executable), Ok(command)) => (executable, command),
+            (Err(error), Ok(command)) => {
+                if command_may_match(&command, cwd.as_deref())? {
+                    return Err(process_inspection_error(pid, "executable", &error));
+                }
+                continue;
+            }
+            (Ok(executable), Err(error)) => {
+                if executable_may_match(&executable)? {
+                    return Err(process_inspection_error(pid, "command line", &error));
+                }
+                continue;
+            }
+            (Err(error), Err(_)) => return Err(process_inspection_error(pid, "executable", &error)),
+        };
+        let process = AppProcess {
+            exe: executable,
+            command,
+            command_inspected: true,
+            cwd,
+        };
+        if matches_process(&process)? && inspected_identity_still_matches(identity)? {
+            identities.push(identity);
+        }
+    }
+
+    Ok(identities)
+}
+
+#[cfg(target_os = "linux")]
+fn read_linux_effective_uid(process: &str) -> std::io::Result<u32> {
+    let status = std::fs::read_to_string(format!("/proc/{process}/status"))?;
+    parse_linux_effective_uid(&status).ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("process {process} status has no valid effective UID"),
+        )
+    })
+}
+
+#[cfg(target_os = "linux")]
+fn parse_linux_effective_uid(status: &str) -> Option<u32> {
+    status
+        .lines()
+        .find_map(|line| line.strip_prefix("Uid:"))?
+        .split_whitespace()
+        .nth(1)?
+        .parse()
+        .ok()
+}
+
+#[cfg(target_os = "linux")]
+fn inspect_proc_command(pid: u32, mut executable: Option<&mut PathBuf>) -> std::io::Result<Option<Vec<OsString>>> {
+    let mut command = read_proc_arguments(pid, "cmdline");
+    if executable.is_none() {
+        return command.map(Some);
+    }
+
+    let deadline = std::time::Instant::now() + std::time::Duration::from_millis(100);
+    loop {
+        if command.as_ref().is_err_and(process_exited_during_inspection) {
+            return Ok(None);
+        }
+        if command.is_err() {
+            return command.map(Some);
+        }
+
+        let observed = match std::fs::read_link(format!("/proc/{pid}/exe")) {
+            Ok(observed) => normalize_proc_exe_path(observed),
+            Err(error) if process_exited_during_inspection(&error) => return Ok(None),
+            Err(error) => return Err(error),
+        };
+        let executable_changed = executable.as_mut().is_some_and(|executable| {
+            if observed == **executable {
+                false
+            } else {
+                **executable = observed;
+                true
+            }
+        });
+        if !executable_changed
+            && command
+                .as_ref()
+                .is_ok_and(|arguments| arguments.iter().any(|argument| !argument.is_empty()))
+        {
+            return command.map(Some);
+        }
+        if process_identity(pid)?.is_none() {
+            return Ok(None);
+        }
+        if std::time::Instant::now() >= deadline {
+            return command.map(Some);
+        }
+        std::thread::sleep(std::time::Duration::from_millis(1));
+        command = read_proc_arguments(pid, "cmdline");
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn read_proc_arguments(pid: u32, field: &str) -> std::io::Result<Vec<OsString>> {
+    std::fs::read(format!("/proc/{pid}/{field}")).map(|bytes| parse_proc_cmdline(&bytes))
+}
+
+#[cfg(target_os = "linux")]
+pub(super) fn parse_proc_cmdline(bytes: &[u8]) -> Vec<OsString> {
+    use std::os::unix::ffi::OsStringExt;
+
+    if bytes.is_empty() {
+        return Vec::new();
+    }
+    bytes
+        .strip_suffix(&[0])
+        .unwrap_or(bytes)
+        .split(|byte| *byte == 0)
+        .map(|argument| OsString::from_vec(argument.to_vec()))
+        .collect()
+}
+
+#[cfg(target_os = "linux")]
+fn process_exited_during_inspection(error: &std::io::Error) -> bool {
+    error.kind() == std::io::ErrorKind::NotFound || matches!(error.raw_os_error(), Some(nix::libc::ESRCH))
+}
+
+#[cfg(target_os = "linux")]
+fn process_inspection_error(pid: u32, field: &str, error: &std::io::Error) -> SurgeError {
+    SurgeError::Platform(format!(
+        "Failed to inspect process {pid} {field} before application swap: {error}"
+    ))
+}
+
+#[cfg(target_os = "macos")]
+fn app_process_identities_impl<F, E, C>(
     protected_pid: u32,
     matches_process: &F,
     _executable_may_match: &E,
@@ -43,53 +251,6 @@ where
     F: Fn(&AppProcess) -> Result<bool>,
     E: Fn(&Path) -> Result<bool>,
     C: Fn(&[OsString], Option<&Path>) -> Result<bool>,
-{
-    app_process_identities_impl(protected_pid, matches_process)
-}
-
-#[cfg(target_os = "linux")]
-fn app_process_identities_impl<F>(protected_pid: u32, matches_exe: &F) -> Result<Vec<ProcessIdentity>>
-where
-    F: Fn(&AppProcess) -> Result<bool>,
-{
-    let entries = std::fs::read_dir("/proc")
-        .map_err(|e| SurgeError::Platform(format!("Failed to enumerate processes from /proc: {e}")))?;
-
-    let mut identities = Vec::new();
-    for entry in entries.filter_map(std::result::Result::ok) {
-        let Some(pid) = entry.file_name().to_string_lossy().parse::<u32>().ok() else {
-            continue;
-        };
-        if pid == protected_pid {
-            continue;
-        }
-        let Some(identity) = inspected_process_identity(pid)? else {
-            continue;
-        };
-        let Ok(mut exe) = std::fs::read_link(format!("/proc/{pid}/exe")).map(normalize_proc_exe_path) else {
-            continue;
-        };
-        let Some((command, command_inspected)) = inspect_linux_process_command(pid, &mut exe)? else {
-            continue;
-        };
-        let process = AppProcess {
-            exe,
-            command,
-            command_inspected,
-            cwd: std::fs::read_link(format!("/proc/{pid}/cwd")).ok(),
-        };
-        if matches_exe(&process)? && inspected_identity_still_matches(identity)? {
-            identities.push(identity);
-        }
-    }
-
-    Ok(identities)
-}
-
-#[cfg(target_os = "macos")]
-fn app_process_identities_impl<F>(protected_pid: u32, matches_exe: &F) -> Result<Vec<ProcessIdentity>>
-where
-    F: Fn(&AppProcess) -> Result<bool>,
 {
     use sysinfo::{ProcessesToUpdate, System};
 
@@ -113,7 +274,7 @@ where
             command_inspected: !process.cmd().is_empty(),
             cwd: process.cwd().map(Path::to_path_buf),
         };
-        if matches_exe(&app_process)? && inspected_identity_still_matches(identity)? {
+        if matches_process(&app_process)? && inspected_identity_still_matches(identity)? {
             identities.push(identity);
         }
     }
@@ -121,87 +282,18 @@ where
     Ok(identities)
 }
 
-#[cfg(target_os = "linux")]
-pub(super) fn parse_proc_cmdline(bytes: &[u8]) -> Vec<OsString> {
-    use std::os::unix::ffi::OsStringExt;
-
-    if bytes.is_empty() {
-        return Vec::new();
-    }
-
-    let arguments = bytes.strip_suffix(&[0]).unwrap_or(bytes);
-    arguments
-        .split(|byte| *byte == 0)
-        .map(|argument| OsString::from_vec(argument.to_vec()))
-        .collect()
-}
-
-#[cfg(target_os = "linux")]
-fn inspect_linux_process_command(pid: u32, executable: &mut PathBuf) -> Result<Option<(Vec<OsString>, bool)>> {
-    let deadline = std::time::Instant::now() + Duration::from_millis(100);
-    let mut command = Vec::new();
-    let mut command_inspected = false;
-    loop {
-        if let Ok(bytes) = std::fs::read(format!("/proc/{pid}/cmdline")) {
-            command = parse_proc_cmdline(&bytes);
-            command_inspected = true;
-        }
-
-        let executable_changed = std::fs::read_link(format!("/proc/{pid}/exe"))
-            .map(normalize_proc_exe_path)
-            .is_ok_and(|observed| {
-                if observed == *executable {
-                    false
-                } else {
-                    *executable = observed;
-                    true
-                }
-            });
-        if executable_changed {
-            command.clear();
-            command_inspected = false;
-        }
-        if !executable_changed && command.iter().any(|argument| !argument.is_empty()) {
-            return Ok(Some((command, command_inspected)));
-        }
-        if linux_process_is_gone_or_zombie(pid)? {
-            return Ok(None);
-        }
-        if std::time::Instant::now() >= deadline {
-            return Ok(Some((command, command_inspected)));
-        }
-        std::thread::sleep(Duration::from_millis(1));
-    }
-}
-
-#[cfg(target_os = "linux")]
-fn linux_process_is_gone_or_zombie(pid: u32) -> Result<bool> {
-    let stat = match std::fs::read_to_string(format!("/proc/{pid}/stat")) {
-        Ok(stat) => stat,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(true),
-        Err(error) => {
-            return Err(SurgeError::Platform(format!(
-                "Failed to inspect process PID {pid} state before swap: {error}"
-            )));
-        }
-    };
-    proc_stat_is_zombie(&stat)
-        .ok_or_else(|| SurgeError::Platform(format!("Failed to parse process PID {pid} state before swap")))
-}
-
-#[cfg(target_os = "linux")]
-fn proc_stat_is_zombie(stat: &str) -> Option<bool> {
-    let state = stat.rsplit_once(") ")?.1.as_bytes().first()?;
-    Some(matches!(*state, b'Z' | b'X'))
-}
-
 #[cfg(all(unix, not(any(target_os = "linux", target_os = "macos"))))]
-fn app_process_identities_impl<F>(_protected_pid: u32, _matches_exe: &F) -> Result<Vec<ProcessIdentity>>
+fn app_process_identities_impl<F, E, C>(
+    _protected_pid: u32,
+    _matches_process: &F,
+    _executable_may_match: &E,
+    _command_may_match: &C,
+) -> Result<Vec<ProcessIdentity>>
 where
     F: Fn(&AppProcess) -> Result<bool>,
+    E: Fn(&Path) -> Result<bool>,
+    C: Fn(&[OsString], Option<&Path>) -> Result<bool>,
 {
-    use crate::error::SurgeError;
-
     Err(SurgeError::Platform(
         "Active application process discovery is unsupported on this Unix platform".to_string(),
     ))
@@ -210,7 +302,7 @@ where
 #[cfg(unix)]
 fn inspected_process_identity(pid: u32) -> Result<Option<ProcessIdentity>> {
     process_identity(pid).map_err(|error| {
-        crate::error::SurgeError::Platform(format!(
+        SurgeError::Platform(format!(
             "Failed to inspect process {pid} generation before application swap: {error}"
         ))
     })
@@ -219,7 +311,7 @@ fn inspected_process_identity(pid: u32) -> Result<Option<ProcessIdentity>> {
 #[cfg(unix)]
 fn inspected_identity_still_matches(identity: ProcessIdentity) -> Result<bool> {
     process_identity_matches(identity).map_err(|error| {
-        crate::error::SurgeError::Platform(format!(
+        SurgeError::Platform(format!(
             "Failed to revalidate process {} generation before application swap: {error}",
             identity.pid
         ))
@@ -234,7 +326,6 @@ fn normalize_proc_exe_path(path: PathBuf) -> PathBuf {
         Ok(false) => {}
         Ok(true) | Err(_) => return path,
     }
-
     let Some(path_bytes) = path.as_os_str().as_bytes().strip_suffix(b" (deleted)") else {
         return path;
     };
@@ -245,27 +336,29 @@ fn normalize_proc_exe_path(path: PathBuf) -> PathBuf {
 mod tests {
     use super::*;
 
-    #[cfg(target_os = "linux")]
     #[test]
-    fn proc_exe_deleted_suffix_is_ignored_for_matching() {
-        assert_eq!(
-            normalize_proc_exe_path(PathBuf::from("/opt/demo/app-1.0.0/demo (deleted)")),
-            PathBuf::from("/opt/demo/app-1.0.0/demo")
+    fn effective_uid_is_read_from_status_credentials() {
+        let status = "Name:\tdemo\nUid:\t1000\t1001\t1002\t1003\nGid:\t1000\t1000\t1000\t1000\n";
+        assert_eq!(parse_linux_effective_uid(status), Some(1001));
+        assert_eq!(parse_linux_effective_uid("Name:\tdemo\n"), None);
+    }
+
+    #[test]
+    fn process_inspection_failures_are_not_treated_as_exit_races() {
+        let exited = std::io::Error::from_raw_os_error(nix::libc::ENOENT);
+        let denied = std::io::Error::from_raw_os_error(nix::libc::EACCES);
+
+        assert!(process_exited_during_inspection(&exited));
+        assert!(!process_exited_during_inspection(&denied));
+        assert!(
+            process_inspection_error(42, "command line", &denied)
+                .to_string()
+                .contains("Failed to inspect process 42 command line")
         );
     }
 
-    #[cfg(target_os = "linux")]
     #[test]
-    fn proc_exe_path_preserves_existing_filename_with_deleted_suffix() {
-        let tmp = tempfile::tempdir().unwrap();
-        let executable = tmp.path().join("demo (deleted)");
-        std::fs::write(&executable, "fixture").unwrap();
-
-        assert_eq!(normalize_proc_exe_path(executable.clone()), executable);
-    }
-
-    #[test]
-    fn proc_cmdline_preserves_empty_argument_positions() {
+    fn proc_arguments_preserve_empty_positions_and_drop_only_the_terminator() {
         assert_eq!(
             parse_proc_cmdline(b"\0/opt/demo/app/demo\0\0"),
             vec![OsString::new(), OsString::from("/opt/demo/app/demo"), OsString::new()]
@@ -274,10 +367,19 @@ mod tests {
     }
 
     #[test]
-    fn proc_stat_recognizes_gone_process_states() {
-        assert_eq!(proc_stat_is_zombie("123 (demo) Z 1"), Some(true));
-        assert_eq!(proc_stat_is_zombie("123 (demo) X 1"), Some(true));
-        assert_eq!(proc_stat_is_zombie("123 (demo) S 1"), Some(false));
-        assert_eq!(proc_stat_is_zombie("malformed"), None);
+    fn proc_exe_deleted_suffix_is_ignored_for_matching() {
+        assert_eq!(
+            normalize_proc_exe_path(PathBuf::from("/opt/demo/app-1.0.0/demo (deleted)")),
+            PathBuf::from("/opt/demo/app-1.0.0/demo")
+        );
+    }
+
+    #[test]
+    fn proc_exe_path_preserves_existing_filename_with_deleted_suffix() {
+        let tmp = tempfile::tempdir().unwrap();
+        let executable = tmp.path().join("demo (deleted)");
+        std::fs::write(&executable, "fixture").unwrap();
+
+        assert_eq!(normalize_proc_exe_path(executable.clone()), executable);
     }
 }

--- a/crates/surge-core/src/update/manager/lifecycle/process_quiescence/discovery.rs
+++ b/crates/surge-core/src/update/manager/lifecycle/process_quiescence/discovery.rs
@@ -245,34 +245,64 @@ fn app_process_identities_impl<F, E, C>(
     protected_pid: u32,
     matches_process: &F,
     _executable_may_match: &E,
-    _command_may_match: &C,
+    command_may_match: &C,
 ) -> Result<Vec<ProcessIdentity>>
 where
     F: Fn(&AppProcess) -> Result<bool>,
     E: Fn(&Path) -> Result<bool>,
     C: Fn(&[OsString], Option<&Path>) -> Result<bool>,
 {
-    use sysinfo::{ProcessesToUpdate, System};
+    use sysinfo::{Pid, ProcessRefreshKind, ProcessStatus, ProcessesToUpdate, System, UpdateKind};
 
     let mut system = System::new();
-    let _ = system.refresh_processes(ProcessesToUpdate::All, true);
+    let _ = system.refresh_processes_specifics(
+        ProcessesToUpdate::All,
+        true,
+        ProcessRefreshKind::nothing()
+            .with_exe(UpdateKind::Always)
+            .with_cmd(UpdateKind::Always)
+            .with_cwd(UpdateKind::Always)
+            .with_user(UpdateKind::Always),
+    );
+    let updater = system
+        .process(Pid::from_u32(crate::platform::process::current_pid()))
+        .ok_or_else(|| {
+            SurgeError::Platform("Failed to inspect updater process ownership before application swap".to_string())
+        })?;
+    let updater_user = updater
+        .effective_user_id()
+        .or_else(|| updater.user_id())
+        .ok_or_else(|| {
+            SurgeError::Platform("Failed to inspect updater user identity before application swap".to_string())
+        })?;
+
     let mut identities = Vec::new();
     for (pid, process) in system.processes() {
         let pid = pid.as_u32();
-        if pid == protected_pid {
+        if pid == protected_pid || process.effective_user_id().or_else(|| process.user_id()) != Some(updater_user) {
             continue;
         }
         let Some(identity) = inspected_process_identity(pid)? else {
             continue;
         };
-        let Some(exe) = process.exe() else {
-            continue;
+        let command = process.cmd().to_vec();
+        let cwd = process.cwd().map(Path::to_path_buf);
+        let Some(executable) = process.exe() else {
+            if matches!(process.status(), ProcessStatus::Dead | ProcessStatus::Zombie) {
+                continue;
+            }
+            if !command_may_match(&command, cwd.as_deref())? {
+                continue;
+            }
+            return Err(SurgeError::Platform(format!(
+                "Failed to inspect process {pid} executable before application swap"
+            )));
         };
         let app_process = AppProcess {
-            exe: exe.to_path_buf(),
-            command: process.cmd().to_vec(),
+            exe: executable.to_path_buf(),
+            command,
             command_inspected: !process.cmd().is_empty(),
-            cwd: process.cwd().map(Path::to_path_buf),
+            cwd,
         };
         if matches_process(&app_process)? && inspected_identity_still_matches(identity)? {
             identities.push(identity);


### PR DESCRIPTION
## Summary

- treat Linux process-inspection failures separately from normal exit races
- preserve argument boundaries and executable identity while `/proc` changes
- refresh macOS process ownership without accepting stale snapshots

## Why

Fail-closed quiescence depends on trustworthy process snapshots. Platform inspection must distinguish a process that exited from one that remains live but cannot be identified safely.

This is stack 10 of 16.

- Base: #261
- Next: #284

Relates to fintermobilityas/youpark#1310.

## Validation

- exact layer `bfb80c1` passed Linux and macOS inspection regressions plus rustfmt, blocking Clippy, and maintainability
- complete stack `c48f19f` passed 681 Rust workspace tests, both blocking Clippy tiers, vendor/version/format/maintainability checks, .NET formatting, and all 58 .NET tests

No migration is required.
