### PR TITLE
Match interpreters using observed process environments

### DIFF
--- a/crates/surge-core/src/update/manager/lifecycle/process_quiescence.rs
+++ b/crates/surge-core/src/update/manager/lifecycle/process_quiescence.rs
@@ -11,10 +11,10 @@ mod discovery;
 
 #[cfg(unix)]
 use self::discovery::AppProcess;
-#[cfg(unix)]
-use self::discovery::app_process_identities;
 #[cfg(all(unix, test))]
 use self::discovery::app_process_pids;
+#[cfg(unix)]
+use self::discovery::{app_process_identities, current_process_environment};
 use crate::error::Result;
 #[cfg(unix)]
 use crate::error::SurgeError;
@@ -30,6 +30,7 @@ pub(in crate::update::manager) struct PreparedAppQuiescence {
     main_exe: String,
     active_entrypoint: active_entrypoint::Identity,
     interpreted_main: Option<interpreted_main::Identity>,
+    inspect_environment: bool,
 }
 
 pub(in crate::update::manager) fn terminate_superseded_app_processes(
@@ -77,10 +78,14 @@ fn prepare_app_quiescence_except(
     } else {
         refuse_in_process_swap(&active_entrypoint, interpreted_main.as_ref(), protected_pid)?;
     }
+    let inspect_environment = interpreted_main
+        .as_ref()
+        .is_some_and(interpreted_main::Identity::requires_environment);
     Ok(Some(PreparedAppQuiescence {
         main_exe: main_exe.to_string(),
         active_entrypoint,
         interpreted_main,
+        inspect_environment,
     }))
 }
 
@@ -100,6 +105,7 @@ fn terminate_superseded_app_processes_except(
         main_exe,
         protected_pid,
         "superseded",
+        false,
         |process| {
             Ok(is_superseded_app_exe(
                 install_dir,
@@ -134,6 +140,7 @@ fn terminate_prepared_app_processes_except(prepared: &PreparedAppQuiescence, pro
         &prepared.main_exe,
         protected_pid,
         "active",
+        prepared.inspect_environment,
         |process| is_active_app_process(&prepared.active_entrypoint, prepared.interpreted_main.as_ref(), process),
         |exe| active_app_executable_may_match(&prepared.active_entrypoint, prepared.interpreted_main.as_ref(), exe),
         |command, cwd| {
@@ -165,6 +172,7 @@ fn refuse_in_process_swap(
         })?,
         command: std::env::args_os().collect(),
         command_inspected: true,
+        environment: current_process_environment(),
         cwd: Some(std::env::current_dir().map_err(|e| {
             SurgeError::Platform(format!(
                 "Failed to resolve updater working directory before application swap: {e}"
@@ -209,6 +217,7 @@ fn terminate_matching_app_processes<F, E, C>(
     main_exe: &str,
     protected_pid: u32,
     process_scope: &'static str,
+    inspect_environment: bool,
     matches_process: F,
     executable_may_match: E,
     command_may_match: C,
@@ -228,6 +237,7 @@ where
 
     let identities = app_process_identities(
         protected_pid,
+        inspect_environment,
         &matches_process,
         &executable_may_match,
         &command_may_match,
@@ -245,6 +255,7 @@ where
 
     if wait_until_app_processes_exit(
         protected_pid,
+        inspect_environment,
         &matches_process,
         &executable_may_match,
         &command_may_match,
@@ -256,6 +267,7 @@ where
 
     let remaining = app_process_identities(
         protected_pid,
+        inspect_environment,
         &matches_process,
         &executable_may_match,
         &command_may_match,
@@ -272,6 +284,7 @@ where
 
     if wait_until_app_processes_exit(
         protected_pid,
+        inspect_environment,
         &matches_process,
         &executable_may_match,
         &command_may_match,
@@ -325,6 +338,7 @@ fn terminate_active_app_processes_except(
 #[cfg(unix)]
 fn wait_until_app_processes_exit<F, E, C>(
     protected_pid: u32,
+    inspect_environment: bool,
     matches_process: &F,
     executable_may_match: &E,
     command_may_match: &C,
@@ -337,7 +351,15 @@ where
 {
     let deadline = std::time::Instant::now() + timeout;
     loop {
-        if app_process_identities(protected_pid, matches_process, executable_may_match, command_may_match)?.is_empty() {
+        if app_process_identities(
+            protected_pid,
+            inspect_environment,
+            matches_process,
+            executable_may_match,
+            command_may_match,
+        )?
+        .is_empty()
+        {
             return Ok(true);
         }
         if std::time::Instant::now() >= deadline {
@@ -379,16 +401,29 @@ pub(in crate::update::manager) fn spawn_native_test_app(app_path: &Path) -> std:
 }
 
 #[cfg(all(test, any(target_os = "linux", target_os = "macos")))]
+fn matching_active_app_pids(
+    protected_pid: u32,
+    active_entrypoint: &active_entrypoint::Identity,
+    interpreted_main: Option<&interpreted_main::Identity>,
+) -> Result<Vec<u32>> {
+    app_process_pids(
+        protected_pid,
+        interpreted_main.is_some_and(interpreted_main::Identity::requires_environment),
+        &|process| is_active_app_process(active_entrypoint, interpreted_main, process),
+        &|executable| active_app_executable_may_match(active_entrypoint, interpreted_main, executable),
+        &|command, cwd| active_app_command_may_match(active_entrypoint, interpreted_main, command, cwd),
+    )
+}
+
+#[cfg(all(test, any(target_os = "linux", target_os = "macos")))]
 pub(in crate::update::manager) fn wait_for_native_test_app(app_path: &Path, child_pid: u32) {
     let active_app_dir = app_path.parent().unwrap();
     let main_exe = app_path.file_name().unwrap().to_str().unwrap();
     let active_entrypoint = active_entrypoint::Identity::resolve(active_app_dir, main_exe).unwrap();
     let deadline = std::time::Instant::now() + Duration::from_secs(5);
-    while !app_process_pids(u32::MAX, &|process| {
-        is_active_app_process(&active_entrypoint, None, process)
-    })
-    .unwrap()
-    .contains(&child_pid)
+    while !matching_active_app_pids(u32::MAX, &active_entrypoint, None)
+        .unwrap()
+        .contains(&child_pid)
     {
         assert!(
             std::time::Instant::now() < deadline,
@@ -408,7 +443,7 @@ fn active_app_executable_may_match(
         return Ok(true);
     }
     match interpreted_main {
-        Some(identity) => identity.executable_may_match(executable),
+        Some(identity) => identity.executable_may_match_without_environment(executable),
         None => Ok(false),
     }
 }
@@ -480,7 +515,9 @@ fn is_active_app_process(
     let Some(identity) = interpreted_main else {
         return Ok(false);
     };
-    if process.command.iter().all(|argument| argument.is_empty()) && identity.executable_may_match(&process.exe)? {
+    if process.command.iter().all(|argument| argument.is_empty())
+        && identity.executable_may_match_in_environment(&process.exe, &process.environment)?
+    {
         return Err(SurgeError::Platform(
             "Cannot inspect the command line of the active application interpreter before swap".to_string(),
         ));
@@ -491,12 +528,12 @@ fn is_active_app_process(
     if !active_entrypoint.matches_argument(argument, process.cwd.as_deref())? {
         return Ok(false);
     }
-    if !process.command_inspected && identity.executable_may_match(&process.exe)? {
+    if !process.command_inspected && identity.executable_may_match_in_environment(&process.exe, &process.environment)? {
         return Err(SurgeError::Platform(
             "Cannot inspect the command line of the active application interpreter before swap".to_string(),
         ));
     }
-    if !identity.matches_interpreter(&process.exe, process.command.first().map(OsString::as_os_str))? {
+    if !identity.matches_interpreter_in_environment(&process.exe, &process.command, &process.environment)? {
         return Ok(false);
     }
     Ok(true)
@@ -642,6 +679,7 @@ mod tests {
             exe: std::fs::canonicalize("/bin/sh").unwrap(),
             command: vec![OsString::from("/bin/sh"), app_path.into_os_string()],
             command_inspected: true,
+            environment: Vec::new(),
             cwd: Some(active_app_dir),
         };
 
@@ -663,6 +701,7 @@ mod tests {
             exe: std::fs::canonicalize("/bin/sleep").unwrap(),
             command: vec![app_path.into_os_string()],
             command_inspected: true,
+            environment: Vec::new(),
             cwd: Some(active_app_dir),
         };
 
@@ -683,10 +722,48 @@ mod tests {
             exe: std::fs::canonicalize("/bin/sleep").unwrap(),
             command: vec![OsString::from("/bin/sh"), app_path.into_os_string()],
             command_inspected: true,
+            environment: Vec::new(),
             cwd: Some(active_app_dir),
         };
 
         assert!(!is_active_app_process(&active_entrypoint, Some(&interpreted_main), &process).unwrap());
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    #[test]
+    fn env_interpreter_argv0_does_not_spoof_executable_identity() {
+        use std::os::unix::fs::symlink;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let active_app_dir = tmp.path().join("app");
+        let interpreter_dir = tmp.path().join("interpreters");
+        std::fs::create_dir_all(&active_app_dir).unwrap();
+        std::fs::create_dir_all(&interpreter_dir).unwrap();
+        let interpreter_name = "surge-test-interpreter";
+        symlink("/bin/sh", interpreter_dir.join(interpreter_name)).unwrap();
+        let app_path = active_app_dir.join("demo-script");
+        std::fs::write(&app_path, format!("#!/usr/bin/env {interpreter_name}\n")).unwrap();
+        let active_entrypoint = active_entrypoint::Identity::resolve(&active_app_dir, "demo-script").unwrap();
+        let interpreted_main = interpreted_main::resolve(&active_entrypoint.resolved).unwrap().unwrap();
+        let environment = vec![OsString::from(format!("PATH={}", interpreter_dir.display()))];
+        let command = vec![OsString::from(interpreter_name), app_path.into_os_string()];
+        let valid = AppProcess {
+            exe: std::fs::canonicalize("/bin/sh").unwrap(),
+            command: command.clone(),
+            command_inspected: true,
+            environment: environment.clone(),
+            cwd: None,
+        };
+        let spoofed = AppProcess {
+            exe: std::fs::canonicalize("/bin/sleep").unwrap(),
+            command,
+            command_inspected: true,
+            environment,
+            cwd: None,
+        };
+
+        assert!(is_active_app_process(&active_entrypoint, Some(&interpreted_main), &valid).unwrap());
+        assert!(!is_active_app_process(&active_entrypoint, Some(&interpreted_main), &spoofed).unwrap());
     }
 
     #[cfg(any(target_os = "linux", target_os = "macos"))]
@@ -703,6 +780,7 @@ mod tests {
             exe: std::fs::canonicalize("/bin/sh").unwrap(),
             command: Vec::new(),
             command_inspected: false,
+            environment: Vec::new(),
             cwd: None,
         };
 
@@ -725,6 +803,7 @@ mod tests {
             exe: std::fs::canonicalize("/bin/sh").unwrap(),
             command: vec![OsString::new()],
             command_inspected: true,
+            environment: Vec::new(),
             cwd: None,
         };
 
@@ -747,6 +826,7 @@ mod tests {
             exe: std::fs::canonicalize("/bin/sh").unwrap(),
             command: vec![OsString::new(), OsString::new()],
             command_inspected: true,
+            environment: Vec::new(),
             cwd: None,
         };
 
@@ -769,6 +849,7 @@ mod tests {
             exe: std::fs::canonicalize("/bin/sleep").unwrap(),
             command: vec![OsString::new()],
             command_inspected: true,
+            environment: Vec::new(),
             cwd: None,
         };
 
@@ -791,6 +872,7 @@ mod tests {
             exe: std::fs::canonicalize("/bin/sh").unwrap(),
             command: vec![OsString::from("/bin/sh"), OsString::from("demo-script")],
             command_inspected: true,
+            environment: Vec::new(),
             cwd: None,
         };
 
@@ -851,10 +933,7 @@ mod tests {
 
         let deadline = std::time::Instant::now() + Duration::from_secs(1);
         loop {
-            let matches = app_process_pids(u32::MAX, &|process| {
-                is_active_app_process(&active_entrypoint, None, process)
-            })
-            .unwrap();
+            let matches = matching_active_app_pids(u32::MAX, &active_entrypoint, None).unwrap();
             if matches.contains(&app_child_pid) {
                 assert!(!matches.contains(&unrelated_child_pid));
                 break;
@@ -880,13 +959,30 @@ mod tests {
     }
 
     #[cfg(any(target_os = "linux", target_os = "macos"))]
-    fn assert_interpreted_active_app_process_is_terminated_before_swap(shebang: &str) {
+    fn assert_interpreted_active_app_process_is_terminated_before_swap(
+        shebang: &str,
+        isolated_env_interpreter: Option<&str>,
+    ) {
         use std::os::unix::fs::PermissionsExt;
         use std::process::{Command, Stdio};
 
         let tmp = tempfile::tempdir().unwrap();
         let active_app_dir = tmp.path().join("app");
         std::fs::create_dir_all(&active_app_dir).unwrap();
+        let (shebang, child_path) = if let Some(interpreter_name) = isolated_env_interpreter {
+            let interpreter_dir = tmp.path().join("child-path");
+            std::fs::create_dir_all(&interpreter_dir).unwrap();
+            std::os::unix::fs::symlink("/bin/sh", interpreter_dir.join(interpreter_name)).unwrap();
+            let updater_path = std::env::var_os("PATH").unwrap_or_default();
+            let mut child_paths = vec![interpreter_dir];
+            child_paths.extend(std::env::split_paths(&updater_path));
+            (
+                format!("#!/usr/bin/env {interpreter_name}"),
+                Some(std::env::join_paths(child_paths).unwrap()),
+            )
+        } else {
+            (shebang.to_string(), None)
+        };
         let app_path = active_app_dir.join("demo-script");
         std::fs::write(&app_path, format!("{shebang}\nread _\n")).unwrap();
         let mut permissions = std::fs::metadata(&app_path).unwrap().permissions();
@@ -899,6 +995,9 @@ mod tests {
         let mut child = loop {
             let mut command = Command::new(&app_path);
             command.stdin(Stdio::piped());
+            if let Some(child_path) = &child_path {
+                command.env("PATH", child_path);
+            }
             match command.spawn() {
                 Ok(child) => break child,
                 Err(error)
@@ -912,11 +1011,9 @@ mod tests {
         };
         let child_pid = child.id();
         let deadline = std::time::Instant::now() + Duration::from_secs(1);
-        while !app_process_pids(u32::MAX, &|process| {
-            is_active_app_process(&active_entrypoint, Some(&interpreted_main), process)
-        })
-        .unwrap()
-        .contains(&child_pid)
+        while !matching_active_app_pids(u32::MAX, &active_entrypoint, Some(&interpreted_main))
+            .unwrap()
+            .contains(&child_pid)
         {
             assert!(
                 std::time::Instant::now() < deadline,
@@ -936,7 +1033,13 @@ mod tests {
     #[cfg(any(target_os = "linux", target_os = "macos"))]
     #[test]
     fn interpreted_active_app_process_is_terminated_before_swap() {
-        assert_interpreted_active_app_process_is_terminated_before_swap("#!/bin/sh");
+        assert_interpreted_active_app_process_is_terminated_before_swap("#!/bin/sh", None);
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    #[test]
+    fn env_interpreted_app_uses_the_launched_process_path() {
+        assert_interpreted_active_app_process_is_terminated_before_swap("", Some("surge-test-interpreter"));
     }
 
     #[cfg(any(target_os = "linux", target_os = "macos"))]
@@ -953,6 +1056,7 @@ mod tests {
             exe: std::fs::canonicalize("/bin/sh").unwrap(),
             command: vec![OsString::from("/bin/sh"), OsString::from("./demo-script")],
             command_inspected: true,
+            environment: Vec::new(),
             cwd: Some(std::path::PathBuf::from("/")),
         };
 
@@ -999,9 +1103,11 @@ mod tests {
             std::thread::sleep(Duration::from_millis(10));
         }
         assert!(
-            app_process_pids(u32::MAX, &|process| {
-                is_active_app_process(&prepared.active_entrypoint, prepared.interpreted_main.as_ref(), process)
-            })
+            matching_active_app_pids(
+                u32::MAX,
+                &prepared.active_entrypoint,
+                prepared.interpreted_main.as_ref(),
+            )
             .unwrap()
             .contains(&child_pid)
         );
@@ -1017,7 +1123,7 @@ mod tests {
     #[cfg(any(target_os = "linux", target_os = "macos"))]
     #[test]
     fn interpreted_active_app_with_multiple_interpreter_options_is_terminated_before_swap() {
-        assert_interpreted_active_app_process_is_terminated_before_swap("#!/usr/bin/env -S -i /bin/sh -e -u");
+        assert_interpreted_active_app_process_is_terminated_before_swap("#!/usr/bin/env -S -i /bin/sh -e -u", None);
     }
 
     #[cfg(any(target_os = "linux", target_os = "macos"))]
@@ -1035,6 +1141,7 @@ mod tests {
             exe: std::fs::canonicalize("/bin/sh").unwrap(),
             command: vec![OsString::from(interpreter_name), app_path.into_os_string()],
             command_inspected: true,
+            environment: Vec::new(),
             cwd: Some(active_app_dir),
         };
 
@@ -1062,6 +1169,7 @@ mod tests {
             exe: std::fs::canonicalize("/bin/sh").unwrap(),
             command: vec![OsString::from(interpreter_name), OsString::from("/other/script")],
             command_inspected: true,
+            environment: Vec::new(),
             cwd: Some(active_app_dir),
         };
 
@@ -1071,12 +1179,12 @@ mod tests {
     #[cfg(target_os = "macos")]
     #[test]
     fn direct_interpreted_app_with_multiple_options_is_terminated_before_swap() {
-        assert_interpreted_active_app_process_is_terminated_before_swap("#!/bin/sh -e -u");
+        assert_interpreted_active_app_process_is_terminated_before_swap("#!/bin/sh -e -u", None);
     }
     #[cfg(target_os = "macos")]
     #[test]
     fn env_interpreted_app_with_multiple_options_is_terminated_before_swap() {
-        assert_interpreted_active_app_process_is_terminated_before_swap("#!/usr/bin/env /bin/sh -e -u");
+        assert_interpreted_active_app_process_is_terminated_before_swap("#!/usr/bin/env /bin/sh -e -u", None);
     }
     #[cfg(target_os = "linux")]
     #[test]
@@ -1096,6 +1204,7 @@ mod tests {
             exe: std::fs::canonicalize("/bin/sleep").unwrap(),
             command: discovery::parse_proc_cmdline(&command),
             command_inspected: true,
+            environment: Vec::new(),
             cwd: Some(active_app_dir),
         };
 

--- a/crates/surge-core/src/update/manager/lifecycle/process_quiescence/discovery.rs
+++ b/crates/surge-core/src/update/manager/lifecycle/process_quiescence/discovery.rs
@@ -19,11 +19,13 @@ pub(super) struct AppProcess {
     pub(super) command: Vec<OsString>,
     pub(super) command_inspected: bool,
     pub(super) cwd: Option<std::path::PathBuf>,
+    pub(super) environment: Vec<OsString>,
 }
 
 #[cfg(unix)]
 pub(super) fn app_process_identities<F, E, C>(
     protected_pid: u32,
+    inspect_environment: bool,
     matches_process: &F,
     executable_may_match: &E,
     command_may_match: &C,
@@ -33,21 +35,70 @@ where
     E: Fn(&Path) -> Result<bool>,
     C: Fn(&[OsString], Option<&Path>) -> Result<bool>,
 {
-    app_process_identities_impl(protected_pid, matches_process, executable_may_match, command_may_match)
+    app_process_identities_impl(
+        protected_pid,
+        inspect_environment,
+        matches_process,
+        executable_may_match,
+        command_may_match,
+    )
 }
 
 #[cfg(all(unix, test))]
-pub(super) fn app_process_pids<F>(protected_pid: u32, matches_process: &F) -> Result<Vec<u32>>
+pub(super) fn app_process_pids<F, E, C>(
+    protected_pid: u32,
+    inspect_environment: bool,
+    matches_process: &F,
+    executable_may_match: &E,
+    command_may_match: &C,
+) -> Result<Vec<u32>>
 where
     F: Fn(&AppProcess) -> Result<bool>,
+    E: Fn(&Path) -> Result<bool>,
+    C: Fn(&[OsString], Option<&Path>) -> Result<bool>,
 {
-    app_process_identities(protected_pid, matches_process, &|_| Ok(true), &|_, _| Ok(true))
-        .map(|identities| identities.into_iter().map(|identity| identity.pid).collect())
+    app_process_identities(
+        protected_pid,
+        inspect_environment,
+        matches_process,
+        executable_may_match,
+        command_may_match,
+    )
+    .map(|identities| identities.into_iter().map(|identity| identity.pid).collect())
+}
+
+#[cfg(unix)]
+pub(super) fn current_process_environment() -> Vec<OsString> {
+    std::env::vars_os()
+        .map(|(name, value)| {
+            let mut assignment = name;
+            assignment.push("=");
+            assignment.push(value);
+            assignment
+        })
+        .collect()
+}
+
+#[cfg(unix)]
+fn should_inspect_process_environment<C>(
+    inspect_environment: bool,
+    command: &[OsString],
+    cwd: Option<&Path>,
+    command_may_match: &C,
+) -> Result<bool>
+where
+    C: Fn(&[OsString], Option<&Path>) -> Result<bool>,
+{
+    if !inspect_environment {
+        return Ok(false);
+    }
+    command_may_match(command, cwd)
 }
 
 #[cfg(target_os = "linux")]
 fn app_process_identities_impl<F, E, C>(
     protected_pid: u32,
+    inspect_environment: bool,
     matches_process: &F,
     executable_may_match: &E,
     command_may_match: &C,
@@ -125,11 +176,22 @@ where
             }
             (Err(error), Err(_)) => return Err(process_inspection_error(pid, "executable", &error)),
         };
+        let environment =
+            if should_inspect_process_environment(inspect_environment, &command, cwd.as_deref(), command_may_match)? {
+                match read_proc_arguments(pid, "environ") {
+                    Ok(environment) => environment,
+                    Err(error) if process_exited_during_inspection(&error) => continue,
+                    Err(error) => return Err(process_inspection_error(pid, "environment", &error)),
+                }
+            } else {
+                Vec::new()
+            };
         let process = AppProcess {
             exe: executable,
             command,
             command_inspected: true,
             cwd,
+            environment,
         };
         if matches_process(&process)? && inspected_identity_still_matches(identity)? {
             identities.push(identity);
@@ -243,6 +305,7 @@ fn process_inspection_error(pid: u32, field: &str, error: &std::io::Error) -> Su
 #[cfg(target_os = "macos")]
 fn app_process_identities_impl<F, E, C>(
     protected_pid: u32,
+    inspect_environment: bool,
     matches_process: &F,
     _executable_may_match: &E,
     command_may_match: &C,
@@ -262,7 +325,8 @@ where
             .with_exe(UpdateKind::Always)
             .with_cmd(UpdateKind::Always)
             .with_cwd(UpdateKind::Always)
-            .with_user(UpdateKind::Always),
+            .with_user(UpdateKind::Always)
+            .with_environ(UpdateKind::Never),
     );
     let updater = system
         .process(Pid::from_u32(crate::platform::process::current_pid()))
@@ -272,14 +336,44 @@ where
     let updater_user = updater
         .effective_user_id()
         .or_else(|| updater.user_id())
+        .cloned()
         .ok_or_else(|| {
             SurgeError::Platform("Failed to inspect updater user identity before application swap".to_string())
         })?;
 
     let mut identities = Vec::new();
-    for (pid, process) in system.processes() {
-        let pid = pid.as_u32();
-        if pid == protected_pid || process.effective_user_id().or_else(|| process.user_id()) != Some(updater_user) {
+    let process_ids: Vec<_> = system.processes().keys().copied().collect();
+    for process_id in process_ids {
+        let pid = process_id.as_u32();
+        if pid == protected_pid {
+            continue;
+        }
+
+        let Some(process) = system.process(process_id) else {
+            continue;
+        };
+        if process.effective_user_id().or_else(|| process.user_id()) != Some(&updater_user) {
+            continue;
+        }
+        let inspect_candidate_environment =
+            should_inspect_process_environment(inspect_environment, process.cmd(), process.cwd(), command_may_match)?;
+        if inspect_candidate_environment {
+            let _ = system.refresh_processes_specifics(
+                ProcessesToUpdate::Some(&[process_id]),
+                true,
+                ProcessRefreshKind::nothing()
+                    .with_exe(UpdateKind::Always)
+                    .with_cmd(UpdateKind::Always)
+                    .with_cwd(UpdateKind::Always)
+                    .with_user(UpdateKind::Always)
+                    .with_environ(UpdateKind::Always),
+            );
+        }
+
+        let Some(process) = system.process(process_id) else {
+            continue;
+        };
+        if process.effective_user_id().or_else(|| process.user_id()) != Some(&updater_user) {
             continue;
         }
         let Some(identity) = inspected_process_identity(pid)? else {
@@ -303,6 +397,11 @@ where
             command,
             command_inspected: !process.cmd().is_empty(),
             cwd,
+            environment: if inspect_candidate_environment {
+                process.environ().to_vec()
+            } else {
+                Vec::new()
+            },
         };
         if matches_process(&app_process)? && inspected_identity_still_matches(identity)? {
             identities.push(identity);
@@ -315,6 +414,7 @@ where
 #[cfg(all(unix, not(any(target_os = "linux", target_os = "macos"))))]
 fn app_process_identities_impl<F, E, C>(
     _protected_pid: u32,
+    _inspect_environment: bool,
     _matches_process: &F,
     _executable_may_match: &E,
     _command_may_match: &C,
@@ -385,6 +485,14 @@ mod tests {
                 .to_string()
                 .contains("Failed to inspect process 42 command line")
         );
+    }
+
+    #[test]
+    fn environment_candidate_is_not_evaluated_when_inspection_is_disabled() {
+        let candidate =
+            |_: &[OsString], _: Option<&Path>| -> Result<bool> { panic!("environment candidate must not run") };
+
+        assert!(!should_inspect_process_environment(false, &[], None, &candidate).unwrap());
     }
 
     #[test]

--- a/crates/surge-core/src/update/manager/lifecycle/process_quiescence/interpreted_main.rs
+++ b/crates/surge-core/src/update/manager/lifecycle/process_quiescence/interpreted_main.rs
@@ -14,7 +14,7 @@ const SHEBANG_IDENTITY_LIMIT: usize = 256;
 #[cfg(not(target_os = "macos"))]
 const SHEBANG_READ_LIMIT: u64 = 257;
 const SUPPORTED_ENV_INTERPRETERS: [&str; 2] = ["/usr/bin/env", "/bin/env"];
-const DEFAULT_ENV_SEARCH_PATH: &str = "/usr/bin:/bin";
+const DEFAULT_ENV_SEARCH_PATH: &str = "/bin:/usr/bin";
 
 pub(super) struct Identity {
     interpreter: Interpreter,
@@ -40,41 +40,158 @@ enum EnvSearchPath {
 }
 
 impl Identity {
-    pub(super) fn matches_interpreter(&self, executable: &Path, argv0: Option<&OsStr>) -> Result<bool> {
+    pub(super) fn requires_environment(&self) -> bool {
+        matches!(
+            &self.interpreter,
+            Interpreter::EnvCommand(command) if command.requires_environment()
+        )
+    }
+
+    pub(super) fn matches_interpreter_in_environment(
+        &self,
+        executable: &Path,
+        command: &[OsString],
+        environment: &[OsString],
+    ) -> Result<bool> {
         match &self.interpreter {
             Interpreter::Resolved(expected) => Ok(paths_resolve_to_same_executable(executable, expected)),
             Interpreter::EnvCommand(expected) => {
-                if argv0 != Some(expected.program.as_os_str()) {
+                let Some(argv0) = command.first() else {
+                    #[cfg(target_os = "macos")]
+                    if expected.matches_executable(executable, environment)? {
+                        return Err(SurgeError::Platform(
+                            "Cannot inspect the command line of the configured env interpreter before swap".to_string(),
+                        ));
+                    }
+                    return Ok(false);
+                };
+                if argv0 != &expected.program {
                     return Ok(false);
                 }
-                let resolved = resolve_env_command(expected)?;
-                if paths_resolve_to_same_executable(executable, &resolved) {
-                    Ok(true)
-                } else {
-                    Err(SurgeError::Platform(format!(
-                        "Cannot verify env interpreter '{}' from the updater environment; refusing to swap while its process identity is ambiguous",
-                        expected.program.to_string_lossy()
-                    )))
-                }
+                expected.matches_executable(executable, environment)
             }
         }
     }
 
-    pub(super) fn executable_may_match(&self, executable: &Path) -> Result<bool> {
+    pub(super) fn executable_may_match_in_environment(
+        &self,
+        executable: &Path,
+        environment: &[OsString],
+    ) -> Result<bool> {
         match &self.interpreter {
             Interpreter::Resolved(expected) => Ok(paths_resolve_to_same_executable(executable, expected)),
-            Interpreter::EnvCommand(expected) => {
-                let resolved = resolve_env_command(expected)?;
-                if paths_resolve_to_same_executable(executable, &resolved) {
-                    return Ok(true);
-                }
-                let program = Path::new(&expected.program);
-                Ok(
-                    matches!(expected.search_path, EnvSearchPath::Inherited | EnvSearchPath::Default)
-                        && program.components().count() == 1,
-                )
-            }
+            Interpreter::EnvCommand(expected) => expected.matches_executable(executable, environment),
         }
+    }
+
+    pub(super) fn matches_interpreter(&self, executable: &Path, argv0: Option<&OsStr>) -> Result<bool> {
+        let command = argv0.map_or_else(Vec::new, |argv0| vec![argv0.to_os_string()]);
+        let environment = current_process_path_environment();
+        if let Interpreter::EnvCommand(expected) = &self.interpreter {
+            if argv0 != Some(expected.program.as_os_str()) {
+                return Ok(false);
+            }
+            let _ = resolve_env_command(expected)?;
+        }
+        if self.matches_interpreter_in_environment(executable, &command, &environment)? {
+            return Ok(true);
+        }
+        if let Interpreter::EnvCommand(expected) = &self.interpreter
+            && argv0 == Some(expected.program.as_os_str())
+        {
+            return Err(SurgeError::Platform(format!(
+                "Cannot verify env interpreter '{}' from the updater environment; refusing to swap while its process identity is ambiguous",
+                expected.program.to_string_lossy()
+            )));
+        }
+        Ok(false)
+    }
+
+    pub(super) fn executable_may_match(&self, executable: &Path) -> Result<bool> {
+        let environment = current_process_path_environment();
+        if let Interpreter::EnvCommand(expected) = &self.interpreter {
+            let _ = resolve_env_command(expected)?;
+        }
+        if self.executable_may_match_in_environment(executable, &environment)? {
+            return Ok(true);
+        }
+        let Interpreter::EnvCommand(expected) = &self.interpreter else {
+            return Ok(false);
+        };
+        let program = Path::new(&expected.program);
+        Ok(
+            (self.requires_environment() || matches!(expected.search_path, EnvSearchPath::Default))
+                && program.components().count() == 1,
+        )
+    }
+}
+
+impl EnvCommand {
+    fn requires_environment(&self) -> bool {
+        matches!(self.search_path, EnvSearchPath::Inherited) && Path::new(&self.program).components().count() == 1
+    }
+
+    fn matches_executable(&self, executable: &Path, environment: &[OsString]) -> Result<bool> {
+        let Some(resolved) = self.resolve_executable(Some(environment))? else {
+            return Ok(false);
+        };
+        Ok(paths_resolve_to_same_executable(executable, &resolved))
+    }
+
+    fn resolve_executable(&self, environment: Option<&[OsString]>) -> Result<Option<PathBuf>> {
+        let program = Path::new(&self.program);
+        if program.is_absolute() {
+            let resolved = std::fs::canonicalize(program).map_err(|e| {
+                SurgeError::Platform(format!(
+                    "Failed to resolve active application env interpreter '{}': {e}",
+                    program.display()
+                ))
+            })?;
+            if !is_executable_file(&resolved) {
+                return Err(SurgeError::Platform(format!(
+                    "Active application env interpreter '{}' is not executable",
+                    program.display()
+                )));
+            }
+            return validate_resolved_interpreter(resolved).map(Some);
+        }
+        if program.components().count() != 1 {
+            return Err(SurgeError::Platform(format!(
+                "Cannot safely resolve relative env interpreter '{}' before swap",
+                program.display()
+            )));
+        }
+
+        let current_search_path;
+        let search_path = match (&self.search_path, environment) {
+            (EnvSearchPath::Inherited, Some(environment)) => {
+                environment_variable(environment, b"PATH").unwrap_or_else(|| OsStr::new(DEFAULT_ENV_SEARCH_PATH))
+            }
+            (EnvSearchPath::Inherited, None) => {
+                current_search_path =
+                    std::env::var_os("PATH").unwrap_or_else(|| OsString::from(DEFAULT_ENV_SEARCH_PATH));
+                current_search_path.as_os_str()
+            }
+            (EnvSearchPath::Default, _) => OsStr::new(DEFAULT_ENV_SEARCH_PATH),
+            (EnvSearchPath::Explicit(search_path), _) => search_path,
+        };
+        for directory in std::env::split_paths(search_path) {
+            if directory.as_os_str().is_empty() || directory.is_relative() {
+                return Err(SurgeError::Platform(format!(
+                    "Cannot safely resolve env interpreter '{}' through a relative PATH entry before swap",
+                    program.display()
+                )));
+            }
+            let candidate = directory.join(program);
+            let Ok(candidate) = std::fs::canonicalize(candidate) else {
+                continue;
+            };
+            if !is_executable_file(&candidate) {
+                continue;
+            }
+            return validate_resolved_interpreter(candidate).map(Some);
+        }
+        Ok(None)
     }
 }
 
@@ -109,55 +226,35 @@ fn macos_system_shell_identity_matches(_actual: &Path, _expected: &Path) -> bool
 }
 
 fn resolve_env_command(command: &EnvCommand) -> Result<PathBuf> {
-    let program = Path::new(&command.program);
-    if program.is_absolute() {
-        let resolved = std::fs::canonicalize(program).map_err(|e| {
-            SurgeError::Platform(format!(
-                "Failed to resolve active application env interpreter '{}': {e}",
-                program.display()
-            ))
-        })?;
-        if !is_executable_file(&resolved) {
-            return Err(SurgeError::Platform(format!(
-                "Active application env interpreter '{}' is not executable",
-                program.display()
-            )));
-        }
-        return validate_resolved_interpreter(resolved);
-    }
-    if program.components().count() != 1 {
-        return Err(SurgeError::Platform(format!(
-            "Cannot safely resolve relative env interpreter '{}' before swap",
-            program.display()
-        )));
-    }
+    command.resolve_executable(None)?.ok_or_else(|| {
+        SurgeError::Platform(format!(
+            "Failed to resolve active application env interpreter '{}' from the updater PATH",
+            Path::new(&command.program).display()
+        ))
+    })
+}
 
-    let search_path = match &command.search_path {
-        EnvSearchPath::Inherited => std::env::var_os("PATH").unwrap_or_else(|| OsString::from(DEFAULT_ENV_SEARCH_PATH)),
-        EnvSearchPath::Default => OsString::from(DEFAULT_ENV_SEARCH_PATH),
-        EnvSearchPath::Explicit(search_path) => search_path.clone(),
-    };
-    for directory in std::env::split_paths(&search_path) {
-        if directory.as_os_str().is_empty() || directory.is_relative() {
-            return Err(SurgeError::Platform(format!(
-                "Cannot safely resolve env interpreter '{}' through a relative PATH entry before swap",
-                program.display()
-            )));
-        }
-        let candidate = directory.join(program);
-        let Ok(candidate) = std::fs::canonicalize(candidate) else {
-            continue;
-        };
-        if !is_executable_file(&candidate) {
-            continue;
-        }
-        return validate_resolved_interpreter(candidate);
-    }
+fn environment_variable<'a>(environment: &'a [OsString], name: &[u8]) -> Option<&'a OsStr> {
+    use std::os::unix::ffi::OsStrExt;
 
-    Err(SurgeError::Platform(format!(
-        "Failed to resolve active application env interpreter '{}' from the updater PATH",
-        program.display()
-    )))
+    environment.iter().find_map(|entry| {
+        let bytes = entry.as_os_str().as_bytes();
+        let separator = bytes.iter().position(|byte| *byte == b'=')?;
+        let (entry_name, value) = bytes.split_at(separator);
+        let value = value.get(1..)?;
+        (entry_name == name).then(|| OsStr::from_bytes(value))
+    })
+}
+
+fn current_process_path_environment() -> Vec<OsString> {
+    std::env::var_os("PATH")
+        .map(|path| {
+            let mut assignment = OsString::from("PATH=");
+            assignment.push(path);
+            assignment
+        })
+        .into_iter()
+        .collect()
 }
 
 pub(super) fn resolve(active_exe: &Path) -> Result<Option<Identity>> {
@@ -319,6 +416,12 @@ fn env_command_index(words: &[String]) -> Result<(usize, EnvSearchPath)> {
                     continue;
                 }
                 _ if word.starts_with("--chdir=") => {
+                    index += 1;
+                    continue;
+                }
+                _ if word.starts_with("--path=") => {
+                    search_path = word.strip_prefix("--path=").map(ToString::to_string);
+                    path_unset = false;
                     index += 1;
                     continue;
                 }
@@ -565,6 +668,69 @@ mod tests {
             command.search_path,
             EnvSearchPath::Explicit(OsString::from("/opt/interpreters"))
         );
+
+        let long_option = parse_env_command("-S --path=/srv/interpreters demo-interpreter").unwrap();
+        assert_eq!(
+            long_option.search_path,
+            EnvSearchPath::Explicit(OsString::from("/srv/interpreters"))
+        );
+    }
+
+    #[test]
+    fn observed_environment_uses_the_first_path_assignment_and_executable() {
+        use std::os::unix::fs::symlink;
+
+        let first = tempfile::tempdir().unwrap();
+        let second = tempfile::tempdir().unwrap();
+        symlink("/bin/sleep", first.path().join("demo-interpreter")).unwrap();
+        symlink("/bin/sh", second.path().join("demo-interpreter")).unwrap();
+        let environment = [
+            OsString::from(format!("PATH={}", first.path().display())),
+            OsString::from(format!("PATH={}", second.path().display())),
+        ];
+        let command = EnvCommand {
+            program: OsString::from("demo-interpreter"),
+            fixed_argument_count: 0,
+            search_path: EnvSearchPath::Inherited,
+        };
+
+        assert!(
+            command
+                .matches_executable(&std::fs::canonicalize("/bin/sleep").unwrap(), &environment)
+                .unwrap()
+        );
+        assert!(
+            !command
+                .matches_executable(&std::fs::canonicalize("/bin/sh").unwrap(), &environment)
+                .unwrap()
+        );
+        assert_eq!(
+            environment_variable(&environment, b"PATH"),
+            Some(OsStr::new(&format!("{}", first.path().display())))
+        );
+    }
+
+    #[test]
+    fn inherited_env_identity_requires_the_observed_environment() {
+        let inherited = Identity {
+            interpreter: Interpreter::EnvCommand(EnvCommand {
+                program: OsString::from("sh"),
+                fixed_argument_count: 0,
+                search_path: EnvSearchPath::Inherited,
+            }),
+            script_argument_index: 1,
+        };
+        let explicit = Identity {
+            interpreter: Interpreter::EnvCommand(EnvCommand {
+                program: OsString::from("sh"),
+                fixed_argument_count: 0,
+                search_path: EnvSearchPath::Explicit(OsString::from("/bin")),
+            }),
+            script_argument_index: 1,
+        };
+
+        assert!(inherited.requires_environment());
+        assert!(!explicit.requires_environment());
     }
 
     #[test]

--- a/crates/surge-core/src/update/manager/lifecycle/process_quiescence/interpreted_main.rs
+++ b/crates/surge-core/src/update/manager/lifecycle/process_quiescence/interpreted_main.rs
@@ -68,7 +68,7 @@ impl Identity {
                 if argv0 != &expected.program {
                     return Ok(false);
                 }
-                expected.matches_executable(executable, environment)
+                expected.matches_required_executable(executable, environment)
             }
         }
     }
@@ -84,29 +84,19 @@ impl Identity {
         }
     }
 
-    pub(super) fn matches_interpreter(&self, executable: &Path, argv0: Option<&OsStr>) -> Result<bool> {
-        let command = argv0.map_or_else(Vec::new, |argv0| vec![argv0.to_os_string()]);
-        let environment = current_process_path_environment();
-        if let Interpreter::EnvCommand(expected) = &self.interpreter {
-            if argv0 != Some(expected.program.as_os_str()) {
-                return Ok(false);
+    pub(super) fn executable_may_match_without_environment(&self, executable: &Path) -> Result<bool> {
+        match &self.interpreter {
+            Interpreter::Resolved(expected) => Ok(paths_resolve_to_same_executable(executable, expected)),
+            Interpreter::EnvCommand(expected) => {
+                if expected.matches_executable(executable, &[])? {
+                    return Ok(true);
+                }
+                Ok(expected.requires_environment())
             }
-            let _ = resolve_env_command(expected)?;
         }
-        if self.matches_interpreter_in_environment(executable, &command, &environment)? {
-            return Ok(true);
-        }
-        if let Interpreter::EnvCommand(expected) = &self.interpreter
-            && argv0 == Some(expected.program.as_os_str())
-        {
-            return Err(SurgeError::Platform(format!(
-                "Cannot verify env interpreter '{}' from the updater environment; refusing to swap while its process identity is ambiguous",
-                expected.program.to_string_lossy()
-            )));
-        }
-        Ok(false)
     }
 
+    #[cfg(test)]
     pub(super) fn executable_may_match(&self, executable: &Path) -> Result<bool> {
         let environment = current_process_path_environment();
         if let Interpreter::EnvCommand(expected) = &self.interpreter {
@@ -135,6 +125,16 @@ impl EnvCommand {
         let Some(resolved) = self.resolve_executable(Some(environment))? else {
             return Ok(false);
         };
+        Ok(paths_resolve_to_same_executable(executable, &resolved))
+    }
+
+    fn matches_required_executable(&self, executable: &Path, environment: &[OsString]) -> Result<bool> {
+        let resolved = self.resolve_executable(Some(environment))?.ok_or_else(|| {
+            SurgeError::Platform(format!(
+                "Failed to resolve active application env interpreter '{}' from its configured launch environment",
+                Path::new(&self.program).display()
+            ))
+        })?;
         Ok(paths_resolve_to_same_executable(executable, &resolved))
     }
 
@@ -225,6 +225,7 @@ fn macos_system_shell_identity_matches(_actual: &Path, _expected: &Path) -> bool
     false
 }
 
+#[cfg(test)]
 fn resolve_env_command(command: &EnvCommand) -> Result<PathBuf> {
     command.resolve_executable(None)?.ok_or_else(|| {
         SurgeError::Platform(format!(
@@ -246,6 +247,7 @@ fn environment_variable<'a>(environment: &'a [OsString], name: &[u8]) -> Option<
     })
 }
 
+#[cfg(test)]
 fn current_process_path_environment() -> Vec<OsString> {
     std::env::var_os("PATH")
         .map(|path| {
@@ -861,6 +863,37 @@ mod tests {
         };
 
         assert!(identity.executable_may_match(Path::new("/bin/sleep")).unwrap());
+    }
+
+    #[test]
+    fn missing_environment_broadens_only_inherited_path_candidates() {
+        let inherited = Identity {
+            interpreter: Interpreter::EnvCommand(EnvCommand {
+                program: OsString::from("sh"),
+                fixed_argument_count: 0,
+                search_path: EnvSearchPath::Inherited,
+            }),
+            script_argument_index: 1,
+        };
+        let default = Identity {
+            interpreter: Interpreter::EnvCommand(EnvCommand {
+                program: OsString::from("sh"),
+                fixed_argument_count: 0,
+                search_path: EnvSearchPath::Default,
+            }),
+            script_argument_index: 1,
+        };
+
+        assert!(
+            inherited
+                .executable_may_match_without_environment(Path::new("/bin/sleep"))
+                .unwrap()
+        );
+        assert!(
+            !default
+                .executable_may_match_without_environment(Path::new("/bin/sleep"))
+                .unwrap()
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- inspect the observed process environment when resolving `env`-launched interpreters
- resolve candidates against the process search path rather than updater-local assumptions
- fail closed when the environment or executable identity cannot be inspected safely

## Why

Interpreter identity is only trustworthy when resolution uses the environment of the process being matched. The updater's own `PATH` can point at a different executable.

This is stack 11 of 16.

- Base: #283
- Next: #285

Relates to fintermobilityas/youpark#1310.

## Validation

- exact layer `904f508` passed interpreter environment and discovery regressions plus rustfmt, blocking Clippy, and maintainability
- complete stack `c48f19f` passed 681 Rust workspace tests, both blocking Clippy tiers, vendor/version/format/maintainability checks, .NET formatting, and all 58 .NET tests

No migration is required.
