### PR TITLE
Quiesce exact supervised child generations

### DIFF
--- a/crates/surge-core/Cargo.toml
+++ b/crates/surge-core/Cargo.toml
@@ -45,7 +45,7 @@ nix = { version = "0.31", features = ["signal", "process", "fs"] }
 libc = "0.2"
 
 [target.'cfg(target_os = "linux")'.dependencies]
-rustix = { version = "1.1", features = ["process"] }
+rustix = { version = "1.1", features = ["event", "process"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 sysinfo = "0.39.3"

--- a/crates/surge-core/src/platform/process/identity.rs
+++ b/crates/surge-core/src/platform/process/identity.rs
@@ -64,7 +64,25 @@ impl StableProcessHandle {
     }
 
     pub fn is_running(&self) -> io::Result<bool> {
-        process_identity_matches(self.identity)
+        #[cfg(target_os = "linux")]
+        {
+            use rustix::event::{PollFd, PollFlags, Timespec, poll};
+
+            let mut descriptor = [PollFd::new(&self.pidfd, PollFlags::IN)];
+            let _ = poll(&mut descriptor, Some(&Timespec::default()))?;
+            let events = descriptor[0].revents();
+            if events.contains(PollFlags::NVAL) {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "stable process handle is invalid",
+                ));
+            }
+            Ok(events.is_empty())
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            process_identity_matches(self.identity)
+        }
     }
 
     pub fn terminate(&self) -> io::Result<ProcessSignalOutcome> {

--- a/crates/surge-core/src/update/manager/finalize.rs
+++ b/crates/surge-core/src/update/manager/finalize.rs
@@ -263,6 +263,7 @@ where
             let quarantined_quiescence = lifecycle::prepare_app_quiescence(
                 &previous_swap_quarantine_dir,
                 previous_main_exe,
+                None,
                 manager.allow_in_process_swap,
             )?
             .ok_or_else(|| {

--- a/crates/surge-core/src/update/manager/finalize_quiescence.rs
+++ b/crates/surge-core/src/update/manager/finalize_quiescence.rs
@@ -22,7 +22,12 @@ pub(super) fn prepare_and_quiesce_active_app_before_swap(
     allow_in_process_swap: bool,
 ) -> Result<Option<lifecycle::PreparedAppQuiescence>> {
     let result = (|| {
-        let prepared = lifecycle::prepare_app_quiescence(current_app_dir, current_main_exe, allow_in_process_swap)?;
+        let prepared = lifecycle::prepare_app_quiescence(
+            current_app_dir,
+            current_main_exe,
+            supervised_child_identity,
+            allow_in_process_swap,
+        )?;
         if let Some(prepared) = &prepared {
             lifecycle::terminate_prepared_app_processes(prepared)?;
         }
@@ -119,6 +124,7 @@ pub(super) async fn prepare_and_quiesce_previous_swap_before_reuse(
         let prepared = lifecycle::prepare_app_quiescence(
             previous_swap_dir,
             &previous_swap_identity.main_exe,
+            previous_supervised_child_identity,
             manager.allow_in_process_swap,
         )?
         .ok_or_else(|| {

--- a/crates/surge-core/src/update/manager/lifecycle/process_quiescence.rs
+++ b/crates/surge-core/src/update/manager/lifecycle/process_quiescence.rs
@@ -8,6 +8,8 @@ use std::time::Duration;
 use tracing::{info, warn};
 
 mod discovery;
+#[cfg(unix)]
+mod process_target;
 
 #[cfg(unix)]
 use self::discovery::AppProcess;
@@ -15,10 +17,14 @@ use self::discovery::AppProcess;
 use self::discovery::app_process_pids;
 #[cfg(unix)]
 use self::discovery::{app_process_identities, current_process_environment};
+#[cfg(unix)]
+use self::process_target::ProcessTarget;
 use crate::error::Result;
 #[cfg(unix)]
 use crate::error::SurgeError;
 use crate::platform::process::current_pid;
+#[cfg(unix)]
+use crate::platform::process::{ProcessIdentity, ProcessSignalOutcome};
 
 #[cfg(unix)]
 mod active_entrypoint;
@@ -213,6 +219,32 @@ fn refuse_process_in_swap(
 }
 
 #[cfg(unix)]
+fn add_process_targets(
+    targets: &mut Vec<ProcessTarget>,
+    identities: impl IntoIterator<Item = ProcessIdentity>,
+) -> Result<()> {
+    for identity in identities {
+        if targets.iter().any(|target| target.identity() == identity) {
+            continue;
+        }
+        if let Some(target) = ProcessTarget::open(identity)? {
+            targets.push(target);
+        }
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn process_targets_are_running(targets: &[ProcessTarget]) -> Result<bool> {
+    for target in targets {
+        if target.is_running()? {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+#[cfg(unix)]
 fn terminate_matching_app_processes<F, E, C>(
     main_exe: &str,
     protected_pid: u32,
@@ -227,9 +259,6 @@ where
     E: Fn(&Path) -> Result<bool>,
     C: Fn(&[OsString], Option<&Path>) -> Result<bool>,
 {
-    use nix::errno::Errno;
-    use nix::sys::signal::Signal;
-
     let main_exe = main_exe.trim();
     if main_exe.is_empty() {
         return Ok(0);
@@ -242,14 +271,17 @@ where
         &executable_may_match,
         &command_may_match,
     )?;
-    if identities.is_empty() {
+    let mut targets = Vec::new();
+    add_process_targets(&mut targets, identities)?;
+    if targets.is_empty() {
         return Ok(0);
     }
+    let initial_count = targets.len();
 
-    for identity in &identities {
-        if let Err(e) = signal_pid(identity.pid, Signal::SIGTERM) {
-            let pid = identity.pid;
-            warn!(pid, error = %e, process_scope, "Failed to request app process termination");
+    for target in &targets {
+        if let Err(error) = target.terminate() {
+            let pid = target.identity().pid;
+            warn!(pid, error = %error, process_scope, "Failed to request app process termination");
         }
     }
 
@@ -259,10 +291,11 @@ where
         &matches_process,
         &executable_may_match,
         &command_may_match,
+        &mut targets,
         Duration::from_secs(5),
     )? {
-        info!(count = identities.len(), process_scope, "Terminated app processes");
-        return Ok(identities.len());
+        info!(count = initial_count, process_scope, "Terminated app processes");
+        return Ok(initial_count);
     }
 
     let remaining = app_process_identities(
@@ -272,12 +305,15 @@ where
         &executable_may_match,
         &command_may_match,
     )?;
-    for identity in &remaining {
-        match signal_pid(identity.pid, Signal::SIGKILL) {
-            Ok(()) | Err(Errno::ESRCH) => {}
-            Err(e) => {
-                let pid = identity.pid;
-                warn!(pid, error = %e, process_scope, "Failed to force-kill app process");
+    add_process_targets(&mut targets, remaining)?;
+    let mut forced_count = 0;
+    for target in &targets {
+        match target.kill() {
+            Ok(ProcessSignalOutcome::Delivered) => forced_count += 1,
+            Ok(ProcessSignalOutcome::Exited) => {}
+            Err(error) => {
+                let pid = target.identity().pid;
+                warn!(pid, error = %error, process_scope, "Failed to force-kill app process");
             }
         }
     }
@@ -288,31 +324,21 @@ where
         &matches_process,
         &executable_may_match,
         &command_may_match,
+        &mut targets,
         Duration::from_secs(2),
     )? {
         info!(
-            count = identities.len(),
-            forced = remaining.len(),
+            count = initial_count,
+            forced = forced_count,
             process_scope,
             "Force-killed app processes"
         );
-        return Ok(identities.len());
+        return Ok(initial_count);
     }
 
     Err(SurgeError::Platform(format!(
         "Timed out waiting for {process_scope} '{main_exe}' processes to exit"
     )))
-}
-
-#[cfg(unix)]
-fn signal_pid(pid: u32, signal: nix::sys::signal::Signal) -> std::result::Result<(), nix::errno::Errno> {
-    use nix::sys::signal::kill;
-    use nix::unistd::Pid;
-
-    let Ok(raw_pid) = i32::try_from(pid) else {
-        return Ok(());
-    };
-    kill(Pid::from_raw(raw_pid), signal)
 }
 
 #[cfg(not(unix))]
@@ -342,6 +368,7 @@ fn wait_until_app_processes_exit<F, E, C>(
     matches_process: &F,
     executable_may_match: &E,
     command_may_match: &C,
+    targets: &mut Vec<ProcessTarget>,
     timeout: Duration,
 ) -> Result<bool>
 where
@@ -351,15 +378,16 @@ where
 {
     let deadline = std::time::Instant::now() + timeout;
     loop {
-        if app_process_identities(
+        let identities = app_process_identities(
             protected_pid,
             inspect_environment,
             matches_process,
             executable_may_match,
             command_may_match,
-        )?
-        .is_empty()
-        {
+        )?;
+        let snapshot_is_empty = identities.is_empty();
+        add_process_targets(targets, identities)?;
+        if snapshot_is_empty && !process_targets_are_running(targets)? {
             return Ok(true);
         }
         if std::time::Instant::now() >= deadline {
@@ -562,6 +590,42 @@ fn is_superseded_app_exe(install_dir: &Path, active_app_dir: &Path, main_exe: &s
 mod tests {
     #[cfg(unix)]
     use super::*;
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn stable_process_target_survives_exec() {
+        use std::io::Write;
+        use std::process::{Command, Stdio};
+
+        let mut child = Command::new("/bin/sh")
+            .args(["-c", "read _; exec sleep 30"])
+            .stdin(Stdio::piped())
+            .spawn()
+            .unwrap();
+        let identity = crate::platform::process::process_identity(child.id()).unwrap().unwrap();
+        let target = ProcessTarget::open(identity).unwrap().unwrap();
+
+        writeln!(child.stdin.as_mut().unwrap(), "continue").unwrap();
+        let expected_executable = std::fs::canonicalize("/bin/sleep").unwrap();
+        let deadline = std::time::Instant::now() + Duration::from_secs(1);
+        loop {
+            if std::fs::read_link(format!("/proc/{}/exe", child.id()))
+                .ok()
+                .and_then(|path| std::fs::canonicalize(path).ok())
+                .as_deref()
+                == Some(expected_executable.as_path())
+            {
+                break;
+            }
+            assert!(std::time::Instant::now() < deadline, "child did not exec sleep");
+            std::thread::sleep(Duration::from_millis(10));
+        }
+
+        assert!(target.is_running().unwrap());
+        assert_eq!(target.terminate().unwrap(), ProcessSignalOutcome::Delivered);
+        assert!(!child.wait().unwrap().success());
+        assert!(!target.is_running().unwrap());
+    }
 
     #[cfg(unix)]
     #[test]

--- a/crates/surge-core/src/update/manager/lifecycle/process_quiescence.rs
+++ b/crates/surge-core/src/update/manager/lifecycle/process_quiescence.rs
@@ -18,7 +18,7 @@ use self::discovery::app_process_pids;
 #[cfg(unix)]
 use self::discovery::{app_process_identities, current_process_environment};
 #[cfg(unix)]
-use self::process_target::ProcessTarget;
+use self::process_target::{ProcessTarget, add_process_targets, process_targets_are_running};
 use crate::error::Result;
 #[cfg(unix)]
 use crate::error::SurgeError;
@@ -37,6 +37,7 @@ pub(in crate::update::manager) struct PreparedAppQuiescence {
     active_entrypoint: active_entrypoint::Identity,
     interpreted_main: Option<interpreted_main::Identity>,
     inspect_environment: bool,
+    supervised_child_identity: Option<ProcessIdentity>,
 }
 
 pub(in crate::update::manager) fn terminate_superseded_app_processes(
@@ -60,9 +61,16 @@ pub(in crate::update::manager) fn terminate_active_app_processes_before_swap(
 pub(in crate::update::manager) fn prepare_app_quiescence(
     active_app_dir: &Path,
     main_exe: &str,
+    supervised_child_identity: Option<ProcessIdentity>,
     allow_in_process_swap: bool,
 ) -> Result<Option<PreparedAppQuiescence>> {
-    prepare_app_quiescence_except(active_app_dir, main_exe, current_pid(), allow_in_process_swap)
+    prepare_app_quiescence_except(
+        active_app_dir,
+        main_exe,
+        current_pid(),
+        supervised_child_identity,
+        allow_in_process_swap,
+    )
 }
 
 #[cfg(unix)]
@@ -70,6 +78,7 @@ fn prepare_app_quiescence_except(
     active_app_dir: &Path,
     main_exe: &str,
     protected_pid: u32,
+    supervised_child_identity: Option<ProcessIdentity>,
     allow_in_process_swap: bool,
 ) -> Result<Option<PreparedAppQuiescence>> {
     let main_exe = main_exe.trim();
@@ -92,6 +101,7 @@ fn prepare_app_quiescence_except(
         active_entrypoint,
         interpreted_main,
         inspect_environment,
+        supervised_child_identity,
     }))
 }
 
@@ -112,6 +122,7 @@ fn terminate_superseded_app_processes_except(
         protected_pid,
         "superseded",
         false,
+        None,
         |process| {
             Ok(is_superseded_app_exe(
                 install_dir,
@@ -130,9 +141,16 @@ fn terminate_active_app_processes_except(
     active_app_dir: &Path,
     main_exe: &str,
     protected_pid: u32,
+    supervised_child_identity: Option<ProcessIdentity>,
     allow_in_process_swap: bool,
 ) -> Result<usize> {
-    let Some(prepared) = prepare_app_quiescence_except(active_app_dir, main_exe, protected_pid, allow_in_process_swap)?
+    let Some(prepared) = prepare_app_quiescence_except(
+        active_app_dir,
+        main_exe,
+        protected_pid,
+        supervised_child_identity,
+        allow_in_process_swap,
+    )?
     else {
         return Ok(0);
     };
@@ -147,6 +165,7 @@ fn terminate_prepared_app_processes_except(prepared: &PreparedAppQuiescence, pro
         protected_pid,
         "active",
         prepared.inspect_environment,
+        prepared.supervised_child_identity,
         |process| is_active_app_process(&prepared.active_entrypoint, prepared.interpreted_main.as_ref(), process),
         |exe| active_app_executable_may_match(&prepared.active_entrypoint, prepared.interpreted_main.as_ref(), exe),
         |command, cwd| {
@@ -219,37 +238,12 @@ fn refuse_process_in_swap(
 }
 
 #[cfg(unix)]
-fn add_process_targets(
-    targets: &mut Vec<ProcessTarget>,
-    identities: impl IntoIterator<Item = ProcessIdentity>,
-) -> Result<()> {
-    for identity in identities {
-        if targets.iter().any(|target| target.identity() == identity) {
-            continue;
-        }
-        if let Some(target) = ProcessTarget::open(identity)? {
-            targets.push(target);
-        }
-    }
-    Ok(())
-}
-
-#[cfg(unix)]
-fn process_targets_are_running(targets: &[ProcessTarget]) -> Result<bool> {
-    for target in targets {
-        if target.is_running()? {
-            return Ok(true);
-        }
-    }
-    Ok(false)
-}
-
-#[cfg(unix)]
 fn terminate_matching_app_processes<F, E, C>(
     main_exe: &str,
     protected_pid: u32,
     process_scope: &'static str,
     inspect_environment: bool,
+    supervised_child_identity: Option<ProcessIdentity>,
     matches_process: F,
     executable_may_match: E,
     command_may_match: C,
@@ -264,6 +258,15 @@ where
         return Ok(0);
     }
 
+    if let Some(identity) = supervised_child_identity
+        && (identity.pid == 0 || identity.pid == protected_pid)
+    {
+        return Err(SurgeError::Platform(format!(
+            "Supervisor returned invalid child process identity for PID {} during update handoff",
+            identity.pid
+        )));
+    }
+
     let identities = app_process_identities(
         protected_pid,
         inspect_environment,
@@ -273,6 +276,9 @@ where
     )?;
     let mut targets = Vec::new();
     add_process_targets(&mut targets, identities)?;
+    if let Some(identity) = supervised_child_identity {
+        add_process_targets(&mut targets, [identity])?;
+    }
     if targets.is_empty() {
         return Ok(0);
     }
@@ -627,6 +633,96 @@ mod tests {
         assert!(!target.is_running().unwrap());
     }
 
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn supervised_child_remains_a_target_after_exec() {
+        use std::io::Write;
+        use std::os::unix::fs::symlink;
+        use std::process::{Command, Stdio};
+
+        let tmp = tempfile::tempdir().unwrap();
+        let active_app_dir = tmp.path().join("app");
+        std::fs::create_dir_all(&active_app_dir).unwrap();
+        symlink("/bin/true", active_app_dir.join("demo")).unwrap();
+
+        let mut child = Command::new("/bin/sh")
+            .args(["-c", "read _; exec sleep 30"])
+            .stdin(Stdio::piped())
+            .spawn()
+            .unwrap();
+        let identity = crate::platform::process::process_identity(child.id()).unwrap().unwrap();
+        writeln!(child.stdin.as_mut().unwrap(), "continue").unwrap();
+        let expected_executable = std::fs::canonicalize("/bin/sleep").unwrap();
+        let deadline = std::time::Instant::now() + Duration::from_secs(1);
+        while std::fs::read_link(format!("/proc/{}/exe", child.id()))
+            .ok()
+            .and_then(|path| std::fs::canonicalize(path).ok())
+            .as_deref()
+            != Some(expected_executable.as_path())
+        {
+            assert!(std::time::Instant::now() < deadline, "child did not exec sleep");
+            std::thread::sleep(Duration::from_millis(10));
+        }
+
+        let terminated =
+            terminate_active_app_processes_except(&active_app_dir, "demo", u32::MAX, Some(identity), false).unwrap();
+        let status = child.wait().unwrap();
+
+        assert_eq!(terminated, 1);
+        assert!(!status.success());
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    #[test]
+    fn stale_supervised_child_generation_is_not_signalled() {
+        use std::os::unix::fs::symlink;
+        use std::process::Command;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let active_app_dir = tmp.path().join("app");
+        std::fs::create_dir_all(&active_app_dir).unwrap();
+        symlink("/bin/true", active_app_dir.join("demo")).unwrap();
+
+        let mut child = Command::new("/bin/sleep").arg("30").spawn().unwrap();
+        let identity = crate::platform::process::process_identity(child.id()).unwrap().unwrap();
+        let stale_identity = ProcessIdentity {
+            generation: identity.generation.wrapping_add(1),
+            ..identity
+        };
+
+        let terminated =
+            terminate_active_app_processes_except(&active_app_dir, "demo", u32::MAX, Some(stale_identity), false)
+                .unwrap();
+        let child_still_running = child.try_wait().unwrap().is_none();
+        if child_still_running {
+            child.kill().unwrap();
+        }
+        let _ = child.wait();
+
+        assert_eq!(terminated, 0);
+        assert!(child_still_running);
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    #[test]
+    fn updater_identity_is_rejected_as_a_supervised_child() {
+        use std::os::unix::fs::symlink;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let active_app_dir = tmp.path().join("app");
+        std::fs::create_dir_all(&active_app_dir).unwrap();
+        symlink("/bin/true", active_app_dir.join("demo")).unwrap();
+        let identity = crate::platform::process::process_identity(current_pid())
+            .unwrap()
+            .unwrap();
+
+        let error =
+            terminate_active_app_processes_except(&active_app_dir, "demo", current_pid(), Some(identity), false)
+                .unwrap_err();
+
+        assert!(error.to_string().contains("invalid child process identity"));
+    }
+
     #[cfg(unix)]
     #[test]
     fn superseded_app_exe_detection_matches_retained_directories_only() {
@@ -688,7 +784,7 @@ mod tests {
         wait_for_native_test_app(&app_path, child_pid);
 
         let terminated =
-            terminate_active_app_processes_except(&linked_active_app_dir, "demo", u32::MAX, false).unwrap();
+            terminate_active_app_processes_except(&linked_active_app_dir, "demo", u32::MAX, None, false).unwrap();
         let status = child.wait().unwrap();
 
         assert_eq!(terminated, 1);
@@ -711,7 +807,8 @@ mod tests {
         std::fs::create_dir_all(&active_app_dir).unwrap();
         std::fs::hard_link(std::env::current_exe().unwrap(), active_app_dir.join("demo")).unwrap();
 
-        let error = terminate_active_app_processes_except(&active_app_dir, "demo", current_pid(), false).unwrap_err();
+        let error =
+            terminate_active_app_processes_except(&active_app_dir, "demo", current_pid(), None, false).unwrap_err();
 
         assert!(error.to_string().contains("refusing an in-process directory swap"));
     }
@@ -724,7 +821,8 @@ mod tests {
         std::fs::create_dir_all(&active_app_dir).unwrap();
         std::fs::hard_link(std::env::current_exe().unwrap(), active_app_dir.join("demo")).unwrap();
 
-        let terminated = terminate_active_app_processes_except(&active_app_dir, "demo", current_pid(), true).unwrap();
+        let terminated =
+            terminate_active_app_processes_except(&active_app_dir, "demo", current_pid(), None, true).unwrap();
 
         assert_eq!(terminated, 0);
     }
@@ -961,7 +1059,7 @@ mod tests {
         let mut child = Command::new(&app_path).arg("30").spawn().unwrap();
         std::fs::remove_file(&app_path).unwrap();
 
-        let error = terminate_active_app_processes_except(&active_app_dir, "demo", u32::MAX, false).unwrap_err();
+        let error = terminate_active_app_processes_except(&active_app_dir, "demo", u32::MAX, None, false).unwrap_err();
         let child_still_running = child.try_wait().unwrap().is_none();
         if child_still_running {
             child.kill().unwrap();
@@ -1009,7 +1107,7 @@ mod tests {
             std::thread::sleep(Duration::from_millis(10));
         }
 
-        let terminated = terminate_active_app_processes_except(&active_app_dir, "demo", u32::MAX, false);
+        let terminated = terminate_active_app_processes_except(&active_app_dir, "demo", u32::MAX, None, false);
         let app_status = app_child.wait().unwrap();
         let unrelated_still_running = unrelated_child.try_wait().unwrap().is_none();
         if unrelated_still_running {
@@ -1087,7 +1185,7 @@ mod tests {
         }
 
         let terminated =
-            terminate_active_app_processes_except(&active_app_dir, "demo-script", u32::MAX, false).unwrap();
+            terminate_active_app_processes_except(&active_app_dir, "demo-script", u32::MAX, None, false).unwrap();
         let status = child.wait().unwrap();
 
         assert_eq!(terminated, 1);
@@ -1147,7 +1245,7 @@ mod tests {
         permissions.set_mode(0o755);
         std::fs::set_permissions(&app_path, permissions).unwrap();
 
-        let prepared = prepare_app_quiescence_except(&active_app_dir, "demo-script", u32::MAX, false)
+        let prepared = prepare_app_quiescence_except(&active_app_dir, "demo-script", u32::MAX, None, false)
             .unwrap()
             .unwrap();
         assert_eq!(terminate_prepared_app_processes_except(&prepared, u32::MAX).unwrap(), 0);

--- a/crates/surge-core/src/update/manager/lifecycle/process_quiescence/process_target.rs
+++ b/crates/surge-core/src/update/manager/lifecycle/process_quiescence/process_target.rs
@@ -12,6 +12,30 @@ pub(super) struct ProcessTarget {
     handle: StableProcessHandle,
 }
 
+pub(super) fn add_process_targets(
+    targets: &mut Vec<ProcessTarget>,
+    identities: impl IntoIterator<Item = ProcessIdentity>,
+) -> Result<()> {
+    for identity in identities {
+        if targets.iter().any(|target| target.identity() == identity) {
+            continue;
+        }
+        if let Some(target) = ProcessTarget::open(identity)? {
+            targets.push(target);
+        }
+    }
+    Ok(())
+}
+
+pub(super) fn process_targets_are_running(targets: &[ProcessTarget]) -> Result<bool> {
+    for target in targets {
+        if target.is_running()? {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
 impl ProcessTarget {
     pub(super) fn open(identity: ProcessIdentity) -> Result<Option<Self>> {
         #[cfg(target_os = "linux")]

--- a/crates/surge-core/src/update/manager/lifecycle/process_quiescence/process_target.rs
+++ b/crates/surge-core/src/update/manager/lifecycle/process_quiescence/process_target.rs
@@ -1,0 +1,117 @@
+use crate::error::{Result, SurgeError};
+#[cfg(target_os = "linux")]
+use crate::platform::process::StableProcessHandle;
+#[cfg(not(target_os = "linux"))]
+use crate::platform::process::process_identity_matches;
+use crate::platform::process::{ProcessIdentity, ProcessSignalOutcome};
+
+#[derive(Debug)]
+pub(super) struct ProcessTarget {
+    identity: ProcessIdentity,
+    #[cfg(target_os = "linux")]
+    handle: StableProcessHandle,
+}
+
+impl ProcessTarget {
+    pub(super) fn open(identity: ProcessIdentity) -> Result<Option<Self>> {
+        #[cfg(target_os = "linux")]
+        {
+            StableProcessHandle::open(identity)
+                .map(|handle| handle.map(|handle| Self { identity, handle }))
+                .map_err(|error| {
+                    SurgeError::Platform(format!(
+                        "Failed to open stable handle for process {} before application swap: {error}",
+                        identity.pid
+                    ))
+                })
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            if process_identity_matches(identity).map_err(|error| {
+                SurgeError::Platform(format!(
+                    "Failed to revalidate process {} before application swap: {error}",
+                    identity.pid
+                ))
+            })? {
+                Ok(Some(Self { identity }))
+            } else {
+                Ok(None)
+            }
+        }
+    }
+
+    pub(super) fn identity(&self) -> ProcessIdentity {
+        self.identity
+    }
+
+    pub(super) fn is_running(&self) -> Result<bool> {
+        #[cfg(target_os = "linux")]
+        {
+            self.handle.is_running().map_err(|error| {
+                SurgeError::Platform(format!(
+                    "Failed to poll stable handle for process {} before application swap: {error}",
+                    self.identity.pid
+                ))
+            })
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            process_identity_matches(self.identity).map_err(|error| {
+                SurgeError::Platform(format!(
+                    "Failed to revalidate process {} before application swap: {error}",
+                    self.identity.pid
+                ))
+            })
+        }
+    }
+
+    pub(super) fn terminate(&self) -> Result<ProcessSignalOutcome> {
+        self.signal(nix::sys::signal::Signal::SIGTERM)
+    }
+
+    pub(super) fn kill(&self) -> Result<ProcessSignalOutcome> {
+        self.signal(nix::sys::signal::Signal::SIGKILL)
+    }
+
+    fn signal(&self, signal: nix::sys::signal::Signal) -> Result<ProcessSignalOutcome> {
+        #[cfg(target_os = "linux")]
+        {
+            let result = match signal {
+                nix::sys::signal::Signal::SIGTERM => self.handle.terminate(),
+                nix::sys::signal::Signal::SIGKILL => self.handle.kill(),
+                _ => unreachable!("process target supports termination signals only"),
+            };
+            result.map_err(|error| {
+                SurgeError::Platform(format!(
+                    "Failed to signal stable process {} before application swap: {error}",
+                    self.identity.pid
+                ))
+            })
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            if !self.is_running()? {
+                return Ok(ProcessSignalOutcome::Exited);
+            }
+            match signal_pid(self.identity.pid, signal) {
+                Ok(()) => Ok(ProcessSignalOutcome::Delivered),
+                Err(nix::errno::Errno::ESRCH) => Ok(ProcessSignalOutcome::Exited),
+                Err(error) => Err(SurgeError::Platform(format!(
+                    "Failed to signal process {} before application swap: {error}",
+                    self.identity.pid
+                ))),
+            }
+        }
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+fn signal_pid(pid: u32, signal: nix::sys::signal::Signal) -> std::result::Result<(), nix::errno::Errno> {
+    use nix::sys::signal::kill;
+    use nix::unistd::Pid;
+
+    let Ok(raw_pid) = i32::try_from(pid) else {
+        return Ok(());
+    };
+    kill(Pid::from_raw(raw_pid), signal)
+}


### PR DESCRIPTION
## Summary

- represent quiescence targets as stable process-generation handles
- attach the exact acknowledged supervised child to the target set
- refuse stale or updater-owned identities before termination

## Why

Discovery, takeover acknowledgement, and signalling must converge on the same process instances. This layer removes the remaining bare-PID boundary from child quiescence.

This is stack 12 of 16.

- Base: #284
- Next: #286

Relates to fintermobilityas/youpark#1310.

## Validation

- exact layer `b2a34df` passed stable-target, supervised-child, and stale-generation regressions plus rustfmt, blocking Clippy, and maintainability
- complete stack `c48f19f` passed 681 Rust workspace tests, both blocking Clippy tiers, vendor/version/format/maintainability checks, .NET formatting, and all 58 .NET tests

No migration is required.
