### PR TITLE
Stabilize updater recovery path identity

### DIFF
--- a/crates/surge-core/src/update/manager/current_install.rs
+++ b/crates/surge-core/src/update/manager/current_install.rs
@@ -151,7 +151,7 @@ fn bind_absolute_parent(path: &Path) -> PathBuf {
     std::fs::canonicalize(parent).map_or_else(|_| path.to_path_buf(), |bound_parent| bound_parent.join(file_name))
 }
 
-fn safe_relative_path(path: &Path) -> Option<String> {
+pub(super) fn safe_relative_path(path: &Path) -> Option<String> {
     let mut has_normal_component = false;
     for component in path.components() {
         match component {

--- a/crates/surge-core/src/update/manager/current_install.rs
+++ b/crates/surge-core/src/update/manager/current_install.rs
@@ -36,6 +36,19 @@ pub(super) fn load(manager: &UpdateManager) -> Result<Option<ReleaseIdentity>> {
     load_from_app_dir(manager, &active_app_dir, Some(&manager.current_version))
 }
 
+pub(super) fn ensure_captured_install_still_has_app_dir(
+    current_app_dir: Option<&Path>,
+    captured_release_identity: bool,
+) -> Result<()> {
+    if current_app_dir.is_none() && captured_release_identity {
+        return Err(SurgeError::Update(
+            "Installed application directory disappeared after the update check; refusing to swap the active application"
+                .to_string(),
+        ));
+    }
+    Ok(())
+}
+
 #[cfg(unix)]
 pub(super) fn load_previous_swap(manager: &UpdateManager, app_dir: &Path) -> Result<Option<ReleaseIdentity>> {
     load_from_app_dir(manager, app_dir, None)
@@ -185,6 +198,17 @@ mod tests {
         assert_eq!(safe_relative_path(Path::new("")), None);
         assert_eq!(safe_relative_path(Path::new("../demo")), None);
         assert_eq!(safe_relative_path(Path::new("/opt/demo")), None);
+    }
+
+    #[test]
+    fn captured_install_requires_a_current_app_directory() {
+        let tmp = tempfile::tempdir().unwrap();
+
+        assert!(ensure_captured_install_still_has_app_dir(Some(tmp.path()), true).is_ok());
+        assert!(ensure_captured_install_still_has_app_dir(None, false).is_ok());
+        let error = ensure_captured_install_still_has_app_dir(None, true).unwrap_err();
+
+        assert!(error.to_string().contains("disappeared after the update check"));
     }
 
     #[cfg(unix)]

--- a/crates/surge-core/src/update/manager/finalize.rs
+++ b/crates/surge-core/src/update/manager/finalize.rs
@@ -28,6 +28,7 @@ use crate::releases::restore::{
 };
 use crate::supervisor::state::supervisor_pid_file;
 
+use super::current_install::ensure_captured_install_still_has_app_dir;
 #[cfg(unix)]
 use super::finalize_quiescence::{
     prepare_and_quiesce_active_app_before_swap, prepare_and_quiesce_previous_swap_before_reuse,
@@ -151,14 +152,7 @@ where
     } else {
         fallback_previous_app_dir.as_deref()
     };
-    #[cfg(unix)]
-    if current_app_dir.is_none() && manager.current_release_identity.is_some() {
-        return Err(SurgeError::Update(
-            "Installed application directory disappeared after the update check; refusing to swap the active application"
-                .to_string(),
-        )
-        .into());
-    }
+    ensure_captured_install_still_has_app_dir(current_app_dir, manager.current_release_identity.is_some())?;
     #[cfg(unix)]
     let (current_version, current_main_exe, current_supervisor_id, current_environment) = if current_app_dir.is_some() {
         let installed_identity = super::current_install::load(manager)?;

--- a/crates/surge-core/src/update/manager/lifecycle/process_quiescence/active_entrypoint.rs
+++ b/crates/surge-core/src/update/manager/lifecycle/process_quiescence/active_entrypoint.rs
@@ -2,6 +2,7 @@ use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
 
 use crate::error::{Result, SurgeError};
+use crate::update::manager::current_install::safe_relative_path;
 
 pub(super) struct Identity {
     configured_launch_path: PathBuf,
@@ -12,6 +13,11 @@ pub(super) struct Identity {
 
 impl Identity {
     pub(super) fn resolve(active_app_dir: &Path, main_exe: &str) -> Result<Self> {
+        if safe_relative_path(Path::new(main_exe)).is_none() {
+            return Err(SurgeError::Platform(
+                "Active application executable must be a safe relative path".to_string(),
+            ));
+        }
         let configured_launch_path = std::path::absolute(active_app_dir.join(main_exe)).map_err(|e| {
             SurgeError::Platform(format!(
                 "Failed to resolve configured active application path before swap: {e}"
@@ -205,5 +211,32 @@ mod tests {
                 .matches_argument(shared_dir.join("demo").as_os_str(), None)
                 .unwrap()
         );
+    }
+
+    #[test]
+    fn resolve_accepts_dot_prefixed_entrypoint() {
+        let tmp = tempfile::tempdir().unwrap();
+        let active_app_dir = tmp.path().join("app");
+        std::fs::create_dir_all(&active_app_dir).unwrap();
+        std::fs::write(active_app_dir.join("demo"), "fixture").unwrap();
+
+        let identity = Identity::resolve(&active_app_dir, "./demo").unwrap();
+
+        assert_eq!(
+            identity.resolved,
+            std::fs::canonicalize(active_app_dir.join("demo")).unwrap()
+        );
+    }
+
+    #[test]
+    fn resolve_rejects_entrypoints_outside_the_active_app() {
+        let tmp = tempfile::tempdir().unwrap();
+        let active_app_dir = tmp.path().join("app");
+        std::fs::create_dir_all(&active_app_dir).unwrap();
+
+        for main_exe in ["../other-app", "/opt/other-app", "."] {
+            let error = Identity::resolve(&active_app_dir, main_exe).err().unwrap();
+            assert!(error.to_string().contains("must be a safe relative path"));
+        }
     }
 }

--- a/crates/surge-core/src/update/manager/lifecycle/process_quiescence/interpreted_main.rs
+++ b/crates/surge-core/src/update/manager/lifecycle/process_quiescence/interpreted_main.rs
@@ -1,9 +1,12 @@
 use std::ffi::{OsStr, OsString};
 use std::io::Read;
-use std::os::unix::fs::MetadataExt;
 use std::path::{Path, PathBuf};
 
 use crate::error::{Result, SurgeError};
+
+mod env_path;
+
+use self::env_path::{paths_resolve_to_same_executable, select_path_executable};
 
 #[cfg(target_os = "macos")]
 const SHEBANG_IDENTITY_LIMIT: usize = 512;
@@ -122,23 +125,29 @@ impl EnvCommand {
     }
 
     fn matches_executable(&self, executable: &Path, environment: &[OsString]) -> Result<bool> {
-        let Some(resolved) = self.resolve_executable(Some(environment))? else {
+        let Some(resolved) = self.resolve_executable(Some(environment), Some(executable))? else {
             return Ok(false);
         };
         Ok(paths_resolve_to_same_executable(executable, &resolved))
     }
 
     fn matches_required_executable(&self, executable: &Path, environment: &[OsString]) -> Result<bool> {
-        let resolved = self.resolve_executable(Some(environment))?.ok_or_else(|| {
-            SurgeError::Platform(format!(
-                "Failed to resolve active application env interpreter '{}' from its configured launch environment",
-                Path::new(&self.program).display()
-            ))
-        })?;
+        let resolved = self
+            .resolve_executable(Some(environment), Some(executable))?
+            .ok_or_else(|| {
+                SurgeError::Platform(format!(
+                    "Failed to resolve active application env interpreter '{}' from its configured launch environment",
+                    Path::new(&self.program).display()
+                ))
+            })?;
         Ok(paths_resolve_to_same_executable(executable, &resolved))
     }
 
-    fn resolve_executable(&self, environment: Option<&[OsString]>) -> Result<Option<PathBuf>> {
+    fn resolve_executable(
+        &self,
+        environment: Option<&[OsString]>,
+        observed_executable: Option<&Path>,
+    ) -> Result<Option<PathBuf>> {
         let program = Path::new(&self.program);
         if program.is_absolute() {
             let resolved = std::fs::canonicalize(program).map_err(|e| {
@@ -147,7 +156,9 @@ impl EnvCommand {
                     program.display()
                 ))
             })?;
-            if !is_executable_file(&resolved) {
+            if !observed_executable.is_some_and(|observed| paths_resolve_to_same_executable(observed, &resolved))
+                && !is_executable_file(&resolved)
+            {
                 return Err(SurgeError::Platform(format!(
                     "Active application env interpreter '{}' is not executable",
                     program.display()
@@ -175,59 +186,16 @@ impl EnvCommand {
             (EnvSearchPath::Default, _) => OsStr::new(DEFAULT_ENV_SEARCH_PATH),
             (EnvSearchPath::Explicit(search_path), _) => search_path,
         };
-        for directory in std::env::split_paths(search_path) {
-            if directory.as_os_str().is_empty() || directory.is_relative() {
-                return Err(SurgeError::Platform(format!(
-                    "Cannot safely resolve env interpreter '{}' through a relative PATH entry before swap",
-                    program.display()
-                )));
-            }
-            let candidate = directory.join(program);
-            let Ok(candidate) = std::fs::canonicalize(candidate) else {
-                continue;
-            };
-            if !is_executable_file(&candidate) {
-                continue;
-            }
-            return validate_resolved_interpreter(candidate).map(Some);
-        }
-        Ok(None)
+        let Some(candidate) = select_path_executable(search_path, program, observed_executable)? else {
+            return Ok(None);
+        };
+        validate_resolved_interpreter(candidate).map(Some)
     }
-}
-
-fn paths_resolve_to_same_executable(actual: &Path, expected: &Path) -> bool {
-    if actual == expected {
-        return true;
-    }
-    if std::fs::canonicalize(actual)
-        .ok()
-        .zip(std::fs::canonicalize(expected).ok())
-        .is_some_and(|(actual, expected)| actual == expected)
-    {
-        return true;
-    }
-
-    std::fs::metadata(actual)
-        .ok()
-        .zip(std::fs::metadata(expected).ok())
-        .is_some_and(|(actual, expected)| actual.dev() == expected.dev() && actual.ino() == expected.ino())
-        || macos_system_shell_identity_matches(actual, expected)
-}
-
-#[cfg(target_os = "macos")]
-fn macos_system_shell_identity_matches(actual: &Path, expected: &Path) -> bool {
-    // macOS reports a stable /bin/sh script process as /bin/bash while retaining /bin/sh as argv[0].
-    actual == Path::new("/bin/bash") && expected == Path::new("/bin/sh")
-}
-
-#[cfg(not(target_os = "macos"))]
-fn macos_system_shell_identity_matches(_actual: &Path, _expected: &Path) -> bool {
-    false
 }
 
 #[cfg(test)]
 fn resolve_env_command(command: &EnvCommand) -> Result<PathBuf> {
-    command.resolve_executable(None)?.ok_or_else(|| {
+    command.resolve_executable(None, None)?.ok_or_else(|| {
         SurgeError::Platform(format!(
             "Failed to resolve active application env interpreter '{}' from the updater PATH",
             Path::new(&command.program).display()
@@ -771,6 +739,26 @@ mod tests {
             &resolve_env_command(&command).unwrap(),
             &expected
         ));
+    }
+
+    #[test]
+    fn env_path_matches_observed_candidate_after_execute_permission_is_removed() {
+        use std::os::unix::fs::{PermissionsExt, symlink};
+
+        let first = tempfile::tempdir().unwrap();
+        let second = tempfile::tempdir().unwrap();
+        let observed = first.path().join("demo-interpreter");
+        std::fs::copy(std::env::current_exe().unwrap(), &observed).unwrap();
+        std::fs::set_permissions(&observed, std::fs::Permissions::from_mode(0o644)).unwrap();
+        symlink("/bin/sh", second.path().join("demo-interpreter")).unwrap();
+        let search_path = std::env::join_paths([first.path(), second.path()]).unwrap();
+        let command = EnvCommand {
+            program: OsString::from("demo-interpreter"),
+            fixed_argument_count: 0,
+            search_path: EnvSearchPath::Explicit(search_path),
+        };
+
+        assert!(command.matches_executable(&observed, &[]).unwrap());
     }
 
     #[test]

--- a/crates/surge-core/src/update/manager/lifecycle/process_quiescence/interpreted_main/env_path.rs
+++ b/crates/surge-core/src/update/manager/lifecycle/process_quiescence/interpreted_main/env_path.rs
@@ -1,0 +1,211 @@
+use std::ffi::OsStr;
+use std::os::unix::fs::MetadataExt;
+use std::path::{Path, PathBuf};
+
+use nix::errno::Errno;
+use nix::unistd::{AccessFlags, access};
+
+use crate::error::{Result, SurgeError};
+
+pub(super) fn select_path_executable(
+    search_path: &OsStr,
+    program: &Path,
+    observed_executable: Option<&Path>,
+) -> Result<Option<PathBuf>> {
+    select_path_executable_with(search_path, program, observed_executable, |_| {})
+}
+
+fn select_path_executable_with<F>(
+    search_path: &OsStr,
+    program: &Path,
+    observed_executable: Option<&Path>,
+    mut after_metadata: F,
+) -> Result<Option<PathBuf>>
+where
+    F: FnMut(&Path),
+{
+    for directory in std::env::split_paths(search_path) {
+        if directory.as_os_str().is_empty() || directory.is_relative() {
+            return Err(SurgeError::Platform(format!(
+                "Cannot safely resolve env interpreter '{}' through a relative PATH entry before swap",
+                program.display()
+            )));
+        }
+        let candidate = directory.join(program);
+        let metadata = match std::fs::metadata(&candidate) {
+            Ok(metadata) => metadata,
+            Err(error)
+                if matches!(
+                    error.kind(),
+                    std::io::ErrorKind::NotFound | std::io::ErrorKind::NotADirectory
+                ) =>
+            {
+                continue;
+            }
+            Err(error) => return Err(candidate_inspection_error(&candidate, error)),
+        };
+        if !metadata.is_file() {
+            continue;
+        }
+
+        after_metadata(&candidate);
+        let resolved = std::fs::canonicalize(&candidate).map_err(|error| candidate_changed_error(&candidate, error))?;
+        ensure_candidate_identity(&candidate, &metadata)?;
+
+        if observed_executable.is_some_and(|observed| paths_resolve_to_same_executable(observed, &resolved)) {
+            return Ok(Some(resolved));
+        }
+
+        match access(&candidate, AccessFlags::X_OK) {
+            Ok(()) => {}
+            Err(Errno::EACCES) => {
+                ensure_candidate_identity(&candidate, &metadata)?;
+                continue;
+            }
+            Err(error @ (Errno::ENOENT | Errno::ENOTDIR)) => {
+                return Err(candidate_changed_error(&candidate, error));
+            }
+            Err(error) => {
+                return Err(SurgeError::Platform(format!(
+                    "Cannot safely inspect env interpreter candidate '{}': {error}",
+                    candidate.display()
+                )));
+            }
+        }
+
+        ensure_candidate_identity(&candidate, &metadata)?;
+        return Ok(Some(resolved));
+    }
+    Ok(None)
+}
+
+fn ensure_candidate_identity(candidate: &Path, expected: &std::fs::Metadata) -> Result<()> {
+    let current_resolved =
+        std::fs::canonicalize(candidate).map_err(|error| candidate_changed_error(candidate, error))?;
+    let current_metadata =
+        std::fs::metadata(&current_resolved).map_err(|error| candidate_changed_error(candidate, error))?;
+    if expected.dev() != current_metadata.dev() || expected.ino() != current_metadata.ino() {
+        return Err(SurgeError::Platform(format!(
+            "Env interpreter candidate '{}' changed during inspection before application swap",
+            candidate.display()
+        )));
+    }
+    Ok(())
+}
+
+fn candidate_inspection_error(candidate: &Path, error: std::io::Error) -> SurgeError {
+    SurgeError::Platform(format!(
+        "Cannot safely inspect env interpreter candidate '{}': {error}",
+        candidate.display()
+    ))
+}
+
+fn candidate_changed_error(candidate: &Path, error: impl std::fmt::Display) -> SurgeError {
+    SurgeError::Platform(format!(
+        "Env interpreter candidate '{}' changed during inspection before application swap: {error}",
+        candidate.display()
+    ))
+}
+
+pub(super) fn paths_resolve_to_same_executable(actual: &Path, expected: &Path) -> bool {
+    if actual == expected {
+        return true;
+    }
+    if std::fs::canonicalize(actual)
+        .ok()
+        .zip(std::fs::canonicalize(expected).ok())
+        .is_some_and(|(actual, expected)| actual == expected)
+    {
+        return true;
+    }
+
+    std::fs::metadata(actual)
+        .ok()
+        .zip(std::fs::metadata(expected).ok())
+        .is_some_and(|(actual, expected)| actual.dev() == expected.dev() && actual.ino() == expected.ino())
+        || macos_system_shell_identity_matches(actual, expected)
+}
+
+#[cfg(target_os = "macos")]
+fn macos_system_shell_identity_matches(actual: &Path, expected: &Path) -> bool {
+    // macOS reports a stable /bin/sh script process as /bin/bash while retaining /bin/sh as argv[0].
+    actual == Path::new("/bin/bash") && expected == Path::new("/bin/sh")
+}
+
+#[cfg(not(target_os = "macos"))]
+fn macos_system_shell_identity_matches(_actual: &Path, _expected: &Path) -> bool {
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use std::os::unix::fs::{PermissionsExt, symlink};
+
+    use super::*;
+
+    #[test]
+    fn observed_candidate_is_selected_after_execute_permission_is_removed() {
+        let first = tempfile::tempdir().unwrap();
+        let second = tempfile::tempdir().unwrap();
+        let observed = first.path().join("demo-interpreter");
+        std::fs::copy(std::env::current_exe().unwrap(), &observed).unwrap();
+        std::fs::set_permissions(&observed, std::fs::Permissions::from_mode(0o644)).unwrap();
+        symlink("/bin/sh", second.path().join("demo-interpreter")).unwrap();
+        let search_path = std::env::join_paths([first.path(), second.path()]).unwrap();
+
+        let selected = select_path_executable(&search_path, Path::new("demo-interpreter"), Some(&observed))
+            .unwrap()
+            .unwrap();
+
+        assert!(paths_resolve_to_same_executable(&selected, &observed));
+    }
+
+    #[test]
+    fn candidate_disappearance_after_metadata_fails_closed() {
+        let directory = tempfile::tempdir().unwrap();
+        let candidate = directory.path().join("demo-interpreter");
+        std::fs::copy(std::env::current_exe().unwrap(), &candidate).unwrap();
+        let mut removed = false;
+
+        let error = select_path_executable_with(
+            directory.path().as_os_str(),
+            Path::new("demo-interpreter"),
+            None,
+            |inspected| {
+                if !removed {
+                    std::fs::remove_file(inspected).unwrap();
+                    removed = true;
+                }
+            },
+        )
+        .unwrap_err();
+
+        assert!(error.to_string().contains("changed during inspection"));
+    }
+
+    #[test]
+    fn non_executable_replacement_after_metadata_fails_closed() {
+        let directory = tempfile::tempdir().unwrap();
+        let candidate = directory.path().join("demo-interpreter");
+        let replacement = directory.path().join("replacement");
+        std::fs::copy(std::env::current_exe().unwrap(), &candidate).unwrap();
+        std::fs::copy(std::env::current_exe().unwrap(), &replacement).unwrap();
+        std::fs::set_permissions(&replacement, std::fs::Permissions::from_mode(0o644)).unwrap();
+        let mut replaced = false;
+
+        let error = select_path_executable_with(
+            directory.path().as_os_str(),
+            Path::new("demo-interpreter"),
+            None,
+            |inspected| {
+                if !replaced {
+                    std::fs::rename(&replacement, inspected).unwrap();
+                    replaced = true;
+                }
+            },
+        )
+        .unwrap_err();
+
+        assert!(error.to_string().contains("changed during inspection"));
+    }
+}


### PR DESCRIPTION
## Summary

- normalize trusted relative and dot-prefixed launch paths within the captured installation
- preserve interpreter path identity across later permission or alias changes
- reject a captured installation that disappears before finalize

## Why

Recovery cannot depend on resolving launch paths after shutdown or accepting an installation that changed beneath the updater. These checks stabilize the inputs consumed by the final preflight layer.

This is stack 13 of 16.

- Base: #285
- Next: #262

Relates to fintermobilityas/youpark#1310.

## Validation

- exact layer `bbdd80a` passed launch-path, interpreter-path, and vanished-install regressions plus rustfmt, blocking Clippy, and maintainability
- complete stack `c48f19f` passed 681 Rust workspace tests, both blocking Clippy tiers, vendor/version/format/maintainability checks, .NET formatting, and all 58 .NET tests

No migration is required.
