### PR TITLE
Address updater stack lint feedback

### DIFF
--- a/crates/surge-core/src/update/manager.rs
+++ b/crates/surge-core/src/update/manager.rs
@@ -577,6 +577,7 @@ mod tests {
     #![allow(clippy::cast_possible_wrap)]
 
     use std::collections::BTreeSet;
+    use std::fmt::Write as _;
     use std::path::{Path, PathBuf};
     use std::sync::Mutex;
     use std::time::Duration;
@@ -706,7 +707,7 @@ mod tests {
         if !environment.is_empty() {
             manifest.push_str("environment:\n");
             for (key, value) in environment {
-                manifest.push_str(&format!("  {key}: \"{value}\"\n"));
+                let _ = writeln!(manifest, "  {key}: \"{value}\"");
             }
         }
         std::fs::write(manifest_path, manifest).unwrap();

--- a/crates/surge-core/src/update/manager/finalize_recovery.rs
+++ b/crates/surge-core/src/update/manager/finalize_recovery.rs
@@ -14,6 +14,13 @@ pub(super) enum RecoveredGeneration {
     Target,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TargetPlacement {
+    Unknown,
+    Staged,
+    Active,
+}
+
 pub(super) struct Guard {
     install_dir: PathBuf,
     current_app_dir: Option<PathBuf>,
@@ -23,8 +30,7 @@ pub(super) struct Guard {
     previous: ReleaseEntry,
     target: ReleaseEntry,
     previous_moved: bool,
-    target_staged: bool,
-    target_active: bool,
+    target_placement: TargetPlacement,
     armed: bool,
 }
 
@@ -57,14 +63,13 @@ impl Guard {
             },
             target: target.clone(),
             previous_moved: false,
-            target_staged: false,
-            target_active: false,
+            target_placement: TargetPlacement::Unknown,
             armed: true,
         }
     }
 
     pub(super) fn mark_target_staged(&mut self) {
-        self.target_staged = true;
+        self.target_placement = TargetPlacement::Staged;
     }
 
     pub(super) fn mark_previous_moved(&mut self) {
@@ -72,8 +77,7 @@ impl Guard {
     }
 
     pub(super) fn mark_target_active(&mut self) {
-        self.target_staged = false;
-        self.target_active = true;
+        self.target_placement = TargetPlacement::Active;
     }
 
     pub(super) fn complete_supervisor_restart(&mut self) {
@@ -114,7 +118,8 @@ impl Guard {
     }
 
     fn recovery_start(&mut self) -> Option<RecoveryStart> {
-        if self.target_active && self.active_app_dir.is_dir() && !self.move_target_aside() {
+        if self.target_placement == TargetPlacement::Active && self.active_app_dir.is_dir() && !self.move_target_aside()
+        {
             return Some(RecoveryStart::target(self.active_app_dir.clone()));
         }
 
@@ -144,7 +149,7 @@ impl Guard {
             return Some(RecoveryStart::previous(current_app_dir.clone()));
         }
 
-        if self.target_staged || self.next_app_dir.is_dir() {
+        if self.target_placement == TargetPlacement::Staged || self.next_app_dir.is_dir() {
             return self.restore_target_to_canonical_path().or_else(|| {
                 self.next_app_dir
                     .is_dir()
@@ -152,7 +157,7 @@ impl Guard {
             });
         }
 
-        if self.target_active && self.active_app_dir.is_dir() {
+        if self.target_placement == TargetPlacement::Active && self.active_app_dir.is_dir() {
             return Some(RecoveryStart::target(self.active_app_dir.clone()));
         }
         None
@@ -169,8 +174,7 @@ impl Guard {
         }
         match atomic_rename(&self.active_app_dir, &self.next_app_dir) {
             Ok(()) => {
-                self.target_active = false;
-                self.target_staged = true;
+                self.target_placement = TargetPlacement::Staged;
                 true
             }
             Err(error) => {
@@ -187,8 +191,7 @@ impl Guard {
 
     fn restore_target_to_canonical_path(&mut self) -> Option<RecoveryStart> {
         if self.active_app_dir.is_dir() {
-            return self
-                .target_active
+            return (self.target_placement == TargetPlacement::Active)
                 .then(|| RecoveryStart::target(self.active_app_dir.clone()));
         }
         if !self.next_app_dir.is_dir() {
@@ -196,8 +199,7 @@ impl Guard {
         }
         match atomic_rename(&self.next_app_dir, &self.active_app_dir) {
             Ok(()) => {
-                self.target_staged = false;
-                self.target_active = true;
+                self.target_placement = TargetPlacement::Active;
                 Some(RecoveryStart::target(self.active_app_dir.clone()))
             }
             Err(error) => {

--- a/crates/surge-core/src/update/manager/lifecycle.rs
+++ b/crates/surge-core/src/update/manager/lifecycle.rs
@@ -560,14 +560,10 @@ mod tests {
     fn prepare_supervisor_instance(
         install_dir: &Path,
         supervisor_id: &str,
-        supervisor_pid: u32,
+        owner_pid: u32,
     ) -> SupervisorTakeoverInstance {
-        std::fs::write(
-            supervisor_pid_file(install_dir, supervisor_id),
-            supervisor_pid.to_string(),
-        )
-        .unwrap();
-        let instance = SupervisorTakeoverInstance::new(supervisor_pid);
+        std::fs::write(supervisor_pid_file(install_dir, supervisor_id), owner_pid.to_string()).unwrap();
+        let instance = SupervisorTakeoverInstance::new(owner_pid);
         write_supervisor_takeover_instance(install_dir, supervisor_id, &instance).unwrap();
         instance
     }
@@ -577,8 +573,8 @@ mod tests {
     async fn acknowledged_supervisor_handoff_returns_the_refreshed_child_identity() {
         let dir = tempfile::tempdir().unwrap();
         let supervisor_id = "demo-supervisor";
-        let supervisor_pid = 42;
-        prepare_supervisor_instance(dir.path(), supervisor_id, supervisor_pid);
+        let owner_pid = 42;
+        prepare_supervisor_instance(dir.path(), supervisor_id, owner_pid);
         let install_dir = dir.path().to_path_buf();
         let responder = std::thread::spawn(move || {
             let request = wait_for_takeover_request(&install_dir, supervisor_id);

--- a/crates/surge-core/src/update/manager/lifecycle/process_quiescence/interpreted_main/env_path.rs
+++ b/crates/surge-core/src/update/manager/lifecycle/process_quiescence/interpreted_main/env_path.rs
@@ -42,7 +42,7 @@ where
             {
                 continue;
             }
-            Err(error) => return Err(candidate_inspection_error(&candidate, error)),
+            Err(error) => return Err(candidate_inspection_error(&candidate, &error)),
         };
         if !metadata.is_file() {
             continue;
@@ -93,7 +93,7 @@ fn ensure_candidate_identity(candidate: &Path, expected: &std::fs::Metadata) -> 
     Ok(())
 }
 
-fn candidate_inspection_error(candidate: &Path, error: std::io::Error) -> SurgeError {
+fn candidate_inspection_error(candidate: &Path, error: &std::io::Error) -> SurgeError {
     SurgeError::Platform(format!(
         "Cannot safely inspect env interpreter candidate '{}': {error}",
         candidate.display()

--- a/crates/surge-core/src/update/manager/lifecycle/supervisor_takeover.rs
+++ b/crates/surge-core/src/update/manager/lifecycle/supervisor_takeover.rs
@@ -20,7 +20,7 @@ pub(super) async fn request_shutdown(
     poll_interval: Duration,
 ) -> Result<Option<ProcessIdentity>> {
     let pid_file = supervisor_pid_file(install_dir, supervisor_id);
-    let Some(supervisor_pid) = read_supervisor_pid_owner(&pid_file)? else {
+    let Some(owner_pid) = read_supervisor_pid_owner(&pid_file)? else {
         if let Some(handoff) = take_accepted_supervisor_takeover(install_dir, supervisor_id)? {
             return Ok(handoff.child_identity);
         }
@@ -37,9 +37,9 @@ pub(super) async fn request_shutdown(
             "Supervisor '{supervisor_id}' does not advertise acknowledged takeover support"
         ))
     })?;
-    if instance.supervisor_pid != supervisor_pid {
+    if instance.supervisor_pid != owner_pid {
         return Err(SurgeError::Update(format!(
-            "Supervisor '{supervisor_id}' takeover instance belongs to PID {}, but its pid file belongs to PID {supervisor_pid}",
+            "Supervisor '{supervisor_id}' takeover instance belongs to PID {}, but its pid file belongs to PID {owner_pid}",
             instance.supervisor_pid
         )));
     }
@@ -96,7 +96,7 @@ pub(super) async fn request_shutdown(
             )?;
         }
 
-        if read_supervisor_pid_owner(&pid_file)? != Some(supervisor_pid) {
+        if read_supervisor_pid_owner(&pid_file)? != Some(owner_pid) {
             if let Some(handoff) = read_accepted_supervisor_takeover(install_dir, supervisor_id)? {
                 ensure_handoff_matches_request(supervisor_id, &handoff, &request)?;
                 return take_matching_accepted_handoff(install_dir, supervisor_id, &request);


### PR DESCRIPTION
## Summary

- model finalize target placement as one mutually exclusive state
- clarify takeover owner naming
- avoid an unnecessary test-helper allocation and owned error transfer

## Why

This cap keeps stack-local review feedback isolated from the behavior layers. It does not change the updater protocol.

This is stack 16 of 16.

- Base: #263
- Next: merge to `main` after the complete stack is green and reviewed

Relates to fintermobilityas/youpark#1310.

## Validation

- exact layer `c48f19f` passed all 391 `surge-core` tests, compatibility, unsafe-boundary and doc tests, rustfmt, blocking Clippy, and maintainability
- complete stack `c48f19f` passed 681 Rust workspace tests, both blocking Clippy tiers, vendor/version/format/maintainability checks, .NET formatting, and all 58 .NET tests
- the repository's non-blocking pedantic audit was run; remaining warnings are pre-existing debt or belong to earlier protocol layers and do not fail CI

No migration is required.
