### PR TITLE
Finalize self-hosted updates from a stable helper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3262,6 +3262,7 @@ dependencies = [
  "thiserror 2.0.20",
  "tokio",
  "tracing",
+ "uuid",
  "windows-sys 0.61.2",
  "zstd",
 ]
@@ -3308,7 +3309,9 @@ dependencies = [
  "signal-hook",
  "surge-core",
  "sysinfo",
+ "tempfile",
  "thiserror 2.0.20",
+ "tokio",
  "tracing",
  "tracing-subscriber",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ indicatif = "0.18"
 tempfile = "3"
 fs2 = "0.4"
 uuid = { version = "1", features = ["v4"] }
+sysinfo = "0.39.3"
 which = "8"
 eframe = { version = "0.36.0", default-features = false, features = ["glow", "default_fonts", "x11", "wayland"] }
 image = { version = "0.25", default-features = false, features = ["png"] }

--- a/README.md
+++ b/README.md
@@ -230,19 +230,29 @@ explicit SSH identity, pass `--node-user <account>` (or set `--node <account>@<n
 **.NET**
 ```csharp
 using var mgr = new SurgeUpdateManager();
-await mgr.UpdateToLatestReleaseAsync(
+var result = await mgr.UpdateToLatestReleaseAsync(
     onUpdatesAvailable: releases =>
         Console.WriteLine($"{releases.Count} update(s), latest: {releases.Latest?.Version}"),
     onAfterApplyUpdate: release =>
         Console.WriteLine($"Updated to {release.Version}")
 );
+if (result?.IsUpdateFinalizationScheduled == true)
+{
+    Environment.Exit(0);
+}
 ```
 
 **Rust**
 ```rust
 let mut mgr = UpdateManager::new(ctx, "my-app", "1.0.0", "stable", install_dir)?;
 if let Some(info) = mgr.check_for_updates().await? {
-    mgr.download_and_apply(&info, None::<fn(_)>).await?;
+    let outcome = mgr.download_and_apply(&info, None::<fn(_)>).await?;
+    if matches!(
+        outcome,
+        surge_core::update::manager::UpdateApplyOutcome::ExternalFinalizeScheduled
+    ) {
+        return Ok(());
+    }
 }
 ```
 
@@ -250,13 +260,21 @@ if let Some(info) = mgr.check_for_updates().await? {
 ```c
 surge_update_manager* mgr = surge_update_manager_create(ctx, "my-app", "1.0.0", "stable", dir);
 surge_releases_info* info = NULL;
+surge_result apply_result = SURGE_OK;
 if (surge_update_check(mgr, &info) == SURGE_OK) {
-    surge_update_download_and_apply(mgr, info, progress_cb, NULL);
+    apply_result = surge_update_download_and_apply(mgr, info, progress_cb, NULL);
     surge_releases_destroy(info);
 }
 surge_update_manager_destroy(mgr);
 surge_context_destroy(ctx);
+if (apply_result == SURGE_UPDATE_SCHEDULED) {
+    return 0;
+}
 ```
+
+`ExternalFinalizeScheduled` / `IsUpdateFinalizationScheduled` / `SURGE_UPDATE_SCHEDULED`
+means the helper accepted the remaining work, not that installation finished. Stop application
+work and exit promptly, then verify the persisted convergence status after restart.
 
 ## CI/CD Integration
 

--- a/crates/surge-bench/src/runner/update.rs
+++ b/crates/surge-bench/src/runner/update.rs
@@ -13,7 +13,7 @@ use surge_core::install::{InstallProfile, RuntimeManifestMetadata, write_runtime
 use surge_core::pack::builder::{PackBuilder, TimedArtifact};
 use surge_core::platform::detect::current_rid;
 use surge_core::releases::delta::SparseTreeReuse;
-use surge_core::update::manager::{ApplyStrategy, ProgressInfo, UpdateManager};
+use surge_core::update::manager::{ApplyStrategy, ProgressInfo, UpdateApplyOutcome, UpdateManager};
 
 use crate::payload::{PayloadTemplate, ScenarioProfile};
 use crate::report::BenchmarkResult;
@@ -377,7 +377,7 @@ pub async fn run_update_scenario(
     let t0 = apply_started;
     let last_items = std::sync::Arc::new(std::sync::atomic::AtomicI64::new(-1));
     let li = last_items.clone();
-    update_manager
+    let outcome = update_manager
         .download_and_apply(
             &info,
             Some(move |p: ProgressInfo| {
@@ -394,6 +394,11 @@ pub async fn run_update_scenario(
             }),
         )
         .await?;
+    if outcome == UpdateApplyOutcome::ExternalFinalizeScheduled {
+        return Err(SurgeError::Update(
+            "Benchmark update unexpectedly required external finalization".to_string(),
+        ));
+    }
     let apply_duration = apply_started.elapsed();
     assert_directories_match(&install_dir.join("app"), &artifacts_dir)?;
     results.push(BenchmarkResult {

--- a/crates/surge-cli/src/commands/setup/convergence.rs
+++ b/crates/surge-cli/src/commands/setup/convergence.rs
@@ -9,7 +9,7 @@ use surge_core::error::{Result, SurgeError};
 use surge_core::install::{self as core_install, InstallProfile};
 use surge_core::releases::version::compare_versions;
 use surge_core::storage_config::build_storage_config_from_installer_manifest;
-use surge_core::update::manager::{ApplyStrategy, ProgressInfo, UpdateInfo, UpdateManager};
+use surge_core::update::manager::{ApplyStrategy, ProgressInfo, UpdateApplyOutcome, UpdateInfo, UpdateManager};
 
 #[derive(Debug, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -120,7 +120,7 @@ async fn update_existing_install(
     apply_installer_runtime_environment(&mut update, manifest);
 
     let update_progress = Mutex::new(ProgressReporter::new("Applying update..."));
-    manager
+    let outcome = manager
         .download_and_apply(
             &update,
             Some(|progress: ProgressInfo| {
@@ -133,6 +133,12 @@ async fn update_existing_install(
             }),
         )
         .await?;
+    if outcome == UpdateApplyOutcome::ExternalFinalizeScheduled {
+        return Err(SurgeError::Update(
+            "Installer convergence unexpectedly required external finalization; exit before verifying the installed version"
+                .to_string(),
+        ));
+    }
 
     repair_runtime_metadata(manifest, install_root)?;
     logline::success(&format!(

--- a/crates/surge-core/Cargo.toml
+++ b/crates/surge-core/Cargo.toml
@@ -39,13 +39,11 @@ futures-util = { workspace = true }
 tempfile = { workspace = true }
 fs2 = { workspace = true }
 uuid = { workspace = true }
+sysinfo = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
 nix = { version = "0.31", features = ["signal", "process", "fs"] }
 libc = "0.2"
-
-[target.'cfg(target_os = "macos")'.dependencies]
-sysinfo = "0.39.3"
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_System_Threading", "Win32_Security", "Win32_Storage_FileSystem"] }

--- a/crates/surge-core/Cargo.toml
+++ b/crates/surge-core/Cargo.toml
@@ -38,6 +38,7 @@ async-trait = { workspace = true }
 futures-util = { workspace = true }
 tempfile = { workspace = true }
 fs2 = { workspace = true }
+uuid = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
 nix = { version = "0.31", features = ["signal", "process", "fs"] }

--- a/crates/surge-core/src/platform/process.rs
+++ b/crates/surge-core/src/platform/process.rs
@@ -2,11 +2,10 @@ use std::collections::BTreeMap;
 use std::path::Path;
 use std::process::{Child, Command, Stdio};
 
-use sysinfo::{Pid, ProcessesToUpdate, System};
-
 use crate::error::{Result, SurgeError};
 
 mod descriptors;
+mod identity;
 
 pub struct ProcessHandle {
     child: Child,
@@ -155,21 +154,11 @@ pub fn current_pid() -> u32 {
     std::process::id()
 }
 
-/// Start-time identity for a live process, in the platform units exposed by
-/// `sysinfo`. Combined with a PID, this distinguishes a worker from an
-/// unrelated process that later reused the same PID.
+/// High-resolution native creation identity for a live process. Combined with
+/// a PID, this distinguishes a worker from a later process that reused it.
 #[must_use]
-pub(crate) fn process_start_time(pid: u32) -> Option<u64> {
-    if pid == 0 {
-        return None;
-    }
-    let pid = Pid::from_u32(pid);
-    let mut system = System::new();
-    let _ = system.refresh_processes(ProcessesToUpdate::Some(&[pid]), true);
-    system
-        .process(pid)
-        .map(sysinfo::Process::start_time)
-        .filter(|start_time| *start_time != 0)
+pub fn process_start_time(pid: u32) -> Option<u64> {
+    identity::process_start_time(pid)
 }
 
 /// Liveness of the process identified by `pid`.
@@ -258,7 +247,7 @@ pub fn probe_pid_liveness(pid: u32) -> PidLiveness {
 /// the PID was reused. If start-time inspection is unavailable while the PID
 /// still appears live, the result is `Unknown` and callers must fail closed.
 #[must_use]
-pub(crate) fn probe_process_identity(pid: u32, expected_start_time: u64) -> PidLiveness {
+pub fn probe_process_identity(pid: u32, expected_start_time: u64) -> PidLiveness {
     match process_start_time(pid) {
         Some(actual_start_time) if actual_start_time == expected_start_time => PidLiveness::Alive,
         Some(_) => PidLiveness::Dead,

--- a/crates/surge-core/src/platform/process.rs
+++ b/crates/surge-core/src/platform/process.rs
@@ -2,6 +2,8 @@ use std::collections::BTreeMap;
 use std::path::Path;
 use std::process::{Child, Command, Stdio};
 
+use sysinfo::{Pid, ProcessesToUpdate, System};
+
 use crate::error::{Result, SurgeError};
 
 mod descriptors;
@@ -142,6 +144,23 @@ pub fn current_pid() -> u32 {
     std::process::id()
 }
 
+/// Start-time identity for a live process, in the platform units exposed by
+/// `sysinfo`. Combined with a PID, this distinguishes a worker from an
+/// unrelated process that later reused the same PID.
+#[must_use]
+pub(crate) fn process_start_time(pid: u32) -> Option<u64> {
+    if pid == 0 {
+        return None;
+    }
+    let pid = Pid::from_u32(pid);
+    let mut system = System::new();
+    let _ = system.refresh_processes(ProcessesToUpdate::Some(&[pid]), true);
+    system
+        .process(pid)
+        .map(sysinfo::Process::start_time)
+        .filter(|start_time| *start_time != 0)
+}
+
 /// Liveness of the process identified by `pid`.
 ///
 /// `Unknown` means the probe itself failed (the probe utility could not be
@@ -219,6 +238,23 @@ pub fn probe_pid_liveness(pid: u32) -> PidLiveness {
     {
         let _ = pid;
         PidLiveness::Unknown
+    }
+}
+
+/// Probe whether `pid` still identifies the process with `expected_start_time`.
+///
+/// A different start time conclusively means the original process exited and
+/// the PID was reused. If start-time inspection is unavailable while the PID
+/// still appears live, the result is `Unknown` and callers must fail closed.
+#[must_use]
+pub(crate) fn probe_process_identity(pid: u32, expected_start_time: u64) -> PidLiveness {
+    match process_start_time(pid) {
+        Some(actual_start_time) if actual_start_time == expected_start_time => PidLiveness::Alive,
+        Some(_) => PidLiveness::Dead,
+        None => match probe_pid_liveness(pid) {
+            PidLiveness::Dead => PidLiveness::Dead,
+            PidLiveness::Alive | PidLiveness::Unknown => PidLiveness::Unknown,
+        },
     }
 }
 
@@ -325,7 +361,7 @@ mod tests {
         assert_eq!(result.exit_code, 0);
     }
 
-    use super::{PidLiveness, is_pid_alive, probe_pid_liveness};
+    use super::{PidLiveness, is_pid_alive, probe_pid_liveness, probe_process_identity, process_start_time};
     use std::time::{Duration, Instant};
 
     #[test]
@@ -338,6 +374,15 @@ mod tests {
         assert_eq!(probe_pid_liveness(std::process::id()), PidLiveness::Alive);
         // PID 0 is not a valid process id on any supported platform.
         assert_eq!(probe_pid_liveness(0), PidLiveness::Dead);
+    }
+
+    #[test]
+    fn process_identity_rejects_a_reused_pid() {
+        let pid = std::process::id();
+        let start_time = process_start_time(pid).expect("current process start time");
+
+        assert_eq!(probe_process_identity(pid, start_time), PidLiveness::Alive);
+        assert_eq!(probe_process_identity(pid, start_time ^ 1), PidLiveness::Dead);
     }
 
     #[test]

--- a/crates/surge-core/src/platform/process.rs
+++ b/crates/surge-core/src/platform/process.rs
@@ -70,7 +70,8 @@ pub fn spawn_process(
     spawn_impl(exe, args, working_dir, envs, Stdio::inherit(), Stdio::inherit(), false)
 }
 
-/// Spawn a process fully detached (stdin/stdout/stderr = null).
+/// Spawn a process fully detached (stdin/stdout/stderr = null and independent
+/// from the caller's process group or job).
 pub fn spawn_detached(
     exe: &Path,
     args: &[&str],
@@ -92,13 +93,23 @@ fn spawn_impl(
     let mut cmd = Command::new(exe);
     cmd.args(args).stdin(Stdio::null()).stdout(stdout).stderr(stderr);
 
-    #[cfg(not(unix))]
+    #[cfg(not(any(unix, windows)))]
     let _ = detached;
 
     #[cfg(unix)]
     if detached {
         use std::os::unix::process::CommandExt;
         cmd.process_group(0);
+    }
+
+    #[cfg(windows)]
+    if detached {
+        use std::os::windows::process::CommandExt;
+        use windows_sys::Win32::System::Threading::{
+            CREATE_BREAKAWAY_FROM_JOB, CREATE_NEW_PROCESS_GROUP, DETACHED_PROCESS,
+        };
+
+        cmd.creation_flags(CREATE_BREAKAWAY_FROM_JOB | CREATE_NEW_PROCESS_GROUP | DETACHED_PROCESS);
     }
 
     if let Some(wd) = working_dir {

--- a/crates/surge-core/src/platform/process/identity.rs
+++ b/crates/surge-core/src/platform/process/identity.rs
@@ -1,0 +1,87 @@
+//! Native process-creation identity probes used to distinguish PID reuse.
+#![allow(unsafe_code)]
+
+#[cfg(target_os = "linux")]
+pub(super) fn process_start_time(pid: u32) -> Option<u64> {
+    if pid == 0 {
+        return None;
+    }
+    let stat = std::fs::read_to_string(format!("/proc/{pid}/stat")).ok()?;
+    let fields_after_command = stat.get(stat.rfind(')')? + 1..)?;
+    fields_after_command.split_whitespace().nth(19)?.parse().ok()
+}
+
+#[cfg(target_os = "macos")]
+pub(super) fn process_start_time(pid: u32) -> Option<u64> {
+    let pid = libc::pid_t::try_from(pid).ok()?;
+    if pid <= 0 {
+        return None;
+    }
+    let mut info = std::mem::MaybeUninit::<libc::proc_bsdinfo>::zeroed();
+    let size = libc::c_int::try_from(std::mem::size_of::<libc::proc_bsdinfo>()).ok()?;
+    // SAFETY: `info` points to writable storage of exactly the size passed to
+    // proc_pidinfo. A full-size return is required before the value is read.
+    let written = unsafe {
+        libc::proc_pidinfo(
+            pid,
+            libc::PROC_PIDTBSDINFO,
+            0,
+            info.as_mut_ptr().cast::<libc::c_void>(),
+            size,
+        )
+    };
+    if written != size {
+        return None;
+    }
+    // SAFETY: proc_pidinfo reported that it initialized the complete structure.
+    let info = unsafe { info.assume_init() };
+    info.pbi_start_tvsec
+        .checked_mul(1_000_000)?
+        .checked_add(info.pbi_start_tvusec)
+}
+
+#[cfg(windows)]
+pub(super) fn process_start_time(pid: u32) -> Option<u64> {
+    use windows_sys::Win32::Foundation::{CloseHandle, FILETIME};
+    use windows_sys::Win32::System::Threading::{GetProcessTimes, OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION};
+
+    if pid == 0 {
+        return None;
+    }
+    // SAFETY: OpenProcess is called with a non-inheritable handle and a numeric
+    // PID. The returned handle is checked and closed on every path below.
+    let handle = unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid) };
+    if handle.is_null() {
+        return None;
+    }
+    let mut creation = FILETIME::default();
+    let mut exit = FILETIME::default();
+    let mut kernel = FILETIME::default();
+    let mut user = FILETIME::default();
+    // SAFETY: all pointers reference initialized writable FILETIME values and
+    // `handle` remains valid until CloseHandle immediately after the call.
+    let succeeded = unsafe { GetProcessTimes(handle, &mut creation, &mut exit, &mut kernel, &mut user) };
+    // SAFETY: `handle` is the live owned handle returned by OpenProcess above.
+    let _ = unsafe { CloseHandle(handle) };
+    if succeeded == 0 {
+        return None;
+    }
+    Some((u64::from(creation.dwHighDateTime) << 32) | u64::from(creation.dwLowDateTime))
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos", windows)))]
+pub(super) fn process_start_time(pid: u32) -> Option<u64> {
+    let _ = pid;
+    None
+}
+
+#[cfg(all(test, target_os = "linux"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn linux_process_start_time_reads_proc_stat_field() {
+        let start_time = process_start_time(std::process::id()).expect("current process start time");
+        assert!(start_time > 0);
+    }
+}

--- a/crates/surge-core/src/update/manager.rs
+++ b/crates/surge-core/src/update/manager.rs
@@ -363,13 +363,7 @@ impl UpdateManager {
             .flatten()
             .filter(|record| record.app_id == self.app_id && record.target_version == target_version);
 
-        let _worker_guard = match UpdateWorkerGuard::record(&self.install_dir, &self.app_id, &target_version) {
-            Ok(guard) => Some(guard),
-            Err(e) => {
-                warn!(error = %e, "Failed to persist update worker marker (continuing)");
-                None
-            }
-        };
+        let _worker_guard = UpdateWorkerGuard::record(&self.install_dir, &self.app_id, &target_version)?;
 
         let in_progress_record = UpdateStatusRecord::in_progress(
             &self.app_id,

--- a/crates/surge-core/src/update/manager.rs
+++ b/crates/surge-core/src/update/manager.rs
@@ -42,6 +42,7 @@ pub enum ApplyStrategy {
 }
 
 /// Result of a successful update apply request.
+#[must_use = "handle ExternalFinalizeScheduled by exiting promptly and verifying persisted convergence after restart"]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum UpdateApplyOutcome {
     /// Finalization completed before the apply call returned.
@@ -1762,7 +1763,7 @@ echo started > new-child-started
         let info = manager.check_for_updates().await.unwrap().unwrap();
         assert_eq!(info.apply_strategy, ApplyStrategy::Full);
 
-        manager
+        let _ = manager
             .download_and_apply(&info, None::<fn(ProgressInfo)>)
             .await
             .unwrap();
@@ -1783,7 +1784,7 @@ echo started > new-child-started
         std::fs::remove_file(app_store.join(&full_filename)).unwrap();
         manager.set_current_version("1.1.0").unwrap();
         manager.current_release_identity = current_install::load(&manager).unwrap();
-        manager
+        let _ = manager
             .download_and_apply(&info, None::<fn(ProgressInfo)>)
             .await
             .unwrap();
@@ -2069,7 +2070,7 @@ echo started > new-child-started
         let info = manager.check_for_updates().await.unwrap().unwrap();
         assert_eq!(info.apply_strategy, ApplyStrategy::Full);
 
-        manager
+        let _ = manager
             .download_and_apply(&info, None::<fn(ProgressInfo)>)
             .await
             .unwrap();
@@ -2166,7 +2167,7 @@ echo started > new-child-started
         let observed = Arc::new(Mutex::new(Vec::<ProgressInfo>::new()));
         let observed_for_progress = Arc::clone(&observed);
 
-        manager
+        let _ = manager
             .download_and_apply(
                 &info,
                 Some(move |progress: ProgressInfo| {
@@ -2322,7 +2323,7 @@ echo started > new-child-started
         let mut manager = UpdateManager::new(ctx, app_id, "1.0.0", "stable", install_root.to_str().unwrap()).unwrap();
         let info = manager.check_for_updates().await.unwrap().unwrap();
 
-        manager
+        let _ = manager
             .download_and_apply(
                 &info,
                 Some(move |progress: ProgressInfo| {
@@ -2442,7 +2443,7 @@ echo started > new-child-started
 
         let mut manager = UpdateManager::new(ctx, app_id, "1.0.0", "stable", install_root.to_str().unwrap()).unwrap();
         let info = manager.check_for_updates().await.unwrap().unwrap();
-        manager
+        let _ = manager
             .download_and_apply(&info, None::<fn(ProgressInfo)>)
             .await
             .unwrap();
@@ -2664,7 +2665,7 @@ echo started > new-child-started
 
         let observed = Arc::new(Mutex::new(Vec::<ProgressInfo>::new()));
         let observed_for_progress = Arc::clone(&observed);
-        manager
+        let _ = manager
             .download_and_apply(
                 &info,
                 Some(move |progress: ProgressInfo| {
@@ -2837,7 +2838,7 @@ echo started > new-child-started
 
         let observed = Arc::new(Mutex::new(Vec::<ProgressInfo>::new()));
         let observed_for_progress = Arc::clone(&observed);
-        manager
+        let _ = manager
             .download_and_apply(
                 &info,
                 Some(move |progress: ProgressInfo| {
@@ -3026,7 +3027,7 @@ echo started > new-child-started
 
         let observed = Arc::new(Mutex::new(Vec::<ProgressInfo>::new()));
         let observed_for_progress = Arc::clone(&observed);
-        manager
+        let _ = manager
             .download_and_apply(
                 &info,
                 Some(move |progress: ProgressInfo| {
@@ -3284,7 +3285,7 @@ echo started > new-child-started
         let mut manager = UpdateManager::new(ctx, app_id, "1.0.0", "stable", install_root.to_str().unwrap()).unwrap();
         let info = manager.check_for_updates().await.unwrap().unwrap();
         assert_eq!(info.apply_strategy, ApplyStrategy::Delta);
-        manager
+        let _ = manager
             .download_and_apply(&info, None::<fn(ProgressInfo)>)
             .await
             .unwrap();
@@ -3402,7 +3403,7 @@ echo started > new-child-started
             ApplyStrategy::Full,
             "no delta path exists from 1.0.0"
         );
-        manager
+        let _ = manager
             .download_and_apply(&info, None::<fn(ProgressInfo)>)
             .await
             .expect("the missing full must be rebuilt from v2 full + v3 delta");
@@ -3577,7 +3578,7 @@ echo started > new-child-started
 
         let observed = Arc::new(Mutex::new(Vec::<ProgressInfo>::new()));
         let observed_for_progress = Arc::clone(&observed);
-        manager
+        let _ = manager
             .download_and_apply(
                 &info,
                 Some(move |progress: ProgressInfo| {
@@ -3751,7 +3752,7 @@ echo started > new-child-started
 
         let observed = Arc::new(Mutex::new(Vec::<ProgressInfo>::new()));
         let observed_for_progress = Arc::clone(&observed);
-        manager
+        let _ = manager
             .download_and_apply(
                 &info,
                 Some(move |progress: ProgressInfo| {
@@ -3963,7 +3964,7 @@ echo started > new-child-started
         let mut manager = UpdateManager::new(ctx, app_id, "1.0.0", "stable", install_root.to_str().unwrap()).unwrap();
         let info = manager.check_for_updates().await.unwrap().unwrap();
         assert_eq!(info.apply_strategy, ApplyStrategy::Delta);
-        manager
+        let _ = manager
             .download_and_apply(&info, None::<fn(ProgressInfo)>)
             .await
             .unwrap();
@@ -4460,7 +4461,7 @@ echo started > new-child-started
         let info = manager.check_for_updates().await.unwrap().unwrap();
         assert_eq!(ctx.storage_config().prefix, app_id);
         assert_eq!(info.apply_strategy, ApplyStrategy::Delta);
-        manager
+        let _ = manager
             .download_and_apply(&info, None::<fn(ProgressInfo)>)
             .await
             .unwrap();
@@ -4541,7 +4542,7 @@ echo started > new-child-started
 
         let mut manager = UpdateManager::new(ctx, app_id, "1.0.0", "stable", install_root.to_str().unwrap()).unwrap();
         let info = manager.check_for_updates().await.unwrap().unwrap();
-        manager
+        let _ = manager
             .download_and_apply(&info, None::<fn(ProgressInfo)>)
             .await
             .unwrap();
@@ -4625,7 +4626,7 @@ echo started > new-child-started
                 .map(|release| release.main_exe.as_str()),
             Some("old-app")
         );
-        manager
+        let _ = manager
             .download_and_apply(&info, None::<fn(ProgressInfo)>)
             .await
             .unwrap();
@@ -4695,7 +4696,7 @@ echo started > new-child-started
         );
         let mut manager = UpdateManager::new(ctx, app_id, "1.0.0", "stable", install_root.to_str().unwrap()).unwrap();
         let info = manager.check_for_updates().await.unwrap().unwrap();
-        manager
+        let _ = manager
             .download_and_apply(&info, None::<fn(ProgressInfo)>)
             .await
             .unwrap();
@@ -4783,7 +4784,7 @@ echo started > new-child-started
         manager.set_release_retention_limit(1);
 
         let info = manager.check_for_updates().await.unwrap().unwrap();
-        manager
+        let _ = manager
             .download_and_apply(&info, None::<fn(ProgressInfo)>)
             .await
             .unwrap();
@@ -4868,7 +4869,7 @@ echo started > new-child-started
         manager.set_release_retention_limit(0);
 
         let info = manager.check_for_updates().await.unwrap().unwrap();
-        manager
+        let _ = manager
             .download_and_apply(&info, None::<fn(ProgressInfo)>)
             .await
             .unwrap();
@@ -4960,7 +4961,7 @@ echo started > new-child-started
             .unwrap();
 
         let info = manager.check_for_updates().await.unwrap().unwrap();
-        manager
+        let _ = manager
             .download_and_apply(&info, None::<fn(ProgressInfo)>)
             .await
             .unwrap();
@@ -5045,7 +5046,7 @@ echo started > new-child-started
             .unwrap();
 
         let info = manager.check_for_updates().await.unwrap().unwrap();
-        manager
+        let _ = manager
             .download_and_apply(&info, None::<fn(ProgressInfo)>)
             .await
             .unwrap();
@@ -5144,7 +5145,7 @@ echo started > new-child-started
         let mut manager = UpdateManager::new(ctx, app_id, "1.0.0", "stable", install_root.to_str().unwrap()).unwrap();
         let info = manager.check_for_updates().await.unwrap().unwrap();
         assert_eq!(info.apply_strategy, ApplyStrategy::Full);
-        manager
+        let _ = manager
             .download_and_apply(&info, None::<fn(ProgressInfo)>)
             .await
             .unwrap();

--- a/crates/surge-core/src/update/manager.rs
+++ b/crates/surge-core/src/update/manager.rs
@@ -41,6 +41,16 @@ pub enum ApplyStrategy {
     Delta,
 }
 
+/// Result of a successful update apply request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UpdateApplyOutcome {
+    /// Finalization completed before the apply call returned.
+    Finalized,
+    /// A stable helper accepted ownership and will finalize after the calling
+    /// application exits.
+    ExternalFinalizeScheduled,
+}
+
 /// Information about available updates.
 #[derive(Debug, Clone)]
 pub struct UpdateInfo {
@@ -322,15 +332,18 @@ impl UpdateManager {
     /// 6. Finalize - move files into place, clean up
     ///
     /// A self-hosted updater leaves phase 6 to a stable external helper. In
-    /// that case this method returns after the helper is ready and armed; the
-    /// helper waits for the caller to exit before it swaps the `app` directory.
+    /// that case this method returns [`UpdateApplyOutcome::ExternalFinalizeScheduled`]
+    /// after the helper accepts ownership, before the directory swap. The
+    /// caller must stop new work and exit promptly. After restart, read the
+    /// persisted update status until it reaches `Converged`, `PendingRestart`,
+    /// or `Failed`; scheduling alone is not installation success.
     ///
     /// On every attempt this method also writes an explicit convergence record
     /// to `{install_dir}/.surge-update-status.json` so dashboards and repair
     /// tooling can distinguish "update in progress", "applied but pending
     /// supervisor restart", "fully converged", and "failed" without inferring
     /// state from version drift alone (see [`status`]).
-    pub async fn download_and_apply<F>(&self, info: &UpdateInfo, progress: Option<F>) -> Result<()>
+    pub async fn download_and_apply<F>(&self, info: &UpdateInfo, progress: Option<F>) -> Result<UpdateApplyOutcome>
     where
         F: Fn(ProgressInfo) + Send + Sync,
     {
@@ -388,16 +401,19 @@ impl UpdateManager {
         {
             Ok(restart_outcome) => {
                 let completed_at_utc = status::now_utc_rfc3339();
-                let record = match restart_outcome {
-                    SupervisorRestartOutcome::NotApplicable => Some(UpdateStatusRecord::converged(
-                        &self.app_id,
-                        &target_version,
-                        &self.channel,
-                        Some(attempted_at_utc),
-                        completed_at_utc,
-                        false,
-                    )),
-                    SupervisorRestartOutcome::PendingRestart { reason, failure_phase } => {
+                let (record, outcome) = match restart_outcome {
+                    SupervisorRestartOutcome::NotApplicable => (
+                        Some(UpdateStatusRecord::converged(
+                            &self.app_id,
+                            &target_version,
+                            &self.channel,
+                            Some(attempted_at_utc),
+                            completed_at_utc,
+                            false,
+                        )),
+                        UpdateApplyOutcome::Finalized,
+                    ),
+                    SupervisorRestartOutcome::PendingRestart { reason, failure_phase } => (
                         Some(UpdateStatusRecord::pending_restart_with_failure_phase(
                             &self.app_id,
                             &target_version,
@@ -407,16 +423,19 @@ impl UpdateManager {
                             completed_at_utc,
                             &reason,
                             failure_phase,
-                        ))
+                        )),
+                        UpdateApplyOutcome::Finalized,
+                    ),
+                    SupervisorRestartOutcome::ExternalFinalizeScheduled => {
+                        (None, UpdateApplyOutcome::ExternalFinalizeScheduled)
                     }
-                    SupervisorRestartOutcome::ExternalFinalizeScheduled => None,
                 };
                 if let Some(record) = record
                     && let Err(e) = status::write_update_status(&self.install_dir, &record)
                 {
                     warn!(error = %e, "Failed to persist post-update convergence status (continuing)");
                 }
-                Ok(())
+                Ok(outcome)
             }
             Err(e) => {
                 let status_context = status::read_update_status(&self.install_dir).ok().flatten();

--- a/crates/surge-core/src/update/manager.rs
+++ b/crates/surge-core/src/update/manager.rs
@@ -3,6 +3,7 @@
 mod apply;
 mod artifacts;
 mod current_install;
+mod external_finalize;
 mod finalize;
 mod lifecycle;
 mod progress;
@@ -24,6 +25,7 @@ use crate::update::status::{self, FailureContext, UpdateStatusRecord, UpdateWork
 
 use self::apply::materialize_update_payload;
 use self::artifacts::prepare_update_artifacts;
+pub use self::external_finalize::run_external_finalize;
 use self::finalize::finalize_update;
 use self::lifecycle::SupervisorRestartOutcome;
 pub use self::progress::ProgressInfo;
@@ -69,6 +71,7 @@ pub struct UpdateCheckState {
     current_version: String,
     channel: String,
     install_dir: PathBuf,
+    cached_index: Option<ReleaseIndex>,
     current_release_identity: Option<current_install::ReleaseIdentity>,
 }
 
@@ -207,6 +210,7 @@ impl UpdateManager {
             current_version: self.current_version.clone(),
             channel: self.channel.clone(),
             install_dir: self.install_dir.clone(),
+            cached_index: self.cached_index.clone(),
             current_release_identity: self.current_release_identity.clone(),
         }
     }
@@ -231,6 +235,7 @@ impl UpdateManager {
             ));
         }
 
+        self.cached_index.clone_from(&state.cached_index);
         self.current_release_identity = installed_identity;
         Ok(())
     }
@@ -266,12 +271,11 @@ impl UpdateManager {
 
     /// Allow the running application to swap its own active directory during apply.
     ///
-    /// Defaults to `false`, matching the fail-closed pre-swap quiescence contract: an
-    /// updater running from the active application executable refuses the swap and
-    /// expects an external Surge updater. A self-hosted application that updates
-    /// in-process can opt back in to the legacy in-place swap; other processes running
-    /// the active executable are still quiesced before the swap, and the
-    /// interpreted-entrypoint and shared-executable checks remain fail-closed.
+    /// Defaults to `false`: an updater running from the active application
+    /// executable hands finalization to the bundled supervisor at a stable path,
+    /// then the helper waits for the caller to exit before swapping directories.
+    /// A self-hosted application can opt back in to the legacy in-process swap;
+    /// other processes running the active executable are still quiesced first.
     pub fn set_allow_in_process_swap(&mut self, allow: bool) {
         self.allow_in_process_swap = allow;
     }
@@ -316,6 +320,10 @@ impl UpdateManager {
     /// 4. Extract - extract the final archive into the install tree
     /// 5. Apply delta - rebuild the final archive when using delta updates
     /// 6. Finalize - move files into place, clean up
+    ///
+    /// A self-hosted updater leaves phase 6 to a stable external helper. In
+    /// that case this method returns after the helper is ready and armed; the
+    /// helper waits for the caller to exit before it swaps the `app` directory.
     ///
     /// On every attempt this method also writes an explicit convergence record
     /// to `{install_dir}/.surge-update-status.json` so dashboards and repair
@@ -376,22 +384,27 @@ impl UpdateManager {
 
         let progress = progress.map(Arc::new);
         match self
-            .download_and_apply_inner(info, progress, in_progress_record.clone())
+            .download_and_apply_inner(
+                info,
+                progress,
+                in_progress_record.clone(),
+                previous_attempt_status.clone(),
+            )
             .await
         {
             Ok(restart_outcome) => {
                 let completed_at_utc = status::now_utc_rfc3339();
                 let record = match restart_outcome {
-                    SupervisorRestartOutcome::NotApplicable => UpdateStatusRecord::converged(
+                    SupervisorRestartOutcome::NotApplicable => Some(UpdateStatusRecord::converged(
                         &self.app_id,
                         &target_version,
                         &self.channel,
                         Some(attempted_at_utc),
                         completed_at_utc,
                         false,
-                    ),
+                    )),
                     SupervisorRestartOutcome::PendingRestart { reason, failure_phase } => {
-                        UpdateStatusRecord::pending_restart_with_failure_phase(
+                        Some(UpdateStatusRecord::pending_restart_with_failure_phase(
                             &self.app_id,
                             &target_version,
                             &target_version,
@@ -400,10 +413,13 @@ impl UpdateManager {
                             completed_at_utc,
                             &reason,
                             failure_phase,
-                        )
+                        ))
                     }
+                    SupervisorRestartOutcome::ExternalFinalizeScheduled => None,
                 };
-                if let Err(e) = status::write_update_status(&self.install_dir, &record) {
+                if let Some(record) = record
+                    && let Err(e) = status::write_update_status(&self.install_dir, &record)
+                {
                     warn!(error = %e, "Failed to persist post-update convergence status (continuing)");
                 }
                 Ok(())
@@ -439,6 +455,7 @@ impl UpdateManager {
         info: &UpdateInfo,
         progress: Option<Arc<F>>,
         in_progress_template: UpdateStatusRecord,
+        previous_attempt_status: Option<UpdateStatusRecord>,
     ) -> Result<SupervisorRestartOutcome>
     where
         F: Fn(ProgressInfo) + Send + Sync,
@@ -513,6 +530,23 @@ impl UpdateManager {
         progress_emitter.emit_completed_phase(update_phase::PACKAGE_APPLY_COMPLETED);
 
         // Phase 6: Finalize
+        if external_finalize::schedule_if_required(
+            self,
+            info,
+            &extracted_final_dir,
+            &in_progress_template,
+            previous_attempt_status,
+            &progress_emitter,
+        )
+        .await?
+        {
+            info!(
+                version = %info.latest_version,
+                "Update staged; external finalizer scheduled"
+            );
+            return Ok(SupervisorRestartOutcome::ExternalFinalizeScheduled);
+        }
+
         let restart_outcome = finalize_update(
             self,
             info,
@@ -789,6 +823,38 @@ mod tests {
         let error = applying.restore_check_state(&check_state).unwrap_err();
 
         assert!(error.to_string().contains("does not match"));
+    }
+
+    #[test]
+    fn restore_check_state_preserves_release_index_for_deferred_finalization() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store_root = tmp.path().join("store");
+        std::fs::create_dir_all(&store_root).unwrap();
+
+        let ctx = Arc::new(Context::new());
+        ctx.set_storage(
+            StorageProvider::Filesystem,
+            store_root.to_str().unwrap(),
+            "",
+            "",
+            "",
+            "",
+        );
+        let mut checked =
+            UpdateManager::new(Arc::clone(&ctx), "app", "1.0.0", "stable", tmp.path().to_str().unwrap()).unwrap();
+        checked.cached_index = Some(ReleaseIndex {
+            app_id: "app".to_string(),
+            ..ReleaseIndex::default()
+        });
+        let check_state = checked.capture_check_state();
+        let mut applying = UpdateManager::new(ctx, "app", "1.0.0", "stable", tmp.path().to_str().unwrap()).unwrap();
+
+        applying.restore_check_state(&check_state).unwrap();
+
+        assert_eq!(
+            applying.cached_index.as_ref().map(|index| index.app_id.as_str()),
+            Some("app")
+        );
     }
 
     #[test]

--- a/crates/surge-core/src/update/manager/current_install.rs
+++ b/crates/surge-core/src/update/manager/current_install.rs
@@ -2,6 +2,8 @@ use std::cmp::Ordering;
 use std::collections::BTreeMap;
 use std::path::{Component, Path, PathBuf};
 
+use serde::{Deserialize, Serialize};
+
 use crate::error::{Result, SurgeError};
 use crate::install::read_runtime_manifest_identity;
 use crate::releases::version::compare_versions;
@@ -9,7 +11,7 @@ use crate::supervisor::state::read_supervisor_exe_path;
 
 use super::{UpdateManager, apply};
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub(super) struct ReleaseIdentity {
     pub(super) version: String,
     pub(super) main_exe: String,
@@ -36,7 +38,6 @@ pub(super) fn load(manager: &UpdateManager) -> Result<Option<ReleaseIdentity>> {
     load_from_app_dir(manager, &active_app_dir, Some(&manager.current_version))
 }
 
-#[cfg(unix)]
 pub(super) fn load_previous_swap(manager: &UpdateManager, app_dir: &Path) -> Result<Option<ReleaseIdentity>> {
     load_from_app_dir(manager, app_dir, None)
 }

--- a/crates/surge-core/src/update/manager/external_finalize.rs
+++ b/crates/surge-core/src/update/manager/external_finalize.rs
@@ -1,0 +1,6 @@
+mod plan;
+mod runner;
+mod schedule;
+
+pub use runner::run_external_finalize;
+pub(super) use schedule::schedule_if_required;

--- a/crates/surge-core/src/update/manager/external_finalize/plan.rs
+++ b/crates/surge-core/src/update/manager/external_finalize/plan.rs
@@ -1,0 +1,329 @@
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::config::manifest::InstallArtifactCachePolicy;
+use crate::context::{Context, StorageConfig, StorageProvider};
+use crate::error::{Result, SurgeError};
+use crate::platform::fs::write_file_atomic;
+use crate::platform::process::{current_pid, supervisor_binary_name};
+use crate::releases::manifest::{ReleaseEntry, ReleaseIndex};
+use crate::update::status::UpdateStatusRecord;
+
+use super::super::current_install::ReleaseIdentity;
+use super::super::{UpdateManager, current_install};
+
+const EXTERNAL_FINALIZE_SCHEMA: u32 = 1;
+pub(super) const EXTERNAL_FINALIZE_DIR: &str = ".surge-finalize";
+pub(super) const PLAN_FILE_NAME: &str = "plan.json";
+pub(super) const READY_FILE_NAME: &str = "ready";
+pub(super) const ARMED_FILE_NAME: &str = "armed";
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct ExternalStorageConfig {
+    provider: i32,
+    bucket: String,
+    region: String,
+    endpoint: String,
+    prefix: String,
+}
+
+impl ExternalStorageConfig {
+    fn from_storage_config(config: &StorageConfig) -> Result<Self> {
+        let provider = config
+            .provider
+            .ok_or_else(|| SurgeError::Config("External finalizer requires a storage provider".to_string()))?;
+        Ok(Self {
+            provider: provider as i32,
+            bucket: config.bucket.clone(),
+            region: config.region.clone(),
+            endpoint: config.endpoint.clone(),
+            prefix: config.prefix.clone(),
+        })
+    }
+
+    fn apply_to_context(&self, context: &Context) -> Result<()> {
+        let provider = StorageProvider::from_i32(self.provider).ok_or_else(|| {
+            SurgeError::Config(format!(
+                "External finalizer plan uses unknown storage provider {}",
+                self.provider
+            ))
+        })?;
+        context.set_storage(provider, &self.bucket, &self.region, "", "", &self.endpoint);
+        context.set_storage_prefix(&self.prefix);
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(super) struct ExternalFinalizePlan {
+    pub(super) schema: u32,
+    pub(super) operation_id: String,
+    pub(super) install_dir: PathBuf,
+    pub(super) updater_pid: u32,
+    pub(super) updater_exe: PathBuf,
+    pub(super) current_app_dir: PathBuf,
+    pub(super) app_id: String,
+    pub(super) current_version: String,
+    pub(super) channel: String,
+    pub(super) release_retention_limit: usize,
+    pub(super) artifact_retention_policy: InstallArtifactCachePolicy,
+    storage: ExternalStorageConfig,
+    pub(super) release_index: ReleaseIndex,
+    pub(super) current_release_identity: ReleaseIdentity,
+    pub(super) latest: ReleaseEntry,
+    pub(super) in_progress_template: UpdateStatusRecord,
+    pub(super) previous_attempt_status: Option<UpdateStatusRecord>,
+}
+
+impl ExternalFinalizePlan {
+    pub(super) fn from_manager(
+        manager: &UpdateManager,
+        latest: &ReleaseEntry,
+        updater_exe: PathBuf,
+        current_app_dir: PathBuf,
+        in_progress_template: &UpdateStatusRecord,
+        previous_attempt_status: Option<UpdateStatusRecord>,
+    ) -> Result<Self> {
+        let release_index = manager.cached_index.clone().ok_or_else(|| {
+            SurgeError::Update(
+                "External finalization requires the release index captured during update check".to_string(),
+            )
+        })?;
+        let current_release_identity = manager.current_release_identity.clone().ok_or_else(|| {
+            SurgeError::Update("External finalization requires the installed application identity".to_string())
+        })?;
+        Ok(Self {
+            schema: EXTERNAL_FINALIZE_SCHEMA,
+            operation_id: Uuid::new_v4().to_string(),
+            install_dir: manager.install_dir.clone(),
+            updater_pid: current_pid(),
+            updater_exe,
+            current_app_dir,
+            app_id: manager.app_id.clone(),
+            current_version: manager.current_version.clone(),
+            channel: manager.channel.clone(),
+            release_retention_limit: manager.release_retention_limit,
+            artifact_retention_policy: manager.artifact_retention_policy,
+            storage: ExternalStorageConfig::from_storage_config(&manager.ctx.storage_config())?,
+            release_index,
+            current_release_identity,
+            latest: latest.clone(),
+            in_progress_template: in_progress_template.clone(),
+            previous_attempt_status,
+        })
+    }
+
+    pub(super) fn operation_dir(&self) -> PathBuf {
+        self.install_dir.join(EXTERNAL_FINALIZE_DIR).join(&self.operation_id)
+    }
+
+    pub(super) fn plan_path(&self) -> PathBuf {
+        self.operation_dir().join(PLAN_FILE_NAME)
+    }
+
+    pub(super) fn ready_path(&self) -> PathBuf {
+        self.operation_dir().join(READY_FILE_NAME)
+    }
+
+    pub(super) fn armed_path(&self) -> PathBuf {
+        self.operation_dir().join(ARMED_FILE_NAME)
+    }
+
+    pub(super) fn staging_dir(&self) -> PathBuf {
+        self.install_dir.join(".surge-staging")
+    }
+
+    pub(super) fn extracted_final_dir(&self) -> PathBuf {
+        self.staging_dir().join("extracted")
+    }
+
+    pub(super) fn artifact_cache_dir(&self) -> PathBuf {
+        self.install_dir.join(".surge-cache").join("artifacts")
+    }
+}
+
+pub(super) fn write_plan(plan: &ExternalFinalizePlan) -> Result<()> {
+    let json = serde_json::to_vec_pretty(plan)
+        .map_err(|error| SurgeError::Config(format!("Failed to encode external finalizer plan: {error}")))?;
+    write_file_atomic(&plan.plan_path(), &json)
+}
+
+pub(super) fn read_and_validate_plan(plan_path: &Path) -> Result<ExternalFinalizePlan> {
+    let raw = std::fs::read(plan_path)?;
+    let plan: ExternalFinalizePlan = serde_json::from_slice(&raw)
+        .map_err(|error| SurgeError::Config(format!("Failed to decode external finalizer plan: {error}")))?;
+    if plan.schema != EXTERNAL_FINALIZE_SCHEMA {
+        return Err(SurgeError::Config(format!(
+            "Unsupported external finalizer plan schema {}",
+            plan.schema
+        )));
+    }
+    Uuid::parse_str(&plan.operation_id)
+        .map_err(|error| SurgeError::Config(format!("Invalid external finalizer operation id: {error}")))?;
+    let bound_install_dir = super::super::bind_install_dir(&plan.install_dir.to_string_lossy())?;
+    if bound_install_dir != plan.install_dir {
+        return Err(SurgeError::Config(
+            "External finalizer plan install directory is not canonically bound".to_string(),
+        ));
+    }
+    let absolute_plan_path = std::path::absolute(plan_path)?;
+    if absolute_plan_path != plan.plan_path() {
+        return Err(SurgeError::Config(format!(
+            "External finalizer plan path '{}' does not match operation '{}'",
+            absolute_plan_path.display(),
+            plan.operation_id
+        )));
+    }
+    if plan.updater_pid == 0 || plan.updater_pid == current_pid() {
+        return Err(SurgeError::Config(
+            "External finalizer plan has an invalid updating process id".to_string(),
+        ));
+    }
+    let stable_app_dir = plan.install_dir.join("app");
+    let is_legacy_snapshot = plan.current_app_dir.parent() == Some(plan.install_dir.as_path())
+        && plan
+            .current_app_dir
+            .file_name()
+            .and_then(|name| name.to_str())
+            .is_some_and(|name| name.starts_with("app-") && name.len() > 4);
+    if plan.current_app_dir != stable_app_dir && !is_legacy_snapshot {
+        return Err(SurgeError::Config(
+            "External finalizer plan current application directory is outside the supported install layout".to_string(),
+        ));
+    }
+    if plan.app_id.trim().is_empty()
+        || plan.current_version.trim().is_empty()
+        || plan.channel.trim().is_empty()
+        || plan.latest.version.trim().is_empty()
+    {
+        return Err(SurgeError::Config(
+            "External finalizer plan is missing application identity".to_string(),
+        ));
+    }
+    if plan.latest.version != plan.in_progress_template.target_version
+        || plan.app_id != plan.in_progress_template.app_id
+        || plan.channel != plan.in_progress_template.channel
+        || plan.current_version != plan.in_progress_template.installed_version
+    {
+        return Err(SurgeError::Config(
+            "External finalizer plan does not match its update status transaction".to_string(),
+        ));
+    }
+    Ok(plan)
+}
+
+pub(super) fn manager_from_plan(plan: &ExternalFinalizePlan) -> Result<UpdateManager> {
+    let context = Arc::new(Context::new());
+    plan.storage.apply_to_context(&context)?;
+    let mut manager = UpdateManager::new(
+        context,
+        &plan.app_id,
+        &plan.current_version,
+        &plan.channel,
+        &plan.install_dir.to_string_lossy(),
+    )?;
+    manager.release_retention_limit = plan.release_retention_limit;
+    manager.artifact_retention_policy = plan.artifact_retention_policy;
+    manager.cached_index = Some(plan.release_index.clone());
+    manager.current_release_identity = Some(plan.current_release_identity.clone());
+    Ok(manager)
+}
+
+pub(super) fn validate_materialized_target(plan: &ExternalFinalizePlan, manager: &UpdateManager) -> Result<()> {
+    let actual_identity = current_install::load(manager)?;
+    if actual_identity.as_ref() != Some(&plan.current_release_identity) {
+        return Err(SurgeError::Update(
+            "Installed application identity changed before the external finalizer became ready".to_string(),
+        ));
+    }
+    let extracted = plan.extracted_final_dir();
+    if !extracted.is_dir() {
+        return Err(SurgeError::Update(format!(
+            "External finalizer payload is missing at '{}'",
+            extracted.display()
+        )));
+    }
+    let main_exe = extracted.join(&plan.latest.main_exe);
+    if !main_exe.is_file() {
+        return Err(SurgeError::Update(format!(
+            "External finalizer target executable is missing at '{}'",
+            main_exe.display()
+        )));
+    }
+    let supervisor = extracted.join(supervisor_binary_name());
+    if !supervisor.is_file() {
+        return Err(SurgeError::Update(format!(
+            "External finalizer target supervisor is missing at '{}'",
+            supervisor.display()
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use super::*;
+
+    #[test]
+    fn handshake_marker_paths_are_scoped_to_the_operation() {
+        let install_dir = PathBuf::from("/tmp/demo-install");
+        let operation_id = Uuid::new_v4().to_string();
+        let plan = ExternalFinalizePlan {
+            schema: EXTERNAL_FINALIZE_SCHEMA,
+            operation_id: operation_id.clone(),
+            install_dir: install_dir.clone(),
+            updater_pid: 42,
+            updater_exe: install_dir.join("app/demo"),
+            current_app_dir: install_dir.join("app"),
+            app_id: "demo".to_string(),
+            current_version: "1.0.0".to_string(),
+            channel: "test".to_string(),
+            release_retention_limit: 1,
+            artifact_retention_policy: InstallArtifactCachePolicy::default(),
+            storage: ExternalStorageConfig {
+                provider: StorageProvider::Filesystem as i32,
+                bucket: String::new(),
+                region: String::new(),
+                endpoint: String::new(),
+                prefix: String::new(),
+            },
+            release_index: ReleaseIndex::default(),
+            current_release_identity: ReleaseIdentity {
+                version: "1.0.0".to_string(),
+                main_exe: "demo".to_string(),
+                supervisor_id: "demo-supervisor".to_string(),
+                environment: BTreeMap::default(),
+            },
+            latest: ReleaseEntry::default(),
+            in_progress_template: UpdateStatusRecord::in_progress(
+                "demo",
+                "1.0.0",
+                "2.0.0",
+                "test",
+                "2026-09-02T00:00:00Z".to_string(),
+            ),
+            previous_attempt_status: None,
+        };
+
+        assert_eq!(
+            plan.plan_path(),
+            install_dir
+                .join(EXTERNAL_FINALIZE_DIR)
+                .join(operation_id)
+                .join(PLAN_FILE_NAME)
+        );
+        assert_eq!(
+            plan.ready_path().file_name().and_then(|name| name.to_str()),
+            Some("ready")
+        );
+        assert_eq!(
+            plan.armed_path().file_name().and_then(|name| name.to_str()),
+            Some("armed")
+        );
+    }
+}

--- a/crates/surge-core/src/update/manager/external_finalize/plan.rs
+++ b/crates/surge-core/src/update/manager/external_finalize/plan.rs
@@ -20,6 +20,7 @@ pub(super) const EXTERNAL_FINALIZE_DIR: &str = ".surge-finalize";
 pub(super) const PLAN_FILE_NAME: &str = "plan.json";
 pub(super) const READY_FILE_NAME: &str = "ready";
 pub(super) const ARMED_FILE_NAME: &str = "armed";
+pub(super) const ACCEPTED_FILE_NAME: &str = "accepted";
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct ExternalStorageConfig {
@@ -117,7 +118,11 @@ impl ExternalFinalizePlan {
     }
 
     pub(super) fn operation_dir(&self) -> PathBuf {
-        self.install_dir.join(EXTERNAL_FINALIZE_DIR).join(&self.operation_id)
+        self.operations_dir().join(&self.operation_id)
+    }
+
+    pub(super) fn operations_dir(&self) -> PathBuf {
+        self.install_dir.join(EXTERNAL_FINALIZE_DIR)
     }
 
     pub(super) fn plan_path(&self) -> PathBuf {
@@ -130,6 +135,10 @@ impl ExternalFinalizePlan {
 
     pub(super) fn armed_path(&self) -> PathBuf {
         self.operation_dir().join(ARMED_FILE_NAME)
+    }
+
+    pub(super) fn accepted_path(&self) -> PathBuf {
+        self.operation_dir().join(ACCEPTED_FILE_NAME)
     }
 
     pub(super) fn staging_dir(&self) -> PathBuf {
@@ -324,6 +333,10 @@ mod tests {
         assert_eq!(
             plan.armed_path().file_name().and_then(|name| name.to_str()),
             Some("armed")
+        );
+        assert_eq!(
+            plan.accepted_path().file_name().and_then(|name| name.to_str()),
+            Some("accepted")
         );
     }
 }

--- a/crates/surge-core/src/update/manager/external_finalize/runner.rs
+++ b/crates/surge-core/src/update/manager/external_finalize/runner.rs
@@ -117,12 +117,12 @@ where
     F: FnMut(u32, &Path) -> Result<()>,
 {
     persist_external_phase(plan, update_phase::STOPPING_SUPERVISOR);
+    *recovery_required = true;
     super::super::lifecycle::request_supervisor_shutdown(
         &plan.install_dir,
         &plan.current_release_identity.supervisor_id,
     )
     .await?;
-    *recovery_required = true;
 
     persist_external_phase(plan, update_phase::WAITING_FOR_UPDATER_EXIT);
     quiesce_updater(plan.updater_pid, &plan.updater_exe)?;
@@ -317,6 +317,11 @@ async fn recover_previous_runtime<F>(
 where
     F: FnMut(u32, &Path) -> Result<()>,
 {
+    super::super::lifecycle::request_supervisor_shutdown(
+        &plan.install_dir,
+        &plan.current_release_identity.supervisor_id,
+    )
+    .await?;
     if plan.latest.supervisor_id != plan.current_release_identity.supervisor_id {
         super::super::lifecycle::request_supervisor_shutdown(&plan.install_dir, &plan.latest.supervisor_id).await?;
     }

--- a/crates/surge-core/src/update/manager/external_finalize/runner.rs
+++ b/crates/surge-core/src/update/manager/external_finalize/runner.rs
@@ -34,11 +34,22 @@ where
     let mut manager = manager_from_plan(&plan)?;
     validate_materialized_target(&plan, &manager)?;
 
-    let _worker_guard = UpdateWorkerGuard::record(&plan.install_dir, &plan.app_id, &plan.latest.version)?;
-    write_handshake_marker(&plan.ready_path(), &plan.operation_id)?;
+    let _worker_guard =
+        UpdateWorkerGuard::take_over(&plan.install_dir, &plan.app_id, &plan.latest.version, plan.updater_pid)?;
+    if let Err(error) = write_handshake_marker(&plan.ready_path(), &plan.operation_id) {
+        persist_external_failure(&plan, &error, None);
+        cleanup_operation(&plan, "failed");
+        return Err(error);
+    }
 
     if let Err(error) = wait_until_armed(&plan).await {
         persist_external_failure(&plan, &error, None);
+        cleanup_operation(&plan, "failed");
+        return Err(error);
+    }
+    if let Err(error) = write_handshake_marker(&plan.accepted_path(), &plan.operation_id) {
+        persist_external_failure(&plan, &error, None);
+        cleanup_operation(&plan, "failed");
         return Err(error);
     }
 
@@ -46,9 +57,7 @@ where
     match result {
         Ok(outcome) => {
             persist_external_success(&plan, &outcome);
-            if let Err(error) = std::fs::remove_dir_all(plan.operation_dir()) {
-                warn!(error = %error, "Failed to remove completed external finalizer plan directory");
-            }
+            cleanup_operation(&plan, "completed");
             Ok(())
         }
         Err(error) => {
@@ -56,6 +65,7 @@ where
             let _ = std::fs::remove_file(plan.armed_path());
             let _ = std::fs::remove_file(plan.ready_path());
             persist_external_failure(&plan, &error, recovery_error.as_ref());
+            cleanup_operation(&plan, "failed");
             if let Some(recovery_error) = recovery_error {
                 return Err(SurgeError::Update(format!(
                     "External finalization failed: {error}; previous runtime recovery also failed: {recovery_error}"
@@ -63,6 +73,12 @@ where
             }
             Err(error)
         }
+    }
+}
+
+fn cleanup_operation(plan: &ExternalFinalizePlan, outcome: &str) {
+    if let Err(error) = std::fs::remove_dir_all(plan.operation_dir()) {
+        warn!(error = %error, outcome, "Failed to remove terminal external finalizer plan directory");
     }
 }
 

--- a/crates/surge-core/src/update/manager/external_finalize/runner.rs
+++ b/crates/surge-core/src/update/manager/external_finalize/runner.rs
@@ -6,7 +6,7 @@ use tracing::warn;
 
 use crate::error::{Result, SurgeError};
 use crate::platform::fs::atomic_rename;
-use crate::platform::process::{current_pid, is_pid_alive, spawn_detached};
+use crate::platform::process::{current_pid, spawn_detached};
 use crate::releases::manifest::ReleaseEntry;
 use crate::update::status::{self, FailureContext, UpdateStatusRecord, UpdateWorkerGuard};
 
@@ -28,9 +28,9 @@ const TERMINAL_STATUS_WRITE_RETRY_DELAY: Duration = Duration::from_millis(200);
 /// This API is intended for `surge-supervisor finalize-update`; consumers
 /// should continue to use [`UpdateManager::download_and_apply`].
 #[doc(hidden)]
-pub async fn run_external_finalize<F>(plan_path: &Path, quiesce_updater: F) -> Result<()>
+pub async fn run_external_finalize<F>(plan_path: &Path, mut quiesce_updater: F) -> Result<()>
 where
-    F: FnOnce(u32, &Path) -> Result<()>,
+    F: FnMut(u32, &Path) -> Result<()>,
 {
     let plan = read_and_validate_plan(plan_path)?;
     let mut manager = manager_from_plan(&plan)?;
@@ -67,7 +67,8 @@ where
         return Err(error);
     }
 
-    let result = run_armed_finalize(&plan, &mut manager, quiesce_updater).await;
+    let mut recovery_required = false;
+    let result = run_armed_finalize(&plan, &mut manager, &mut quiesce_updater, &mut recovery_required).await;
     match result {
         Ok(outcome) => {
             persist_external_success(&plan, &outcome)?;
@@ -75,7 +76,13 @@ where
             Ok(())
         }
         Err(error) => {
-            let recovery_error = recover_previous_runtime(&plan, &manager).await.err();
+            let recovery_error = if recovery_required {
+                recover_previous_runtime(&plan, &manager, &mut quiesce_updater)
+                    .await
+                    .err()
+            } else {
+                None
+            };
             let _ = std::fs::remove_file(plan.armed_path());
             let _ = std::fs::remove_file(plan.ready_path());
             if let Err(status_error) = persist_external_failure(&plan, &error, recovery_error.as_ref()) {
@@ -103,10 +110,11 @@ fn cleanup_operation(plan: &ExternalFinalizePlan, outcome: &str) {
 async fn run_armed_finalize<F>(
     plan: &ExternalFinalizePlan,
     manager: &mut UpdateManager,
-    quiesce_updater: F,
+    quiesce_updater: &mut F,
+    recovery_required: &mut bool,
 ) -> Result<SupervisorRestartOutcome>
 where
-    F: FnOnce(u32, &Path) -> Result<()>,
+    F: FnMut(u32, &Path) -> Result<()>,
 {
     persist_external_phase(plan, update_phase::STOPPING_SUPERVISOR);
     super::super::lifecycle::request_supervisor_shutdown(
@@ -114,6 +122,7 @@ where
         &plan.current_release_identity.supervisor_id,
     )
     .await?;
+    *recovery_required = true;
 
     persist_external_phase(plan, update_phase::WAITING_FOR_UPDATER_EXIT);
     quiesce_updater(plan.updater_pid, &plan.updater_exe)?;
@@ -300,10 +309,23 @@ where
     unreachable!("terminal status write loop always returns")
 }
 
-async fn recover_previous_runtime(plan: &ExternalFinalizePlan, manager: &UpdateManager) -> Result<()> {
+async fn recover_previous_runtime<F>(
+    plan: &ExternalFinalizePlan,
+    manager: &UpdateManager,
+    quiesce_updater: &mut F,
+) -> Result<()>
+where
+    F: FnMut(u32, &Path) -> Result<()>,
+{
     if plan.latest.supervisor_id != plan.current_release_identity.supervisor_id {
         super::super::lifecycle::request_supervisor_shutdown(&plan.install_dir, &plan.latest.supervisor_id).await?;
     }
+
+    quiesce_updater(plan.updater_pid, &plan.updater_exe).map_err(|error| {
+        SurgeError::Supervisor(format!(
+            "Refusing to restart the previous runtime because application quiescence could not be confirmed: {error}"
+        ))
+    })?;
 
     let current_app_dir = restore_previous_app_dir(
         manager,
@@ -321,29 +343,22 @@ async fn recover_previous_runtime(plan: &ExternalFinalizePlan, manager: &UpdateM
 
     let current_release = release_from_identity(&plan.current_release_identity);
     if current_release.supervisor_id.trim().is_empty() {
-        if !is_pid_alive(plan.updater_pid) {
-            let executable = current_app_dir.join(&current_release.main_exe);
-            let args: [&str; 0] = [];
-            let _ = spawn_detached(
-                &executable,
-                &args,
-                Some(&plan.install_dir),
-                &current_release.environment,
-            )?;
-        }
+        let executable = current_app_dir.join(&current_release.main_exe);
+        let args: [&str; 0] = [];
+        let _ = spawn_detached(
+            &executable,
+            &args,
+            Some(&plan.install_dir),
+            &current_release.environment,
+        )?;
         return Ok(());
     }
 
-    let watched_pid = if is_pid_alive(plan.updater_pid) {
-        plan.updater_pid
-    } else {
-        current_pid()
-    };
     match super::super::lifecycle::restart_supervisor_after_update_with_pid(
         &plan.install_dir,
         &current_app_dir,
         &current_release,
-        watched_pid,
+        current_pid(),
     ) {
         SupervisorRestartOutcome::PendingRestart { failure_phase, reason }
             if failure_phase == status::RESTART_HANDOFF_FAILED_PHASE =>
@@ -438,6 +453,7 @@ mod tests {
 
     use crate::context::{Context, StorageProvider};
     use crate::install::{InstallProfile, RuntimeManifestMetadata, write_runtime_manifest};
+    use crate::releases::manifest::ReleaseIndex;
 
     use super::*;
 
@@ -539,6 +555,51 @@ mod tests {
 
         assert_eq!(attempts.get(), 3);
         assert!(error.to_string().contains("after 3 attempts"));
+    }
+
+    #[tokio::test]
+    async fn recovery_refuses_to_restart_without_confirmed_application_quiescence() {
+        let temp = tempfile::tempdir().unwrap();
+        let (mut manager, identity) = fixture_manager(&temp);
+        let active = manager.install_dir.join("app");
+        write_app(&active, "1.0.0", "previous");
+        manager.current_release_identity = Some(identity.clone());
+        let latest = ReleaseEntry {
+            version: "2.0.0".to_string(),
+            main_exe: "demo".to_string(),
+            supervisor_id: identity.supervisor_id.clone(),
+            ..ReleaseEntry::default()
+        };
+        manager.cached_index = Some(ReleaseIndex {
+            app_id: "demo".to_string(),
+            releases: vec![latest.clone()],
+            ..ReleaseIndex::default()
+        });
+        let in_progress = UpdateStatusRecord::in_progress("demo", "1.0.0", "2.0.0", "test", status::now_utc_rfc3339());
+        let plan = ExternalFinalizePlan::from_manager(
+            &manager,
+            &latest,
+            active.join("demo"),
+            active.clone(),
+            &in_progress,
+            None,
+        )
+        .unwrap();
+        let attempts = Cell::new(0);
+        let mut reject_quiescence = |pid, executable: &Path| {
+            attempts.set(attempts.get() + 1);
+            assert_eq!(pid, plan.updater_pid);
+            assert_eq!(executable, plan.updater_exe);
+            Err(SurgeError::Supervisor("matching process remains".to_string()))
+        };
+
+        let error = recover_previous_runtime(&plan, &manager, &mut reject_quiescence)
+            .await
+            .unwrap_err();
+
+        assert_eq!(attempts.get(), 1);
+        assert!(error.to_string().contains("quiescence could not be confirmed"));
+        assert_eq!(std::fs::read_to_string(active.join("version")).unwrap(), "previous");
     }
 
     fn fixture_manager(

--- a/crates/surge-core/src/update/manager/external_finalize/runner.rs
+++ b/crates/surge-core/src/update/manager/external_finalize/runner.rs
@@ -374,8 +374,8 @@ mod tests {
     fn rollback_restores_previous_app_and_removes_failed_target() {
         let temp = tempfile::tempdir().unwrap();
         let (manager, identity) = fixture_manager(&temp);
-        let active = temp.path().join("app");
-        let previous = temp.path().join(".surge-app-prev");
+        let active = manager.install_dir.join("app");
+        let previous = manager.install_dir.join(".surge-app-prev");
         write_app(&active, "2.0.0", "target");
         write_app(&previous, "1.0.0", "previous");
 
@@ -386,14 +386,14 @@ mod tests {
 
         assert_eq!(std::fs::read_to_string(active.join("version")).unwrap(), "previous");
         assert!(!previous.exists());
-        assert!(!temp.path().join(".surge-app-failed-operation").exists());
+        assert!(!manager.install_dir.join(".surge-app-failed-operation").exists());
     }
 
     #[test]
     fn rollback_is_noop_before_directory_swap() {
         let temp = tempfile::tempdir().unwrap();
         let (manager, identity) = fixture_manager(&temp);
-        let active = temp.path().join("app");
+        let active = manager.install_dir.join("app");
         write_app(&active, "1.0.0", "previous");
 
         assert_eq!(
@@ -407,8 +407,8 @@ mod tests {
     fn rollback_ignores_stale_previous_swap_before_new_swap() {
         let temp = tempfile::tempdir().unwrap();
         let (manager, identity) = fixture_manager(&temp);
-        let active = temp.path().join("app");
-        let stale = temp.path().join(".surge-app-prev");
+        let active = manager.install_dir.join("app");
+        let stale = manager.install_dir.join(".surge-app-prev");
         write_app(&active, "1.0.0", "current");
         write_app(&stale, "0.9.0", "stale");
 
@@ -424,8 +424,8 @@ mod tests {
     fn rollback_restores_legacy_versioned_app_after_target_activation() {
         let temp = tempfile::tempdir().unwrap();
         let (manager, identity) = fixture_manager(&temp);
-        let active = temp.path().join("app");
-        let legacy = temp.path().join("app-1.0.0");
+        let active = manager.install_dir.join("app");
+        let legacy = manager.install_dir.join("app-1.0.0");
         write_app(&active, "2.0.0", "target");
         write_app(&legacy, "1.0.0", "previous");
         assert_eq!(

--- a/crates/surge-core/src/update/manager/external_finalize/runner.rs
+++ b/crates/surge-core/src/update/manager/external_finalize/runner.rs
@@ -20,6 +20,8 @@ use super::schedule::{marker_matches, write_handshake_marker};
 
 const HELPER_ARM_TIMEOUT: Duration = Duration::from_secs(30);
 const HANDSHAKE_POLL_INTERVAL: Duration = Duration::from_millis(50);
+const TERMINAL_STATUS_WRITE_ATTEMPTS: u32 = 5;
+const TERMINAL_STATUS_WRITE_RETRY_DELAY: Duration = Duration::from_millis(200);
 
 /// Complete a staged update from the stable helper process.
 ///
@@ -37,18 +39,30 @@ where
     let _worker_guard =
         UpdateWorkerGuard::take_over(&plan.install_dir, &plan.app_id, &plan.latest.version, plan.updater_pid)?;
     if let Err(error) = write_handshake_marker(&plan.ready_path(), &plan.operation_id) {
-        persist_external_failure(&plan, &error, None);
+        if let Err(status_error) = persist_external_failure(&plan, &error, None) {
+            return Err(SurgeError::Update(format!(
+                "External finalizer failed before becoming ready: {error}; terminal status persistence also failed: {status_error}"
+            )));
+        }
         cleanup_operation(&plan, "failed");
         return Err(error);
     }
 
     if let Err(error) = wait_until_armed(&plan).await {
-        persist_external_failure(&plan, &error, None);
+        if let Err(status_error) = persist_external_failure(&plan, &error, None) {
+            return Err(SurgeError::Update(format!(
+                "External finalizer failed before it was armed: {error}; terminal status persistence also failed: {status_error}"
+            )));
+        }
         cleanup_operation(&plan, "failed");
         return Err(error);
     }
     if let Err(error) = write_handshake_marker(&plan.accepted_path(), &plan.operation_id) {
-        persist_external_failure(&plan, &error, None);
+        if let Err(status_error) = persist_external_failure(&plan, &error, None) {
+            return Err(SurgeError::Update(format!(
+                "External finalizer failed before accepting ownership: {error}; terminal status persistence also failed: {status_error}"
+            )));
+        }
         cleanup_operation(&plan, "failed");
         return Err(error);
     }
@@ -56,7 +70,7 @@ where
     let result = run_armed_finalize(&plan, &mut manager, quiesce_updater).await;
     match result {
         Ok(outcome) => {
-            persist_external_success(&plan, &outcome);
+            persist_external_success(&plan, &outcome)?;
             cleanup_operation(&plan, "completed");
             Ok(())
         }
@@ -64,7 +78,11 @@ where
             let recovery_error = recover_previous_runtime(&plan, &manager).await.err();
             let _ = std::fs::remove_file(plan.armed_path());
             let _ = std::fs::remove_file(plan.ready_path());
-            persist_external_failure(&plan, &error, recovery_error.as_ref());
+            if let Err(status_error) = persist_external_failure(&plan, &error, recovery_error.as_ref()) {
+                return Err(SurgeError::Update(format!(
+                    "External finalization failed: {error}; terminal status persistence also failed: {status_error}"
+                )));
+            }
             cleanup_operation(&plan, "failed");
             if let Some(recovery_error) = recovery_error {
                 return Err(SurgeError::Update(format!(
@@ -161,7 +179,7 @@ fn persist_external_phase(plan: &ExternalFinalizePlan, phase: &'static str) {
     }
 }
 
-fn persist_external_success(plan: &ExternalFinalizePlan, outcome: &SupervisorRestartOutcome) {
+fn persist_external_success(plan: &ExternalFinalizePlan, outcome: &SupervisorRestartOutcome) -> Result<()> {
     let completed_at_utc = status::now_utc_rfc3339();
     let attempted_at_utc = plan
         .in_progress_template
@@ -190,16 +208,19 @@ fn persist_external_success(plan: &ExternalFinalizePlan, outcome: &SupervisorRes
             )
         }
         SupervisorRestartOutcome::ExternalFinalizeScheduled => {
-            warn!("External finalizer unexpectedly scheduled another external finalizer");
-            return;
+            return Err(SurgeError::Update(
+                "External finalizer unexpectedly scheduled another external finalizer".to_string(),
+            ));
         }
     };
-    if let Err(error) = status::write_update_status(&plan.install_dir, &record) {
-        warn!(error = %error, "Failed to persist external finalizer completion status");
-    }
+    write_terminal_status(&plan.install_dir, &record)
 }
 
-fn persist_external_failure(plan: &ExternalFinalizePlan, error: &SurgeError, recovery_error: Option<&SurgeError>) {
+fn persist_external_failure(
+    plan: &ExternalFinalizePlan,
+    error: &SurgeError,
+    recovery_error: Option<&SurgeError>,
+) -> Result<()> {
     let attempted_at_utc = plan
         .in_progress_template
         .attempted_at_utc
@@ -225,9 +246,58 @@ fn persist_external_failure(plan: &ExternalFinalizePlan, error: &SurgeError, rec
     } else {
         record
     };
-    if let Err(write_error) = status::write_update_status(&plan.install_dir, &record) {
-        warn!(error = %write_error, "Failed to persist external finalizer failure status");
+    write_terminal_status(&plan.install_dir, &record)
+}
+
+fn write_terminal_status(install_dir: &Path, record: &UpdateStatusRecord) -> Result<()> {
+    write_terminal_status_with(
+        install_dir,
+        record,
+        TERMINAL_STATUS_WRITE_ATTEMPTS,
+        TERMINAL_STATUS_WRITE_RETRY_DELAY,
+        status::write_update_status,
+    )
+}
+
+fn write_terminal_status_with<F>(
+    install_dir: &Path,
+    record: &UpdateStatusRecord,
+    attempts: u32,
+    retry_delay: Duration,
+    mut write_status: F,
+) -> Result<()>
+where
+    F: FnMut(&Path, &UpdateStatusRecord) -> Result<()>,
+{
+    if attempts == 0 {
+        return Err(SurgeError::Config(
+            "Terminal status persistence requires at least one attempt".to_string(),
+        ));
     }
+
+    for attempt in 1..=attempts {
+        match write_status(install_dir, record) {
+            Ok(()) => return Ok(()),
+            Err(error) if attempt < attempts => {
+                warn!(
+                    error = %error,
+                    attempt,
+                    attempts,
+                    "Failed to persist terminal external finalizer status; retrying"
+                );
+                if !retry_delay.is_zero() {
+                    std::thread::sleep(retry_delay);
+                }
+            }
+            Err(error) => {
+                return Err(SurgeError::Update(format!(
+                    "Failed to persist terminal external finalizer status after {attempts} attempts: {error}"
+                )));
+            }
+        }
+    }
+
+    unreachable!("terminal status write loop always returns")
 }
 
 async fn recover_previous_runtime(plan: &ExternalFinalizePlan, manager: &UpdateManager) -> Result<()> {
@@ -362,6 +432,7 @@ fn release_from_identity(identity: &super::super::current_install::ReleaseIdenti
 
 #[cfg(test)]
 mod tests {
+    use std::cell::Cell;
     use std::collections::BTreeMap;
     use std::sync::Arc;
 
@@ -433,6 +504,41 @@ mod tests {
             active
         );
         assert_eq!(std::fs::read_to_string(active.join("version")).unwrap(), "previous");
+    }
+
+    #[test]
+    fn terminal_status_write_retries_transient_failure() {
+        let temp = tempfile::tempdir().unwrap();
+        let attempts = Cell::new(0);
+        let record = UpdateStatusRecord::converged("demo", "2.0.0", "test", None, status::now_utc_rfc3339(), true);
+
+        write_terminal_status_with(temp.path(), &record, 3, Duration::ZERO, |_, _| {
+            attempts.set(attempts.get() + 1);
+            if attempts.get() < 3 {
+                Err(SurgeError::Update("transient write failure".to_string()))
+            } else {
+                Ok(())
+            }
+        })
+        .unwrap();
+
+        assert_eq!(attempts.get(), 3);
+    }
+
+    #[test]
+    fn terminal_status_write_reports_exhausted_retries() {
+        let temp = tempfile::tempdir().unwrap();
+        let attempts = Cell::new(0);
+        let record = UpdateStatusRecord::converged("demo", "2.0.0", "test", None, status::now_utc_rfc3339(), true);
+
+        let error = write_terminal_status_with(temp.path(), &record, 3, Duration::ZERO, |_, _| {
+            attempts.set(attempts.get() + 1);
+            Err(SurgeError::Update("persistent write failure".to_string()))
+        })
+        .unwrap_err();
+
+        assert_eq!(attempts.get(), 3);
+        assert!(error.to_string().contains("after 3 attempts"));
     }
 
     fn fixture_manager(

--- a/crates/surge-core/src/update/manager/external_finalize/runner.rs
+++ b/crates/surge-core/src/update/manager/external_finalize/runner.rs
@@ -1,0 +1,458 @@
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::Duration;
+
+use tracing::warn;
+
+use crate::error::{Result, SurgeError};
+use crate::platform::fs::atomic_rename;
+use crate::platform::process::{current_pid, is_pid_alive, spawn_detached};
+use crate::releases::manifest::ReleaseEntry;
+use crate::update::status::{self, FailureContext, UpdateStatusRecord, UpdateWorkerGuard};
+
+use super::super::progress::ProgressInfo;
+use super::super::progress_substep::{PhaseProgressEmitter, labels as update_phase};
+use super::super::{
+    ApplyStrategy, SupervisorRestartOutcome, UpdateInfo, UpdateManager, current_install, finalize_update,
+};
+use super::plan::{ExternalFinalizePlan, manager_from_plan, read_and_validate_plan, validate_materialized_target};
+use super::schedule::{marker_matches, write_handshake_marker};
+
+const HELPER_ARM_TIMEOUT: Duration = Duration::from_secs(30);
+const HANDSHAKE_POLL_INTERVAL: Duration = Duration::from_millis(50);
+
+/// Complete a staged update from the stable helper process.
+///
+/// This API is intended for `surge-supervisor finalize-update`; consumers
+/// should continue to use [`UpdateManager::download_and_apply`].
+#[doc(hidden)]
+pub async fn run_external_finalize<F>(plan_path: &Path, quiesce_updater: F) -> Result<()>
+where
+    F: FnOnce(u32, &Path) -> Result<()>,
+{
+    let plan = read_and_validate_plan(plan_path)?;
+    let mut manager = manager_from_plan(&plan)?;
+    validate_materialized_target(&plan, &manager)?;
+
+    let _worker_guard = UpdateWorkerGuard::record(&plan.install_dir, &plan.app_id, &plan.latest.version)?;
+    write_handshake_marker(&plan.ready_path(), &plan.operation_id)?;
+
+    if let Err(error) = wait_until_armed(&plan).await {
+        persist_external_failure(&plan, &error, None);
+        return Err(error);
+    }
+
+    let result = run_armed_finalize(&plan, &mut manager, quiesce_updater).await;
+    match result {
+        Ok(outcome) => {
+            persist_external_success(&plan, &outcome);
+            if let Err(error) = std::fs::remove_dir_all(plan.operation_dir()) {
+                warn!(error = %error, "Failed to remove completed external finalizer plan directory");
+            }
+            Ok(())
+        }
+        Err(error) => {
+            let recovery_error = recover_previous_runtime(&plan, &manager).await.err();
+            let _ = std::fs::remove_file(plan.armed_path());
+            let _ = std::fs::remove_file(plan.ready_path());
+            persist_external_failure(&plan, &error, recovery_error.as_ref());
+            if let Some(recovery_error) = recovery_error {
+                return Err(SurgeError::Update(format!(
+                    "External finalization failed: {error}; previous runtime recovery also failed: {recovery_error}"
+                )));
+            }
+            Err(error)
+        }
+    }
+}
+
+async fn run_armed_finalize<F>(
+    plan: &ExternalFinalizePlan,
+    manager: &mut UpdateManager,
+    quiesce_updater: F,
+) -> Result<SupervisorRestartOutcome>
+where
+    F: FnOnce(u32, &Path) -> Result<()>,
+{
+    persist_external_phase(plan, update_phase::STOPPING_SUPERVISOR);
+    super::super::lifecycle::request_supervisor_shutdown(
+        &plan.install_dir,
+        &plan.current_release_identity.supervisor_id,
+    )
+    .await?;
+
+    persist_external_phase(plan, update_phase::WAITING_FOR_UPDATER_EXIT);
+    quiesce_updater(plan.updater_pid, &plan.updater_exe)?;
+
+    let installed_identity = current_install::load(manager)?;
+    if installed_identity.as_ref() != Some(&plan.current_release_identity) {
+        return Err(SurgeError::Update(
+            "Installed application identity changed while the external finalizer waited for the updater to exit"
+                .to_string(),
+        ));
+    }
+    manager.current_release_identity = installed_identity;
+
+    let info = UpdateInfo {
+        available_releases: vec![plan.latest.clone()],
+        latest_version: plan.latest.version.clone(),
+        delta_available: false,
+        download_size: 0,
+        apply_releases: vec![plan.latest.clone()],
+        apply_strategy: ApplyStrategy::Full,
+        fallback_reason: None,
+    };
+    let progress: Option<Arc<fn(ProgressInfo)>> = None;
+    let progress_emitter = PhaseProgressEmitter {
+        progress: progress.as_ref(),
+        install_dir: &plan.install_dir,
+        in_progress_template: &plan.in_progress_template,
+    };
+    finalize_update(
+        manager,
+        &info,
+        &plan.extracted_final_dir(),
+        &plan.staging_dir(),
+        &plan.artifact_cache_dir(),
+        &progress_emitter,
+    )
+    .await
+}
+
+async fn wait_until_armed(plan: &ExternalFinalizePlan) -> Result<()> {
+    let deadline = tokio::time::Instant::now() + HELPER_ARM_TIMEOUT;
+    loop {
+        if marker_matches(&plan.armed_path(), &plan.operation_id)? {
+            return Ok(());
+        }
+        if tokio::time::Instant::now() >= deadline {
+            return Err(SurgeError::Update(format!(
+                "External finalizer was not armed within {}s; active application was left untouched",
+                HELPER_ARM_TIMEOUT.as_secs()
+            )));
+        }
+        tokio::time::sleep(HANDSHAKE_POLL_INTERVAL).await;
+    }
+}
+
+fn persist_external_phase(plan: &ExternalFinalizePlan, phase: &'static str) {
+    let record = plan
+        .in_progress_template
+        .clone()
+        .with_current_phase_at(phase, status::now_utc_rfc3339());
+    if let Err(error) = status::write_update_status(&plan.install_dir, &record) {
+        warn!(error = %error, phase, "Failed to persist external finalizer progress");
+    }
+}
+
+fn persist_external_success(plan: &ExternalFinalizePlan, outcome: &SupervisorRestartOutcome) {
+    let completed_at_utc = status::now_utc_rfc3339();
+    let attempted_at_utc = plan
+        .in_progress_template
+        .attempted_at_utc
+        .clone()
+        .unwrap_or_else(status::now_utc_rfc3339);
+    let record = match outcome {
+        SupervisorRestartOutcome::NotApplicable => UpdateStatusRecord::converged(
+            &plan.app_id,
+            &plan.latest.version,
+            &plan.channel,
+            Some(attempted_at_utc),
+            completed_at_utc,
+            false,
+        ),
+        SupervisorRestartOutcome::PendingRestart { reason, failure_phase } => {
+            UpdateStatusRecord::pending_restart_with_failure_phase(
+                &plan.app_id,
+                &plan.latest.version,
+                &plan.latest.version,
+                &plan.channel,
+                attempted_at_utc,
+                completed_at_utc,
+                reason,
+                failure_phase,
+            )
+        }
+        SupervisorRestartOutcome::ExternalFinalizeScheduled => {
+            warn!("External finalizer unexpectedly scheduled another external finalizer");
+            return;
+        }
+    };
+    if let Err(error) = status::write_update_status(&plan.install_dir, &record) {
+        warn!(error = %error, "Failed to persist external finalizer completion status");
+    }
+}
+
+fn persist_external_failure(plan: &ExternalFinalizePlan, error: &SurgeError, recovery_error: Option<&SurgeError>) {
+    let attempted_at_utc = plan
+        .in_progress_template
+        .attempted_at_utc
+        .clone()
+        .unwrap_or_else(status::now_utc_rfc3339);
+    let status_context = status::read_update_status(&plan.install_dir).ok().flatten();
+    let reason = recovery_error.map_or_else(
+        || error.to_string(),
+        |recovery| format!("{error}; previous runtime recovery failed: {recovery}"),
+    );
+    let record = UpdateStatusRecord::failed_with_context(
+        &plan.app_id,
+        &plan.current_version,
+        &plan.latest.version,
+        &plan.channel,
+        attempted_at_utc,
+        &reason,
+        FailureContext::from_record(status_context.as_ref(), recovery_error.is_none()),
+    );
+    let record = if recovery_error.is_none() {
+        let schedule = status::retry_schedule(plan.previous_attempt_status.as_ref(), &plan.latest.version);
+        record.with_retry_schedule_at(&schedule, status::next_retry_timestamp(chrono::Utc::now(), &schedule))
+    } else {
+        record
+    };
+    if let Err(write_error) = status::write_update_status(&plan.install_dir, &record) {
+        warn!(error = %write_error, "Failed to persist external finalizer failure status");
+    }
+}
+
+async fn recover_previous_runtime(plan: &ExternalFinalizePlan, manager: &UpdateManager) -> Result<()> {
+    if plan.latest.supervisor_id != plan.current_release_identity.supervisor_id {
+        super::super::lifecycle::request_supervisor_shutdown(&plan.install_dir, &plan.latest.supervisor_id).await?;
+    }
+
+    let current_app_dir = restore_previous_app_dir(
+        manager,
+        &plan.current_app_dir,
+        &plan.current_release_identity,
+        &plan.operation_id,
+    )?;
+
+    if !current_app_dir.join(&plan.current_release_identity.main_exe).is_file() {
+        return Err(SurgeError::Update(format!(
+            "Previous application executable is unavailable at '{}'",
+            current_app_dir.join(&plan.current_release_identity.main_exe).display()
+        )));
+    }
+
+    let current_release = release_from_identity(&plan.current_release_identity);
+    if current_release.supervisor_id.trim().is_empty() {
+        if !is_pid_alive(plan.updater_pid) {
+            let executable = current_app_dir.join(&current_release.main_exe);
+            let args: [&str; 0] = [];
+            let _ = spawn_detached(
+                &executable,
+                &args,
+                Some(&plan.install_dir),
+                &current_release.environment,
+            )?;
+        }
+        return Ok(());
+    }
+
+    let watched_pid = if is_pid_alive(plan.updater_pid) {
+        plan.updater_pid
+    } else {
+        current_pid()
+    };
+    match super::super::lifecycle::restart_supervisor_after_update_with_pid(
+        &plan.install_dir,
+        &current_app_dir,
+        &current_release,
+        watched_pid,
+    ) {
+        SupervisorRestartOutcome::PendingRestart { failure_phase, reason }
+            if failure_phase == status::RESTART_HANDOFF_FAILED_PHASE =>
+        {
+            Err(SurgeError::Supervisor(reason))
+        }
+        SupervisorRestartOutcome::NotApplicable => Err(SurgeError::Supervisor(
+            "Previous release supervisor was not restarted".to_string(),
+        )),
+        SupervisorRestartOutcome::PendingRestart { .. } => Ok(()),
+        SupervisorRestartOutcome::ExternalFinalizeScheduled => Err(SurgeError::Supervisor(
+            "Previous release recovery unexpectedly scheduled external finalization".to_string(),
+        )),
+    }
+}
+
+fn restore_previous_app_dir(
+    manager: &UpdateManager,
+    current_app_dir: &Path,
+    current_identity: &super::super::current_install::ReleaseIdentity,
+    operation_id: &str,
+) -> Result<PathBuf> {
+    let active_app_dir = manager.install_dir.join("app");
+    let previous_swap_dir = manager.install_dir.join(".surge-app-prev");
+    let previous_swap_matches = previous_swap_dir.is_dir()
+        && current_install::load_previous_swap(manager, &previous_swap_dir)?.as_ref() == Some(current_identity);
+    if previous_swap_matches {
+        replace_failed_target(&active_app_dir, &previous_swap_dir, operation_id)?;
+        return Ok(active_app_dir);
+    }
+
+    if current_app_dir != active_app_dir && current_app_dir.is_dir() {
+        if current_install::load_previous_swap(manager, current_app_dir)?.as_ref() != Some(current_identity) {
+            return Err(SurgeError::Update(
+                "Previous application directory no longer matches the external finalizer plan".to_string(),
+            ));
+        }
+        if active_app_dir.exists() {
+            replace_failed_target(&active_app_dir, current_app_dir, operation_id)?;
+            return Ok(active_app_dir);
+        }
+        return Ok(current_app_dir.to_path_buf());
+    }
+
+    if active_app_dir.is_dir()
+        && current_install::load_previous_swap(manager, &active_app_dir)?.as_ref() == Some(current_identity)
+    {
+        return Ok(active_app_dir);
+    }
+
+    Err(SurgeError::Update(
+        "No application directory matching the pre-update release is available for recovery".to_string(),
+    ))
+}
+
+fn replace_failed_target(active_app_dir: &Path, previous_app_dir: &Path, operation_id: &str) -> Result<()> {
+    let install_dir = active_app_dir
+        .parent()
+        .ok_or_else(|| SurgeError::Config("Active application directory has no install root".to_string()))?;
+    let failed_target_dir = install_dir.join(format!(".surge-app-failed-{operation_id}"));
+    if failed_target_dir.exists() {
+        std::fs::remove_dir_all(&failed_target_dir)?;
+    }
+    if active_app_dir.exists() {
+        atomic_rename(active_app_dir, &failed_target_dir)?;
+    }
+    if let Err(error) = atomic_rename(previous_app_dir, active_app_dir) {
+        if failed_target_dir.is_dir() && !active_app_dir.exists() {
+            let _ = atomic_rename(&failed_target_dir, active_app_dir);
+        }
+        return Err(error);
+    }
+    let _ = std::fs::remove_dir_all(&failed_target_dir);
+    Ok(())
+}
+
+fn release_from_identity(identity: &super::super::current_install::ReleaseIdentity) -> ReleaseEntry {
+    ReleaseEntry {
+        version: identity.version.clone(),
+        main_exe: identity.main_exe.clone(),
+        supervisor_id: identity.supervisor_id.clone(),
+        environment: identity.environment.clone(),
+        ..ReleaseEntry::default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+    use std::sync::Arc;
+
+    use crate::context::{Context, StorageProvider};
+    use crate::install::{InstallProfile, RuntimeManifestMetadata, write_runtime_manifest};
+
+    use super::*;
+
+    #[test]
+    fn rollback_restores_previous_app_and_removes_failed_target() {
+        let temp = tempfile::tempdir().unwrap();
+        let (manager, identity) = fixture_manager(&temp);
+        let active = temp.path().join("app");
+        let previous = temp.path().join(".surge-app-prev");
+        write_app(&active, "2.0.0", "target");
+        write_app(&previous, "1.0.0", "previous");
+
+        assert_eq!(
+            restore_previous_app_dir(&manager, &active, &identity, "operation").unwrap(),
+            active
+        );
+
+        assert_eq!(std::fs::read_to_string(active.join("version")).unwrap(), "previous");
+        assert!(!previous.exists());
+        assert!(!temp.path().join(".surge-app-failed-operation").exists());
+    }
+
+    #[test]
+    fn rollback_is_noop_before_directory_swap() {
+        let temp = tempfile::tempdir().unwrap();
+        let (manager, identity) = fixture_manager(&temp);
+        let active = temp.path().join("app");
+        write_app(&active, "1.0.0", "previous");
+
+        assert_eq!(
+            restore_previous_app_dir(&manager, &active, &identity, "operation").unwrap(),
+            active
+        );
+        assert_eq!(std::fs::read_to_string(active.join("version")).unwrap(), "previous");
+    }
+
+    #[test]
+    fn rollback_ignores_stale_previous_swap_before_new_swap() {
+        let temp = tempfile::tempdir().unwrap();
+        let (manager, identity) = fixture_manager(&temp);
+        let active = temp.path().join("app");
+        let stale = temp.path().join(".surge-app-prev");
+        write_app(&active, "1.0.0", "current");
+        write_app(&stale, "0.9.0", "stale");
+
+        assert_eq!(
+            restore_previous_app_dir(&manager, &active, &identity, "operation").unwrap(),
+            active
+        );
+        assert_eq!(std::fs::read_to_string(active.join("version")).unwrap(), "current");
+        assert_eq!(std::fs::read_to_string(stale.join("version")).unwrap(), "stale");
+    }
+
+    #[test]
+    fn rollback_restores_legacy_versioned_app_after_target_activation() {
+        let temp = tempfile::tempdir().unwrap();
+        let (manager, identity) = fixture_manager(&temp);
+        let active = temp.path().join("app");
+        let legacy = temp.path().join("app-1.0.0");
+        write_app(&active, "2.0.0", "target");
+        write_app(&legacy, "1.0.0", "previous");
+        assert_eq!(
+            restore_previous_app_dir(&manager, &legacy, &identity, "operation").unwrap(),
+            active
+        );
+        assert_eq!(std::fs::read_to_string(active.join("version")).unwrap(), "previous");
+    }
+
+    fn fixture_manager(
+        temp: &tempfile::TempDir,
+    ) -> (UpdateManager, super::super::super::current_install::ReleaseIdentity) {
+        let store = temp.path().join("store");
+        std::fs::create_dir_all(&store).unwrap();
+        let context = Arc::new(Context::new());
+        context.set_storage(StorageProvider::Filesystem, store.to_str().unwrap(), "", "", "", "");
+        let manager = UpdateManager::new(context, "demo", "1.0.0", "test", temp.path().to_str().unwrap()).unwrap();
+        let identity = super::super::super::current_install::ReleaseIdentity {
+            version: "1.0.0".to_string(),
+            main_exe: "demo".to_string(),
+            supervisor_id: "demo-supervisor".to_string(),
+            environment: BTreeMap::new(),
+        };
+        (manager, identity)
+    }
+
+    fn write_app(app_dir: &Path, version: &str, marker: &str) {
+        std::fs::create_dir_all(app_dir).unwrap();
+        std::fs::write(app_dir.join("demo"), "fixture").unwrap();
+        std::fs::write(app_dir.join("version"), marker).unwrap();
+        let environment = BTreeMap::new();
+        let profile = InstallProfile::new(
+            "demo",
+            "Demo",
+            "demo",
+            "demo",
+            "demo-supervisor",
+            "",
+            &[],
+            &[],
+            &environment,
+        );
+        let metadata = RuntimeManifestMetadata::new(version, "test", "filesystem", ".", "", "");
+        write_runtime_manifest(app_dir, &profile, &metadata).unwrap();
+    }
+}

--- a/crates/surge-core/src/update/manager/external_finalize/schedule.rs
+++ b/crates/surge-core/src/update/manager/external_finalize/schedule.rs
@@ -69,6 +69,9 @@ where
     }
 
     progress_emitter.emit_substep(6, update_phase::STARTING_EXTERNAL_FINALIZER, 90);
+    if plan.operations_dir().exists() {
+        std::fs::remove_dir_all(plan.operations_dir())?;
+    }
     std::fs::create_dir_all(plan.operation_dir())?;
 
     let current_helper = updater.active_app_dir.join(supervisor_binary_name());
@@ -99,6 +102,12 @@ where
         let _ = std::fs::remove_dir_all(plan.operation_dir());
         return Err(error);
     }
+    if let Err(error) = wait_for_helper_accepted(&plan, &mut helper).await {
+        let _ = helper.kill();
+        let _ = helper.wait();
+        let _ = std::fs::remove_dir_all(plan.operation_dir());
+        return Err(error);
+    }
 
     progress_emitter.emit_substep(6, update_phase::WAITING_FOR_UPDATER_EXIT, 91);
     info!(
@@ -107,6 +116,32 @@ where
         "Transferred update finalization to stable helper"
     );
     Ok(true)
+}
+
+async fn wait_for_helper_accepted(
+    plan: &ExternalFinalizePlan,
+    helper: &mut crate::platform::process::ProcessHandle,
+) -> Result<()> {
+    let deadline = tokio::time::Instant::now() + HELPER_READY_TIMEOUT;
+    loop {
+        if marker_matches(&plan.accepted_path(), &plan.operation_id)? {
+            return Ok(());
+        }
+        if !helper.poll_running() {
+            let result = helper.wait()?;
+            return Err(SurgeError::Update(format!(
+                "External finalizer helper exited before accepting ownership with code {}",
+                result.exit_code
+            )));
+        }
+        if tokio::time::Instant::now() >= deadline {
+            return Err(SurgeError::Update(format!(
+                "Timed out after {}s waiting for the external finalizer helper to accept ownership",
+                HELPER_READY_TIMEOUT.as_secs()
+            )));
+        }
+        tokio::time::sleep(HANDSHAKE_POLL_INTERVAL).await;
+    }
 }
 
 fn self_hosted_updater(manager: &UpdateManager) -> Result<Option<SelfHostedUpdater>> {

--- a/crates/surge-core/src/update/manager/external_finalize/schedule.rs
+++ b/crates/surge-core/src/update/manager/external_finalize/schedule.rs
@@ -189,21 +189,12 @@ fn resolve_active_executable(active_app_dir: &Path, main_exe: &str) -> Result<Pa
     Ok(active_exe)
 }
 
-#[cfg(unix)]
-fn same_executable(left: &Path, right: &Path) -> Result<bool> {
-    use std::os::unix::fs::MetadataExt;
-
-    let left = std::fs::metadata(left)?;
-    let right = std::fs::metadata(right)?;
-    Ok(left.dev() == right.dev() && left.ino() == right.ino())
-}
-
 #[cfg(windows)]
 fn same_executable(left: &Path, right: &Path) -> Result<bool> {
     Ok(left.to_string_lossy().eq_ignore_ascii_case(&right.to_string_lossy()))
 }
 
-#[cfg(not(any(unix, windows)))]
+#[cfg(not(windows))]
 fn same_executable(left: &Path, right: &Path) -> Result<bool> {
     Ok(left == right)
 }
@@ -283,7 +274,7 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn executable_identity_accepts_hard_linked_active_path() {
+    fn executable_identity_rejects_hard_linked_external_path() {
         let temp = tempfile::tempdir().unwrap();
         let current = std::env::current_exe().unwrap();
         let active_root = temp.path().join("app");
@@ -292,7 +283,7 @@ mod tests {
         std::fs::hard_link(&current, &active).unwrap();
 
         let resolved = resolve_active_executable(&active_root, "active-app").unwrap();
-        assert!(same_executable(&current, &resolved).unwrap());
+        assert!(!same_executable(&current, &resolved).unwrap());
     }
 
     #[cfg(unix)]

--- a/crates/surge-core/src/update/manager/external_finalize/schedule.rs
+++ b/crates/surge-core/src/update/manager/external_finalize/schedule.rs
@@ -1,0 +1,252 @@
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use tracing::info;
+
+use crate::error::{Result, SurgeError};
+use crate::platform::fs::{atomic_rename, make_executable, write_file_atomic};
+use crate::platform::process::{spawn_detached, supervisor_binary_name};
+use crate::update::status::UpdateStatusRecord;
+
+use super::super::progress::ProgressInfo;
+use super::super::progress_substep::{PhaseProgressEmitter, labels as update_phase};
+use super::super::{UpdateInfo, UpdateManager, apply};
+use super::plan::{ExternalFinalizePlan, write_plan};
+
+const EXTERNAL_TOOLS_DIR: &str = ".surge-tools";
+const HELPER_READY_TIMEOUT: Duration = Duration::from_secs(10);
+const HANDSHAKE_POLL_INTERVAL: Duration = Duration::from_millis(50);
+
+struct SelfHostedUpdater {
+    executable: PathBuf,
+    active_app_dir: PathBuf,
+}
+
+pub(in crate::update::manager) async fn schedule_if_required<F>(
+    manager: &UpdateManager,
+    info: &UpdateInfo,
+    extracted_final_dir: &Path,
+    in_progress_template: &UpdateStatusRecord,
+    previous_attempt_status: Option<UpdateStatusRecord>,
+    progress_emitter: &PhaseProgressEmitter<'_, F>,
+) -> Result<bool>
+where
+    F: Fn(ProgressInfo) + Send + Sync,
+{
+    if manager.allow_in_process_swap {
+        return Ok(false);
+    }
+
+    let Some(updater) = self_hosted_updater(manager)? else {
+        return Ok(false);
+    };
+    let latest = info
+        .apply_releases
+        .last()
+        .ok_or_else(|| SurgeError::Update("No latest release".to_string()))?;
+    if latest.supervisor_id.trim().is_empty() {
+        return Err(SurgeError::Update(
+            "A self-hosted update requires a supervised target release so finalization can run outside the active application"
+                .to_string(),
+        ));
+    }
+
+    let plan = ExternalFinalizePlan::from_manager(
+        manager,
+        latest,
+        updater.executable,
+        updater.active_app_dir.clone(),
+        in_progress_template,
+        previous_attempt_status,
+    )?;
+    if extracted_final_dir != plan.extracted_final_dir() {
+        return Err(SurgeError::Update(format!(
+            "External finalizer expected materialized payload at '{}', found '{}'",
+            plan.extracted_final_dir().display(),
+            extracted_final_dir.display()
+        )));
+    }
+
+    progress_emitter.emit_substep(6, update_phase::STARTING_EXTERNAL_FINALIZER, 90);
+    std::fs::create_dir_all(plan.operation_dir())?;
+
+    let current_helper = updater.active_app_dir.join(supervisor_binary_name());
+    let helper_path = install_stable_helper(&plan, &current_helper)?;
+    write_plan(&plan)?;
+
+    let plan_arg = plan.plan_path().to_string_lossy().into_owned();
+    let args = ["finalize-update", "--plan", plan_arg.as_str()];
+    let environment = BTreeMap::new();
+    let mut helper = match spawn_detached(&helper_path, &args, Some(&manager.install_dir), &environment) {
+        Ok(helper) => helper,
+        Err(error) => {
+            let _ = std::fs::remove_dir_all(plan.operation_dir());
+            return Err(error);
+        }
+    };
+
+    if let Err(error) = wait_for_helper_ready(&plan, &mut helper).await {
+        let _ = helper.kill();
+        let _ = helper.wait();
+        let _ = std::fs::remove_dir_all(plan.operation_dir());
+        return Err(error);
+    }
+
+    if let Err(error) = write_handshake_marker(&plan.armed_path(), &plan.operation_id) {
+        let _ = helper.kill();
+        let _ = helper.wait();
+        let _ = std::fs::remove_dir_all(plan.operation_dir());
+        return Err(error);
+    }
+
+    progress_emitter.emit_substep(6, update_phase::WAITING_FOR_UPDATER_EXIT, 91);
+    info!(
+        target_version = %plan.latest.version,
+        helper = %helper_path.display(),
+        "Transferred update finalization to stable helper"
+    );
+    Ok(true)
+}
+
+fn self_hosted_updater(manager: &UpdateManager) -> Result<Option<SelfHostedUpdater>> {
+    let Some(identity) = manager.current_release_identity.as_ref() else {
+        return Ok(None);
+    };
+    let Some(current_app_dir) = apply::find_previous_app_dir(&manager.install_dir, &manager.current_version) else {
+        return Ok(None);
+    };
+    let active_exe = std::fs::canonicalize(current_app_dir.join(&identity.main_exe)).map_err(|error| {
+        SurgeError::Platform(format!(
+            "Failed to resolve the active application executable before external finalization: {error}"
+        ))
+    })?;
+    let updater_exe = std::fs::canonicalize(std::env::current_exe()?).map_err(|error| {
+        SurgeError::Platform(format!(
+            "Failed to resolve the updating process executable before external finalization: {error}"
+        ))
+    })?;
+
+    if same_executable(&active_exe, &updater_exe)? {
+        Ok(Some(SelfHostedUpdater {
+            executable: updater_exe,
+            active_app_dir: current_app_dir,
+        }))
+    } else {
+        Ok(None)
+    }
+}
+
+#[cfg(unix)]
+fn same_executable(left: &Path, right: &Path) -> Result<bool> {
+    use std::os::unix::fs::MetadataExt;
+
+    let left = std::fs::metadata(left)?;
+    let right = std::fs::metadata(right)?;
+    Ok(left.dev() == right.dev() && left.ino() == right.ino())
+}
+
+#[cfg(windows)]
+fn same_executable(left: &Path, right: &Path) -> Result<bool> {
+    Ok(left.to_string_lossy().eq_ignore_ascii_case(&right.to_string_lossy()))
+}
+
+#[cfg(not(any(unix, windows)))]
+fn same_executable(left: &Path, right: &Path) -> Result<bool> {
+    Ok(left == right)
+}
+
+fn install_stable_helper(plan: &ExternalFinalizePlan, current_helper: &Path) -> Result<PathBuf> {
+    if !current_helper.is_file() {
+        return Err(SurgeError::Update(format!(
+            "Current release does not contain the external finalizer helper at '{}'",
+            current_helper.display()
+        )));
+    }
+
+    let tools_dir = plan.install_dir.join(EXTERNAL_TOOLS_DIR);
+    std::fs::create_dir_all(&tools_dir)?;
+    let helper_path = tools_dir.join(supervisor_binary_name());
+    let temporary_path = tools_dir.join(format!(".{}-{}.next", supervisor_binary_name(), plan.operation_id));
+    if temporary_path.exists() {
+        std::fs::remove_file(&temporary_path)?;
+    }
+    let copied = std::fs::copy(current_helper, &temporary_path)?;
+    let expected = std::fs::metadata(current_helper)?.len();
+    if copied != expected {
+        let _ = std::fs::remove_file(&temporary_path);
+        return Err(SurgeError::Io(std::io::Error::new(
+            std::io::ErrorKind::WriteZero,
+            format!("Copied {copied} of {expected} helper bytes"),
+        )));
+    }
+    make_executable(&temporary_path)?;
+    if helper_path.exists() {
+        std::fs::remove_file(&helper_path)?;
+    }
+    atomic_rename(&temporary_path, &helper_path)?;
+    Ok(helper_path)
+}
+
+async fn wait_for_helper_ready(
+    plan: &ExternalFinalizePlan,
+    helper: &mut crate::platform::process::ProcessHandle,
+) -> Result<()> {
+    let deadline = tokio::time::Instant::now() + HELPER_READY_TIMEOUT;
+    loop {
+        if marker_matches(&plan.ready_path(), &plan.operation_id)? {
+            return Ok(());
+        }
+        if !helper.poll_running() {
+            let result = helper.wait()?;
+            return Err(SurgeError::Update(format!(
+                "External finalizer helper exited before becoming ready with code {}",
+                result.exit_code
+            )));
+        }
+        if tokio::time::Instant::now() >= deadline {
+            return Err(SurgeError::Update(format!(
+                "Timed out after {}s waiting for the external finalizer helper to become ready",
+                HELPER_READY_TIMEOUT.as_secs()
+            )));
+        }
+        tokio::time::sleep(HANDSHAKE_POLL_INTERVAL).await;
+    }
+}
+
+pub(super) fn write_handshake_marker(path: &Path, operation_id: &str) -> Result<()> {
+    write_file_atomic(path, operation_id.as_bytes())
+}
+
+pub(super) fn marker_matches(path: &Path, operation_id: &str) -> Result<bool> {
+    if !path.is_file() {
+        return Ok(false);
+    }
+    Ok(std::fs::read(path)? == operation_id.as_bytes())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(unix)]
+    #[test]
+    fn executable_identity_accepts_hard_linked_active_path() {
+        let temp = tempfile::tempdir().unwrap();
+        let current = std::env::current_exe().unwrap();
+        let active = temp.path().join("active-app");
+        std::fs::hard_link(&current, &active).unwrap();
+
+        assert!(same_executable(&current, &active).unwrap());
+    }
+
+    #[test]
+    fn handshake_marker_requires_matching_operation() {
+        let temp = tempfile::tempdir().unwrap();
+        let marker = temp.path().join("ready");
+        write_handshake_marker(&marker, "operation-a").unwrap();
+
+        assert!(marker_matches(&marker, "operation-a").unwrap());
+        assert!(!marker_matches(&marker, "operation-b").unwrap());
+    }
+}

--- a/crates/surge-core/src/update/manager/external_finalize/schedule.rs
+++ b/crates/surge-core/src/update/manager/external_finalize/schedule.rs
@@ -151,11 +151,7 @@ fn self_hosted_updater(manager: &UpdateManager) -> Result<Option<SelfHostedUpdat
     let Some(current_app_dir) = apply::find_previous_app_dir(&manager.install_dir, &manager.current_version) else {
         return Ok(None);
     };
-    let active_exe = std::fs::canonicalize(current_app_dir.join(&identity.main_exe)).map_err(|error| {
-        SurgeError::Platform(format!(
-            "Failed to resolve the active application executable before external finalization: {error}"
-        ))
-    })?;
+    let active_exe = resolve_active_executable(&current_app_dir, &identity.main_exe)?;
     let updater_exe = std::fs::canonicalize(std::env::current_exe()?).map_err(|error| {
         SurgeError::Platform(format!(
             "Failed to resolve the updating process executable before external finalization: {error}"
@@ -170,6 +166,27 @@ fn self_hosted_updater(manager: &UpdateManager) -> Result<Option<SelfHostedUpdat
     } else {
         Ok(None)
     }
+}
+
+fn resolve_active_executable(active_app_dir: &Path, main_exe: &str) -> Result<PathBuf> {
+    let active_app_root = std::fs::canonicalize(active_app_dir).map_err(|error| {
+        SurgeError::Platform(format!(
+            "Failed to resolve the active application directory before external finalization: {error}"
+        ))
+    })?;
+    let unresolved_executable = active_app_root.join(main_exe);
+    let active_exe = std::fs::canonicalize(&unresolved_executable).map_err(|error| {
+        SurgeError::Platform(format!(
+            "Failed to resolve the active application executable before external finalization: {error}"
+        ))
+    })?;
+    if !active_exe.starts_with(&active_app_root) {
+        return Err(SurgeError::Platform(format!(
+            "Active application executable '{}' resolves outside the active application directory; refusing to signal a shared executable",
+            unresolved_executable.display()
+        )));
+    }
+    Ok(active_exe)
 }
 
 #[cfg(unix)]
@@ -269,10 +286,27 @@ mod tests {
     fn executable_identity_accepts_hard_linked_active_path() {
         let temp = tempfile::tempdir().unwrap();
         let current = std::env::current_exe().unwrap();
-        let active = temp.path().join("active-app");
+        let active_root = temp.path().join("app");
+        std::fs::create_dir(&active_root).unwrap();
+        let active = active_root.join("active-app");
         std::fs::hard_link(&current, &active).unwrap();
 
-        assert!(same_executable(&current, &active).unwrap());
+        let resolved = resolve_active_executable(&active_root, "active-app").unwrap();
+        assert!(same_executable(&current, &resolved).unwrap());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn active_executable_symlink_cannot_escape_application_directory() {
+        let temp = tempfile::tempdir().unwrap();
+        let active_root = temp.path().join("app");
+        std::fs::create_dir(&active_root).unwrap();
+        let shared_executable = temp.path().join("shared-app");
+        std::fs::write(&shared_executable, "shared").unwrap();
+        std::os::unix::fs::symlink(&shared_executable, active_root.join("demo")).unwrap();
+
+        let error = resolve_active_executable(&active_root, "demo").unwrap_err();
+        assert!(error.to_string().contains("resolves outside"));
     }
 
     #[test]

--- a/crates/surge-core/src/update/manager/finalize.rs
+++ b/crates/surge-core/src/update/manager/finalize.rs
@@ -348,7 +348,9 @@ where
                 "Terminated stale app processes from superseded install directories"
             );
         }
-        Err(e) => return Err(e),
+        Err(e) => {
+            warn!(error = %e, "Failed to terminate stale app processes after update");
+        }
     }
 
     emit_progress(

--- a/crates/surge-core/src/update/manager/finalize.rs
+++ b/crates/surge-core/src/update/manager/finalize.rs
@@ -348,9 +348,7 @@ where
                 "Terminated stale app processes from superseded install directories"
             );
         }
-        Err(e) => {
-            warn!(error = %e, "Failed to terminate stale app processes after update");
-        }
+        Err(e) => return Err(e),
     }
 
     emit_progress(

--- a/crates/surge-core/src/update/manager/lifecycle.rs
+++ b/crates/surge-core/src/update/manager/lifecycle.rs
@@ -37,6 +37,9 @@ pub(super) enum SupervisorRestartOutcome {
         reason: String,
         failure_phase: &'static str,
     },
+    /// The payload is fully materialized and a stable helper owns the remaining
+    /// quiesce, swap, and restart work. The helper writes the terminal status.
+    ExternalFinalizeScheduled,
 }
 
 pub(super) async fn request_supervisor_shutdown(install_dir: &Path, supervisor_id: &str) -> Result<()> {
@@ -405,6 +408,9 @@ mod tests {
                 assert_eq!(failure_phase, RESTART_HANDOFF_FAILED_PHASE);
             }
             SupervisorRestartOutcome::NotApplicable => panic!("expected PendingRestart failure, got NotApplicable"),
+            SupervisorRestartOutcome::ExternalFinalizeScheduled => {
+                panic!("expected PendingRestart failure, got ExternalFinalizeScheduled")
+            }
         }
 
         let deadline = std::time::Instant::now() + Duration::from_secs(2);

--- a/crates/surge-core/src/update/manager/lifecycle.rs
+++ b/crates/surge-core/src/update/manager/lifecycle.rs
@@ -4,7 +4,9 @@ use std::time::Duration;
 use tracing::{debug, info, warn};
 
 use crate::error::{Result, SurgeError};
-use crate::platform::process::{ProcessHandle, current_pid, spawn_detached, spawn_process, supervisor_binary_name};
+use crate::platform::process::{
+    ProcessHandle, current_pid, process_start_time, spawn_detached, spawn_process, supervisor_binary_name,
+};
 use crate::releases::manifest::ReleaseEntry;
 use crate::supervisor::state::{
     read_restart_args, supervisor_pid_file, supervisor_stop_file, write_supervisor_exe_path,
@@ -195,6 +197,18 @@ fn restart_supervisor_after_update_with_config(
         return SupervisorRestartOutcome::NotApplicable;
     }
 
+    let Some(watched_pid_start_time) = process_start_time(watched_pid) else {
+        let reason = format!("could not capture start-time identity for watched process {watched_pid}");
+        warn!(
+            watched_pid,
+            "Cannot restart supervisor without a stable watched-process identity"
+        );
+        return SupervisorRestartOutcome::PendingRestart {
+            reason,
+            failure_phase: RESTART_HANDOFF_FAILED_PHASE,
+        };
+    };
+
     let supervisor_path = active_app_dir.join(supervisor_binary_name());
     if !supervisor_path.is_file() {
         warn!(
@@ -243,7 +257,14 @@ fn restart_supervisor_after_update_with_config(
         }
     };
 
-    let args = supervisor_watch_args(supervisor_id, install_dir, watched_pid, &latest.version, &restart_args);
+    let args = supervisor_watch_args(
+        supervisor_id,
+        install_dir,
+        watched_pid,
+        watched_pid_start_time,
+        &latest.version,
+        &restart_args,
+    );
     let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
 
     let mut last_failure: Option<(String, &'static str)> = None;
@@ -303,6 +324,7 @@ fn supervisor_watch_args(
     supervisor_id: &str,
     install_dir: &Path,
     watched_pid: u32,
+    watched_pid_start_time: u64,
     handoff_version: &str,
     restart_args: &[String],
 ) -> Vec<String> {
@@ -314,6 +336,8 @@ fn supervisor_watch_args(
         install_dir.to_string_lossy().into_owned(),
         "--pid".to_string(),
         watched_pid.to_string(),
+        "--pid-start-time".to_string(),
+        watched_pid_start_time.to_string(),
         "--handoff-version".to_string(),
         handoff_version.to_string(),
     ];
@@ -334,7 +358,14 @@ mod tests {
     fn supervisor_watch_args_include_handoff_version_before_child_args() {
         let restart_args = vec!["--app-mode".to_string(), "service".to_string()];
 
-        let args = supervisor_watch_args("demo-supervisor", Path::new("/opt/demo"), 42, "2.0.0", &restart_args);
+        let args = supervisor_watch_args(
+            "demo-supervisor",
+            Path::new("/opt/demo"),
+            42,
+            1_234,
+            "2.0.0",
+            &restart_args,
+        );
 
         assert_eq!(
             args,
@@ -346,6 +377,8 @@ mod tests {
                 "/opt/demo",
                 "--pid",
                 "42",
+                "--pid-start-time",
+                "1234",
                 "--handoff-version",
                 "2.0.0",
                 "--",

--- a/crates/surge-core/src/update/manager/progress_substep.rs
+++ b/crates/surge-core/src/update/manager/progress_substep.rs
@@ -33,6 +33,8 @@ pub(crate) mod labels {
     pub const WRITING_REBUILT_PACKAGE: &str = "writing rebuilt package";
     pub const EXTRACTING_REBUILT_PACKAGE: &str = "extracting rebuilt package";
     pub const PACKAGE_APPLY_COMPLETED: &str = "package apply completed";
+    pub const STARTING_EXTERNAL_FINALIZER: &str = "starting external finalizer";
+    pub const WAITING_FOR_UPDATER_EXIT: &str = "waiting for updating application to exit";
     pub const STOPPING_SUPERVISOR: &str = "stopping supervisor";
     pub const QUIESCING_ACTIVE_APP: &str = "quiescing active app before swap";
     pub const PREPARING_SWAP: &str = "preparing app swap";

--- a/crates/surge-core/src/update/status/worker.rs
+++ b/crates/surge-core/src/update/status/worker.rs
@@ -29,9 +29,7 @@ use uuid::Uuid;
 
 use crate::error::{Result, SurgeError};
 use crate::platform::fs::write_file_atomic;
-use crate::platform::process::{
-    PidLiveness, current_pid, probe_pid_liveness, probe_process_identity, process_start_time,
-};
+use crate::platform::process::{PidLiveness, current_pid, probe_process_identity, process_start_time};
 
 use super::{
     FailureContext, UpdateConvergenceState, UpdateStatusRecord, next_retry_timestamp, now_utc_rfc3339,
@@ -48,6 +46,7 @@ const UPDATE_WORKER_LOCK_FILE_NAME: &str = ".surge-update-worker.lock";
 /// window used without a marker, because a live substep may be quiet for a
 /// while without being hung.
 const STALLED_LIVE_WORKER_PROGRESS_DEADLINE: Duration = Duration::from_mins(30);
+const LEGACY_WORKER_MARKER_GRACE: Duration = Duration::from_mins(5);
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 struct UpdateWorkerRecord {
@@ -72,7 +71,7 @@ impl UpdateWorkerGuard {
         let lock_path = update_worker_lock_path(install_dir);
         let _lock = acquire_worker_lock(&lock_path)?;
         if let Some(existing) = read_update_worker(install_dir)?
-            && !matches!(probe_worker_liveness(&existing), PidLiveness::Dead)
+            && worker_blocks_new_attempt(install_dir, &existing)?
         {
             return Err(SurgeError::Update(format!(
                 "Another update worker (pid {}) already owns this installation",
@@ -161,10 +160,30 @@ fn acquire_worker_lock(path: &Path) -> Result<File> {
 }
 
 fn probe_worker_liveness(worker: &UpdateWorkerRecord) -> PidLiveness {
-    worker.process_start_time.map_or_else(
-        || probe_pid_liveness(worker.pid),
-        |start_time| probe_process_identity(worker.pid, start_time),
-    )
+    worker.process_start_time.map_or(PidLiveness::Unknown, |start_time| {
+        probe_process_identity(worker.pid, start_time)
+    })
+}
+
+fn worker_blocks_new_attempt(install_dir: &Path, worker: &UpdateWorkerRecord) -> Result<bool> {
+    if worker.process_start_time.is_some() {
+        return Ok(!matches!(probe_worker_liveness(worker), PidLiveness::Dead));
+    }
+
+    if let Some(status) = read_update_status(install_dir)?
+        && status.app_id == worker.app_id
+        && status.target_version == worker.target_version
+    {
+        return Ok(status.state == UpdateConvergenceState::InProgress);
+    }
+
+    let started_at = chrono::DateTime::parse_from_rfc3339(&worker.started_at_utc)
+        .ok()
+        .map(|timestamp| timestamp.with_timezone(&chrono::Utc));
+    Ok(started_at.is_some_and(|started_at| {
+        let age = chrono::Utc::now().signed_duration_since(started_at);
+        chrono::Duration::from_std(LEGACY_WORKER_MARKER_GRACE).is_ok_and(|grace| age < grace)
+    }))
 }
 
 pub fn fail_abandoned_in_progress_update(
@@ -488,7 +507,8 @@ mod tests {
             "2026-05-15T20:09:45Z".to_string(),
         );
         write_update_status(dir.path(), &record).unwrap();
-        write_worker_file(dir.path(), dead_helper_pid(), "demo-app", "9999.0.0");
+        let (pid, start_time) = dead_helper_identity();
+        write_worker_file_with_start_time(dir.path(), pid, "demo-app", "9999.0.0", Some(start_time));
 
         let failed = fail_abandoned_in_progress_update_at(
             dir.path(),
@@ -638,28 +658,39 @@ mod tests {
     }
 
     fn write_worker_file(dir: &Path, pid: u32, app_id: &str, target_version: &str) {
+        write_worker_file_with_start_time(dir, pid, app_id, target_version, process_start_time(pid));
+    }
+
+    fn write_worker_file_with_start_time(
+        dir: &Path,
+        pid: u32,
+        app_id: &str,
+        target_version: &str,
+        process_start_time: Option<u64>,
+    ) {
         let record = UpdateWorkerRecord {
             pid,
             app_id: app_id.to_string(),
             target_version: target_version.to_string(),
             started_at_utc: now_utc_rfc3339(),
-            process_start_time: process_start_time(pid),
+            process_start_time,
             owner_id: String::new(),
         };
         let json = serde_json::to_vec_pretty(&record).unwrap();
         write_file_atomic(&update_worker_path(dir), &json).unwrap();
     }
 
-    fn dead_helper_pid() -> u32 {
-        let mut child = spawn_helper(false);
+    fn dead_helper_identity() -> (u32, u64) {
+        let (pid, mut child) = live_helper_pid();
+        let start_time = process_start_time(pid).expect("live helper start time");
+        let _ = child.kill();
         let _ = child.wait();
-        let pid = child.id();
         let deadline = Instant::now() + Duration::from_secs(5);
         while is_pid_alive(pid) && Instant::now() < deadline {
             std::thread::sleep(Duration::from_millis(50));
         }
         assert!(!is_pid_alive(pid), "helper pid {pid} should be dead before the test");
-        pid
+        (pid, start_time)
     }
 
     fn live_helper_pid() -> (u32, std::process::Child) {
@@ -773,6 +804,56 @@ mod tests {
         assert_eq!(current.pid, pid);
         assert_eq!(current.process_start_time, Some(current_start_time));
         drop(guard);
+    }
+
+    #[test]
+    fn stale_identityless_worker_marker_is_retired_after_status_becomes_terminal() {
+        let dir = tempfile::tempdir().unwrap();
+        let record = UpdateStatusRecord::in_progress(
+            "demo-app",
+            "9998.0.0",
+            "9999.0.0",
+            "stable",
+            "2026-05-15T20:00:00Z".to_string(),
+        )
+        .with_current_phase_at("package apply started", "2026-05-15T20:01:00Z".to_string());
+        write_update_status(dir.path(), &record).unwrap();
+        let (pid, mut child) = live_helper_pid();
+        let legacy = UpdateWorkerRecord {
+            pid,
+            app_id: "demo-app".to_string(),
+            target_version: "9999.0.0".to_string(),
+            started_at_utc: "2026-05-15T20:00:00Z".to_string(),
+            process_start_time: None,
+            owner_id: String::new(),
+        };
+        write_file_atomic(
+            &update_worker_path(dir.path()),
+            &serde_json::to_vec_pretty(&legacy).unwrap(),
+        )
+        .unwrap();
+
+        let now = chrono::DateTime::parse_from_rfc3339("2026-05-15T20:10:00Z")
+            .unwrap()
+            .with_timezone(&chrono::Utc);
+        let failed = fail_abandoned_in_progress_update_at(
+            dir.path(),
+            "demo-app",
+            "9999.0.0",
+            "stable",
+            Duration::from_mins(1),
+            now,
+        )
+        .unwrap()
+        .expect("identity-less worker status should become retry-safe after stalling");
+        assert_eq!(failed.state, UpdateConvergenceState::Failed);
+
+        let guard = UpdateWorkerGuard::record(dir.path(), "demo-app", "9999.0.0").unwrap();
+        let replacement = read_update_worker(dir.path()).unwrap().unwrap();
+        assert!(replacement.process_start_time.is_some());
+        drop(guard);
+        let _ = child.kill();
+        let _ = child.wait();
     }
 
     #[test]

--- a/crates/surge-core/src/update/status/worker.rs
+++ b/crates/surge-core/src/update/status/worker.rs
@@ -29,7 +29,9 @@ use uuid::Uuid;
 
 use crate::error::{Result, SurgeError};
 use crate::platform::fs::write_file_atomic;
-use crate::platform::process::{PidLiveness, probe_pid_liveness};
+use crate::platform::process::{
+    PidLiveness, current_pid, probe_pid_liveness, probe_process_identity, process_start_time,
+};
 
 use super::{
     FailureContext, UpdateConvergenceState, UpdateStatusRecord, next_retry_timestamp, now_utc_rfc3339,
@@ -54,6 +56,8 @@ struct UpdateWorkerRecord {
     target_version: String,
     started_at_utc: String,
     #[serde(default)]
+    process_start_time: Option<u64>,
+    #[serde(default)]
     owner_id: String,
 }
 
@@ -68,7 +72,7 @@ impl UpdateWorkerGuard {
         let lock_path = update_worker_lock_path(install_dir);
         let _lock = acquire_worker_lock(&lock_path)?;
         if let Some(existing) = read_update_worker(install_dir)?
-            && !matches!(probe_pid_liveness(existing.pid), PidLiveness::Dead)
+            && !matches!(probe_worker_liveness(&existing), PidLiveness::Dead)
         {
             return Err(SurgeError::Update(format!(
                 "Another update worker (pid {}) already owns this installation",
@@ -84,7 +88,11 @@ impl UpdateWorkerGuard {
         let existing = read_update_worker(install_dir)?.ok_or_else(|| {
             SurgeError::Update("The external finalizer could not find the updating worker to take over".to_string())
         })?;
-        if existing.pid != expected_pid || existing.app_id != app_id || existing.target_version != target_version {
+        if existing.pid != expected_pid
+            || existing.app_id != app_id
+            || existing.target_version != target_version
+            || !matches!(probe_worker_liveness(&existing), PidLiveness::Alive)
+        {
             return Err(SurgeError::Update(
                 "Update worker ownership changed before the external finalizer took over".to_string(),
             ));
@@ -116,11 +124,18 @@ fn write_owned_worker(
     app_id: &str,
     target_version: &str,
 ) -> Result<UpdateWorkerGuard> {
+    let pid = current_pid();
+    let process_start_time = process_start_time(pid).ok_or_else(|| {
+        SurgeError::Platform(format!(
+            "Could not read start-time identity for update worker process {pid}"
+        ))
+    })?;
     let record = UpdateWorkerRecord {
-        pid: std::process::id(),
+        pid,
         app_id: app_id.to_string(),
         target_version: target_version.to_string(),
         started_at_utc: now_utc_rfc3339(),
+        process_start_time: Some(process_start_time),
         owner_id: Uuid::new_v4().to_string(),
     };
     let path = update_worker_path(install_dir);
@@ -143,6 +158,13 @@ fn acquire_worker_lock(path: &Path) -> Result<File> {
         .open(path)?;
     FileExt::lock_exclusive(&file)?;
     Ok(file)
+}
+
+fn probe_worker_liveness(worker: &UpdateWorkerRecord) -> PidLiveness {
+    worker.process_start_time.map_or_else(
+        || probe_pid_liveness(worker.pid),
+        |start_time| probe_process_identity(worker.pid, start_time),
+    )
 }
 
 pub fn fail_abandoned_in_progress_update(
@@ -207,13 +229,14 @@ fn fail_abandoned_in_progress_update_at(
         return Ok(Some(failed));
     };
 
-    if worker.pid == std::process::id() {
+    let worker_liveness = probe_worker_liveness(&worker);
+    if worker.pid == current_pid() && matches!(worker_liveness, PidLiveness::Alive) {
         // Do not reclassify work owned by this process as abandoned. The
         // exclusive acquisition that follows rejects an overlapping apply.
         return Ok(None);
     }
 
-    match probe_pid_liveness(worker.pid) {
+    match worker_liveness {
         PidLiveness::Dead => {
             // Dead foreign worker: the attempt can never make progress again,
             // so fail it immediately instead of waiting out the staleness
@@ -620,6 +643,7 @@ mod tests {
             app_id: app_id.to_string(),
             target_version: target_version.to_string(),
             started_at_utc: now_utc_rfc3339(),
+            process_start_time: process_start_time(pid),
             owner_id: String::new(),
         };
         let json = serde_json::to_vec_pretty(&record).unwrap();
@@ -722,6 +746,33 @@ mod tests {
         assert!(error.to_string().contains("already owns"));
         drop(first);
         assert!(UpdateWorkerGuard::record(dir.path(), "demo-app", "9999.0.0").is_ok());
+    }
+
+    #[test]
+    fn reused_worker_pid_does_not_exclude_a_new_attempt() {
+        let dir = tempfile::tempdir().unwrap();
+        let pid = current_pid();
+        let current_start_time = process_start_time(pid).unwrap();
+        let stale = UpdateWorkerRecord {
+            pid,
+            app_id: "demo-app".to_string(),
+            target_version: "9999.0.0".to_string(),
+            started_at_utc: now_utc_rfc3339(),
+            process_start_time: Some(current_start_time ^ 1),
+            owner_id: "stale-owner".to_string(),
+        };
+        write_file_atomic(
+            &update_worker_path(dir.path()),
+            &serde_json::to_vec_pretty(&stale).unwrap(),
+        )
+        .unwrap();
+
+        let guard = UpdateWorkerGuard::record(dir.path(), "demo-app", "9999.0.0").unwrap();
+        let current = read_update_worker(dir.path()).unwrap().unwrap();
+
+        assert_eq!(current.pid, pid);
+        assert_eq!(current.process_start_time, Some(current_start_time));
+        drop(guard);
     }
 
     #[test]

--- a/crates/surge-core/src/update/status/worker.rs
+++ b/crates/surge-core/src/update/status/worker.rs
@@ -3,7 +3,8 @@
 //! A live update attempt records its worker (pid, app, target version) next
 //! to the status file. When a later attempt finds an `InProgress` record it
 //! classifies that attempt against the worker marker:
-//! - worker pid is this process → the attempt is (re)started by us; proceed.
+//! - worker pid is this process → leave the attempt in progress; exclusive
+//!   acquisition still rejects an overlapping apply in that process.
 //! - worker pid is another *live* process with recent progress → a
 //!   concurrent updater is active; never reclassify it.
 //! - worker pid is another *live* process whose progress has been silent
@@ -18,10 +19,13 @@
 //!   progress-staleness window; never fail an attempt on an inconclusive
 //!   probe.
 
+use std::fs::{File, OpenOptions};
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
+use fs2::FileExt;
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 
 use crate::error::{Result, SurgeError};
 use crate::platform::fs::write_file_atomic;
@@ -33,6 +37,7 @@ use super::{
 };
 
 const UPDATE_WORKER_FILE_NAME: &str = ".surge-update-worker.json";
+const UPDATE_WORKER_LOCK_FILE_NAME: &str = ".surge-update-worker.lock";
 
 /// A live worker whose progress has been silent this long is presumed hung
 /// (deadlocked or stalled on a frozen connection): active update work emits
@@ -48,48 +53,96 @@ struct UpdateWorkerRecord {
     app_id: String,
     target_version: String,
     started_at_utc: String,
+    #[serde(default)]
+    owner_id: String,
 }
 
 pub struct UpdateWorkerGuard {
     path: PathBuf,
-    pid: u32,
-    app_id: String,
-    target_version: String,
+    lock_path: PathBuf,
+    owner_id: String,
 }
 
 impl UpdateWorkerGuard {
     pub fn record(install_dir: &Path, app_id: &str, target_version: &str) -> Result<Self> {
-        let record = UpdateWorkerRecord {
-            pid: std::process::id(),
-            app_id: app_id.to_string(),
-            target_version: target_version.to_string(),
-            started_at_utc: now_utc_rfc3339(),
-        };
-        let path = update_worker_path(install_dir);
-        let json = serde_json::to_vec_pretty(&record)
-            .map_err(|e| SurgeError::Config(format!("Failed to encode update worker marker: {e}")))?;
-        write_file_atomic(&path, &json)?;
-        Ok(Self {
-            path,
-            pid: record.pid,
-            app_id: record.app_id,
-            target_version: record.target_version,
-        })
+        let lock_path = update_worker_lock_path(install_dir);
+        let _lock = acquire_worker_lock(&lock_path)?;
+        if let Some(existing) = read_update_worker(install_dir)?
+            && !matches!(probe_pid_liveness(existing.pid), PidLiveness::Dead)
+        {
+            return Err(SurgeError::Update(format!(
+                "Another update worker (pid {}) already owns this installation",
+                existing.pid
+            )));
+        }
+        write_owned_worker(install_dir, &lock_path, app_id, target_version)
+    }
+
+    pub(crate) fn take_over(install_dir: &Path, app_id: &str, target_version: &str, expected_pid: u32) -> Result<Self> {
+        let lock_path = update_worker_lock_path(install_dir);
+        let _lock = acquire_worker_lock(&lock_path)?;
+        let existing = read_update_worker(install_dir)?.ok_or_else(|| {
+            SurgeError::Update("The external finalizer could not find the updating worker to take over".to_string())
+        })?;
+        if existing.pid != expected_pid || existing.app_id != app_id || existing.target_version != target_version {
+            return Err(SurgeError::Update(
+                "Update worker ownership changed before the external finalizer took over".to_string(),
+            ));
+        }
+        write_owned_worker(install_dir, &lock_path, app_id, target_version)
     }
 }
 
 impl Drop for UpdateWorkerGuard {
     fn drop(&mut self) {
+        let Ok(_lock) = acquire_worker_lock(&self.lock_path) else {
+            return;
+        };
         let Ok(raw) = std::fs::read(&self.path) else {
             return;
         };
         let Ok(record) = serde_json::from_slice::<UpdateWorkerRecord>(&raw) else {
             return;
         };
-        if record.pid == self.pid && record.app_id == self.app_id && record.target_version == self.target_version {
+        if record.owner_id == self.owner_id {
             let _ = std::fs::remove_file(&self.path);
         }
     }
+}
+
+fn write_owned_worker(
+    install_dir: &Path,
+    lock_path: &Path,
+    app_id: &str,
+    target_version: &str,
+) -> Result<UpdateWorkerGuard> {
+    let record = UpdateWorkerRecord {
+        pid: std::process::id(),
+        app_id: app_id.to_string(),
+        target_version: target_version.to_string(),
+        started_at_utc: now_utc_rfc3339(),
+        owner_id: Uuid::new_v4().to_string(),
+    };
+    let path = update_worker_path(install_dir);
+    let json = serde_json::to_vec_pretty(&record)
+        .map_err(|e| SurgeError::Config(format!("Failed to encode update worker marker: {e}")))?;
+    write_file_atomic(&path, &json)?;
+    Ok(UpdateWorkerGuard {
+        path,
+        lock_path: lock_path.to_path_buf(),
+        owner_id: record.owner_id,
+    })
+}
+
+fn acquire_worker_lock(path: &Path) -> Result<File> {
+    let file = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(path)?;
+    FileExt::lock_exclusive(&file)?;
+    Ok(file)
 }
 
 pub fn fail_abandoned_in_progress_update(
@@ -155,9 +208,8 @@ fn fail_abandoned_in_progress_update_at(
     };
 
     if worker.pid == std::process::id() {
-        // The marker belongs to this process: a previous in-process attempt
-        // stalled. The caller proceeds with its own attempt, which takes over
-        // the record; there is nothing to reclassify.
+        // Do not reclassify work owned by this process as abandoned. The
+        // exclusive acquisition that follows rejects an overlapping apply.
         return Ok(None);
     }
 
@@ -293,6 +345,11 @@ fn read_update_worker(install_dir: &Path) -> Result<Option<UpdateWorkerRecord>> 
 #[must_use]
 fn update_worker_path(install_dir: &Path) -> PathBuf {
     install_dir.join(UPDATE_WORKER_FILE_NAME)
+}
+
+#[must_use]
+fn update_worker_lock_path(install_dir: &Path) -> PathBuf {
+    install_dir.join(UPDATE_WORKER_LOCK_FILE_NAME)
 }
 
 #[cfg(test)]
@@ -563,6 +620,7 @@ mod tests {
             app_id: app_id.to_string(),
             target_version: target_version.to_string(),
             started_at_utc: now_utc_rfc3339(),
+            owner_id: String::new(),
         };
         let json = serde_json::to_vec_pretty(&record).unwrap();
         write_file_atomic(&update_worker_path(dir), &json).unwrap();
@@ -645,10 +703,38 @@ mod tests {
 
         assert!(
             result.is_none(),
-            "the current process owns the marker; its new attempt takes over"
+            "work owned by the current process must not be reclassified as abandoned"
         );
         let persisted = read_update_status(dir.path()).unwrap().unwrap();
         assert_eq!(persisted.state, UpdateConvergenceState::InProgress);
         assert_eq!(persisted.current_phase.as_deref(), Some("package apply started"));
+    }
+
+    #[test]
+    fn live_worker_excludes_a_second_update_attempt() {
+        let dir = tempfile::tempdir().unwrap();
+        let first = UpdateWorkerGuard::record(dir.path(), "demo-app", "9999.0.0").unwrap();
+
+        let Err(error) = UpdateWorkerGuard::record(dir.path(), "demo-app", "9999.0.0") else {
+            panic!("a live worker must keep exclusive ownership");
+        };
+
+        assert!(error.to_string().contains("already owns"));
+        drop(first);
+        assert!(UpdateWorkerGuard::record(dir.path(), "demo-app", "9999.0.0").is_ok());
+    }
+
+    #[test]
+    fn external_helper_takeover_survives_parent_guard_drop() {
+        let dir = tempfile::tempdir().unwrap();
+        let parent = UpdateWorkerGuard::record(dir.path(), "demo-app", "9999.0.0").unwrap();
+        let helper = UpdateWorkerGuard::take_over(dir.path(), "demo-app", "9999.0.0", std::process::id()).unwrap();
+
+        drop(parent);
+
+        let persisted = read_update_worker(dir.path()).unwrap().unwrap();
+        assert_eq!(persisted.owner_id, helper.owner_id);
+        drop(helper);
+        assert!(read_update_worker(dir.path()).unwrap().is_none());
     }
 }

--- a/crates/surge-core/tests/unsafe_boundaries.rs
+++ b/crates/surge-core/tests/unsafe_boundaries.rs
@@ -33,6 +33,7 @@ fn unsafe_is_confined_to_boundary_modules() {
                 | "src/diff/wrapper.rs"
                 | "src/diff/mod.rs"
                 | "src/platform/process/descriptors.rs"
+                | "src/platform/process/identity.rs"
         );
 
         let content = fs::read_to_string(&file).expect("failed to read rust source file");

--- a/crates/surge-ffi/src/shared.rs
+++ b/crates/surge-ffi/src/shared.rs
@@ -14,6 +14,7 @@ use crate::handles::{SurgeContextHandle, SurgeErrorOwned};
 use crate::utils::lock_recover;
 
 pub(crate) const SURGE_OK: i32 = 0;
+pub(crate) const SURGE_UPDATE_SCHEDULED: i32 = 1;
 pub(crate) const SURGE_ERROR: i32 = -1;
 pub(crate) const SURGE_CANCELLED: i32 = -2;
 pub(crate) const SURGE_NOT_FOUND: i32 = -3;

--- a/crates/surge-ffi/src/update.rs
+++ b/crates/surge-ffi/src/update.rs
@@ -4,12 +4,12 @@ use std::time::Duration;
 
 use surge_core::config::manifest::{InstallArtifactCachePolicy, InstallArtifactCacheRetention};
 use surge_core::error::SurgeError;
-use surge_core::update::manager::{ProgressInfo, UpdateManager};
+use surge_core::update::manager::{ProgressInfo, UpdateApplyOutcome, UpdateManager};
 
 use crate::handles::{ReleaseEntryFfi, SurgeReleasesInfoHandle, SurgeUpdateManagerHandle};
 use crate::shared::{
-    ProgressBridge, SURGE_CANCELLED, SURGE_ERROR, SURGE_NOT_FOUND, SURGE_OK, SurgeProgressCallback, catch_ffi,
-    clear_shared_error, cstr_to_string, ffi_trace, set_ctx_error, set_shared_error,
+    ProgressBridge, SURGE_CANCELLED, SURGE_ERROR, SURGE_NOT_FOUND, SURGE_OK, SURGE_UPDATE_SCHEDULED,
+    SurgeProgressCallback, catch_ffi, clear_shared_error, cstr_to_string, ffi_trace, set_ctx_error, set_shared_error,
 };
 
 const DEFAULT_UPDATE_CHECK_TIMEOUT: Duration = Duration::from_mins(1);
@@ -359,6 +359,12 @@ fn parse_update_check_timeout(value: Option<&str>) -> Duration {
 }
 
 /// Download and apply an update described by `info`.
+///
+/// Returns `SURGE_OK` when finalization completed in this call. A self-hosted
+/// updater returns `SURGE_UPDATE_SCHEDULED` after a stable helper accepts
+/// ownership but before it swaps the active application directory. On that
+/// result, the caller must stop new work and exit promptly, then read the
+/// persisted status after restart for the terminal convergence result.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn surge_update_download_and_apply(
     mgr: *mut SurgeUpdateManagerHandle,
@@ -438,7 +444,8 @@ pub unsafe extern "C" fn surge_update_download_and_apply(
         };
 
         match result {
-            Ok(()) => SURGE_OK,
+            Ok(UpdateApplyOutcome::Finalized) => SURGE_OK,
+            Ok(UpdateApplyOutcome::ExternalFinalizeScheduled) => SURGE_UPDATE_SCHEDULED,
             Err(e) => set_shared_error(&mgr_ref.ctx, &mgr_ref.last_error, &e),
         }
     }))

--- a/crates/surge-ffi/src/update.rs
+++ b/crates/surge-ffi/src/update.rs
@@ -177,11 +177,10 @@ pub unsafe extern "C" fn surge_update_manager_set_release_retention_limit(
 ///
 /// `allow` is treated as a boolean: zero disables (the default), non-zero
 /// enables. When disabled, an updater running from the active application
-/// executable refuses the swap and expects an external Surge updater. A
-/// self-hosted application that updates in-process (calling
-/// `surge_update_download_and_apply` from inside the installed app) must
-/// enable this to keep self-updating; other processes running the active
-/// executable are still quiesced before the swap.
+/// executable transfers finalization to a stable helper, which waits for the
+/// caller to exit before swapping directories. Enabling this restores the
+/// legacy in-process swap; other processes running the active executable are
+/// still quiesced before the swap.
 ///
 /// # Safety
 ///

--- a/crates/surge-supervisor/Cargo.toml
+++ b/crates/surge-supervisor/Cargo.toml
@@ -10,17 +10,26 @@ description = "Process supervisor for the Surge update framework"
 name = "surge-supervisor"
 path = "src/main.rs"
 
+[[test]]
+name = "external_finalize"
+path = "tests/external_finalize.rs"
+harness = false
+
 [dependencies]
 surge-core = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 clap = { workspace = true }
 thiserror = { workspace = true }
+tokio = { workspace = true }
 sysinfo = "0.39.3"
 signal-hook = "0.4.4"
 
 [target.'cfg(unix)'.dependencies]
 nix = { version = "0.31", features = ["signal", "process"] }
+
+[dev-dependencies]
+tempfile = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/surge-supervisor/Cargo.toml
+++ b/crates/surge-supervisor/Cargo.toml
@@ -22,7 +22,7 @@ tracing-subscriber = { workspace = true }
 clap = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
-sysinfo = "0.39.3"
+sysinfo = { workspace = true }
 signal-hook = "0.4.4"
 
 [target.'cfg(unix)'.dependencies]

--- a/crates/surge-supervisor/src/child.rs
+++ b/crates/surge-supervisor/src/child.rs
@@ -1,7 +1,6 @@
 use std::path::Path;
 use std::process::{Child, Command, ExitStatus};
 
-#[cfg(windows)]
 use sysinfo::{Pid, ProcessesToUpdate, System};
 
 use crate::SupervisorError;
@@ -151,6 +150,7 @@ fn wait_for_child_startup_or_stop(
 
 pub(crate) fn wait_for_pid_or_stop(
     pid: u32,
+    expected_start_time: Option<u64>,
     shutdown: &std::sync::Arc<std::sync::atomic::AtomicBool>,
     stop_file: &Path,
     pid_file: &Path,
@@ -169,12 +169,28 @@ pub(crate) fn wait_for_pid_or_stop(
             return WaitOutcome::StopRequested;
         }
 
-        if !is_process_running(pid) {
+        if !is_process_identity_running(pid, expected_start_time) {
             return WaitOutcome::ObservedProcessExited;
         }
 
         std::thread::sleep(std::time::Duration::from_millis(100));
     }
+}
+
+fn is_process_identity_running(pid: u32, expected_start_time: Option<u64>) -> bool {
+    if let Some(expected_start_time) = expected_start_time {
+        let system_pid = Pid::from_u32(pid);
+        let mut system = System::new();
+        let _ = system.refresh_processes(ProcessesToUpdate::Some(&[system_pid]), true);
+        if let Some(process) = system.process(system_pid) {
+            let actual_start_time = process.start_time();
+            if actual_start_time != 0 {
+                return actual_start_time == expected_start_time;
+            }
+        }
+    }
+
+    is_process_running(pid)
 }
 
 fn wait_for_child_or_stop(
@@ -280,6 +296,29 @@ fn is_process_running(pid: u32) -> bool {
     };
 
     matches!(kill(Pid::from_raw(raw_pid), None), Ok(()) | Err(Errno::EPERM))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn watched_process_identity_rejects_a_reused_pid() {
+        let pid = std::process::id();
+        let system_pid = Pid::from_u32(pid);
+        let mut system = System::new();
+        let _ = system.refresh_processes(ProcessesToUpdate::Some(&[system_pid]), true);
+        let start_time = system.process(system_pid).unwrap().start_time();
+        assert_ne!(start_time, 0);
+
+        assert!(is_process_identity_running(pid, Some(start_time)));
+        let reused_start_time = if start_time == u64::MAX {
+            start_time - 1
+        } else {
+            start_time + 1
+        };
+        assert!(!is_process_identity_running(pid, Some(reused_start_time)));
+    }
 }
 
 #[cfg(windows)]

--- a/crates/surge-supervisor/src/child.rs
+++ b/crates/surge-supervisor/src/child.rs
@@ -1,11 +1,13 @@
 use std::path::Path;
 use std::process::{Child, Command, ExitStatus};
 
+#[cfg(windows)]
 use sysinfo::{Pid, ProcessesToUpdate, System};
 
 use crate::SupervisorError;
 use crate::handoff;
 use crate::ownership::supervisor_was_superseded;
+use surge_core::platform::process::{PidLiveness, probe_process_identity};
 
 const RESTART_HANDOFF_STABILITY_WINDOW: std::time::Duration = std::time::Duration::from_secs(4);
 
@@ -179,15 +181,10 @@ pub(crate) fn wait_for_pid_or_stop(
 
 fn is_process_identity_running(pid: u32, expected_start_time: Option<u64>) -> bool {
     if let Some(expected_start_time) = expected_start_time {
-        let system_pid = Pid::from_u32(pid);
-        let mut system = System::new();
-        let _ = system.refresh_processes(ProcessesToUpdate::Some(&[system_pid]), true);
-        if let Some(process) = system.process(system_pid) {
-            let actual_start_time = process.start_time();
-            if actual_start_time != 0 {
-                return actual_start_time == expected_start_time;
-            }
-        }
+        return match probe_process_identity(pid, expected_start_time) {
+            PidLiveness::Dead => false,
+            PidLiveness::Alive | PidLiveness::Unknown => true,
+        };
     }
 
     is_process_running(pid)
@@ -305,11 +302,7 @@ mod tests {
     #[test]
     fn watched_process_identity_rejects_a_reused_pid() {
         let pid = std::process::id();
-        let system_pid = Pid::from_u32(pid);
-        let mut system = System::new();
-        let _ = system.refresh_processes(ProcessesToUpdate::Some(&[system_pid]), true);
-        let start_time = system.process(system_pid).unwrap().start_time();
-        assert_ne!(start_time, 0);
+        let start_time = surge_core::platform::process::process_start_time(pid).unwrap();
 
         assert!(is_process_identity_running(pid, Some(start_time)));
         let reused_start_time = if start_time == u64::MAX {

--- a/crates/surge-supervisor/src/external_finalize.rs
+++ b/crates/surge-supervisor/src/external_finalize.rs
@@ -2,6 +2,8 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use surge_core::error::{Result, SurgeError};
+#[cfg(windows)]
+use surge_core::platform::process::{PidLiveness, probe_process_identity};
 use sysinfo::{Pid, ProcessesToUpdate, System};
 
 const UPDATER_EXIT_GRACE: Duration = Duration::from_secs(20);
@@ -194,10 +196,18 @@ fn signal_process(identity: &ProcessIdentity, _force: bool) -> Result<()> {
             identity.pid
         )));
     };
-    if process.start_time() != identity.start_time
-        || !executable_paths_equal(&normalize_executable(executable), &identity.executable)
-    {
+    if !executable_paths_equal(&normalize_executable(executable), &identity.executable) {
         return Ok(());
+    }
+    match probe_process_identity(identity.pid, identity.start_time) {
+        PidLiveness::Dead => return Ok(()),
+        PidLiveness::Unknown => {
+            return Err(SurgeError::Supervisor(format!(
+                "Could not revalidate creation identity for updating process {}",
+                identity.pid
+            )));
+        }
+        PidLiveness::Alive => {}
     }
     if process.kill() || !identity_is_running(identity)? {
         Ok(())

--- a/crates/surge-supervisor/src/external_finalize.rs
+++ b/crates/surge-supervisor/src/external_finalize.rs
@@ -225,11 +225,10 @@ fn executable_paths_equal(left: &Path, right: &Path) -> bool {
     left == right
 }
 
-#[cfg(test)]
+#[cfg(all(test, unix))]
 mod tests {
     use super::*;
 
-    #[cfg(unix)]
     #[test]
     fn quiesce_stops_only_the_exact_updating_executable() {
         use std::os::unix::fs::PermissionsExt;
@@ -259,7 +258,6 @@ mod tests {
         assert!(child.wait().unwrap().code().is_none_or(|code| code != 0));
     }
 
-    #[cfg(unix)]
     #[test]
     fn mismatched_executable_does_not_stop_process() {
         let mut child = std::process::Command::new("/bin/sleep").arg("30").spawn().unwrap();

--- a/crates/surge-supervisor/src/external_finalize.rs
+++ b/crates/surge-supervisor/src/external_finalize.rs
@@ -194,7 +194,7 @@ fn signal_process(identity: &ProcessIdentity, _force: bool) -> Result<()> {
     {
         return Ok(());
     }
-    if process.kill() {
+    if process.kill() || !identity_is_running(identity)? {
         Ok(())
     } else {
         Err(SurgeError::Supervisor(format!(

--- a/crates/surge-supervisor/src/external_finalize.rs
+++ b/crates/surge-supervisor/src/external_finalize.rs
@@ -92,9 +92,14 @@ fn process_identity(pid: u32, expected_executable: &Path) -> Result<Option<Proce
     if !executable_paths_equal(&executable, expected_executable) {
         return Ok(None);
     }
+    let start_time = surge_core::platform::process::process_start_time(pid).ok_or_else(|| {
+        SurgeError::Supervisor(format!(
+            "Could not resolve creation identity for updating process {pid}"
+        ))
+    })?;
     Ok(Some(ProcessIdentity {
         pid,
-        start_time: process.start_time(),
+        start_time,
         executable,
     }))
 }
@@ -103,22 +108,22 @@ fn matching_processes(expected_executable: &Path) -> Result<Vec<ProcessIdentity>
     let mut system = System::new();
     let _ = system.refresh_processes(ProcessesToUpdate::All, true);
     let own_pid = std::process::id();
-    Ok(system
-        .processes()
-        .iter()
-        .filter_map(|(pid, process)| {
-            let pid = pid.as_u32();
-            if pid == own_pid {
-                return None;
-            }
-            let executable = normalize_executable(process.exe()?);
-            executable_paths_equal(&executable, expected_executable).then_some(ProcessIdentity {
-                pid,
-                start_time: process.start_time(),
-                executable,
-            })
-        })
-        .collect())
+    let mut matching = Vec::new();
+    for (pid, process) in system.processes() {
+        let pid = pid.as_u32();
+        if pid == own_pid {
+            continue;
+        }
+        let Some(executable) = process.exe().map(normalize_executable) else {
+            continue;
+        };
+        if executable_paths_equal(&executable, expected_executable)
+            && let Some(identity) = process_identity(pid, expected_executable)?
+        {
+            matching.push(identity);
+        }
+    }
+    Ok(matching)
 }
 
 fn wait_until_identity_exits(identity: &ProcessIdentity, timeout: Duration) -> Result<bool> {

--- a/crates/surge-supervisor/src/external_finalize.rs
+++ b/crates/surge-supervisor/src/external_finalize.rs
@@ -1,0 +1,283 @@
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use surge_core::error::{Result, SurgeError};
+use sysinfo::{Pid, ProcessesToUpdate, System};
+
+const UPDATER_EXIT_GRACE: Duration = Duration::from_secs(20);
+const TERMINATE_GRACE: Duration = Duration::from_secs(5);
+const KILL_GRACE: Duration = Duration::from_secs(2);
+const PROCESS_POLL_INTERVAL: Duration = Duration::from_millis(100);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ProcessIdentity {
+    pid: u32,
+    start_time: u64,
+    executable: PathBuf,
+}
+
+pub(super) fn quiesce_updating_application(updater_pid: u32, updater_exe: &Path) -> Result<()> {
+    quiesce_updating_application_with_timeouts(
+        updater_pid,
+        updater_exe,
+        UPDATER_EXIT_GRACE,
+        TERMINATE_GRACE,
+        KILL_GRACE,
+    )
+}
+
+fn quiesce_updating_application_with_timeouts(
+    updater_pid: u32,
+    updater_exe: &Path,
+    exit_grace: Duration,
+    terminate_grace: Duration,
+    kill_grace: Duration,
+) -> Result<()> {
+    let expected_executable = normalize_executable(updater_exe);
+    let original = process_identity(updater_pid, &expected_executable)?;
+
+    if let Some(original) = original
+        && wait_until_identity_exits(&original, exit_grace)?
+    {
+        tracing::info!(pid = updater_pid, "Updating application exited before finalization");
+    }
+
+    let mut remaining = matching_processes(&expected_executable)?;
+    if remaining.is_empty() {
+        return Ok(());
+    }
+
+    for process in &remaining {
+        signal_process(process, false)?;
+    }
+    if wait_until_no_matching_processes(&expected_executable, terminate_grace)? {
+        tracing::info!(
+            count = remaining.len(),
+            "Stopped updating application processes before swap"
+        );
+        return Ok(());
+    }
+
+    remaining = matching_processes(&expected_executable)?;
+    for process in &remaining {
+        signal_process(process, true)?;
+    }
+    if wait_until_no_matching_processes(&expected_executable, kill_grace)? {
+        tracing::warn!(
+            count = remaining.len(),
+            "Force-stopped updating application processes before swap"
+        );
+        return Ok(());
+    }
+
+    Err(SurgeError::Supervisor(format!(
+        "Timed out waiting for processes running '{}' to exit before the application swap",
+        expected_executable.display()
+    )))
+}
+
+fn process_identity(pid: u32, expected_executable: &Path) -> Result<Option<ProcessIdentity>> {
+    let system_pid = Pid::from_u32(pid);
+    let mut system = System::new();
+    let _ = system.refresh_processes(ProcessesToUpdate::Some(&[system_pid]), true);
+    let Some(process) = system.process(system_pid) else {
+        return Ok(None);
+    };
+    let Some(executable) = process.exe() else {
+        return Err(SurgeError::Supervisor(format!(
+            "Could not resolve executable for updating process {pid}"
+        )));
+    };
+    let executable = normalize_executable(executable);
+    if !executable_paths_equal(&executable, expected_executable) {
+        return Ok(None);
+    }
+    Ok(Some(ProcessIdentity {
+        pid,
+        start_time: process.start_time(),
+        executable,
+    }))
+}
+
+fn matching_processes(expected_executable: &Path) -> Result<Vec<ProcessIdentity>> {
+    let mut system = System::new();
+    let _ = system.refresh_processes(ProcessesToUpdate::All, true);
+    let own_pid = std::process::id();
+    Ok(system
+        .processes()
+        .iter()
+        .filter_map(|(pid, process)| {
+            let pid = pid.as_u32();
+            if pid == own_pid {
+                return None;
+            }
+            let executable = normalize_executable(process.exe()?);
+            executable_paths_equal(&executable, expected_executable).then_some(ProcessIdentity {
+                pid,
+                start_time: process.start_time(),
+                executable,
+            })
+        })
+        .collect())
+}
+
+fn wait_until_identity_exits(identity: &ProcessIdentity, timeout: Duration) -> Result<bool> {
+    let deadline = std::time::Instant::now() + timeout;
+    loop {
+        if !identity_is_running(identity)? {
+            return Ok(true);
+        }
+        if std::time::Instant::now() >= deadline {
+            return Ok(false);
+        }
+        std::thread::sleep(PROCESS_POLL_INTERVAL);
+    }
+}
+
+fn wait_until_no_matching_processes(expected_executable: &Path, timeout: Duration) -> Result<bool> {
+    let deadline = std::time::Instant::now() + timeout;
+    loop {
+        if matching_processes(expected_executable)?.is_empty() {
+            return Ok(true);
+        }
+        if std::time::Instant::now() >= deadline {
+            return Ok(false);
+        }
+        std::thread::sleep(PROCESS_POLL_INTERVAL);
+    }
+}
+
+fn identity_is_running(identity: &ProcessIdentity) -> Result<bool> {
+    let Some(current) = process_identity(identity.pid, &identity.executable)? else {
+        return Ok(false);
+    };
+    Ok(current.start_time == identity.start_time)
+}
+
+#[cfg(unix)]
+fn signal_process(identity: &ProcessIdentity, force: bool) -> Result<()> {
+    use nix::errno::Errno;
+    use nix::sys::signal::{Signal, kill};
+    use nix::unistd::Pid;
+
+    if !identity_is_running(identity)? {
+        return Ok(());
+    }
+    let raw_pid = i32::try_from(identity.pid)
+        .map_err(|_| SurgeError::Supervisor(format!("Process id {} is outside signal range", identity.pid)))?;
+    let signal = if force { Signal::SIGKILL } else { Signal::SIGTERM };
+    match kill(Pid::from_raw(raw_pid), signal) {
+        Ok(()) | Err(Errno::ESRCH) => Ok(()),
+        Err(error) => Err(SurgeError::Supervisor(format!(
+            "Failed to signal updating process {}: {error}",
+            identity.pid
+        ))),
+    }
+}
+
+#[cfg(windows)]
+fn signal_process(identity: &ProcessIdentity, _force: bool) -> Result<()> {
+    let system_pid = Pid::from_u32(identity.pid);
+    let mut system = System::new();
+    let _ = system.refresh_processes(ProcessesToUpdate::Some(&[system_pid]), true);
+    let Some(process) = system.process(system_pid) else {
+        return Ok(());
+    };
+    let Some(executable) = process.exe() else {
+        return Err(SurgeError::Supervisor(format!(
+            "Could not revalidate executable for updating process {}",
+            identity.pid
+        )));
+    };
+    if process.start_time() != identity.start_time
+        || !executable_paths_equal(&normalize_executable(executable), &identity.executable)
+    {
+        return Ok(());
+    }
+    if process.kill() {
+        Ok(())
+    } else {
+        Err(SurgeError::Supervisor(format!(
+            "Failed to stop updating process {}",
+            identity.pid
+        )))
+    }
+}
+
+#[cfg(not(any(unix, windows)))]
+fn signal_process(_identity: &ProcessIdentity, _force: bool) -> Result<()> {
+    Err(SurgeError::Supervisor(
+        "External update finalization is unsupported on this platform".to_string(),
+    ))
+}
+
+fn normalize_executable(path: &Path) -> PathBuf {
+    std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
+}
+
+#[cfg(windows)]
+fn executable_paths_equal(left: &Path, right: &Path) -> bool {
+    left.to_string_lossy().eq_ignore_ascii_case(&right.to_string_lossy())
+}
+
+#[cfg(not(windows))]
+fn executable_paths_equal(left: &Path, right: &Path) -> bool {
+    left == right
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(unix)]
+    #[test]
+    fn quiesce_stops_only_the_exact_updating_executable() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = tempfile::tempdir().unwrap();
+        let source = if Path::new("/bin/sleep").is_file() {
+            Path::new("/bin/sleep")
+        } else {
+            Path::new("/usr/bin/sleep")
+        };
+        let executable = temp.path().join("surge-external-finalize-sleep");
+        std::fs::copy(source, &executable).unwrap();
+        let mut permissions = std::fs::metadata(&executable).unwrap().permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&executable, permissions).unwrap();
+        let mut child = std::process::Command::new(&executable).arg("30").spawn().unwrap();
+
+        quiesce_updating_application_with_timeouts(
+            child.id(),
+            &executable,
+            Duration::ZERO,
+            Duration::from_secs(2),
+            Duration::from_secs(1),
+        )
+        .unwrap();
+
+        assert!(child.wait().unwrap().code().is_none_or(|code| code != 0));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn mismatched_executable_does_not_stop_process() {
+        let mut child = std::process::Command::new("/bin/sleep").arg("30").spawn().unwrap();
+        let temp = tempfile::tempdir().unwrap();
+        let unrelated = temp.path().join("not-the-running-process");
+        std::fs::write(&unrelated, "fixture").unwrap();
+
+        quiesce_updating_application_with_timeouts(
+            child.id(),
+            &unrelated,
+            Duration::ZERO,
+            Duration::ZERO,
+            Duration::ZERO,
+        )
+        .unwrap();
+
+        assert!(child.try_wait().unwrap().is_none());
+        child.kill().unwrap();
+        child.wait().unwrap();
+    }
+}

--- a/crates/surge-supervisor/src/main.rs
+++ b/crates/surge-supervisor/src/main.rs
@@ -9,6 +9,7 @@ use surge_core::supervisor::state::{read_supervisor_exe_path, supervisor_pid_fil
 use thiserror::Error;
 
 mod child;
+mod external_finalize;
 mod handoff;
 mod ownership;
 
@@ -87,6 +88,18 @@ enum Commands {
         /// Arguments to pass when launching the replacement child process
         #[arg(trailing_var_arg = true)]
         args: Vec<String>,
+
+        /// Enable verbose logging
+        #[arg(long, short = 'v')]
+        verbose: bool,
+    },
+
+    /// Finalize a staged update after the updating application exits
+    #[command(hide = true)]
+    FinalizeUpdate {
+        /// Path to the ready/armed external finalizer plan
+        #[arg(long)]
+        plan: PathBuf,
 
         /// Enable verbose logging
         #[arg(long, short = 'v')]
@@ -184,6 +197,25 @@ fn main() -> ExitCode {
             };
             if let Err(e) = run_supervisor(&id, &dir, &exe_path, &args, Some(pid), handoff_version.as_deref()) {
                 tracing::error!("{e}");
+                return ExitCode::FAILURE;
+            }
+            ExitCode::SUCCESS
+        }
+        Commands::FinalizeUpdate { plan, verbose } => {
+            init_tracing(verbose);
+            let runtime = match tokio::runtime::Builder::new_current_thread().enable_all().build() {
+                Ok(runtime) => runtime,
+                Err(error) => {
+                    tracing::error!(%error, "Failed to create external finalizer runtime");
+                    return ExitCode::FAILURE;
+                }
+            };
+            let result = runtime.block_on(surge_core::update::manager::run_external_finalize(
+                &plan,
+                external_finalize::quiesce_updating_application,
+            ));
+            if let Err(error) = result {
+                tracing::error!(%error, "External update finalization failed");
                 return ExitCode::FAILURE;
             }
             ExitCode::SUCCESS

--- a/crates/surge-supervisor/src/main.rs
+++ b/crates/surge-supervisor/src/main.rs
@@ -76,6 +76,10 @@ enum Commands {
         #[arg(long)]
         pid: u32,
 
+        /// Start-time identity of the process named by --pid
+        #[arg(long)]
+        pid_start_time: Option<u64>,
+
         /// Target version whose update handoff should converge after replacement child startup
         #[arg(long)]
         handoff_version: Option<String>,
@@ -172,7 +176,7 @@ fn main() -> ExitCode {
                     return ExitCode::FAILURE;
                 }
             };
-            if let Err(e) = run_supervisor(&id, &dir, &exe_path, &args, None, None) {
+            if let Err(e) = run_supervisor(&id, &dir, &exe_path, &args, None, None, None) {
                 tracing::error!("{e}");
                 return ExitCode::FAILURE;
             }
@@ -182,6 +186,7 @@ fn main() -> ExitCode {
             id,
             dir,
             pid,
+            pid_start_time,
             handoff_version,
             exe,
             args,
@@ -195,7 +200,15 @@ fn main() -> ExitCode {
                     return ExitCode::FAILURE;
                 }
             };
-            if let Err(e) = run_supervisor(&id, &dir, &exe_path, &args, Some(pid), handoff_version.as_deref()) {
+            if let Err(e) = run_supervisor(
+                &id,
+                &dir,
+                &exe_path,
+                &args,
+                Some(pid),
+                pid_start_time,
+                handoff_version.as_deref(),
+            ) {
                 tracing::error!("{e}");
                 return ExitCode::FAILURE;
             }
@@ -239,6 +252,7 @@ fn run_supervisor(
     exe_path: &Path,
     args: &[String],
     watched_pid: Option<u32>,
+    watched_pid_start_time: Option<u64>,
     handoff_version: Option<&str>,
 ) -> Result<(), SupervisorError> {
     tracing::info!(
@@ -269,6 +283,7 @@ fn run_supervisor(
     let mut next_child_args = Some(first_child_args);
     let mut pending_handoff_version = handoff::pending_restart_handoff_version(watched_pid, handoff_version, args);
     let mut watched_pid = watched_pid;
+    let mut watched_pid_start_time = watched_pid_start_time;
 
     loop {
         if shutdown.load(std::sync::atomic::Ordering::Acquire) || stop_file.exists() {
@@ -282,7 +297,14 @@ fn run_supervisor(
 
         if let Some(pid) = watched_pid.take() {
             tracing::info!("Watching running process PID {pid} before relaunch");
-            match wait_for_pid_or_stop(pid, &shutdown, &stop_file, &pid_file, own_pid) {
+            match wait_for_pid_or_stop(
+                pid,
+                watched_pid_start_time.take(),
+                &shutdown,
+                &stop_file,
+                &pid_file,
+                own_pid,
+            ) {
                 WaitOutcome::ObservedProcessExited => {
                     if supervisor_was_superseded(&pid_file, own_pid) {
                         break;
@@ -465,6 +487,8 @@ mod tests {
             "/tmp/demo",
             "--pid",
             "42",
+            "--pid-start-time",
+            "1234",
             "--handoff-version",
             "2.0.0",
             "--exe",
@@ -475,12 +499,16 @@ mod tests {
         .unwrap();
 
         let Commands::Watch {
-            handoff_version, args, ..
+            pid_start_time,
+            handoff_version,
+            args,
+            ..
         } = cli.command
         else {
             panic!("expected watch command");
         };
 
+        assert_eq!(pid_start_time, Some(1_234));
         assert_eq!(handoff_version.as_deref(), Some("2.0.0"));
         assert_eq!(args, vec!["--app-mode"]);
     }
@@ -523,6 +551,7 @@ mod tests {
                 &exe_path_for_thread,
                 &[],
                 Some(watched_pid),
+                None,
                 None,
             );
             tx.send(result).unwrap();
@@ -643,6 +672,7 @@ mod tests {
                 ],
                 None,
                 None,
+                None,
             );
             tx.send(result).unwrap();
         });
@@ -711,6 +741,7 @@ mod tests {
                 &exe_path_for_thread,
                 &[],
                 Some(watched_pid),
+                None,
                 Some("2.0.0"),
             );
             tx.send(result).unwrap();
@@ -777,6 +808,7 @@ mod tests {
                 &install_dir_for_thread,
                 &exe_path_for_thread,
                 &[],
+                None,
                 None,
                 None,
             );

--- a/crates/surge-supervisor/tests/external_finalize.rs
+++ b/crates/surge-supervisor/tests/external_finalize.rs
@@ -85,6 +85,11 @@ fn run_target() {
 }
 
 fn verify_self_hosted_update() {
+    #[cfg(windows)]
+    if !detached_helper_launch_is_supported() {
+        return;
+    }
+
     let temp = tempfile::tempdir().unwrap();
     let store_root = temp.path().join("store");
     let install_root = temp.path().join("install");
@@ -173,6 +178,28 @@ fn verify_self_hosted_update() {
     );
 
     stop_fixture_processes(&install_root, &target_stop_path, &target_pid_path);
+}
+
+#[cfg(windows)]
+fn detached_helper_launch_is_supported() -> bool {
+    let environment = BTreeMap::new();
+    let mut probe = match surge_core::platform::process::spawn_detached(
+        Path::new("cmd.exe"),
+        &["/d", "/c", "exit", "0"],
+        None,
+        &environment,
+    ) {
+        Ok(probe) => probe,
+        Err(error) if error.to_string().contains("Access is denied") => {
+            eprintln!(
+                "Windows host job denied safe helper breakaway; external finalization correctly failed before handoff"
+            );
+            return false;
+        }
+        Err(error) => panic!("detached helper capability probe failed unexpectedly: {error}"),
+    };
+    assert_eq!(probe.wait().unwrap().exit_code, 0);
+    true
 }
 
 fn required_path(name: &str) -> PathBuf {

--- a/crates/surge-supervisor/tests/external_finalize.rs
+++ b/crates/surge-supervisor/tests/external_finalize.rs
@@ -1,0 +1,301 @@
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use surge_core::archive::packer::ArchivePacker;
+use surge_core::config::constants::{DEFAULT_ZSTD_LEVEL, RELEASES_FILE_COMPRESSED};
+use surge_core::context::{Context, StorageProvider};
+use surge_core::crypto::sha256::sha256_hex_file;
+use surge_core::install::{InstallProfile, RuntimeManifestMetadata, write_runtime_manifest};
+use surge_core::platform::detect::current_rid;
+use surge_core::platform::process::supervisor_binary_name;
+use surge_core::releases::manifest::{ReleaseEntry, ReleaseIndex, compress_release_index};
+use surge_core::update::manager::{ProgressInfo, UpdateManager};
+use surge_core::update::status::{UpdateConvergenceState, read_update_status};
+
+const APP_ID: &str = "external-finalizer-fixture";
+const SUPERVISOR_ID: &str = "external-finalizer-supervisor";
+const CURRENT_VERSION: &str = "1.0.0";
+const TARGET_VERSION: &str = "2.0.0";
+const MODE_ENV: &str = "SURGE_EXTERNAL_FINALIZE_MODE";
+const UPDATER_MODE: &str = "updater";
+const TARGET_MODE: &str = "target";
+
+#[cfg(windows)]
+const UPDATER_EXE: &str = "fixture-updater.exe";
+#[cfg(not(windows))]
+const UPDATER_EXE: &str = "fixture-updater";
+#[cfg(windows)]
+const TARGET_EXE: &str = "fixture-target.exe";
+#[cfg(not(windows))]
+const TARGET_EXE: &str = "fixture-target";
+
+fn main() {
+    match std::env::var(MODE_ENV).as_deref() {
+        Ok(UPDATER_MODE) => run_self_update(),
+        Ok(TARGET_MODE) => run_target(),
+        _ => verify_self_hosted_update(),
+    }
+}
+
+fn run_self_update() {
+    let store_root = required_path("SURGE_EXTERNAL_FINALIZE_STORE");
+    let install_root = required_path("SURGE_EXTERNAL_FINALIZE_INSTALL");
+    let returned_marker = required_path("SURGE_EXTERNAL_FINALIZE_RETURNED");
+    let allow_exit_marker = required_path("SURGE_EXTERNAL_FINALIZE_ALLOW_EXIT");
+    let context = Arc::new(Context::new());
+    context.set_storage(
+        StorageProvider::Filesystem,
+        store_root.to_str().unwrap(),
+        "",
+        "",
+        "",
+        "",
+    );
+    let mut manager =
+        UpdateManager::new(context, APP_ID, CURRENT_VERSION, "test", install_root.to_str().unwrap()).unwrap();
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    runtime.block_on(async move {
+        let update = manager.check_for_updates().await.unwrap().unwrap();
+        manager
+            .download_and_apply(&update, None::<fn(ProgressInfo)>)
+            .await
+            .unwrap();
+    });
+    std::fs::write(returned_marker, "returned").unwrap();
+    assert!(wait_until(Duration::from_secs(10), || allow_exit_marker.is_file()));
+}
+
+fn run_target() {
+    if std::env::args().any(|arg| arg == "--surge-updated" || arg.starts_with("--surge-updated=")) {
+        return;
+    }
+
+    let started_marker = required_path("SURGE_EXTERNAL_FINALIZE_TARGET_STARTED");
+    let pid_path = required_path("SURGE_EXTERNAL_FINALIZE_TARGET_PID");
+    let stop_path = required_path("SURGE_EXTERNAL_FINALIZE_TARGET_STOP");
+    std::fs::write(pid_path, std::process::id().to_string()).unwrap();
+    std::fs::write(started_marker, "started").unwrap();
+    assert!(wait_until(Duration::from_mins(1), || stop_path.is_file()));
+}
+
+fn verify_self_hosted_update() {
+    let temp = tempfile::tempdir().unwrap();
+    let store_root = temp.path().join("store");
+    let install_root = temp.path().join("install");
+    let active_app_dir = install_root.join("app");
+    let updater_path = active_app_dir.join(UPDATER_EXE);
+    let returned_marker = temp.path().join("update-returned");
+    let allow_exit_marker = temp.path().join("allow-updater-exit");
+    let target_started_marker = temp.path().join("target-started");
+    let target_pid_path = temp.path().join("target.pid");
+    let target_stop_path = temp.path().join("target.stop");
+    std::fs::create_dir_all(&active_app_dir).unwrap();
+
+    let fixture_exe = std::env::current_exe().unwrap();
+    std::fs::copy(&fixture_exe, &updater_path).unwrap();
+    make_executable(&updater_path);
+    std::fs::copy(
+        Path::new(env!("CARGO_BIN_EXE_surge-supervisor")),
+        active_app_dir.join(supervisor_binary_name()),
+    )
+    .unwrap();
+    make_executable(&active_app_dir.join(supervisor_binary_name()));
+    write_current_runtime_manifest(&active_app_dir);
+    write_target_release(
+        &store_root,
+        &fixture_exe,
+        &target_started_marker,
+        &target_pid_path,
+        &target_stop_path,
+    );
+
+    let mut updater = std::process::Command::new(&updater_path)
+        .env(MODE_ENV, UPDATER_MODE)
+        .env("SURGE_EXTERNAL_FINALIZE_STORE", &store_root)
+        .env("SURGE_EXTERNAL_FINALIZE_INSTALL", &install_root)
+        .env("SURGE_EXTERNAL_FINALIZE_RETURNED", &returned_marker)
+        .env("SURGE_EXTERNAL_FINALIZE_ALLOW_EXIT", &allow_exit_marker)
+        .spawn()
+        .unwrap();
+
+    assert!(wait_until(Duration::from_secs(20), || returned_marker.is_file()));
+    assert!(updater.try_wait().unwrap().is_none());
+    assert!(active_app_dir.join(UPDATER_EXE).is_file());
+    assert!(!active_app_dir.join(TARGET_EXE).exists());
+    assert!(!target_started_marker.exists());
+    std::fs::write(&allow_exit_marker, "exit").unwrap();
+    assert!(
+        updater.wait().unwrap().success(),
+        "self-hosted updater should hand off successfully"
+    );
+    let target_started = wait_until(Duration::from_secs(20), || target_started_marker.is_file());
+    assert!(
+        target_started,
+        "target did not start; status: {:?}; active entries: {:?}",
+        read_update_status(&install_root),
+        std::fs::read_dir(&active_app_dir).map(|entries| entries
+            .filter_map(std::result::Result::ok)
+            .map(|entry| entry.file_name())
+            .collect::<Vec<_>>()),
+    );
+    assert!(wait_until(Duration::from_secs(15), || {
+        read_update_status(&install_root).ok().flatten().is_some_and(|status| {
+            status.state == UpdateConvergenceState::Converged
+                && status.installed_version == TARGET_VERSION
+                && status.supervisor_restart_confirmed
+        })
+    }));
+
+    assert!(active_app_dir.join(TARGET_EXE).is_file());
+    assert!(
+        install_root
+            .join(format!("app-{CURRENT_VERSION}"))
+            .join(UPDATER_EXE)
+            .is_file()
+    );
+    assert!(
+        install_root
+            .join(".surge-tools")
+            .join(supervisor_binary_name())
+            .is_file()
+    );
+    assert_eq!(
+        surge_core::install::read_runtime_manifest_version(&active_app_dir)
+            .unwrap()
+            .as_deref(),
+        Some(TARGET_VERSION)
+    );
+
+    stop_fixture_processes(&install_root, &target_stop_path, &target_pid_path);
+}
+
+fn required_path(name: &str) -> PathBuf {
+    PathBuf::from(std::env::var_os(name).unwrap_or_else(|| panic!("missing {name}")))
+}
+
+fn write_current_runtime_manifest(active_app_dir: &Path) {
+    let shortcuts = [];
+    let persistent_assets = [];
+    let environment = BTreeMap::new();
+    let profile = InstallProfile::new(
+        APP_ID,
+        "External finalizer fixture",
+        UPDATER_EXE,
+        APP_ID,
+        SUPERVISOR_ID,
+        "",
+        &shortcuts,
+        &persistent_assets,
+        &environment,
+    );
+    let metadata = RuntimeManifestMetadata::new(CURRENT_VERSION, "test", "filesystem", ".", "", "");
+    write_runtime_manifest(active_app_dir, &profile, &metadata).unwrap();
+}
+
+fn write_target_release(
+    store_root: &Path,
+    fixture_exe: &Path,
+    target_started_marker: &Path,
+    target_pid_path: &Path,
+    target_stop_path: &Path,
+) {
+    let app_store = store_root.join(APP_ID);
+    std::fs::create_dir_all(&app_store).unwrap();
+    let full_filename = format!("{APP_ID}-{TARGET_VERSION}-full.tar.zst");
+    let full_path = app_store.join(&full_filename);
+    let mut packer = ArchivePacker::new(DEFAULT_ZSTD_LEVEL).unwrap();
+    packer.add_file(fixture_exe, TARGET_EXE).unwrap();
+    packer
+        .add_file(
+            Path::new(env!("CARGO_BIN_EXE_surge-supervisor")),
+            supervisor_binary_name(),
+        )
+        .unwrap();
+    packer.finalize_to_file(&full_path).unwrap();
+
+    let environment = BTreeMap::from([
+        (MODE_ENV.to_string(), TARGET_MODE.to_string()),
+        (
+            "SURGE_EXTERNAL_FINALIZE_TARGET_STARTED".to_string(),
+            target_started_marker.to_string_lossy().into_owned(),
+        ),
+        (
+            "SURGE_EXTERNAL_FINALIZE_TARGET_PID".to_string(),
+            target_pid_path.to_string_lossy().into_owned(),
+        ),
+        (
+            "SURGE_EXTERNAL_FINALIZE_TARGET_STOP".to_string(),
+            target_stop_path.to_string_lossy().into_owned(),
+        ),
+    ]);
+    let release = ReleaseEntry {
+        version: TARGET_VERSION.to_string(),
+        channels: vec!["test".to_string()],
+        rid: current_rid(),
+        is_genesis: true,
+        full_filename,
+        full_size: i64::try_from(std::fs::metadata(&full_path).unwrap().len()).unwrap(),
+        full_sha256: sha256_hex_file(&full_path).unwrap(),
+        name: "External finalizer fixture".to_string(),
+        main_exe: TARGET_EXE.to_string(),
+        install_directory: APP_ID.to_string(),
+        supervisor_id: SUPERVISOR_ID.to_string(),
+        environment,
+        ..ReleaseEntry::default()
+    };
+    let index = ReleaseIndex {
+        app_id: APP_ID.to_string(),
+        releases: vec![release],
+        ..ReleaseIndex::default()
+    };
+    std::fs::write(
+        app_store.join(RELEASES_FILE_COMPRESSED),
+        compress_release_index(&index, DEFAULT_ZSTD_LEVEL).unwrap(),
+    )
+    .unwrap();
+}
+
+#[cfg(unix)]
+fn make_executable(path: &Path) {
+    use std::os::unix::fs::PermissionsExt;
+
+    let mut permissions = std::fs::metadata(path).unwrap().permissions();
+    permissions.set_mode(permissions.mode() | 0o111);
+    std::fs::set_permissions(path, permissions).unwrap();
+}
+
+#[cfg(not(unix))]
+fn make_executable(_path: &Path) {}
+
+fn wait_until(timeout: Duration, mut condition: impl FnMut() -> bool) -> bool {
+    let deadline = Instant::now() + timeout;
+    while Instant::now() < deadline {
+        if condition() {
+            return true;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    condition()
+}
+
+fn stop_fixture_processes(install_root: &Path, target_stop_path: &Path, target_pid_path: &Path) {
+    let supervisor_stop = install_root.join(format!(".surge-supervisor-{SUPERVISOR_ID}.stop"));
+    let supervisor_pid = install_root.join(format!(".surge-supervisor-{SUPERVISOR_ID}.pid"));
+    std::fs::write(&supervisor_stop, "test cleanup").unwrap();
+    assert!(wait_until(Duration::from_secs(5), || !supervisor_pid.exists()));
+    std::fs::write(target_stop_path, "stop").unwrap();
+
+    let target_pid = std::fs::read_to_string(target_pid_path)
+        .unwrap()
+        .trim()
+        .parse::<u32>()
+        .unwrap();
+    assert!(wait_until(Duration::from_secs(5), || {
+        !surge_core::platform::process::is_pid_alive(target_pid)
+    }));
+}

--- a/crates/surge-supervisor/tests/external_finalize.rs
+++ b/crates/surge-supervisor/tests/external_finalize.rs
@@ -11,7 +11,7 @@ use surge_core::install::{InstallProfile, RuntimeManifestMetadata, write_runtime
 use surge_core::platform::detect::current_rid;
 use surge_core::platform::process::supervisor_binary_name;
 use surge_core::releases::manifest::{ReleaseEntry, ReleaseIndex, compress_release_index};
-use surge_core::update::manager::{ProgressInfo, UpdateManager};
+use surge_core::update::manager::{ProgressInfo, UpdateApplyOutcome, UpdateManager};
 use surge_core::update::status::{UpdateConvergenceState, read_update_status};
 
 const APP_ID: &str = "external-finalizer-fixture";
@@ -61,10 +61,11 @@ fn run_self_update() {
         .unwrap();
     runtime.block_on(async move {
         let update = manager.check_for_updates().await.unwrap().unwrap();
-        manager
+        let outcome = manager
             .download_and_apply(&update, None::<fn(ProgressInfo)>)
             .await
             .unwrap();
+        assert_eq!(outcome, UpdateApplyOutcome::ExternalFinalizeScheduled);
     });
     std::fs::write(returned_marker, "returned").unwrap();
     assert!(wait_until(Duration::from_secs(10), || allow_exit_marker.is_file()));

--- a/docs/integrating-surge.md
+++ b/docs/integrating-surge.md
@@ -197,6 +197,10 @@ At minimum, a green smoke should prove:
 - the update applies successfully
 - the app relaunches successfully after update
 
+For a self-hosted app, an external-finalization result is only an accepted
+handoff. The app must exit promptly, and the smoke must verify a terminal
+persisted status after restart before calling the update successful.
+
 If the app only implements prompt-first UX instead of `download_and_apply()`, the repo should still have one helper that exercises the lower-level apply path during smoke.
 
 If the app ships `online` or `online-gui` installers, include one additional clean-install check:

--- a/dotnet/Surge.NET.Tests/SurgeTests.cs
+++ b/dotnet/Surge.NET.Tests/SurgeTests.cs
@@ -186,6 +186,8 @@ namespace Surge.Tests
             Assert.Equal("", info.StorageRegion);
             Assert.Equal("", info.StorageEndpoint);
             Assert.False(info.IsSupervisorRunning);
+            Assert.False(info.IsUpdateFinalizationScheduled);
+            Assert.Equal("", info.PendingUpdateVersion);
         }
 
         [Fact]
@@ -201,7 +203,9 @@ namespace Surge.Tests
                 StorageProvider = "filesystem",
                 StorageBucket = "/tmp/releases",
                 StorageRegion = "us-east-1",
-                StorageEndpoint = "http://localhost:9000"
+                StorageEndpoint = "http://localhost:9000",
+                IsUpdateFinalizationScheduled = true,
+                PendingUpdateVersion = "1.2.4"
             };
 
             Assert.Equal("myapp", info.Id);
@@ -213,6 +217,8 @@ namespace Surge.Tests
             Assert.Equal("/tmp/releases", info.StorageBucket);
             Assert.Equal("us-east-1", info.StorageRegion);
             Assert.Equal("http://localhost:9000", info.StorageEndpoint);
+            Assert.True(info.IsUpdateFinalizationScheduled);
+            Assert.Equal("1.2.4", info.PendingUpdateVersion);
         }
     }
 
@@ -239,6 +245,7 @@ namespace Surge.Tests
 
         [Theory]
         [InlineData(0)]
+        [InlineData(1)]
         [InlineData(-1)]
         [InlineData(-3)]
         public void HandleNativeCancellation_IgnoresOtherResults(int result)
@@ -260,6 +267,30 @@ namespace Surge.Tests
 
             Assert.Throws<OperationCanceledException>(
                 () => SurgeUpdateManager.HandleNativeCancellation(-2, source.Token));
+        }
+
+        [Fact]
+        public void ScheduledUpdateInfo_KeepsInstalledVersionAndExposesTarget()
+        {
+            var current = new SurgeAppInfo
+            {
+                Id = "demo",
+                Version = "1.2.3",
+                Channel = "beta",
+                InstallDirectory = "/opt/demo",
+                SupervisorId = "demo-supervisor",
+                StorageProvider = "filesystem",
+                StorageBucket = "/tmp/releases"
+            };
+            var release = new SurgeRelease { Version = "1.2.4", Channel = "beta" };
+
+            var result = SurgeUpdateManager.CreateScheduledUpdateInfo(current, "0.0.0", release);
+
+            Assert.Equal("1.2.3", result.Version);
+            Assert.Equal("1.2.4", result.PendingUpdateVersion);
+            Assert.True(result.IsUpdateFinalizationScheduled);
+            Assert.Equal(current.InstallDirectory, result.InstallDirectory);
+            Assert.Equal(current.StorageBucket, result.StorageBucket);
         }
     }
 

--- a/dotnet/Surge.NET/NativeMethods.cs
+++ b/dotnet/Surge.NET/NativeMethods.cs
@@ -58,6 +58,7 @@ namespace Surge
     internal static partial class NativeMethods
     {
         private const string LibName = "surge";
+        internal const int UpdateScheduled = 1;
 
 #if NET10_0_OR_GREATER
         // --- Lifecycle ---

--- a/dotnet/Surge.NET/README.md
+++ b/dotnet/Surge.NET/README.md
@@ -23,6 +23,15 @@ await mgr.UpdateToLatestReleaseAsync(
 
 One call that checks for updates, downloads the smallest available patch, verifies integrity, extracts, and applies — with progress callbacks and cancellation support.
 
+When the running application updates itself, the call returns after a stable
+helper accepts finalization and before the active `app` directory is swapped.
+The returned `SurgeAppInfo` keeps `Version` at the currently installed version,
+sets `IsUpdateFinalizationScheduled`, and exposes the target through
+`PendingUpdateVersion`. Stop new work and exit promptly, then read
+`SurgeApp.LastUpdateStatus` after restart for the terminal `Converged`,
+`PendingRestart`, or `Failed` result. `onAfterApplyUpdate` is not invoked for
+the scheduled handoff.
+
 ## Key Features
 
 - **Zero managed dependencies** — no external NuGet packages are required

--- a/dotnet/Surge.NET/SurgeAppInfo.cs
+++ b/dotnet/Surge.NET/SurgeAppInfo.cs
@@ -31,6 +31,18 @@ namespace Surge
         public string SupervisorId { get; init; } = "";
 
         /// <summary>
+        /// Whether an external helper accepted this update and is waiting for
+        /// the current application process to exit before finalizing it.
+        /// </summary>
+        public bool IsUpdateFinalizationScheduled { get; init; }
+
+        /// <summary>
+        /// Target version awaiting external finalization. Empty unless
+        /// <see cref="IsUpdateFinalizationScheduled"/> is true.
+        /// </summary>
+        public string PendingUpdateVersion { get; init; } = "";
+
+        /// <summary>
         /// Storage provider used for updates (filesystem, s3, azure, gcs, github_releases).
         /// </summary>
         public string StorageProvider { get; init; } = "";

--- a/dotnet/Surge.NET/SurgeUpdateManager.cs
+++ b/dotnet/Surge.NET/SurgeUpdateManager.cs
@@ -243,14 +243,22 @@ namespace Surge
         /// <param name="progressSource">Optional progress source for receiving update progress.</param>
         /// <param name="onUpdatesAvailable">Called when updates are found, before applying.</param>
         /// <param name="onBeforeApplyUpdate">Called before applying a specific release.</param>
-        /// <param name="onAfterApplyUpdate">Called after successfully applying a release.</param>
+        /// <param name="onAfterApplyUpdate">
+        /// Called after a release is fully applied before this method returns.
+        /// It is not called when external finalization is scheduled.
+        /// </param>
         /// <param name="onApplyUpdateException">Called when applying a release fails.</param>
         /// <param name="cancellationToken">Token to cancel the operation.</param>
         /// <returns>
-        /// The <see cref="SurgeAppInfo"/> for the newly installed version,
-        /// or null if no updates were available, native cancellation occurred
-        /// without the supplied token being cancelled, or a previous
-        /// retry-safe failure is still inside its retry-backoff window.
+        /// The <see cref="SurgeAppInfo"/> for the newly installed version. For
+        /// a self-hosted update, returns the current installed version with
+        /// <see cref="SurgeAppInfo.IsUpdateFinalizationScheduled"/> set and
+        /// <see cref="SurgeAppInfo.PendingUpdateVersion"/> identifying the
+        /// target. The caller must then exit promptly and inspect the persisted
+        /// convergence status after restart. Returns null if no updates were
+        /// available, native cancellation occurred without the supplied token
+        /// being cancelled, or a previous retry-safe failure is still inside
+        /// its retry-backoff window.
         /// </returns>
         /// <exception cref="OperationCanceledException">
         /// The supplied cancellation token was cancelled.
@@ -400,12 +408,18 @@ namespace Surge
                             if (HandleNativeCancellation(applyResult, cancellationToken))
                                 return null;
 
-                            if (applyResult != 0)
+                            bool finalizationScheduled = applyResult == NativeMethods.UpdateScheduled;
+                            if (applyResult != 0 && !finalizationScheduled)
                             {
                                 var errorMsg = GetLastError();
                                 var ex = new SurgeException(applyResult, errorMsg ?? "Update apply failed.");
                                 onApplyUpdateException?.Invoke(latestRelease, ex);
                                 throw ex;
+                            }
+
+                            if (finalizationScheduled)
+                            {
+                                return CreateScheduledUpdateInfo(SurgeApp.Current, _currentVersion, latestRelease);
                             }
 
                             onAfterApplyUpdate?.Invoke(latestRelease);
@@ -492,6 +506,28 @@ namespace Surge
         private static string? NullIfEmpty(string value)
         {
             return string.IsNullOrWhiteSpace(value) ? null : value;
+        }
+
+        internal static SurgeAppInfo CreateScheduledUpdateInfo(
+            SurgeAppInfo? currentApp,
+            string currentVersion,
+            SurgeRelease latestRelease)
+        {
+            return new SurgeAppInfo
+            {
+                Id = currentApp?.Id ?? "",
+                Version = currentApp?.Version ?? currentVersion,
+                Channel = latestRelease.Channel,
+                InstallDirectory = currentApp?.InstallDirectory ?? "",
+                SupervisorId = currentApp?.SupervisorId ?? "",
+                StorageProvider = currentApp?.StorageProvider ?? "",
+                StorageBucket = currentApp?.StorageBucket ?? "",
+                StorageRegion = currentApp?.StorageRegion ?? "",
+                StorageEndpoint = currentApp?.StorageEndpoint ?? "",
+                IsSupervisorRunning = currentApp?.IsSupervisorRunning ?? false,
+                IsUpdateFinalizationScheduled = true,
+                PendingUpdateVersion = latestRelease.Version
+            };
         }
 
         internal static bool HandleNativeCancellation(int result, CancellationToken cancellationToken)

--- a/dotnet/Surge.NET/SurgeUpdateManager.cs
+++ b/dotnet/Surge.NET/SurgeUpdateManager.cs
@@ -65,9 +65,9 @@ namespace Surge
         /// <summary>
         /// Allow this process to swap its own active application directory during an update.
         /// Defaults to <c>false</c>, in which case an updater running from the active application
-        /// executable refuses the swap and expects an external Surge updater. A self-hosted
-        /// application that updates in-process must enable this to keep self-updating; other
-        /// processes running the active executable are still stopped before the swap.
+        /// executable transfers finalization to a stable helper that waits for the caller to exit.
+        /// Enabling this restores the legacy in-process swap; other processes running the active
+        /// executable are still stopped before the swap.
         /// </summary>
         public bool AllowInProcessSwap { get; set; }
 

--- a/include/surge/surge_api.h
+++ b/include/surge/surge_api.h
@@ -67,7 +67,13 @@ typedef struct surge_pack_context surge_pack_context;
 /* -------------------------------------------------------------------------- */
 
 /** Result codes returned by most API functions. */
-typedef enum surge_result { SURGE_OK = 0, SURGE_ERROR = -1, SURGE_CANCELLED = -2, SURGE_NOT_FOUND = -3 } surge_result;
+typedef enum surge_result {
+    SURGE_OK = 0,
+    SURGE_UPDATE_SCHEDULED = 1,
+    SURGE_ERROR = -1,
+    SURGE_CANCELLED = -2,
+    SURGE_NOT_FOUND = -3
+} surge_result;
 
 /** Phases reported through progress callbacks. */
 typedef enum surge_progress_phase {
@@ -314,7 +320,15 @@ SURGE_API surge_result SURGE_CALL surge_update_check(surge_update_manager* mgr, 
  * @param info        Release information from surge_update_check().
  * @param progress_cb Optional progress callback (may be NULL).
  * @param user_data   Opaque pointer forwarded to @p progress_cb.
- * @return SURGE_OK on success.
+ * A self-hosted updater normally returns before the active application
+ * directory is changed. SURGE_UPDATE_SCHEDULED means a stable helper accepted
+ * ownership and is waiting for the calling application to exit. The caller
+ * must stop new work and exit promptly, then use
+ * surge_update_status_read_json() after restart until the state is converged,
+ * pending_restart, or failed. Scheduling alone is not installation success.
+ *
+ * @return SURGE_OK when finalization completed in this call;
+ *         SURGE_UPDATE_SCHEDULED when external finalization was accepted.
  */
 SURGE_API surge_result SURGE_CALL surge_update_download_and_apply(surge_update_manager* mgr,
                                                                   const surge_releases_info* info,

--- a/include/surge/surge_api.h
+++ b/include/surge/surge_api.h
@@ -279,11 +279,10 @@ SURGE_API surge_result SURGE_CALL surge_update_manager_set_release_retention_lim
  *
  * `allow` is treated as a boolean: zero disables (the default), non-zero
  * enables. When disabled, an updater running from the active application
- * executable refuses the swap and expects an external Surge updater. A
- * self-hosted application that updates in-process (calling
- * `surge_update_download_and_apply` from inside the installed app) must
- * enable this to keep self-updating; other processes running the active
- * executable are still quiesced before the swap.
+ * executable transfers finalization to a stable helper, which waits for the
+ * caller to exit before swapping directories. Enabling this restores the
+ * legacy in-process swap; other processes running the active executable are
+ * still quiesced before the swap.
  *
  * `mgr` must be a valid update manager handle or NULL.
  */


### PR DESCRIPTION
## Summary

- hand phase-six finalization from a self-hosted updater to the bundled supervisor copied outside the active application directory
- keep the public application path stable at app while the helper waits for the exact updating executable to exit before swapping
- preserve check-time release state across separate FFI check/apply calls and recover only an identity-matched previous runtime on failure
- run the complete handoff fixture on Linux, macOS, and Windows CI

## Atomic scope

The scheduler, serialized plan, ready/armed handshake, exact-process quiescence, swap/restart runner, rollback, and end-to-end fixture are one compatibility protocol. Shipping only part of that protocol would leave a build that can create a plan another component cannot safely execute.

## Validation

- ./scripts/sync-surge-core-vendor.sh --check
- ./scripts/check-version-sync.sh
- cargo fmt --all -- --check
- cargo +1.95.0 check --workspace --all-targets --all-features --locked
- RUSTFLAGS="-D warnings" cargo test --workspace
- cargo clippy --all-targets --all-features -- -D warnings
- cargo clippy --workspace --lib --bins --examples -- -D warnings -D clippy::unwrap_used -D clippy::expect_used
- dotnet format dotnet/Surge.slnx --verify-no-changes
- dotnet test dotnet/Surge.slnx --configuration Release
- cargo clippy --workspace --all-targets --all-features -- -D warnings -W clippy::pedantic reports only the existing advisory findings in sparse delta code and tests outside this patch