### PR TITLE
Bind supervised handoffs to process identity

### DIFF
--- a/crates/surge-core/src/platform/process.rs
+++ b/crates/surge-core/src/platform/process.rs
@@ -142,6 +142,13 @@ pub fn current_pid() -> u32 {
     std::process::id()
 }
 
+/// High-resolution native creation identity for a live process. Combined with
+/// a PID, this distinguishes a process from a later process that reused it.
+#[must_use]
+pub fn process_start_time(pid: u32) -> Option<u64> {
+    descriptors::process_start_time(pid)
+}
+
 /// Liveness of the process identified by `pid`.
 ///
 /// `Unknown` means the probe itself failed (the probe utility could not be
@@ -219,6 +226,24 @@ pub fn probe_pid_liveness(pid: u32) -> PidLiveness {
     {
         let _ = pid;
         PidLiveness::Unknown
+    }
+}
+
+/// Probe whether `pid` still identifies the process with `expected_start_time`.
+///
+/// A different start time conclusively means the original process exited and
+/// the PID was reused. If start-time inspection is unavailable while the PID
+/// still appears live, the result is [`PidLiveness::Unknown`] so callers can
+/// fail closed.
+#[must_use]
+pub fn probe_process_identity(pid: u32, expected_start_time: u64) -> PidLiveness {
+    match process_start_time(pid) {
+        Some(actual_start_time) if actual_start_time == expected_start_time => PidLiveness::Alive,
+        Some(_) => PidLiveness::Dead,
+        None => match probe_pid_liveness(pid) {
+            PidLiveness::Dead => PidLiveness::Dead,
+            PidLiveness::Alive | PidLiveness::Unknown => PidLiveness::Unknown,
+        },
     }
 }
 
@@ -325,7 +350,7 @@ mod tests {
         assert_eq!(result.exit_code, 0);
     }
 
-    use super::{PidLiveness, is_pid_alive, probe_pid_liveness};
+    use super::{PidLiveness, is_pid_alive, probe_pid_liveness, probe_process_identity, process_start_time};
     use std::time::{Duration, Instant};
 
     #[test]
@@ -341,6 +366,15 @@ mod tests {
     }
 
     #[test]
+    fn process_identity_rejects_a_reused_pid() {
+        let pid = std::process::id();
+        let start_time = process_start_time(pid).expect("current process start time");
+
+        assert_eq!(probe_process_identity(pid, start_time), PidLiveness::Alive);
+        assert_eq!(probe_process_identity(pid, start_time ^ 1), PidLiveness::Dead);
+    }
+
+    #[test]
     fn is_pid_alive_reflects_a_positive_probe() {
         assert!(is_pid_alive(std::process::id()));
         assert!(!is_pid_alive(0));
@@ -350,13 +384,14 @@ mod tests {
     fn exited_process_is_reported_dead() {
         let mut child = std::process::Command::new(if cfg!(target_os = "windows") { "cmd" } else { "sh" })
             .args(if cfg!(target_os = "windows") {
-                ["/c", "exit /b 0"]
+                ["/c", "ping -n 2 127.0.0.1 > nul"]
             } else {
-                ["-c", "exit 0"]
+                ["-c", "sleep 0.1"]
             })
             .spawn()
             .expect("spawn helper");
         let pid = child.id();
+        let start_time = process_start_time(pid).expect("child process start time");
         let _ = child.wait();
 
         let deadline = Instant::now() + Duration::from_secs(5);
@@ -366,5 +401,6 @@ mod tests {
         assert!(!is_pid_alive(pid));
         assert!(!is_pid_alive(0));
         assert_eq!(probe_pid_liveness(pid), PidLiveness::Dead);
+        assert_eq!(probe_process_identity(pid, start_time), PidLiveness::Dead);
     }
 }

--- a/crates/surge-core/src/platform/process/descriptors.rs
+++ b/crates/surge-core/src/platform/process/descriptors.rs
@@ -1,5 +1,4 @@
-//! Descriptor hygiene for spawned children: an `unsafe` boundary around the
-//! post-fork, pre-exec hook that marks inherited descriptors close-on-exec.
+//! Native process boundary for descriptor hygiene and creation identity.
 #![allow(unsafe_code)]
 
 use std::process::Command;
@@ -79,5 +78,113 @@ fn mark_close_on_exec_from(first: libc::c_int) {
                 libc::fcntl(descriptor, libc::F_SETFD, flags | libc::FD_CLOEXEC);
             }
         }
+    }
+}
+
+#[cfg(target_os = "linux")]
+pub(super) fn process_start_time(pid: u32) -> Option<u64> {
+    if pid == 0 {
+        return None;
+    }
+
+    let stat = std::fs::read(format!("/proc/{pid}/stat")).ok()?;
+    parse_linux_process_start_time(&stat)
+}
+
+#[cfg(target_os = "linux")]
+fn parse_linux_process_start_time(stat: &[u8]) -> Option<u64> {
+    let command_end = stat.iter().rposition(|byte| *byte == b')')?;
+    let fields_after_command = std::str::from_utf8(stat.get(command_end + 1..)?).ok()?;
+    fields_after_command.split_ascii_whitespace().nth(19)?.parse().ok()
+}
+
+#[cfg(target_os = "macos")]
+pub(super) fn process_start_time(pid: u32) -> Option<u64> {
+    let pid = libc::pid_t::try_from(pid).ok()?;
+    if pid <= 0 {
+        return None;
+    }
+
+    let mut info = std::mem::MaybeUninit::<libc::proc_bsdinfo>::zeroed();
+    let size = libc::c_int::try_from(std::mem::size_of::<libc::proc_bsdinfo>()).ok()?;
+    // SAFETY: `info` points to writable storage of exactly the size passed to
+    // proc_pidinfo. A full-size return is required before the value is read.
+    let written = unsafe {
+        libc::proc_pidinfo(
+            pid,
+            libc::PROC_PIDTBSDINFO,
+            0,
+            info.as_mut_ptr().cast::<libc::c_void>(),
+            size,
+        )
+    };
+    if written != size {
+        return None;
+    }
+
+    // SAFETY: proc_pidinfo reported that it initialized the complete structure.
+    let info = unsafe { info.assume_init() };
+    info.pbi_start_tvsec
+        .checked_mul(1_000_000)?
+        .checked_add(info.pbi_start_tvusec)
+}
+
+#[cfg(windows)]
+pub(super) fn process_start_time(pid: u32) -> Option<u64> {
+    use windows_sys::Win32::Foundation::{CloseHandle, FILETIME, WAIT_TIMEOUT};
+    use windows_sys::Win32::System::Threading::{
+        GetProcessTimes, OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION, PROCESS_SYNCHRONIZE, WaitForSingleObject,
+    };
+
+    if pid == 0 {
+        return None;
+    }
+
+    // SAFETY: OpenProcess is called with a non-inheritable handle and a numeric
+    // PID. The returned handle is checked and closed on every path below.
+    let handle = unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION | PROCESS_SYNCHRONIZE, 0, pid) };
+    if handle.is_null() {
+        return None;
+    }
+
+    let mut creation = FILETIME::default();
+    let mut exit = FILETIME::default();
+    let mut kernel = FILETIME::default();
+    let mut user = FILETIME::default();
+    // SAFETY: all pointers reference initialized writable FILETIME values and
+    // `handle` remains valid until CloseHandle immediately after the call.
+    let succeeded = unsafe { GetProcessTimes(handle, &mut creation, &mut exit, &mut kernel, &mut user) };
+    // SAFETY: a process handle with synchronize access is waitable. A live process
+    // must remain unsignaled during this zero-timeout probe.
+    let wait_status = unsafe { WaitForSingleObject(handle, 0) };
+    // SAFETY: `handle` is the live owned handle returned by OpenProcess above.
+    let _ = unsafe { CloseHandle(handle) };
+    if succeeded == 0 || wait_status != WAIT_TIMEOUT {
+        return None;
+    }
+
+    Some((u64::from(creation.dwHighDateTime) << 32) | u64::from(creation.dwLowDateTime))
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos", windows)))]
+pub(super) fn process_start_time(pid: u32) -> Option<u64> {
+    let _ = pid;
+    None
+}
+
+#[cfg(all(test, target_os = "linux"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn linux_process_start_time_reads_proc_stat_field() {
+        let start_time = process_start_time(std::process::id()).expect("current process start time");
+        assert!(start_time > 0);
+    }
+
+    #[test]
+    fn linux_process_start_time_accepts_non_utf8_command_name() {
+        let stat = b"123 (non-utf8-\xff) S 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 4242 20";
+        assert_eq!(parse_linux_process_start_time(stat), Some(4242));
     }
 }

--- a/crates/surge-core/src/update/manager/lifecycle.rs
+++ b/crates/surge-core/src/update/manager/lifecycle.rs
@@ -4,7 +4,9 @@ use std::time::Duration;
 use tracing::{debug, info, warn};
 
 use crate::error::{Result, SurgeError};
-use crate::platform::process::{ProcessHandle, current_pid, spawn_detached, spawn_process, supervisor_binary_name};
+use crate::platform::process::{
+    ProcessHandle, current_pid, process_start_time, spawn_detached, spawn_process, supervisor_binary_name,
+};
 use crate::releases::manifest::ReleaseEntry;
 use crate::supervisor::state::{
     read_restart_args, supervisor_pid_file, supervisor_stop_file, write_supervisor_exe_path,
@@ -192,6 +194,18 @@ fn restart_supervisor_after_update_with_config(
         return SupervisorRestartOutcome::NotApplicable;
     }
 
+    let Some(watched_pid_start_time) = process_start_time(watched_pid) else {
+        let reason = format!("could not capture start-time identity for watched process {watched_pid}");
+        warn!(
+            watched_pid,
+            "Cannot restart supervisor without a stable watched-process identity"
+        );
+        return SupervisorRestartOutcome::PendingRestart {
+            reason,
+            failure_phase: RESTART_HANDOFF_FAILED_PHASE,
+        };
+    };
+
     let supervisor_path = active_app_dir.join(supervisor_binary_name());
     if !supervisor_path.is_file() {
         warn!(
@@ -240,7 +254,14 @@ fn restart_supervisor_after_update_with_config(
         }
     };
 
-    let args = supervisor_watch_args(supervisor_id, install_dir, watched_pid, &latest.version, &restart_args);
+    let args = supervisor_watch_args(
+        supervisor_id,
+        install_dir,
+        watched_pid,
+        watched_pid_start_time,
+        &latest.version,
+        &restart_args,
+    );
     let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
 
     let mut last_failure: Option<(String, &'static str)> = None;
@@ -300,6 +321,7 @@ fn supervisor_watch_args(
     supervisor_id: &str,
     install_dir: &Path,
     watched_pid: u32,
+    watched_pid_start_time: u64,
     handoff_version: &str,
     restart_args: &[String],
 ) -> Vec<String> {
@@ -311,6 +333,8 @@ fn supervisor_watch_args(
         install_dir.to_string_lossy().into_owned(),
         "--pid".to_string(),
         watched_pid.to_string(),
+        "--pid-start-time".to_string(),
+        watched_pid_start_time.to_string(),
         "--handoff-version".to_string(),
         handoff_version.to_string(),
     ];
@@ -331,7 +355,14 @@ mod tests {
     fn supervisor_watch_args_include_handoff_version_before_child_args() {
         let restart_args = vec!["--app-mode".to_string(), "service".to_string()];
 
-        let args = supervisor_watch_args("demo-supervisor", Path::new("/opt/demo"), 42, "2.0.0", &restart_args);
+        let args = supervisor_watch_args(
+            "demo-supervisor",
+            Path::new("/opt/demo"),
+            42,
+            1_234,
+            "2.0.0",
+            &restart_args,
+        );
 
         assert_eq!(
             args,
@@ -343,6 +374,8 @@ mod tests {
                 "/opt/demo",
                 "--pid",
                 "42",
+                "--pid-start-time",
+                "1234",
                 "--handoff-version",
                 "2.0.0",
                 "--",

--- a/crates/surge-core/src/update/status/worker.rs
+++ b/crates/surge-core/src/update/status/worker.rs
@@ -1,9 +1,10 @@
 //! Update-worker ownership marker and abandoned-attempt classification.
 //!
-//! A live update attempt records its worker (pid, app, target version) next
-//! to the status file. When a later attempt finds an `InProgress` record it
-//! classifies that attempt against the worker marker:
-//! - worker pid is this process → the attempt is (re)started by us; proceed.
+//! A live update attempt records its worker (pid, process start time, app,
+//! target version) next to the status file. When a later attempt finds an
+//! `InProgress` record it classifies that attempt against the worker marker:
+//! - worker identity is this process → the attempt is (re)started by us;
+//!   proceed.
 //! - worker pid is another *live* process with recent progress → a
 //!   concurrent updater is active; never reclassify it.
 //! - worker pid is another *live* process whose progress has been silent
@@ -25,7 +26,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::error::{Result, SurgeError};
 use crate::platform::fs::write_file_atomic;
-use crate::platform::process::{PidLiveness, probe_pid_liveness};
+use crate::platform::process::{PidLiveness, probe_pid_liveness, probe_process_identity, process_start_time};
 
 use super::{
     FailureContext, UpdateConvergenceState, UpdateStatusRecord, next_retry_timestamp, now_utc_rfc3339,
@@ -48,6 +49,8 @@ struct UpdateWorkerRecord {
     app_id: String,
     target_version: String,
     started_at_utc: String,
+    #[serde(default)]
+    process_start_time: Option<u64>,
 }
 
 pub struct UpdateWorkerGuard {
@@ -64,6 +67,7 @@ impl UpdateWorkerGuard {
             app_id: app_id.to_string(),
             target_version: target_version.to_string(),
             started_at_utc: now_utc_rfc3339(),
+            process_start_time: process_start_time(std::process::id()),
         };
         let path = update_worker_path(install_dir);
         let json = serde_json::to_vec_pretty(&record)
@@ -154,14 +158,22 @@ fn fail_abandoned_in_progress_update_at(
         return Ok(Some(failed));
     };
 
-    if worker.pid == std::process::id() {
+    let worker_liveness = worker.process_start_time.map_or_else(
+        || probe_pid_liveness(worker.pid),
+        |start_time| probe_process_identity(worker.pid, start_time),
+    );
+
+    if worker.process_start_time.is_some()
+        && worker.pid == std::process::id()
+        && matches!(worker_liveness, PidLiveness::Alive)
+    {
         // The marker belongs to this process: a previous in-process attempt
         // stalled. The caller proceeds with its own attempt, which takes over
         // the record; there is nothing to reclassify.
         return Ok(None);
     }
 
-    match probe_pid_liveness(worker.pid) {
+    match worker_liveness {
         PidLiveness::Dead => {
             // Dead foreign worker: the attempt can never make progress again,
             // so fail it immediately instead of waiting out the staleness
@@ -563,6 +575,7 @@ mod tests {
             app_id: app_id.to_string(),
             target_version: target_version.to_string(),
             started_at_utc: now_utc_rfc3339(),
+            process_start_time: process_start_time(pid),
         };
         let json = serde_json::to_vec_pretty(&record).unwrap();
         write_file_atomic(&update_worker_path(dir), &json).unwrap();
@@ -650,5 +663,48 @@ mod tests {
         let persisted = read_update_status(dir.path()).unwrap().unwrap();
         assert_eq!(persisted.state, UpdateConvergenceState::InProgress);
         assert_eq!(persisted.current_phase.as_deref(), Some("package apply started"));
+    }
+
+    #[test]
+    fn reused_current_pid_does_not_own_worker_marker() {
+        let dir = tempfile::tempdir().unwrap();
+        let record = UpdateStatusRecord::in_progress(
+            "demo-app",
+            "9998.0.0",
+            "9999.0.0",
+            "stable",
+            "2026-05-15T20:00:00Z".to_string(),
+        )
+        .with_current_phase_at("package apply started", "2026-05-15T20:09:45Z".to_string());
+        write_update_status(dir.path(), &record).unwrap();
+
+        let pid = std::process::id();
+        let actual_start_time = process_start_time(pid).expect("current process start time");
+        let worker = UpdateWorkerRecord {
+            pid,
+            app_id: "demo-app".to_string(),
+            target_version: "9999.0.0".to_string(),
+            started_at_utc: now_utc_rfc3339(),
+            process_start_time: Some(actual_start_time ^ 1),
+        };
+        let json = serde_json::to_vec_pretty(&worker).unwrap();
+        write_file_atomic(&update_worker_path(dir.path()), &json).unwrap();
+
+        let now = chrono::DateTime::parse_from_rfc3339("2026-05-15T20:10:00Z")
+            .unwrap()
+            .with_timezone(&chrono::Utc);
+        let failed = fail_abandoned_in_progress_update_at(
+            dir.path(),
+            "demo-app",
+            "9999.0.0",
+            "stable",
+            Duration::from_mins(5),
+            now,
+        )
+        .unwrap()
+        .expect("a reused pid must not retain worker ownership");
+
+        assert_eq!(failed.state, UpdateConvergenceState::Failed);
+        assert!(failed.reason.as_deref().unwrap().contains("exited without completing"));
     }
 }

--- a/crates/surge-ffi/src/lib.rs
+++ b/crates/surge-ffi/src/lib.rs
@@ -256,6 +256,16 @@ pub unsafe extern "C" fn surge_supervisor_start(
             return SURGE_ERROR;
         }
 
+        let process_id = surge_core::platform::process::current_pid();
+        let Some(process_start_time) = surge_core::platform::process::process_start_time(process_id) else {
+            tracing::error!(
+                process_id,
+                "supervisor_start failed: could not capture exact process identity"
+            );
+            ffi_trace("surge_supervisor_start: process identity unavailable");
+            return SURGE_ERROR;
+        };
+
         ffi_trace("surge_supervisor_start: writing restart args");
         if let Err(e) = write_restart_args(install_dir, &sup_id, &args_owned) {
             tracing::error!("supervisor_start failed: {e}");
@@ -270,12 +280,9 @@ pub unsafe extern "C" fn surge_supervisor_start(
             return SURGE_ERROR;
         }
 
-        let pid = surge_core::platform::process::current_pid().to_string();
-        let mut args: Vec<&str> = vec!["watch", "--id", &sup_id, "--dir", &install_dir_s, "--pid", &pid];
-        if !args_owned.is_empty() {
-            args.push("--");
-            args.extend(args_owned.iter().map(String::as_str));
-        }
+        let args_owned =
+            build_self_supervisor_watch_args(&sup_id, &install_dir_s, process_id, process_start_time, &args_owned);
+        let args = args_owned.iter().map(String::as_str).collect::<Vec<_>>();
 
         ffi_trace("surge_supervisor_start: spawning supervisor");
         match surge_core::platform::process::spawn_detached(
@@ -296,6 +303,31 @@ pub unsafe extern "C" fn surge_supervisor_start(
             }
         }
     }))
+}
+
+fn build_self_supervisor_watch_args(
+    supervisor_id: &str,
+    install_dir: &str,
+    process_id: u32,
+    process_start_time: u64,
+    child_args: &[String],
+) -> Vec<String> {
+    let mut args = vec![
+        "watch".to_string(),
+        "--id".to_string(),
+        supervisor_id.to_string(),
+        "--dir".to_string(),
+        install_dir.to_string(),
+        "--pid".to_string(),
+        process_id.to_string(),
+        "--pid-start-time".to_string(),
+        process_start_time.to_string(),
+    ];
+    if !child_args.is_empty() {
+        args.push("--".to_string());
+        args.extend(child_args.iter().cloned());
+    }
+    args
 }
 
 fn mark_self_supervised_runtime_converged(install_dir: &Path, active_app_dir: &Path) {
@@ -585,6 +617,31 @@ mod tests {
             format!("id: demo-app\nversion: {version}\nchannel: test\n"),
         )
         .unwrap();
+    }
+
+    #[test]
+    fn self_supervisor_watch_args_include_exact_process_identity() {
+        let child_args = vec!["--mode".to_string(), "service".to_string()];
+
+        let args = super::build_self_supervisor_watch_args("demo-supervisor", "/opt/demo", 42, 1_234, &child_args);
+
+        assert_eq!(
+            args,
+            vec![
+                "watch",
+                "--id",
+                "demo-supervisor",
+                "--dir",
+                "/opt/demo",
+                "--pid",
+                "42",
+                "--pid-start-time",
+                "1234",
+                "--",
+                "--mode",
+                "service",
+            ]
+        );
     }
 
     #[test]

--- a/crates/surge-supervisor/src/child.rs
+++ b/crates/surge-supervisor/src/child.rs
@@ -7,6 +7,7 @@ use sysinfo::{Pid, ProcessesToUpdate, System};
 use crate::SupervisorError;
 use crate::handoff;
 use crate::ownership::supervisor_was_superseded;
+use surge_core::platform::process::{PidLiveness, probe_process_identity};
 
 const RESTART_HANDOFF_STABILITY_WINDOW: std::time::Duration = std::time::Duration::from_secs(4);
 
@@ -151,6 +152,7 @@ fn wait_for_child_startup_or_stop(
 
 pub(crate) fn wait_for_pid_or_stop(
     pid: u32,
+    expected_start_time: Option<u64>,
     shutdown: &std::sync::Arc<std::sync::atomic::AtomicBool>,
     stop_file: &Path,
     pid_file: &Path,
@@ -169,12 +171,23 @@ pub(crate) fn wait_for_pid_or_stop(
             return WaitOutcome::StopRequested;
         }
 
-        if !is_process_running(pid) {
+        if !is_process_identity_running(pid, expected_start_time) {
             return WaitOutcome::ObservedProcessExited;
         }
 
         std::thread::sleep(std::time::Duration::from_millis(100));
     }
+}
+
+fn is_process_identity_running(pid: u32, expected_start_time: Option<u64>) -> bool {
+    if let Some(expected_start_time) = expected_start_time {
+        return match probe_process_identity(pid, expected_start_time) {
+            PidLiveness::Dead => false,
+            PidLiveness::Alive | PidLiveness::Unknown => true,
+        };
+    }
+
+    is_process_running(pid)
 }
 
 fn wait_for_child_or_stop(
@@ -280,6 +293,20 @@ fn is_process_running(pid: u32) -> bool {
     };
 
     matches!(kill(Pid::from_raw(raw_pid), None), Ok(()) | Err(Errno::EPERM))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn watched_process_identity_rejects_a_reused_pid() {
+        let pid = std::process::id();
+        let start_time = surge_core::platform::process::process_start_time(pid).unwrap();
+
+        assert!(is_process_identity_running(pid, Some(start_time)));
+        assert!(!is_process_identity_running(pid, Some(start_time ^ 1)));
+    }
 }
 
 #[cfg(windows)]

--- a/crates/surge-supervisor/src/main.rs
+++ b/crates/surge-supervisor/src/main.rs
@@ -75,6 +75,10 @@ enum Commands {
         #[arg(long)]
         pid: u32,
 
+        /// Start-time identity of the process named by --pid
+        #[arg(long)]
+        pid_start_time: Option<u64>,
+
         /// Target version whose update handoff should converge after replacement child startup
         #[arg(long)]
         handoff_version: Option<String>,
@@ -159,7 +163,7 @@ fn main() -> ExitCode {
                     return ExitCode::FAILURE;
                 }
             };
-            if let Err(e) = run_supervisor(&id, &dir, &exe_path, &args, None, None) {
+            if let Err(e) = run_supervisor(&id, &dir, &exe_path, &args, None, None, None) {
                 tracing::error!("{e}");
                 return ExitCode::FAILURE;
             }
@@ -169,6 +173,7 @@ fn main() -> ExitCode {
             id,
             dir,
             pid,
+            pid_start_time,
             handoff_version,
             exe,
             args,
@@ -182,7 +187,15 @@ fn main() -> ExitCode {
                     return ExitCode::FAILURE;
                 }
             };
-            if let Err(e) = run_supervisor(&id, &dir, &exe_path, &args, Some(pid), handoff_version.as_deref()) {
+            if let Err(e) = run_supervisor(
+                &id,
+                &dir,
+                &exe_path,
+                &args,
+                Some(pid),
+                pid_start_time,
+                handoff_version.as_deref(),
+            ) {
                 tracing::error!("{e}");
                 return ExitCode::FAILURE;
             }
@@ -207,6 +220,7 @@ fn run_supervisor(
     exe_path: &Path,
     args: &[String],
     watched_pid: Option<u32>,
+    watched_pid_start_time: Option<u64>,
     handoff_version: Option<&str>,
 ) -> Result<(), SupervisorError> {
     tracing::info!(
@@ -237,6 +251,7 @@ fn run_supervisor(
     let mut next_child_args = Some(first_child_args);
     let mut pending_handoff_version = handoff::pending_restart_handoff_version(watched_pid, handoff_version, args);
     let mut watched_pid = watched_pid;
+    let mut watched_pid_start_time = watched_pid_start_time;
 
     loop {
         if shutdown.load(std::sync::atomic::Ordering::Acquire) || stop_file.exists() {
@@ -250,7 +265,14 @@ fn run_supervisor(
 
         if let Some(pid) = watched_pid.take() {
             tracing::info!("Watching running process PID {pid} before relaunch");
-            match wait_for_pid_or_stop(pid, &shutdown, &stop_file, &pid_file, own_pid) {
+            match wait_for_pid_or_stop(
+                pid,
+                watched_pid_start_time.take(),
+                &shutdown,
+                &stop_file,
+                &pid_file,
+                own_pid,
+            ) {
                 WaitOutcome::ObservedProcessExited => {
                     if supervisor_was_superseded(&pid_file, own_pid) {
                         break;
@@ -433,6 +455,8 @@ mod tests {
             "/tmp/demo",
             "--pid",
             "42",
+            "--pid-start-time",
+            "1234",
             "--handoff-version",
             "2.0.0",
             "--exe",
@@ -443,12 +467,16 @@ mod tests {
         .unwrap();
 
         let Commands::Watch {
-            handoff_version, args, ..
+            pid_start_time,
+            handoff_version,
+            args,
+            ..
         } = cli.command
         else {
             panic!("expected watch command");
         };
 
+        assert_eq!(pid_start_time, Some(1_234));
         assert_eq!(handoff_version.as_deref(), Some("2.0.0"));
         assert_eq!(args, vec!["--app-mode"]);
     }
@@ -491,6 +519,7 @@ mod tests {
                 &exe_path_for_thread,
                 &[],
                 Some(watched_pid),
+                None,
                 None,
             );
             tx.send(result).unwrap();
@@ -611,6 +640,7 @@ mod tests {
                 ],
                 None,
                 None,
+                None,
             );
             tx.send(result).unwrap();
         });
@@ -679,6 +709,7 @@ mod tests {
                 &exe_path_for_thread,
                 &[],
                 Some(watched_pid),
+                None,
                 Some("2.0.0"),
             );
             tx.send(result).unwrap();
@@ -745,6 +776,7 @@ mod tests {
                 &install_dir_for_thread,
                 &exe_path_for_thread,
                 &[],
+                None,
                 None,
                 None,
             );


### PR DESCRIPTION
## Summary

- capture native process creation identity on Linux, macOS, and Windows
- carry that identity through supervisor watch handoffs so PID reuse cannot release a wait early
- keep legacy PID-only supervisor invocations compatible while failing closed on inconclusive exact-identity probes

## Stack

1. This PR (#294): process-identity foundation
2. #295: external finalizer and recovery
3. #296: consumer outcome and end-to-end smoke

Each PR is based on the preceding branch. Review and merge in order.

## Why

This is the first of three deliberately bounded changes for #292. Exact process identity is the prerequisite for safely waiting on or signalling a self-updating supervised application.

## Validation

- `RUSTFLAGS="-D warnings" cargo test --workspace`
- `cargo clippy --all-targets --all-features -- -D warnings`
- strict library and binary Clippy gate forbidding `unwrap` and `expect`

Refs #292
