### PR TITLE
Finalize supervised self-updates outside the app

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3262,6 +3262,7 @@ dependencies = [
  "thiserror 2.0.20",
  "tokio",
  "tracing",
+ "uuid",
  "windows-sys 0.61.2",
  "zstd",
 ]
@@ -3309,6 +3310,7 @@ dependencies = [
  "surge-core",
  "sysinfo",
  "thiserror 2.0.20",
+ "tokio",
  "tracing",
  "tracing-subscriber",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ indicatif = "0.18"
 tempfile = "3"
 fs2 = "0.4"
 uuid = { version = "1", features = ["v4"] }
+sysinfo = "0.39.3"
 which = "8"
 eframe = { version = "0.36.0", default-features = false, features = ["glow", "default_fonts", "x11", "wayland"] }
 image = { version = "0.25", default-features = false, features = ["png"] }

--- a/crates/surge-core/Cargo.toml
+++ b/crates/surge-core/Cargo.toml
@@ -38,13 +38,12 @@ async-trait = { workspace = true }
 futures-util = { workspace = true }
 tempfile = { workspace = true }
 fs2 = { workspace = true }
+uuid = { workspace = true }
+sysinfo = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
 nix = { version = "0.31", features = ["signal", "process", "fs"] }
 libc = "0.2"
-
-[target.'cfg(target_os = "macos")'.dependencies]
-sysinfo = "0.39.3"
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_System_Threading", "Win32_Security", "Win32_Storage_FileSystem"] }

--- a/crates/surge-core/src/platform/process.rs
+++ b/crates/surge-core/src/platform/process.rs
@@ -68,7 +68,8 @@ pub fn spawn_process(
     spawn_impl(exe, args, working_dir, envs, Stdio::inherit(), Stdio::inherit(), false)
 }
 
-/// Spawn a process fully detached (stdin/stdout/stderr = null).
+/// Spawn a process fully detached (stdin/stdout/stderr = null and independent
+/// from the caller's process group or job).
 pub fn spawn_detached(
     exe: &Path,
     args: &[&str],
@@ -90,13 +91,23 @@ fn spawn_impl(
     let mut cmd = Command::new(exe);
     cmd.args(args).stdin(Stdio::null()).stdout(stdout).stderr(stderr);
 
-    #[cfg(not(unix))]
+    #[cfg(not(any(unix, windows)))]
     let _ = detached;
 
     #[cfg(unix)]
     if detached {
         use std::os::unix::process::CommandExt;
         cmd.process_group(0);
+    }
+
+    #[cfg(windows)]
+    if detached {
+        use std::os::windows::process::CommandExt;
+        use windows_sys::Win32::System::Threading::{
+            CREATE_BREAKAWAY_FROM_JOB, CREATE_NEW_PROCESS_GROUP, DETACHED_PROCESS,
+        };
+
+        cmd.creation_flags(CREATE_BREAKAWAY_FROM_JOB | CREATE_NEW_PROCESS_GROUP | DETACHED_PROCESS);
     }
 
     if let Some(wd) = working_dir {
@@ -231,19 +242,44 @@ pub fn probe_pid_liveness(pid: u32) -> PidLiveness {
 
 /// Probe whether `pid` still identifies the process with `expected_start_time`.
 ///
-/// A different start time conclusively means the original process exited and
-/// the PID was reused. If start-time inspection is unavailable while the PID
-/// still appears live, the result is [`PidLiveness::Unknown`] so callers can
-/// fail closed.
+/// A different start time or a confirmed terminal state conclusively means the
+/// original process exited. If identity inspection is unavailable while the
+/// PID still appears live, the result is [`PidLiveness::Unknown`] so callers
+/// can fail closed.
 #[must_use]
 pub fn probe_process_identity(pid: u32, expected_start_time: u64) -> PidLiveness {
-    match process_start_time(pid) {
-        Some(actual_start_time) if actual_start_time == expected_start_time => PidLiveness::Alive,
-        Some(_) => PidLiveness::Dead,
-        None => match probe_pid_liveness(pid) {
-            PidLiveness::Dead => PidLiveness::Dead,
-            PidLiveness::Alive | PidLiveness::Unknown => PidLiveness::Unknown,
-        },
+    #[cfg(target_os = "macos")]
+    let known_liveness = descriptors::process_identity_is_alive(pid, expected_start_time).map(|is_alive| {
+        if is_alive {
+            PidLiveness::Alive
+        } else {
+            PidLiveness::Dead
+        }
+    });
+    #[cfg(not(target_os = "macos"))]
+    let known_liveness = process_start_time(pid).map(|actual_start_time| {
+        if actual_start_time == expected_start_time {
+            PidLiveness::Alive
+        } else {
+            PidLiveness::Dead
+        }
+    });
+
+    known_liveness.unwrap_or_else(|| match probe_pid_liveness(pid) {
+        PidLiveness::Dead => PidLiveness::Dead,
+        PidLiveness::Alive | PidLiveness::Unknown => PidLiveness::Unknown,
+    })
+}
+
+#[cfg(all(test, target_os = "macos"))]
+fn wait_for_identity_to_exit(pid: u32, start_time: u64) -> PidLiveness {
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    loop {
+        let liveness = probe_process_identity(pid, start_time);
+        if liveness == PidLiveness::Dead || std::time::Instant::now() >= deadline {
+            return liveness;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(20));
     }
 }
 
@@ -372,6 +408,21 @@ mod tests {
 
         assert_eq!(probe_process_identity(pid, start_time), PidLiveness::Alive);
         assert_eq!(probe_process_identity(pid, start_time ^ 1), PidLiveness::Dead);
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn process_identity_reports_an_unreaped_zombie_dead() {
+        let mut child = std::process::Command::new("/bin/sleep")
+            .arg("30")
+            .spawn()
+            .expect("spawn helper");
+        let pid = child.id();
+        let start_time = process_start_time(pid).expect("child process start time");
+        child.kill().expect("kill helper");
+
+        assert_eq!(super::wait_for_identity_to_exit(pid, start_time), PidLiveness::Dead);
+        child.wait().expect("reap helper");
     }
 
     #[test]

--- a/crates/surge-core/src/platform/process/descriptors.rs
+++ b/crates/surge-core/src/platform/process/descriptors.rs
@@ -100,6 +100,18 @@ fn parse_linux_process_start_time(stat: &[u8]) -> Option<u64> {
 
 #[cfg(target_os = "macos")]
 pub(super) fn process_start_time(pid: u32) -> Option<u64> {
+    macos_process_info(pid, false).and_then(|info| macos_process_start_time(&info))
+}
+
+#[cfg(target_os = "macos")]
+pub(super) fn process_identity_is_alive(pid: u32, expected_start_time: u64) -> Option<bool> {
+    let info = macos_process_info(pid, true)?;
+    let actual_start_time = macos_process_start_time(&info)?;
+    Some(actual_start_time == expected_start_time && info.pbi_status != libc::SZOMB)
+}
+
+#[cfg(target_os = "macos")]
+fn macos_process_info(pid: u32, include_zombies: bool) -> Option<libc::proc_bsdinfo> {
     let pid = libc::pid_t::try_from(pid).ok()?;
     if pid <= 0 {
         return None;
@@ -107,13 +119,15 @@ pub(super) fn process_start_time(pid: u32) -> Option<u64> {
 
     let mut info = std::mem::MaybeUninit::<libc::proc_bsdinfo>::zeroed();
     let size = libc::c_int::try_from(std::mem::size_of::<libc::proc_bsdinfo>()).ok()?;
+    // XNU searches its zombie list for BSD process info only when arg is nonzero.
+    let zombie_lookup = if include_zombies { 1 } else { 0 };
     // SAFETY: `info` points to writable storage of exactly the size passed to
     // proc_pidinfo. A full-size return is required before the value is read.
     let written = unsafe {
         libc::proc_pidinfo(
             pid,
             libc::PROC_PIDTBSDINFO,
-            0,
+            zombie_lookup,
             info.as_mut_ptr().cast::<libc::c_void>(),
             size,
         )
@@ -123,7 +137,11 @@ pub(super) fn process_start_time(pid: u32) -> Option<u64> {
     }
 
     // SAFETY: proc_pidinfo reported that it initialized the complete structure.
-    let info = unsafe { info.assume_init() };
+    Some(unsafe { info.assume_init() })
+}
+
+#[cfg(target_os = "macos")]
+fn macos_process_start_time(info: &libc::proc_bsdinfo) -> Option<u64> {
     info.pbi_start_tvsec
         .checked_mul(1_000_000)?
         .checked_add(info.pbi_start_tvusec)

--- a/crates/surge-core/src/update/manager.rs
+++ b/crates/surge-core/src/update/manager.rs
@@ -3,6 +3,7 @@
 mod apply;
 mod artifacts;
 mod current_install;
+mod external_finalize;
 mod finalize;
 mod lifecycle;
 mod progress;
@@ -24,6 +25,7 @@ use crate::update::status::{self, FailureContext, UpdateStatusRecord, UpdateWork
 
 use self::apply::materialize_update_payload;
 use self::artifacts::prepare_update_artifacts;
+pub use self::external_finalize::run_external_finalize;
 use self::finalize::finalize_update;
 use self::lifecycle::SupervisorRestartOutcome;
 pub use self::progress::ProgressInfo;
@@ -37,6 +39,16 @@ use self::release_index::{load_release_index as load_release_index_impl, resolve
 pub enum ApplyStrategy {
     Full,
     Delta,
+}
+
+/// Result of a successful update apply request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UpdateApplyOutcome {
+    /// Finalization completed before the apply call returned.
+    Finalized,
+    /// A stable helper accepted ownership and will finalize after the calling
+    /// supervised application exits.
+    ExternalFinalizeScheduled,
 }
 
 /// Information about available updates.
@@ -69,6 +81,7 @@ pub struct UpdateCheckState {
     current_version: String,
     channel: String,
     install_dir: PathBuf,
+    cached_index: Option<ReleaseIndex>,
     current_release_identity: Option<current_install::ReleaseIdentity>,
 }
 
@@ -207,6 +220,7 @@ impl UpdateManager {
             current_version: self.current_version.clone(),
             channel: self.channel.clone(),
             install_dir: self.install_dir.clone(),
+            cached_index: self.cached_index.clone(),
             current_release_identity: self.current_release_identity.clone(),
         }
     }
@@ -231,6 +245,7 @@ impl UpdateManager {
             ));
         }
 
+        self.cached_index.clone_from(&state.cached_index);
         self.current_release_identity = installed_identity;
         Ok(())
     }
@@ -322,7 +337,7 @@ impl UpdateManager {
     /// tooling can distinguish "update in progress", "applied but pending
     /// supervisor restart", "fully converged", and "failed" without inferring
     /// state from version drift alone (see [`status`]).
-    pub async fn download_and_apply<F>(&self, info: &UpdateInfo, progress: Option<F>) -> Result<()>
+    pub async fn download_and_apply<F>(&self, info: &UpdateInfo, progress: Option<F>) -> Result<UpdateApplyOutcome>
     where
         F: Fn(ProgressInfo) + Send + Sync,
     {
@@ -355,13 +370,7 @@ impl UpdateManager {
             .flatten()
             .filter(|record| record.app_id == self.app_id && record.target_version == target_version);
 
-        let _worker_guard = match UpdateWorkerGuard::record(&self.install_dir, &self.app_id, &target_version) {
-            Ok(guard) => Some(guard),
-            Err(e) => {
-                warn!(error = %e, "Failed to persist update worker marker (continuing)");
-                None
-            }
-        };
+        let _worker_guard = UpdateWorkerGuard::record(&self.install_dir, &self.app_id, &target_version)?;
 
         let in_progress_record = UpdateStatusRecord::in_progress(
             &self.app_id,
@@ -376,22 +385,30 @@ impl UpdateManager {
 
         let progress = progress.map(Arc::new);
         match self
-            .download_and_apply_inner(info, progress, in_progress_record.clone())
+            .download_and_apply_inner(
+                info,
+                progress,
+                in_progress_record.clone(),
+                previous_attempt_status.clone(),
+            )
             .await
         {
             Ok(restart_outcome) => {
                 let completed_at_utc = status::now_utc_rfc3339();
-                let record = match restart_outcome {
-                    SupervisorRestartOutcome::NotApplicable => UpdateStatusRecord::converged(
-                        &self.app_id,
-                        &target_version,
-                        &self.channel,
-                        Some(attempted_at_utc),
-                        completed_at_utc,
-                        false,
+                let (record, outcome) = match restart_outcome {
+                    SupervisorRestartOutcome::NotApplicable => (
+                        Some(UpdateStatusRecord::converged(
+                            &self.app_id,
+                            &target_version,
+                            &self.channel,
+                            Some(attempted_at_utc),
+                            completed_at_utc,
+                            false,
+                        )),
+                        UpdateApplyOutcome::Finalized,
                     ),
-                    SupervisorRestartOutcome::PendingRestart { reason, failure_phase } => {
-                        UpdateStatusRecord::pending_restart_with_failure_phase(
+                    SupervisorRestartOutcome::PendingRestart { reason, failure_phase } => (
+                        Some(UpdateStatusRecord::pending_restart_with_failure_phase(
                             &self.app_id,
                             &target_version,
                             &target_version,
@@ -400,13 +417,19 @@ impl UpdateManager {
                             completed_at_utc,
                             &reason,
                             failure_phase,
-                        )
+                        )),
+                        UpdateApplyOutcome::Finalized,
+                    ),
+                    SupervisorRestartOutcome::ExternalFinalizeScheduled => {
+                        (None, UpdateApplyOutcome::ExternalFinalizeScheduled)
                     }
                 };
-                if let Err(e) = status::write_update_status(&self.install_dir, &record) {
+                if let Some(record) = record
+                    && let Err(e) = status::write_update_status(&self.install_dir, &record)
+                {
                     warn!(error = %e, "Failed to persist post-update convergence status (continuing)");
                 }
-                Ok(())
+                Ok(outcome)
             }
             Err(e) => {
                 let status_context = status::read_update_status(&self.install_dir).ok().flatten();
@@ -439,6 +462,7 @@ impl UpdateManager {
         info: &UpdateInfo,
         progress: Option<Arc<F>>,
         in_progress_template: UpdateStatusRecord,
+        previous_attempt_status: Option<UpdateStatusRecord>,
     ) -> Result<SupervisorRestartOutcome>
     where
         F: Fn(ProgressInfo) + Send + Sync,
@@ -513,6 +537,23 @@ impl UpdateManager {
         progress_emitter.emit_completed_phase(update_phase::PACKAGE_APPLY_COMPLETED);
 
         // Phase 6: Finalize
+        if external_finalize::schedule_if_required(
+            self,
+            info,
+            &extracted_final_dir,
+            &in_progress_template,
+            previous_attempt_status,
+            &progress_emitter,
+        )
+        .await?
+        {
+            info!(
+                version = %info.latest_version,
+                "Update staged; external finalizer scheduled"
+            );
+            return Ok(SupervisorRestartOutcome::ExternalFinalizeScheduled);
+        }
+
         let restart_outcome = finalize_update(
             self,
             info,
@@ -789,6 +830,39 @@ mod tests {
         let error = applying.restore_check_state(&check_state).unwrap_err();
 
         assert!(error.to_string().contains("does not match"));
+    }
+
+    #[test]
+    fn restore_check_state_preserves_the_checked_release_index() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store_root = tmp.path().join("store");
+        std::fs::create_dir_all(&store_root).unwrap();
+
+        let ctx = Arc::new(Context::new());
+        ctx.set_storage(
+            StorageProvider::Filesystem,
+            store_root.to_str().unwrap(),
+            "",
+            "",
+            "",
+            "",
+        );
+        let mut checked =
+            UpdateManager::new(Arc::clone(&ctx), "app", "1.0.0", "stable", tmp.path().to_str().unwrap()).unwrap();
+        checked.cached_index = Some(ReleaseIndex {
+            app_id: "app".to_string(),
+            releases: vec![make_entry("2.0.0", "stable", "linux", "linux-x64")],
+            ..ReleaseIndex::default()
+        });
+        let check_state = checked.capture_check_state();
+        let mut applying = UpdateManager::new(ctx, "app", "1.0.0", "stable", tmp.path().to_str().unwrap()).unwrap();
+
+        applying.restore_check_state(&check_state).unwrap();
+
+        let restored = applying.cached_index.as_ref().unwrap();
+        assert_eq!(restored.app_id, "app");
+        assert_eq!(restored.releases.len(), 1);
+        assert_eq!(restored.releases[0].version, "2.0.0");
     }
 
     #[test]

--- a/crates/surge-core/src/update/manager/current_install.rs
+++ b/crates/surge-core/src/update/manager/current_install.rs
@@ -2,6 +2,8 @@ use std::cmp::Ordering;
 use std::collections::BTreeMap;
 use std::path::{Component, Path, PathBuf};
 
+use serde::{Deserialize, Serialize};
+
 use crate::error::{Result, SurgeError};
 use crate::install::read_runtime_manifest_identity;
 use crate::releases::version::compare_versions;
@@ -9,24 +11,13 @@ use crate::supervisor::state::read_supervisor_exe_path;
 
 use super::{UpdateManager, apply};
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub(super) struct ReleaseIdentity {
     pub(super) version: String,
     pub(super) main_exe: String,
     pub(super) supervisor_id: String,
     pub(super) environment: BTreeMap<String, String>,
 }
-
-impl PartialEq for ReleaseIdentity {
-    fn eq(&self, other: &Self) -> bool {
-        self.version == other.version
-            && self.main_exe == other.main_exe
-            && self.supervisor_id == other.supervisor_id
-            && self.environment == other.environment
-    }
-}
-
-impl Eq for ReleaseIdentity {}
 
 pub(super) fn load(manager: &UpdateManager) -> Result<Option<ReleaseIdentity>> {
     let Some(active_app_dir) = apply::find_previous_app_dir(&manager.install_dir, &manager.current_version) else {
@@ -36,7 +27,6 @@ pub(super) fn load(manager: &UpdateManager) -> Result<Option<ReleaseIdentity>> {
     load_from_app_dir(manager, &active_app_dir, Some(&manager.current_version))
 }
 
-#[cfg(unix)]
 pub(super) fn load_previous_swap(manager: &UpdateManager, app_dir: &Path) -> Result<Option<ReleaseIdentity>> {
     load_from_app_dir(manager, app_dir, None)
 }

--- a/crates/surge-core/src/update/manager/external_finalize.rs
+++ b/crates/surge-core/src/update/manager/external_finalize.rs
@@ -1,0 +1,7 @@
+mod plan;
+mod quiesce;
+mod runner;
+mod schedule;
+
+pub use runner::run_external_finalize;
+pub(super) use schedule::schedule_if_required;

--- a/crates/surge-core/src/update/manager/external_finalize/plan.rs
+++ b/crates/surge-core/src/update/manager/external_finalize/plan.rs
@@ -1,0 +1,396 @@
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::config::manifest::InstallArtifactCachePolicy;
+use crate::context::{Context, StorageConfig, StorageProvider};
+use crate::error::{Result, SurgeError};
+use crate::platform::fs::write_file_atomic;
+use crate::platform::process::{current_pid, supervisor_binary_name};
+use crate::releases::manifest::{ReleaseEntry, ReleaseIndex};
+use crate::update::status::UpdateStatusRecord;
+
+use super::super::current_install::ReleaseIdentity;
+use super::super::{UpdateManager, current_install};
+
+const EXTERNAL_FINALIZE_SCHEMA: u32 = 1;
+pub(super) const EXTERNAL_FINALIZE_DIR: &str = ".surge-finalize";
+pub(super) const PLAN_FILE_NAME: &str = "plan.json";
+pub(super) const READY_FILE_NAME: &str = "ready";
+pub(super) const ARMED_FILE_NAME: &str = "armed";
+pub(super) const ACCEPTED_FILE_NAME: &str = "accepted";
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct ExternalStorageConfig {
+    provider: i32,
+    bucket: String,
+    region: String,
+    endpoint: String,
+    prefix: String,
+}
+
+impl ExternalStorageConfig {
+    fn from_storage_config(config: &StorageConfig) -> Result<Self> {
+        let provider = config
+            .provider
+            .ok_or_else(|| SurgeError::Config("External finalizer requires a storage provider".to_string()))?;
+        Ok(Self {
+            provider: provider as i32,
+            bucket: config.bucket.clone(),
+            region: config.region.clone(),
+            endpoint: config.endpoint.clone(),
+            prefix: config.prefix.clone(),
+        })
+    }
+
+    fn apply_to_context(&self, context: &Context) -> Result<()> {
+        let provider = StorageProvider::from_i32(self.provider).ok_or_else(|| {
+            SurgeError::Config(format!(
+                "External finalizer plan uses unknown storage provider {}",
+                self.provider
+            ))
+        })?;
+        context.set_storage(provider, &self.bucket, &self.region, "", "", &self.endpoint);
+        context.set_storage_prefix(&self.prefix);
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(super) struct ExternalFinalizePlan {
+    schema: u32,
+    pub(super) operation_id: String,
+    pub(super) install_dir: PathBuf,
+    pub(super) updater_pid: u32,
+    pub(super) updater_start_time: u64,
+    pub(super) updater_exe: PathBuf,
+    pub(super) app_id: String,
+    pub(super) current_version: String,
+    pub(super) channel: String,
+    pub(super) release_retention_limit: usize,
+    pub(super) artifact_retention_policy: InstallArtifactCachePolicy,
+    storage: ExternalStorageConfig,
+    pub(super) release_index: ReleaseIndex,
+    pub(super) current_release_identity: ReleaseIdentity,
+    pub(super) target_release: ReleaseEntry,
+    pub(super) restart_args: Vec<String>,
+    pub(super) in_progress_template: UpdateStatusRecord,
+    pub(super) previous_attempt_status: Option<UpdateStatusRecord>,
+}
+
+impl ExternalFinalizePlan {
+    pub(super) fn from_manager(
+        manager: &UpdateManager,
+        target_release: &ReleaseEntry,
+        updater_exe: PathBuf,
+        updater_start_time: u64,
+        restart_args: Vec<String>,
+        in_progress_template: &UpdateStatusRecord,
+        previous_attempt_status: Option<UpdateStatusRecord>,
+    ) -> Result<Self> {
+        let release_index = manager.cached_index.clone().ok_or_else(|| {
+            SurgeError::Update(
+                "External finalization requires the release index captured during update check".to_string(),
+            )
+        })?;
+        let current_release_identity = manager.current_release_identity.clone().ok_or_else(|| {
+            SurgeError::Update("External finalization requires the installed application identity".to_string())
+        })?;
+        if current_release_identity.supervisor_id.trim().is_empty() {
+            return Err(SurgeError::Update(
+                "External finalization requires a supervised current release".to_string(),
+            ));
+        }
+        if target_release.supervisor_id.trim().is_empty() {
+            return Err(SurgeError::Update(
+                "External finalization requires a supervised target release".to_string(),
+            ));
+        }
+
+        Ok(Self {
+            schema: EXTERNAL_FINALIZE_SCHEMA,
+            operation_id: Uuid::new_v4().to_string(),
+            install_dir: manager.install_dir.clone(),
+            updater_pid: current_pid(),
+            updater_start_time,
+            updater_exe,
+            app_id: manager.app_id.clone(),
+            current_version: manager.current_version.clone(),
+            channel: manager.channel.clone(),
+            release_retention_limit: manager.release_retention_limit,
+            artifact_retention_policy: manager.artifact_retention_policy,
+            storage: ExternalStorageConfig::from_storage_config(&manager.ctx.storage_config())?,
+            release_index,
+            current_release_identity,
+            target_release: target_release.clone(),
+            restart_args,
+            in_progress_template: in_progress_template.clone(),
+            previous_attempt_status,
+        })
+    }
+
+    pub(super) fn operations_dir(&self) -> PathBuf {
+        self.install_dir.join(EXTERNAL_FINALIZE_DIR)
+    }
+
+    pub(super) fn operation_dir(&self) -> PathBuf {
+        self.operations_dir().join(&self.operation_id)
+    }
+
+    pub(super) fn plan_path(&self) -> PathBuf {
+        self.operation_dir().join(PLAN_FILE_NAME)
+    }
+
+    pub(super) fn ready_path(&self) -> PathBuf {
+        self.operation_dir().join(READY_FILE_NAME)
+    }
+
+    pub(super) fn armed_path(&self) -> PathBuf {
+        self.operation_dir().join(ARMED_FILE_NAME)
+    }
+
+    pub(super) fn accepted_path(&self) -> PathBuf {
+        self.operation_dir().join(ACCEPTED_FILE_NAME)
+    }
+
+    pub(super) fn active_app_dir(&self) -> PathBuf {
+        self.install_dir.join("app")
+    }
+
+    pub(super) fn previous_version_dir(&self) -> PathBuf {
+        self.install_dir.join(format!("app-{}", self.current_version))
+    }
+
+    pub(super) fn staging_dir(&self) -> PathBuf {
+        self.install_dir.join(".surge-staging")
+    }
+
+    pub(super) fn extracted_final_dir(&self) -> PathBuf {
+        self.staging_dir().join("extracted")
+    }
+
+    pub(super) fn artifact_cache_dir(&self) -> PathBuf {
+        self.install_dir.join(".surge-cache").join("artifacts")
+    }
+}
+
+pub(super) fn write_plan(plan: &ExternalFinalizePlan) -> Result<()> {
+    let json = serde_json::to_vec_pretty(plan)
+        .map_err(|error| SurgeError::Config(format!("Failed to encode external finalizer plan: {error}")))?;
+    write_file_atomic(&plan.plan_path(), &json)
+}
+
+pub(super) fn read_and_validate_plan(plan_path: &Path) -> Result<ExternalFinalizePlan> {
+    let raw = std::fs::read(plan_path)?;
+    let plan: ExternalFinalizePlan = serde_json::from_slice(&raw)
+        .map_err(|error| SurgeError::Config(format!("Failed to decode external finalizer plan: {error}")))?;
+    if plan.schema != EXTERNAL_FINALIZE_SCHEMA {
+        return Err(SurgeError::Config(format!(
+            "Unsupported external finalizer plan schema {}",
+            plan.schema
+        )));
+    }
+    Uuid::parse_str(&plan.operation_id)
+        .map_err(|error| SurgeError::Config(format!("Invalid external finalizer operation id: {error}")))?;
+    let bound_install_dir = super::super::bind_install_dir(&plan.install_dir.to_string_lossy())?;
+    if bound_install_dir != plan.install_dir {
+        return Err(SurgeError::Config(
+            "External finalizer plan install directory is not canonically bound".to_string(),
+        ));
+    }
+    if std::path::absolute(plan_path)? != plan.plan_path() {
+        return Err(SurgeError::Config(
+            "External finalizer plan path does not match its operation id".to_string(),
+        ));
+    }
+    if plan.updater_pid == 0 || plan.updater_pid == current_pid() || plan.updater_start_time == 0 {
+        return Err(SurgeError::Config(
+            "External finalizer plan has an invalid updating process identity".to_string(),
+        ));
+    }
+    if plan.app_id.trim().is_empty()
+        || plan.current_version.trim().is_empty()
+        || plan.channel.trim().is_empty()
+        || plan.target_release.version.trim().is_empty()
+        || plan.current_release_identity.supervisor_id.trim().is_empty()
+        || plan.target_release.supervisor_id.trim().is_empty()
+    {
+        return Err(SurgeError::Config(
+            "External finalizer plan is missing supervised application identity".to_string(),
+        ));
+    }
+    if plan.target_release.version != plan.in_progress_template.target_version
+        || plan.app_id != plan.in_progress_template.app_id
+        || plan.channel != plan.in_progress_template.channel
+        || plan.current_version != plan.in_progress_template.installed_version
+    {
+        return Err(SurgeError::Config(
+            "External finalizer plan does not match its update status transaction".to_string(),
+        ));
+    }
+    let expected_updater = plan.active_app_dir().join(&plan.current_release_identity.main_exe);
+    if plan.updater_exe != std::fs::canonicalize(&expected_updater)? {
+        return Err(SurgeError::Config(
+            "External finalizer updater is not the stable active application executable".to_string(),
+        ));
+    }
+    if !plan.release_index.releases.iter().any(|release| {
+        release.version == plan.target_release.version
+            && release.rid == plan.target_release.rid
+            && release.full_sha256 == plan.target_release.full_sha256
+    }) {
+        return Err(SurgeError::Config(
+            "External finalizer target does not match its captured release index".to_string(),
+        ));
+    }
+    Ok(plan)
+}
+
+pub(super) fn manager_from_plan(plan: &ExternalFinalizePlan) -> Result<UpdateManager> {
+    let context = Arc::new(Context::new());
+    plan.storage.apply_to_context(&context)?;
+    let mut manager = UpdateManager::new(
+        context,
+        &plan.app_id,
+        &plan.current_version,
+        &plan.channel,
+        &plan.install_dir.to_string_lossy(),
+    )?;
+    manager.release_retention_limit = plan.release_retention_limit.max(1);
+    manager.artifact_retention_policy = plan.artifact_retention_policy;
+    manager.cached_index = Some(plan.release_index.clone());
+    manager.current_release_identity = Some(plan.current_release_identity.clone());
+    Ok(manager)
+}
+
+pub(super) fn validate_materialized_target(plan: &ExternalFinalizePlan, manager: &UpdateManager) -> Result<()> {
+    let actual_identity = current_install::load(manager)?;
+    if actual_identity.as_ref() != Some(&plan.current_release_identity) {
+        return Err(SurgeError::Update(
+            "Installed application identity changed before the external finalizer became ready".to_string(),
+        ));
+    }
+    if !plan.extracted_final_dir().is_dir() {
+        return Err(SurgeError::Update("External finalizer payload is missing".to_string()));
+    }
+    if !plan.extracted_final_dir().join(&plan.target_release.main_exe).is_file() {
+        return Err(SurgeError::Update(
+            "External finalizer target executable is missing".to_string(),
+        ));
+    }
+    if !plan.extracted_final_dir().join(supervisor_binary_name()).is_file() {
+        return Err(SurgeError::Update(
+            "External finalizer target supervisor is missing".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn plan_fixture() -> (tempfile::TempDir, UpdateManager, ReleaseEntry, UpdateStatusRecord) {
+        let temp = tempfile::tempdir().unwrap();
+        let context = Arc::new(Context::new());
+        context.set_storage(
+            StorageProvider::Filesystem,
+            &temp.path().to_string_lossy(),
+            "",
+            "",
+            "",
+            "",
+        );
+        let mut manager = UpdateManager::new(
+            Arc::clone(&context),
+            "demo",
+            "1.0.0",
+            "test",
+            &temp.path().to_string_lossy(),
+        )
+        .unwrap();
+        context.set_storage(
+            StorageProvider::Filesystem,
+            &temp.path().to_string_lossy(),
+            "",
+            "secret-access-key",
+            "secret-private-key",
+            "",
+        );
+        manager.current_release_identity = Some(ReleaseIdentity {
+            version: "1.0.0".to_string(),
+            main_exe: "demo".to_string(),
+            supervisor_id: "demo-supervisor".to_string(),
+            environment: std::collections::BTreeMap::default(),
+        });
+        let target = ReleaseEntry {
+            version: "2.0.0".to_string(),
+            rid: "test-rid".to_string(),
+            full_sha256: "target-sha".to_string(),
+            main_exe: "demo".to_string(),
+            supervisor_id: "demo-supervisor".to_string(),
+            ..ReleaseEntry::default()
+        };
+        manager.cached_index = Some(ReleaseIndex {
+            app_id: "demo".to_string(),
+            releases: vec![target.clone()],
+            ..ReleaseIndex::default()
+        });
+        let status =
+            UpdateStatusRecord::in_progress("demo", "1.0.0", "2.0.0", "test", "2026-01-01T00:00:00Z".to_string());
+        (temp, manager, target, status)
+    }
+
+    #[test]
+    fn external_plan_rejects_unsupervised_current_or_target_release() {
+        let (_temp, mut manager, mut target, status) = plan_fixture();
+        manager.current_release_identity.as_mut().unwrap().supervisor_id.clear();
+
+        let current_error = ExternalFinalizePlan::from_manager(
+            &manager,
+            &target,
+            PathBuf::from("updater"),
+            1,
+            Vec::new(),
+            &status,
+            None,
+        )
+        .unwrap_err();
+        assert!(current_error.to_string().contains("supervised current release"));
+
+        manager.current_release_identity.as_mut().unwrap().supervisor_id = "demo-supervisor".to_string();
+        target.supervisor_id.clear();
+        let target_error = ExternalFinalizePlan::from_manager(
+            &manager,
+            &target,
+            PathBuf::from("updater"),
+            1,
+            Vec::new(),
+            &status,
+            None,
+        )
+        .unwrap_err();
+        assert!(target_error.to_string().contains("supervised target release"));
+    }
+
+    #[test]
+    fn external_plan_does_not_serialize_storage_credentials() {
+        let (_temp, manager, target, status) = plan_fixture();
+        let plan = ExternalFinalizePlan::from_manager(
+            &manager,
+            &target,
+            PathBuf::from("updater"),
+            1,
+            Vec::new(),
+            &status,
+            None,
+        )
+        .unwrap();
+
+        let json = serde_json::to_string(&plan).unwrap();
+        assert!(!json.contains("secret-access-key"));
+        assert!(!json.contains("secret-private-key"));
+    }
+}

--- a/crates/surge-core/src/update/manager/external_finalize/quiesce.rs
+++ b/crates/surge-core/src/update/manager/external_finalize/quiesce.rs
@@ -1,0 +1,328 @@
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use sysinfo::{Pid, ProcessStatus, ProcessesToUpdate, System};
+
+use crate::error::{Result, SurgeError};
+use crate::platform::process::{PidLiveness, probe_process_identity, process_start_time};
+
+const UPDATER_EXIT_GRACE: Duration = Duration::from_secs(20);
+const TERMINATE_GRACE: Duration = Duration::from_secs(5);
+const KILL_GRACE: Duration = Duration::from_secs(2);
+const PROCESS_POLL_INTERVAL: Duration = Duration::from_millis(100);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ProcessIdentity {
+    pid: u32,
+    start_time: u64,
+    executable: PathBuf,
+}
+
+pub(super) fn quiesce_updating_application(
+    updater_pid: u32,
+    updater_start_time: u64,
+    updater_exe: &Path,
+) -> Result<()> {
+    quiesce_updating_application_with_timeouts(
+        updater_pid,
+        updater_start_time,
+        updater_exe,
+        UPDATER_EXIT_GRACE,
+        TERMINATE_GRACE,
+        KILL_GRACE,
+    )
+}
+
+fn quiesce_updating_application_with_timeouts(
+    updater_pid: u32,
+    updater_start_time: u64,
+    updater_exe: &Path,
+    exit_grace: Duration,
+    terminate_grace: Duration,
+    kill_grace: Duration,
+) -> Result<()> {
+    let expected_executable = normalize_executable(updater_exe);
+    let updater = ProcessIdentity {
+        pid: updater_pid,
+        start_time: updater_start_time,
+        executable: expected_executable.clone(),
+    };
+    if wait_until_identity_exits(&updater, exit_grace)? {
+        tracing::info!(pid = updater_pid, "Updating application exited before finalization");
+    }
+
+    let mut remaining = matching_processes(&expected_executable)?;
+    include_running_identity(&mut remaining, &updater)?;
+    if remaining.is_empty() {
+        return Ok(());
+    }
+
+    for process in &remaining {
+        signal_process(process, false)?;
+    }
+    if wait_until_no_matching_processes(&expected_executable, &updater, terminate_grace)? {
+        tracing::info!(
+            count = remaining.len(),
+            "Stopped updating application processes before swap"
+        );
+        return Ok(());
+    }
+
+    remaining = matching_processes(&expected_executable)?;
+    include_running_identity(&mut remaining, &updater)?;
+    for process in &remaining {
+        signal_process(process, true)?;
+    }
+    if wait_until_no_matching_processes(&expected_executable, &updater, kill_grace)? {
+        tracing::warn!(
+            count = remaining.len(),
+            "Force-stopped updating application processes before swap"
+        );
+        return Ok(());
+    }
+
+    Err(SurgeError::Supervisor(format!(
+        "Timed out waiting for processes running '{}' to exit before the application swap",
+        expected_executable.display()
+    )))
+}
+
+fn include_running_identity(processes: &mut Vec<ProcessIdentity>, identity: &ProcessIdentity) -> Result<()> {
+    if identity_is_running(identity)?
+        && !processes
+            .iter()
+            .any(|process| process.pid == identity.pid && process.start_time == identity.start_time)
+    {
+        processes.push(identity.clone());
+    }
+    Ok(())
+}
+
+fn matching_processes(expected_executable: &Path) -> Result<Vec<ProcessIdentity>> {
+    let mut system = System::new();
+    let _ = system.refresh_processes(ProcessesToUpdate::All, true);
+    let own_pid = std::process::id();
+    let mut matching = Vec::new();
+    for (pid, process) in system.processes() {
+        let pid = pid.as_u32();
+        if pid == own_pid {
+            continue;
+        }
+        let Some(executable) = process.exe().map(normalize_executable) else {
+            continue;
+        };
+        if !executable_paths_equal(&executable, expected_executable) {
+            continue;
+        }
+        let start_time = process_start_time(pid).ok_or_else(|| {
+            SurgeError::Supervisor(format!(
+                "Could not resolve creation identity for application process {pid}"
+            ))
+        })?;
+        matching.push(ProcessIdentity {
+            pid,
+            start_time,
+            executable,
+        });
+    }
+    Ok(matching)
+}
+
+fn wait_until_identity_exits(identity: &ProcessIdentity, timeout: Duration) -> Result<bool> {
+    let deadline = std::time::Instant::now() + timeout;
+    loop {
+        let metadata_error = match identity_is_running(identity) {
+            Ok(false) => return Ok(true),
+            Ok(true) => None,
+            Err(error) => Some(error),
+        };
+        if std::time::Instant::now() >= deadline {
+            return metadata_error.map_or(Ok(false), Err);
+        }
+        std::thread::sleep(PROCESS_POLL_INTERVAL);
+    }
+}
+
+fn wait_until_no_matching_processes(
+    expected_executable: &Path,
+    updater: &ProcessIdentity,
+    timeout: Duration,
+) -> Result<bool> {
+    let deadline = std::time::Instant::now() + timeout;
+    loop {
+        let metadata_error = match identity_is_running(updater) {
+            Ok(false) => {
+                if matching_processes(expected_executable)?.is_empty() {
+                    return Ok(true);
+                }
+                None
+            }
+            Ok(true) => None,
+            Err(error) => Some(error),
+        };
+        if std::time::Instant::now() >= deadline {
+            return metadata_error.map_or(Ok(false), Err);
+        }
+        std::thread::sleep(PROCESS_POLL_INTERVAL);
+    }
+}
+
+fn identity_is_running(identity: &ProcessIdentity) -> Result<bool> {
+    match probe_process_identity(identity.pid, identity.start_time) {
+        PidLiveness::Dead => return Ok(false),
+        PidLiveness::Unknown => {
+            return Err(SurgeError::Supervisor(format!(
+                "Could not revalidate creation identity for process {}",
+                identity.pid
+            )));
+        }
+        PidLiveness::Alive => {}
+    }
+
+    let system_pid = Pid::from_u32(identity.pid);
+    let mut system = System::new();
+    let _ = system.refresh_processes(ProcessesToUpdate::Some(&[system_pid]), true);
+    let process = system.process(system_pid).ok_or_else(|| {
+        SurgeError::Supervisor(format!(
+            "Process {} is alive but missing from the process metadata snapshot",
+            identity.pid
+        ))
+    })?;
+    if matches!(process.status(), ProcessStatus::Dead | ProcessStatus::Zombie) {
+        return Ok(false);
+    }
+    let executable = process.exe().ok_or_else(|| {
+        SurgeError::Supervisor(format!(
+            "Could not resolve executable for live process {}",
+            identity.pid
+        ))
+    })?;
+    if !executable_paths_equal(&normalize_executable(executable), &identity.executable) {
+        return Err(SurgeError::Supervisor(format!(
+            "Executable identity changed for live process {}",
+            identity.pid
+        )));
+    }
+    Ok(true)
+}
+
+#[cfg(unix)]
+fn signal_process(identity: &ProcessIdentity, force: bool) -> Result<()> {
+    use nix::errno::Errno;
+    use nix::sys::signal::{Signal, kill};
+    use nix::unistd::Pid;
+
+    if !identity_is_running(identity)? {
+        return Ok(());
+    }
+    let raw_pid = i32::try_from(identity.pid)
+        .map_err(|_| SurgeError::Supervisor(format!("Process id {} is outside signal range", identity.pid)))?;
+    let signal = if force { Signal::SIGKILL } else { Signal::SIGTERM };
+    match kill(Pid::from_raw(raw_pid), signal) {
+        Ok(()) | Err(Errno::ESRCH) => Ok(()),
+        Err(error) => Err(SurgeError::Supervisor(format!(
+            "Failed to signal updating process {}: {error}",
+            identity.pid
+        ))),
+    }
+}
+
+#[cfg(windows)]
+fn signal_process(identity: &ProcessIdentity, _force: bool) -> Result<()> {
+    if !identity_is_running(identity)? {
+        return Ok(());
+    }
+    let system_pid = Pid::from_u32(identity.pid);
+    let mut system = System::new();
+    let _ = system.refresh_processes(ProcessesToUpdate::Some(&[system_pid]), true);
+    let Some(process) = system.process(system_pid) else {
+        return Ok(());
+    };
+    if process.kill() || !identity_is_running(identity)? {
+        Ok(())
+    } else {
+        Err(SurgeError::Supervisor(format!(
+            "Failed to stop updating process {}",
+            identity.pid
+        )))
+    }
+}
+
+#[cfg(not(any(unix, windows)))]
+fn signal_process(_identity: &ProcessIdentity, _force: bool) -> Result<()> {
+    Err(SurgeError::Supervisor(
+        "External update finalization is unsupported on this platform".to_string(),
+    ))
+}
+
+fn normalize_executable(path: &Path) -> PathBuf {
+    std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
+}
+
+#[cfg(windows)]
+fn executable_paths_equal(left: &Path, right: &Path) -> bool {
+    left.to_string_lossy().eq_ignore_ascii_case(&right.to_string_lossy())
+}
+
+#[cfg(not(windows))]
+fn executable_paths_equal(left: &Path, right: &Path) -> bool {
+    left == right
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use std::os::unix::fs::PermissionsExt;
+
+    use super::*;
+
+    #[test]
+    fn quiesce_stops_only_the_exact_updating_executable() {
+        let temp = tempfile::tempdir().unwrap();
+        let source = if Path::new("/bin/sleep").is_file() {
+            Path::new("/bin/sleep")
+        } else {
+            Path::new("/usr/bin/sleep")
+        };
+        let executable = temp.path().join("surge-external-finalize-sleep");
+        std::fs::copy(source, &executable).unwrap();
+        let mut permissions = std::fs::metadata(&executable).unwrap().permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&executable, permissions).unwrap();
+        let mut child = std::process::Command::new(&executable).arg("30").spawn().unwrap();
+        let start_time = process_start_time(child.id()).unwrap();
+
+        quiesce_updating_application_with_timeouts(
+            child.id(),
+            start_time,
+            &executable,
+            Duration::ZERO,
+            Duration::from_secs(2),
+            Duration::from_secs(1),
+        )
+        .unwrap();
+
+        assert!(child.wait().unwrap().code().is_none_or(|code| code != 0));
+    }
+
+    #[test]
+    fn mismatched_process_metadata_fails_closed_without_signalling() {
+        let mut child = std::process::Command::new("/bin/sleep").arg("30").spawn().unwrap();
+        let start_time = process_start_time(child.id()).unwrap();
+        let unrelated = tempfile::NamedTempFile::new().unwrap();
+
+        let error = quiesce_updating_application_with_timeouts(
+            child.id(),
+            start_time,
+            unrelated.path(),
+            Duration::ZERO,
+            Duration::ZERO,
+            Duration::ZERO,
+        )
+        .unwrap_err();
+
+        assert!(error.to_string().contains("Executable identity changed"));
+        assert!(child.try_wait().unwrap().is_none());
+        child.kill().unwrap();
+        child.wait().unwrap();
+    }
+}

--- a/crates/surge-core/src/update/manager/external_finalize/runner.rs
+++ b/crates/surge-core/src/update/manager/external_finalize/runner.rs
@@ -1,0 +1,486 @@
+use std::path::Path;
+use std::sync::Arc;
+use std::time::Duration;
+
+use tracing::warn;
+
+use crate::error::{Result, SurgeError};
+use crate::install::prune_version_snapshots;
+use crate::platform::fs::atomic_rename;
+use crate::releases::manifest::ReleaseEntry;
+use crate::update::status::{self, FailureContext, UpdateStatusRecord, UpdateWorkerGuard};
+
+use super::super::finalize::finalize_update_with_pre_restart;
+use super::super::lifecycle::SupervisorRestartOutcome;
+use super::super::progress::ProgressInfo;
+use super::super::progress_substep::{PhaseProgressEmitter, labels as update_phase};
+use super::super::{ApplyStrategy, UpdateInfo, UpdateManager, current_install, lifecycle};
+use super::plan::{ExternalFinalizePlan, manager_from_plan, read_and_validate_plan, validate_materialized_target};
+use super::quiesce::quiesce_updating_application;
+use super::schedule::{marker_matches, write_handshake_marker};
+
+const HELPER_ARM_TIMEOUT: Duration = Duration::from_secs(30);
+const HANDSHAKE_POLL_INTERVAL: Duration = Duration::from_millis(50);
+const TERMINAL_STATUS_WRITE_ATTEMPTS: u32 = 5;
+const TERMINAL_STATUS_WRITE_RETRY_DELAY: Duration = Duration::from_millis(200);
+
+/// Complete a staged update from the stable supervisor helper process.
+///
+/// This entry point is for `surge-supervisor finalize-update`; applications
+/// should use [`UpdateManager::download_and_apply`](super::super::UpdateManager::download_and_apply).
+#[doc(hidden)]
+pub async fn run_external_finalize(plan_path: &Path) -> Result<()> {
+    let plan = read_and_validate_plan(plan_path)?;
+    let mut manager = manager_from_plan(&plan)?;
+    validate_materialized_target(&plan, &manager)?;
+
+    let _worker_guard = UpdateWorkerGuard::take_over(
+        &plan.install_dir,
+        &plan.app_id,
+        &plan.target_release.version,
+        plan.updater_pid,
+        plan.updater_start_time,
+    )?;
+    write_handshake_marker(&plan.ready_path(), &plan.operation_id)?;
+    wait_until_armed(&plan).await?;
+    write_handshake_marker(&plan.accepted_path(), &plan.operation_id)?;
+
+    let mut recovery_required = false;
+    let result = run_accepted_finalize(&plan, &mut manager, &mut recovery_required).await;
+    match result {
+        Ok(()) => {
+            if let Err(error) =
+                commit_previous_snapshot(&plan.install_dir, &plan.current_version, plan.release_retention_limit)
+            {
+                warn!(error = %error, "Failed to finalize previous-version snapshot after handoff acceptance");
+            }
+            cleanup_operation(&plan, "completed");
+            Ok(())
+        }
+        Err(error) => {
+            let recovery = if recovery_required {
+                recover_previous_install(&plan, &manager).await
+            } else {
+                Ok(plan.active_app_dir())
+            };
+            let previous_app_dir = match recovery {
+                Ok(previous_app_dir) => previous_app_dir,
+                Err(recovery_error) => {
+                    persist_external_failure(&plan, &error, Some(&recovery_error))?;
+                    cleanup_operation(&plan, "failed");
+                    return Err(SurgeError::Update(format!(
+                        "External finalization failed: {error}; previous install recovery failed: {recovery_error}"
+                    )));
+                }
+            };
+            persist_external_failure(&plan, &error, None)?;
+
+            if let Err(restart_error) = restart_previous_runtime(&plan, &previous_app_dir) {
+                persist_external_failure(&plan, &error, Some(&restart_error))?;
+                cleanup_operation(&plan, "failed");
+                return Err(SurgeError::Update(format!(
+                    "External finalization failed: {error}; previous runtime restart failed: {restart_error}"
+                )));
+            }
+
+            cleanup_operation(&plan, "failed");
+            Err(error)
+        }
+    }
+}
+
+async fn run_accepted_finalize(
+    plan: &ExternalFinalizePlan,
+    manager: &mut UpdateManager,
+    recovery_required: &mut bool,
+) -> Result<()> {
+    persist_external_phase(plan, update_phase::STOPPING_SUPERVISOR);
+    *recovery_required = true;
+    lifecycle::request_supervisor_shutdown(&plan.install_dir, &plan.current_release_identity.supervisor_id).await?;
+
+    persist_external_phase(plan, update_phase::WAITING_FOR_UPDATER_EXIT);
+    quiesce_updating_application(plan.updater_pid, plan.updater_start_time, &plan.updater_exe)?;
+
+    let installed_identity = current_install::load(manager)?;
+    if installed_identity.as_ref() != Some(&plan.current_release_identity) {
+        return Err(SurgeError::Update(
+            "Installed application identity changed while the external finalizer waited for the updater to exit"
+                .to_string(),
+        ));
+    }
+    manager.current_release_identity = installed_identity;
+
+    let info = UpdateInfo {
+        available_releases: vec![plan.target_release.clone()],
+        latest_version: plan.target_release.version.clone(),
+        delta_available: false,
+        download_size: 0,
+        apply_releases: vec![plan.target_release.clone()],
+        apply_strategy: ApplyStrategy::Full,
+        fallback_reason: None,
+    };
+    let progress: Option<Arc<fn(ProgressInfo)>> = None;
+    let progress_emitter = PhaseProgressEmitter {
+        progress: progress.as_ref(),
+        install_dir: &plan.install_dir,
+        in_progress_template: &plan.in_progress_template,
+    };
+    let persist_pending = || persist_external_pending_restart(plan);
+    let outcome = finalize_update_with_pre_restart(
+        manager,
+        &info,
+        &plan.extracted_final_dir(),
+        &plan.staging_dir(),
+        &plan.artifact_cache_dir(),
+        &progress_emitter,
+        Some(&persist_pending),
+        Some(&plan.restart_args),
+    )
+    .await?;
+
+    match outcome {
+        SupervisorRestartOutcome::PendingRestart { failure_phase, .. }
+            if failure_phase == status::RESTART_HANDOFF_WAITING_FOR_OLD_CHILD_PHASE =>
+        {
+            Ok(())
+        }
+        SupervisorRestartOutcome::PendingRestart { reason, .. } => Err(SurgeError::Supervisor(reason)),
+        SupervisorRestartOutcome::NotApplicable => Err(SurgeError::Supervisor(
+            "Target release supervisor was not started".to_string(),
+        )),
+        SupervisorRestartOutcome::ExternalFinalizeScheduled => Err(SurgeError::Supervisor(
+            "External finalizer attempted to schedule another finalizer".to_string(),
+        )),
+    }
+}
+
+async fn wait_until_armed(plan: &ExternalFinalizePlan) -> Result<()> {
+    let deadline = tokio::time::Instant::now() + HELPER_ARM_TIMEOUT;
+    loop {
+        if marker_matches(&plan.armed_path(), &plan.operation_id)? {
+            return Ok(());
+        }
+        if tokio::time::Instant::now() >= deadline {
+            return Err(SurgeError::Update(format!(
+                "External finalizer was not armed within {}s; active application was left untouched",
+                HELPER_ARM_TIMEOUT.as_secs()
+            )));
+        }
+        tokio::time::sleep(HANDSHAKE_POLL_INTERVAL).await;
+    }
+}
+
+fn persist_external_phase(plan: &ExternalFinalizePlan, phase: &'static str) {
+    let record = plan
+        .in_progress_template
+        .clone()
+        .with_current_phase_at(phase, status::now_utc_rfc3339());
+    if let Err(error) = status::write_update_status(&plan.install_dir, &record) {
+        warn!(error = %error, phase, "Failed to persist external finalizer progress");
+    }
+}
+
+fn persist_external_pending_restart(plan: &ExternalFinalizePlan) -> Result<()> {
+    let attempted_at_utc = plan
+        .in_progress_template
+        .attempted_at_utc
+        .clone()
+        .unwrap_or_else(status::now_utc_rfc3339);
+    let record = UpdateStatusRecord::pending_restart_with_failure_phase(
+        &plan.app_id,
+        &plan.target_release.version,
+        &plan.target_release.version,
+        &plan.channel,
+        attempted_at_utc,
+        status::now_utc_rfc3339(),
+        "external finalizer activated the target; waiting for helper exit and target startup proof",
+        status::RESTART_HANDOFF_WAITING_FOR_OLD_CHILD_PHASE,
+    );
+    write_terminal_status(&plan.install_dir, &record)
+}
+
+fn persist_external_failure(
+    plan: &ExternalFinalizePlan,
+    error: &SurgeError,
+    recovery_error: Option<&SurgeError>,
+) -> Result<()> {
+    let attempted_at_utc = plan
+        .in_progress_template
+        .attempted_at_utc
+        .clone()
+        .unwrap_or_else(status::now_utc_rfc3339);
+    let status_context = status::read_update_status(&plan.install_dir).ok().flatten();
+    let reason = recovery_error.map_or_else(
+        || error.to_string(),
+        |recovery| format!("{error}; previous runtime recovery failed: {recovery}"),
+    );
+    let record = UpdateStatusRecord::failed_with_context(
+        &plan.app_id,
+        &plan.current_version,
+        &plan.target_release.version,
+        &plan.channel,
+        attempted_at_utc,
+        &reason,
+        FailureContext::from_record(status_context.as_ref(), recovery_error.is_none()),
+    );
+    let record = if recovery_error.is_none() {
+        let schedule = status::retry_schedule(plan.previous_attempt_status.as_ref(), &plan.target_release.version);
+        record.with_retry_schedule_at(&schedule, status::next_retry_timestamp(chrono::Utc::now(), &schedule))
+    } else {
+        record
+    };
+    write_terminal_status(&plan.install_dir, &record)
+}
+
+fn write_terminal_status(install_dir: &Path, record: &UpdateStatusRecord) -> Result<()> {
+    write_terminal_status_with(
+        install_dir,
+        record,
+        TERMINAL_STATUS_WRITE_ATTEMPTS,
+        TERMINAL_STATUS_WRITE_RETRY_DELAY,
+        status::write_update_status,
+    )
+}
+
+fn write_terminal_status_with<F>(
+    install_dir: &Path,
+    record: &UpdateStatusRecord,
+    attempts: u32,
+    retry_delay: Duration,
+    mut write_status: F,
+) -> Result<()>
+where
+    F: FnMut(&Path, &UpdateStatusRecord) -> Result<()>,
+{
+    if attempts == 0 {
+        return Err(SurgeError::Config(
+            "Terminal status persistence requires at least one attempt".to_string(),
+        ));
+    }
+
+    for attempt in 1..=attempts {
+        match write_status(install_dir, record) {
+            Ok(()) => return Ok(()),
+            Err(error) if attempt < attempts => {
+                warn!(
+                    error = %error,
+                    attempt,
+                    attempts,
+                    "Failed to persist terminal external finalizer status; retrying"
+                );
+                if !retry_delay.is_zero() {
+                    std::thread::sleep(retry_delay);
+                }
+            }
+            Err(error) => {
+                return Err(SurgeError::Update(format!(
+                    "Failed to persist terminal external finalizer status after {attempts} attempts: {error}"
+                )));
+            }
+        }
+    }
+
+    unreachable!("terminal status write loop always returns")
+}
+
+async fn recover_previous_install(plan: &ExternalFinalizePlan, manager: &UpdateManager) -> Result<std::path::PathBuf> {
+    lifecycle::request_supervisor_shutdown(&plan.install_dir, &plan.current_release_identity.supervisor_id).await?;
+    if plan.target_release.supervisor_id != plan.current_release_identity.supervisor_id {
+        lifecycle::request_supervisor_shutdown(&plan.install_dir, &plan.target_release.supervisor_id).await?;
+    }
+    quiesce_updating_application(plan.updater_pid, plan.updater_start_time, &plan.updater_exe)?;
+    restore_previous_app_dir(plan, manager)
+}
+
+fn restore_previous_app_dir(plan: &ExternalFinalizePlan, manager: &UpdateManager) -> Result<std::path::PathBuf> {
+    let active_app_dir = plan.active_app_dir();
+    let previous_swap_dir = plan.install_dir.join(".surge-app-prev");
+    let previous_version_dir = plan.previous_version_dir();
+    for candidate in [&previous_swap_dir, &previous_version_dir] {
+        if candidate.is_dir()
+            && current_install::load_previous_swap(manager, candidate)?.as_ref() == Some(&plan.current_release_identity)
+        {
+            replace_failed_target(&active_app_dir, candidate, &plan.operation_id)?;
+            return Ok(active_app_dir);
+        }
+    }
+
+    if active_app_dir.is_dir()
+        && current_install::load_previous_swap(manager, &active_app_dir)?.as_ref()
+            == Some(&plan.current_release_identity)
+    {
+        return Ok(active_app_dir);
+    }
+
+    Err(SurgeError::Update(
+        "No application directory matching the pre-update release is available for recovery".to_string(),
+    ))
+}
+
+fn replace_failed_target(active_app_dir: &Path, previous_app_dir: &Path, operation_id: &str) -> Result<()> {
+    let install_dir = active_app_dir
+        .parent()
+        .ok_or_else(|| SurgeError::Config("Active application directory has no install root".to_string()))?;
+    let failed_target_dir = install_dir.join(format!(".surge-app-failed-{operation_id}"));
+    if failed_target_dir.exists() {
+        std::fs::remove_dir_all(&failed_target_dir)?;
+    }
+    if active_app_dir.exists() {
+        atomic_rename(active_app_dir, &failed_target_dir)?;
+    }
+    if let Err(error) = atomic_rename(previous_app_dir, active_app_dir) {
+        if failed_target_dir.is_dir() && !active_app_dir.exists() {
+            let _ = atomic_rename(&failed_target_dir, active_app_dir);
+        }
+        return Err(error);
+    }
+    let _ = std::fs::remove_dir_all(&failed_target_dir);
+    Ok(())
+}
+
+fn commit_previous_snapshot(install_dir: &Path, current_version: &str, retention_limit: usize) -> Result<()> {
+    let previous_swap_dir = install_dir.join(".surge-app-prev");
+    if previous_swap_dir.is_dir() {
+        if retention_limit == 0 {
+            std::fs::remove_dir_all(&previous_swap_dir)?;
+        } else {
+            let previous_version_dir = install_dir.join(format!("app-{current_version}"));
+            if previous_version_dir.exists() {
+                std::fs::remove_dir_all(&previous_version_dir)?;
+            }
+            atomic_rename(&previous_swap_dir, &previous_version_dir)?;
+        }
+    }
+    prune_version_snapshots(install_dir, retention_limit)?;
+    Ok(())
+}
+
+fn restart_previous_runtime(plan: &ExternalFinalizePlan, previous_app_dir: &Path) -> Result<()> {
+    let release = release_from_identity(&plan.current_release_identity);
+    match lifecycle::restart_supervisor_after_update_with_args(
+        &plan.install_dir,
+        previous_app_dir,
+        &release,
+        std::process::id(),
+        &plan.restart_args,
+        None,
+    ) {
+        SupervisorRestartOutcome::PendingRestart { failure_phase, reason }
+            if failure_phase == status::RESTART_HANDOFF_FAILED_PHASE =>
+        {
+            Err(SurgeError::Supervisor(reason))
+        }
+        SupervisorRestartOutcome::PendingRestart { .. } => Ok(()),
+        SupervisorRestartOutcome::NotApplicable => Err(SurgeError::Supervisor(
+            "Previous release supervisor was not restarted".to_string(),
+        )),
+        SupervisorRestartOutcome::ExternalFinalizeScheduled => Err(SurgeError::Supervisor(
+            "Previous release recovery attempted to schedule another finalizer".to_string(),
+        )),
+    }
+}
+
+fn release_from_identity(identity: &current_install::ReleaseIdentity) -> ReleaseEntry {
+    ReleaseEntry {
+        version: identity.version.clone(),
+        main_exe: identity.main_exe.clone(),
+        supervisor_id: identity.supervisor_id.clone(),
+        environment: identity.environment.clone(),
+        ..ReleaseEntry::default()
+    }
+}
+
+fn cleanup_operation(plan: &ExternalFinalizePlan, outcome: &str) {
+    if let Err(error) = std::fs::remove_dir_all(plan.operation_dir()) {
+        warn!(error = %error, outcome, "Failed to remove terminal external finalizer plan directory");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::cell::Cell;
+
+    use super::*;
+
+    #[test]
+    fn terminal_status_write_retries_transient_failure() {
+        let temp = tempfile::tempdir().unwrap();
+        let attempts = Cell::new(0_u32);
+        let record = UpdateStatusRecord::converged("demo", "2.0.0", "test", None, status::now_utc_rfc3339(), true);
+
+        write_terminal_status_with(temp.path(), &record, 3, Duration::ZERO, |_, _| {
+            attempts.set(attempts.get() + 1);
+            if attempts.get() < 3 {
+                Err(SurgeError::Update("transient write failure".to_string()))
+            } else {
+                Ok(())
+            }
+        })
+        .unwrap();
+
+        assert_eq!(attempts.get(), 3);
+    }
+
+    #[test]
+    fn terminal_status_write_reports_exhausted_retries() {
+        let temp = tempfile::tempdir().unwrap();
+        let record = UpdateStatusRecord::converged("demo", "2.0.0", "test", None, status::now_utc_rfc3339(), true);
+
+        let error = write_terminal_status_with(temp.path(), &record, 2, Duration::ZERO, |_, _| {
+            Err(SurgeError::Update("persistent write failure".to_string()))
+        })
+        .unwrap_err();
+
+        assert!(error.to_string().contains("after 2 attempts"));
+    }
+
+    #[test]
+    fn failed_target_is_replaced_by_previous_application() {
+        let temp = tempfile::tempdir().unwrap();
+        let active = temp.path().join("app");
+        let previous = temp.path().join("app-1.0.0");
+        std::fs::create_dir_all(&active).unwrap();
+        std::fs::create_dir_all(&previous).unwrap();
+        std::fs::write(active.join("version"), "2.0.0").unwrap();
+        std::fs::write(previous.join("version"), "1.0.0").unwrap();
+
+        replace_failed_target(&active, &previous, "operation").unwrap();
+
+        assert_eq!(std::fs::read_to_string(active.join("version")).unwrap(), "1.0.0");
+        assert!(!previous.exists());
+        assert!(!temp.path().join(".surge-app-failed-operation").exists());
+    }
+
+    #[test]
+    fn failed_recovery_rename_restores_the_target_directory() {
+        let temp = tempfile::tempdir().unwrap();
+        let active = temp.path().join("app");
+        let missing_previous = temp.path().join("app-1.0.0");
+        std::fs::create_dir_all(&active).unwrap();
+        std::fs::write(active.join("version"), "2.0.0").unwrap();
+
+        replace_failed_target(&active, &missing_previous, "operation").unwrap_err();
+
+        assert_eq!(std::fs::read_to_string(active.join("version")).unwrap(), "2.0.0");
+        assert!(!temp.path().join(".surge-app-failed-operation").exists());
+    }
+
+    #[test]
+    fn accepted_handoff_preserves_the_exact_previous_snapshot() {
+        let temp = tempfile::tempdir().unwrap();
+        let previous_swap = temp.path().join(".surge-app-prev");
+        let stale_version_snapshot = temp.path().join("app-1.0.0");
+        std::fs::create_dir_all(&previous_swap).unwrap();
+        std::fs::create_dir_all(&stale_version_snapshot).unwrap();
+        std::fs::write(previous_swap.join("identity"), "exact-pre-update-bits").unwrap();
+        std::fs::write(stale_version_snapshot.join("identity"), "stale-snapshot").unwrap();
+
+        commit_previous_snapshot(temp.path(), "1.0.0", 1).unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(stale_version_snapshot.join("identity")).unwrap(),
+            "exact-pre-update-bits"
+        );
+        assert!(!previous_swap.exists());
+    }
+}

--- a/crates/surge-core/src/update/manager/external_finalize/schedule.rs
+++ b/crates/surge-core/src/update/manager/external_finalize/schedule.rs
@@ -1,0 +1,299 @@
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use tracing::info;
+
+use crate::error::{Result, SurgeError};
+use crate::platform::fs::{atomic_rename, make_executable, write_file_atomic};
+use crate::platform::process::{process_start_time, spawn_detached, supervisor_binary_name};
+use crate::supervisor::state::read_restart_args;
+use crate::update::status::UpdateStatusRecord;
+
+use super::super::progress::ProgressInfo;
+use super::super::progress_substep::{PhaseProgressEmitter, labels as update_phase};
+use super::super::{UpdateInfo, UpdateManager};
+use super::plan::{ExternalFinalizePlan, write_plan};
+
+const EXTERNAL_TOOLS_DIR: &str = ".surge-tools";
+const HELPER_READY_TIMEOUT: Duration = Duration::from_secs(10);
+const HANDSHAKE_POLL_INTERVAL: Duration = Duration::from_millis(50);
+
+struct SelfHostedUpdater {
+    executable: PathBuf,
+    start_time: u64,
+}
+
+pub(in crate::update::manager) async fn schedule_if_required<F>(
+    manager: &UpdateManager,
+    info: &UpdateInfo,
+    extracted_final_dir: &Path,
+    in_progress_template: &UpdateStatusRecord,
+    previous_attempt_status: Option<UpdateStatusRecord>,
+    progress_emitter: &PhaseProgressEmitter<'_, F>,
+) -> Result<bool>
+where
+    F: Fn(ProgressInfo) + Send + Sync,
+{
+    if manager.allow_in_process_swap {
+        return Ok(false);
+    }
+
+    let Some(updater) = self_hosted_updater(manager)? else {
+        return Ok(false);
+    };
+    let target_release = info
+        .apply_releases
+        .last()
+        .ok_or_else(|| SurgeError::Update("No latest release".to_string()))?;
+    let current_identity = manager.current_release_identity.as_ref().ok_or_else(|| {
+        SurgeError::Update("External finalization requires the installed application identity".to_string())
+    })?;
+    if current_identity.supervisor_id.trim().is_empty() || target_release.supervisor_id.trim().is_empty() {
+        return Err(SurgeError::Update(
+            "A self-hosted update requires supervised current and target releases".to_string(),
+        ));
+    }
+    let restart_args = read_restart_args(&manager.install_dir, &current_identity.supervisor_id)?;
+    let plan = ExternalFinalizePlan::from_manager(
+        manager,
+        target_release,
+        updater.executable,
+        updater.start_time,
+        restart_args,
+        in_progress_template,
+        previous_attempt_status,
+    )?;
+    if extracted_final_dir != plan.extracted_final_dir() {
+        return Err(SurgeError::Update(format!(
+            "External finalizer expected materialized payload at '{}', found '{}'",
+            plan.extracted_final_dir().display(),
+            extracted_final_dir.display()
+        )));
+    }
+
+    progress_emitter.emit_substep(6, update_phase::STARTING_EXTERNAL_FINALIZER, 90);
+    std::fs::create_dir_all(plan.operation_dir())?;
+
+    let current_helper = plan.active_app_dir().join(supervisor_binary_name());
+    let helper_path = install_stable_helper(&plan, &current_helper)?;
+    write_plan(&plan)?;
+
+    let plan_arg = plan.plan_path().to_string_lossy().into_owned();
+    let args = ["finalize-update", "--plan", plan_arg.as_str()];
+    let mut helper = match spawn_detached(&helper_path, &args, Some(&manager.install_dir), &BTreeMap::new()) {
+        Ok(helper) => helper,
+        Err(error) => {
+            cleanup_unaccepted_operation(&plan);
+            return Err(error);
+        }
+    };
+
+    if let Err(error) = wait_for_marker(&plan, &mut helper, HandshakeStage::Ready).await {
+        let _ = helper.kill();
+        let _ = helper.wait();
+        cleanup_unaccepted_operation(&plan);
+        return Err(error);
+    }
+    if let Err(error) = write_handshake_marker(&plan.armed_path(), &plan.operation_id) {
+        let _ = helper.kill();
+        let _ = helper.wait();
+        cleanup_unaccepted_operation(&plan);
+        return Err(error);
+    }
+    if let Err(error) = wait_for_marker(&plan, &mut helper, HandshakeStage::Accepted).await {
+        let _ = helper.kill();
+        let _ = helper.wait();
+        cleanup_unaccepted_operation(&plan);
+        return Err(error);
+    }
+
+    progress_emitter.emit_substep(6, update_phase::WAITING_FOR_UPDATER_EXIT, 91);
+    info!(
+        target_version = %plan.target_release.version,
+        helper = %helper_path.display(),
+        "Transferred update finalization to stable helper"
+    );
+    Ok(true)
+}
+
+#[derive(Clone, Copy)]
+enum HandshakeStage {
+    Ready,
+    Accepted,
+}
+
+impl HandshakeStage {
+    fn path(self, plan: &ExternalFinalizePlan) -> PathBuf {
+        match self {
+            Self::Ready => plan.ready_path(),
+            Self::Accepted => plan.accepted_path(),
+        }
+    }
+
+    fn description(self) -> &'static str {
+        match self {
+            Self::Ready => "become ready",
+            Self::Accepted => "accept ownership",
+        }
+    }
+}
+
+async fn wait_for_marker(
+    plan: &ExternalFinalizePlan,
+    helper: &mut crate::platform::process::ProcessHandle,
+    stage: HandshakeStage,
+) -> Result<()> {
+    let deadline = tokio::time::Instant::now() + HELPER_READY_TIMEOUT;
+    loop {
+        if marker_matches(&stage.path(plan), &plan.operation_id)? {
+            return Ok(());
+        }
+        if !helper.poll_running() {
+            let result = helper.wait()?;
+            return Err(SurgeError::Update(format!(
+                "External finalizer helper exited before it could {} (code {})",
+                stage.description(),
+                result.exit_code
+            )));
+        }
+        if tokio::time::Instant::now() >= deadline {
+            return Err(SurgeError::Update(format!(
+                "Timed out after {}s waiting for the external finalizer helper to {}",
+                HELPER_READY_TIMEOUT.as_secs(),
+                stage.description()
+            )));
+        }
+        tokio::time::sleep(HANDSHAKE_POLL_INTERVAL).await;
+    }
+}
+
+fn self_hosted_updater(manager: &UpdateManager) -> Result<Option<SelfHostedUpdater>> {
+    let Some(identity) = manager.current_release_identity.as_ref() else {
+        return Ok(None);
+    };
+    let active_app_dir = manager.install_dir.join("app");
+    if !active_app_dir.is_dir() {
+        return Ok(None);
+    }
+    let active_exe = resolve_active_executable(&active_app_dir, &identity.main_exe)?;
+    let updater_exe = std::fs::canonicalize(std::env::current_exe()?).map_err(|error| {
+        SurgeError::Platform(format!(
+            "Failed to resolve the updating process executable before external finalization: {error}"
+        ))
+    })?;
+    if !same_executable(&active_exe, &updater_exe) {
+        return Ok(None);
+    }
+    let start_time = process_start_time(std::process::id())
+        .ok_or_else(|| SurgeError::Platform("Could not capture exact identity for the updating process".to_string()))?;
+    Ok(Some(SelfHostedUpdater {
+        executable: updater_exe,
+        start_time,
+    }))
+}
+
+fn resolve_active_executable(active_app_dir: &Path, main_exe: &str) -> Result<PathBuf> {
+    let active_app_root = std::fs::canonicalize(active_app_dir).map_err(|error| {
+        SurgeError::Platform(format!(
+            "Failed to resolve the active application directory before external finalization: {error}"
+        ))
+    })?;
+    let unresolved_executable = active_app_root.join(main_exe);
+    let active_exe = std::fs::canonicalize(&unresolved_executable).map_err(|error| {
+        SurgeError::Platform(format!(
+            "Failed to resolve the active application executable before external finalization: {error}"
+        ))
+    })?;
+    if !active_exe.starts_with(&active_app_root) {
+        return Err(SurgeError::Platform(format!(
+            "Active application executable '{}' resolves outside the active application directory",
+            unresolved_executable.display()
+        )));
+    }
+    Ok(active_exe)
+}
+
+#[cfg(windows)]
+fn same_executable(left: &Path, right: &Path) -> bool {
+    left.to_string_lossy().eq_ignore_ascii_case(&right.to_string_lossy())
+}
+
+#[cfg(not(windows))]
+fn same_executable(left: &Path, right: &Path) -> bool {
+    left == right
+}
+
+fn install_stable_helper(plan: &ExternalFinalizePlan, current_helper: &Path) -> Result<PathBuf> {
+    if !current_helper.is_file() {
+        return Err(SurgeError::Update(format!(
+            "Current release does not contain the external finalizer helper at '{}'",
+            current_helper.display()
+        )));
+    }
+
+    let tools_dir = plan.install_dir.join(EXTERNAL_TOOLS_DIR);
+    std::fs::create_dir_all(&tools_dir)?;
+    let helper_path = tools_dir.join(supervisor_binary_name());
+    let temporary_path = tools_dir.join(format!("{}.{}.tmp", supervisor_binary_name(), plan.operation_id));
+    let copied = std::fs::copy(current_helper, &temporary_path)?;
+    let expected = std::fs::metadata(current_helper)?.len();
+    if copied != expected {
+        let _ = std::fs::remove_file(&temporary_path);
+        return Err(SurgeError::Update(format!(
+            "Copied {copied} of {expected} helper bytes"
+        )));
+    }
+    make_executable(&temporary_path)?;
+    if helper_path.exists() {
+        std::fs::remove_file(&helper_path)?;
+    }
+    atomic_rename(&temporary_path, &helper_path)?;
+    Ok(helper_path)
+}
+
+fn cleanup_unaccepted_operation(plan: &ExternalFinalizePlan) {
+    let _ = std::fs::remove_dir_all(plan.operation_dir());
+}
+
+pub(super) fn write_handshake_marker(path: &Path, operation_id: &str) -> Result<()> {
+    write_file_atomic(path, operation_id.as_bytes())
+}
+
+pub(super) fn marker_matches(path: &Path, operation_id: &str) -> Result<bool> {
+    match std::fs::read_to_string(path) {
+        Ok(value) => Ok(value.trim() == operation_id),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(error) => Err(error.into()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(unix)]
+    #[test]
+    fn active_executable_symlink_cannot_escape_application_directory() {
+        let temp = tempfile::tempdir().unwrap();
+        let app = temp.path().join("app");
+        let external = temp.path().join("external");
+        std::fs::create_dir_all(&app).unwrap();
+        std::fs::write(&external, "fixture").unwrap();
+
+        std::os::unix::fs::symlink(&external, app.join("demo")).unwrap();
+
+        let error = resolve_active_executable(&app, "demo").unwrap_err();
+        assert!(error.to_string().contains("outside the active application directory"));
+    }
+
+    #[test]
+    fn handshake_marker_requires_matching_operation() {
+        let temp = tempfile::tempdir().unwrap();
+        let marker = temp.path().join("ready");
+        write_handshake_marker(&marker, "operation-a").unwrap();
+
+        assert!(marker_matches(&marker, "operation-a").unwrap());
+        assert!(!marker_matches(&marker, "operation-b").unwrap());
+    }
+}

--- a/crates/surge-core/src/update/manager/finalize.rs
+++ b/crates/surge-core/src/update/manager/finalize.rs
@@ -49,6 +49,33 @@ pub(super) async fn finalize_update<F>(
 where
     F: Fn(ProgressInfo) + Send + Sync,
 {
+    finalize_update_with_pre_restart(
+        manager,
+        info,
+        extracted_final_dir,
+        staging_dir,
+        artifact_cache_dir,
+        progress_emitter,
+        None,
+        None,
+    )
+    .await
+}
+
+#[allow(clippy::too_many_lines)]
+pub(in crate::update::manager) async fn finalize_update_with_pre_restart<F>(
+    manager: &UpdateManager,
+    info: &UpdateInfo,
+    extracted_final_dir: &Path,
+    staging_dir: &Path,
+    artifact_cache_dir: &Path,
+    progress_emitter: &PhaseProgressEmitter<'_, F>,
+    pre_restart: Option<&(dyn Fn() -> Result<()> + Send + Sync)>,
+    restart_args: Option<&[String]>,
+) -> Result<SupervisorRestartOutcome>
+where
+    F: Fn(ProgressInfo) + Send + Sync,
+{
     emit_progress(
         progress_emitter.progress,
         ProgressInfo {
@@ -218,11 +245,27 @@ where
     // supervisor having been running before the update: if the release
     // configures supervision, a fresh watch supervisor is always started so a
     // supervisor that died before the update is recovered here.
-    let restart_outcome = if latest.supervisor_id.trim().is_empty() {
+    let defer_restart = restart_args.is_some();
+    let mut restart_outcome = if latest.supervisor_id.trim().is_empty() || defer_restart {
         SupervisorRestartOutcome::NotApplicable
     } else {
+        if let Some(pre_restart) = pre_restart {
+            pre_restart()?;
+        }
         progress_emitter.emit_substep(6, finalize_phase::RESTARTING_SUPERVISOR, 96);
-        lifecycle::restart_supervisor_after_update(&manager.install_dir, &active_app_dir, latest)
+        restart_args.map_or_else(
+            || lifecycle::restart_supervisor_after_update(&manager.install_dir, &active_app_dir, latest),
+            |restart_args| {
+                lifecycle::restart_supervisor_after_update_with_args(
+                    &manager.install_dir,
+                    &active_app_dir,
+                    latest,
+                    crate::platform::process::current_pid(),
+                    restart_args,
+                    Some(&latest.version),
+                )
+            },
+        )
     };
 
     if !latest.shortcuts.is_empty() {
@@ -251,7 +294,7 @@ where
     }
 
     progress_emitter.emit_substep(6, finalize_phase::PRUNING_OLD_VERSIONS, 98);
-    if previous_swap_dir.is_dir() {
+    if !defer_restart && previous_swap_dir.is_dir() {
         let previous_version_dir = manager.install_dir.join(format!("app-{}", manager.current_version));
         if !manager.current_version.trim().is_empty()
             && previous_version_dir != active_app_dir
@@ -336,7 +379,23 @@ where
         }
     }
 
-    progress_emitter.emit_substep(6, finalize_phase::POST_UPDATE_HOOK, 99);
+    if defer_restart {
+        let pre_restart = pre_restart.ok_or_else(|| {
+            SurgeError::Update("Deferred supervisor restart requires terminal status persistence".to_string())
+        })?;
+        pre_restart()?;
+        emit_progress(
+            progress_emitter.progress,
+            ProgressInfo {
+                phase: 6,
+                phase_label: finalize_phase::POST_UPDATE_HOOK,
+                total_percent: 99,
+                ..ProgressInfo::default()
+            },
+        );
+    } else {
+        progress_emitter.emit_substep(6, finalize_phase::POST_UPDATE_HOOK, 99);
+    }
     lifecycle::invoke_post_update_hook(&manager.install_dir, &active_app_dir, latest);
 
     match lifecycle::terminate_superseded_app_processes(&manager.install_dir, &active_app_dir, &latest.main_exe) {
@@ -349,6 +408,26 @@ where
             );
         }
         Err(e) => return Err(e),
+    }
+
+    if defer_restart {
+        emit_progress(
+            progress_emitter.progress,
+            ProgressInfo {
+                phase: 6,
+                phase_label: finalize_phase::RESTARTING_SUPERVISOR,
+                total_percent: 99,
+                ..ProgressInfo::default()
+            },
+        );
+        restart_outcome = lifecycle::restart_supervisor_after_update_with_args(
+            &manager.install_dir,
+            &active_app_dir,
+            latest,
+            crate::platform::process::current_pid(),
+            restart_args.unwrap_or_default(),
+            Some(&latest.version),
+        );
     }
 
     emit_progress(

--- a/crates/surge-core/src/update/manager/lifecycle.rs
+++ b/crates/surge-core/src/update/manager/lifecycle.rs
@@ -39,6 +39,8 @@ pub(super) enum SupervisorRestartOutcome {
         reason: String,
         failure_phase: &'static str,
     },
+    /// A stable helper owns the remaining quiesce, swap, and restart work.
+    ExternalFinalizeScheduled,
 }
 
 pub(super) async fn request_supervisor_shutdown(install_dir: &Path, supervisor_id: &str) -> Result<()> {
@@ -174,6 +176,29 @@ pub(super) fn restart_supervisor_after_update_with_pid(
         active_app_dir,
         latest,
         watched_pid,
+        None,
+        Some(&latest.version),
+        SUPERVISOR_RESTART_CONFIRM_TIMEOUT,
+        SUPERVISOR_RESTART_MAX_ATTEMPTS,
+        SUPERVISOR_RESTART_RETRY_DELAY,
+    )
+}
+
+pub(in crate::update::manager) fn restart_supervisor_after_update_with_args(
+    install_dir: &Path,
+    active_app_dir: &Path,
+    release: &ReleaseEntry,
+    watched_pid: u32,
+    restart_args: &[String],
+    handoff_version: Option<&str>,
+) -> SupervisorRestartOutcome {
+    restart_supervisor_after_update_with_config(
+        install_dir,
+        active_app_dir,
+        release,
+        watched_pid,
+        Some(restart_args),
+        handoff_version,
         SUPERVISOR_RESTART_CONFIRM_TIMEOUT,
         SUPERVISOR_RESTART_MAX_ATTEMPTS,
         SUPERVISOR_RESTART_RETRY_DELAY,
@@ -185,6 +210,8 @@ fn restart_supervisor_after_update_with_config(
     active_app_dir: &Path,
     latest: &ReleaseEntry,
     watched_pid: u32,
+    restart_args: Option<&[String]>,
+    handoff_version: Option<&str>,
     confirm_timeout: Duration,
     max_attempts: u32,
     retry_delay: Duration,
@@ -242,24 +269,27 @@ fn restart_supervisor_after_update_with_config(
         };
     }
 
-    let restart_args = match read_restart_args(install_dir, supervisor_id) {
-        Ok(args) => args,
-        Err(e) => {
-            warn!(
-                supervisor_id,
-                error = %e,
-                "Failed reading stored supervisor restart arguments; restarting with no extra args"
-            );
-            Vec::new()
-        }
-    };
+    let restart_args = restart_args.map_or_else(
+        || match read_restart_args(install_dir, supervisor_id) {
+            Ok(args) => args,
+            Err(e) => {
+                warn!(
+                    supervisor_id,
+                    error = %e,
+                    "Failed reading stored supervisor restart arguments; restarting with no extra args"
+                );
+                Vec::new()
+            }
+        },
+        <[String]>::to_vec,
+    );
 
     let args = supervisor_watch_args(
         supervisor_id,
         install_dir,
         watched_pid,
         watched_pid_start_time,
-        &latest.version,
+        handoff_version,
         &restart_args,
     );
     let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
@@ -322,7 +352,7 @@ fn supervisor_watch_args(
     install_dir: &Path,
     watched_pid: u32,
     watched_pid_start_time: u64,
-    handoff_version: &str,
+    handoff_version: Option<&str>,
     restart_args: &[String],
 ) -> Vec<String> {
     let mut args = vec![
@@ -335,9 +365,11 @@ fn supervisor_watch_args(
         watched_pid.to_string(),
         "--pid-start-time".to_string(),
         watched_pid_start_time.to_string(),
-        "--handoff-version".to_string(),
-        handoff_version.to_string(),
     ];
+    if let Some(handoff_version) = handoff_version {
+        args.push("--handoff-version".to_string());
+        args.push(handoff_version.to_string());
+    }
     if !restart_args.is_empty() {
         args.push("--".to_string());
         args.extend(restart_args.iter().cloned());
@@ -360,7 +392,7 @@ mod tests {
             Path::new("/opt/demo"),
             42,
             1_234,
-            "2.0.0",
+            Some("2.0.0"),
             &restart_args,
         );
 
@@ -428,6 +460,8 @@ mod tests {
             &active_app_dir,
             &latest,
             std::process::id(),
+            None,
+            Some(&latest.version),
             Duration::from_millis(200),
             2,
             Duration::from_millis(10),
@@ -438,6 +472,9 @@ mod tests {
                 assert_eq!(failure_phase, RESTART_HANDOFF_FAILED_PHASE);
             }
             SupervisorRestartOutcome::NotApplicable => panic!("expected PendingRestart failure, got NotApplicable"),
+            SupervisorRestartOutcome::ExternalFinalizeScheduled => {
+                panic!("expected PendingRestart failure, got ExternalFinalizeScheduled")
+            }
         }
 
         let deadline = std::time::Instant::now() + Duration::from_secs(2);

--- a/crates/surge-core/src/update/manager/progress_substep.rs
+++ b/crates/surge-core/src/update/manager/progress_substep.rs
@@ -33,6 +33,8 @@ pub(crate) mod labels {
     pub const WRITING_REBUILT_PACKAGE: &str = "writing rebuilt package";
     pub const EXTRACTING_REBUILT_PACKAGE: &str = "extracting rebuilt package";
     pub const PACKAGE_APPLY_COMPLETED: &str = "package apply completed";
+    pub const STARTING_EXTERNAL_FINALIZER: &str = "starting external finalizer";
+    pub const WAITING_FOR_UPDATER_EXIT: &str = "waiting for updating app to exit";
     pub const STOPPING_SUPERVISOR: &str = "stopping supervisor";
     pub const QUIESCING_ACTIVE_APP: &str = "quiescing active app before swap";
     pub const PREPARING_SWAP: &str = "preparing app swap";

--- a/crates/surge-core/src/update/status/worker.rs
+++ b/crates/surge-core/src/update/status/worker.rs
@@ -19,14 +19,17 @@
 //!   progress-staleness window; never fail an attempt on an inconclusive
 //!   probe.
 
+use std::fs::{File, OpenOptions};
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
+use fs2::FileExt;
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 
 use crate::error::{Result, SurgeError};
 use crate::platform::fs::write_file_atomic;
-use crate::platform::process::{PidLiveness, probe_pid_liveness, probe_process_identity, process_start_time};
+use crate::platform::process::{PidLiveness, current_pid, probe_process_identity, process_start_time};
 
 use super::{
     FailureContext, UpdateConvergenceState, UpdateStatusRecord, next_retry_timestamp, now_utc_rfc3339,
@@ -34,6 +37,7 @@ use super::{
 };
 
 const UPDATE_WORKER_FILE_NAME: &str = ".surge-update-worker.json";
+const UPDATE_WORKER_LOCK_FILE_NAME: &str = ".surge-update-worker.lock";
 
 /// A live worker whose progress has been silent this long is presumed hung
 /// (deadlocked or stalled on a frozen connection): active update work emits
@@ -42,6 +46,7 @@ const UPDATE_WORKER_FILE_NAME: &str = ".surge-update-worker.json";
 /// window used without a marker, because a live substep may be quiet for a
 /// while without being hung.
 const STALLED_LIVE_WORKER_PROGRESS_DEADLINE: Duration = Duration::from_mins(30);
+const LEGACY_WORKER_MARKER_GRACE: Duration = Duration::from_mins(5);
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 struct UpdateWorkerRecord {
@@ -51,49 +56,143 @@ struct UpdateWorkerRecord {
     started_at_utc: String,
     #[serde(default)]
     process_start_time: Option<u64>,
+    #[serde(default)]
+    owner_id: String,
 }
 
 pub struct UpdateWorkerGuard {
     path: PathBuf,
-    pid: u32,
-    app_id: String,
-    target_version: String,
+    lock_path: PathBuf,
+    owner_id: String,
 }
 
 impl UpdateWorkerGuard {
     pub fn record(install_dir: &Path, app_id: &str, target_version: &str) -> Result<Self> {
-        let record = UpdateWorkerRecord {
-            pid: std::process::id(),
-            app_id: app_id.to_string(),
-            target_version: target_version.to_string(),
-            started_at_utc: now_utc_rfc3339(),
-            process_start_time: process_start_time(std::process::id()),
-        };
-        let path = update_worker_path(install_dir);
-        let json = serde_json::to_vec_pretty(&record)
-            .map_err(|e| SurgeError::Config(format!("Failed to encode update worker marker: {e}")))?;
-        write_file_atomic(&path, &json)?;
-        Ok(Self {
-            path,
-            pid: record.pid,
-            app_id: record.app_id,
-            target_version: record.target_version,
-        })
+        let lock_path = update_worker_lock_path(install_dir);
+        let _lock = acquire_worker_lock(&lock_path)?;
+        if let Some(existing) = read_update_worker(install_dir)?
+            && worker_blocks_new_attempt(install_dir, &existing)?
+        {
+            return Err(SurgeError::Update(format!(
+                "Another update worker (pid {}) already owns this installation",
+                existing.pid
+            )));
+        }
+
+        write_owned_worker(install_dir, &lock_path, app_id, target_version)
+    }
+
+    pub(crate) fn take_over(
+        install_dir: &Path,
+        app_id: &str,
+        target_version: &str,
+        expected_pid: u32,
+        expected_start_time: u64,
+    ) -> Result<Self> {
+        let lock_path = update_worker_lock_path(install_dir);
+        let _lock = acquire_worker_lock(&lock_path)?;
+        let existing = read_update_worker(install_dir)?.ok_or_else(|| {
+            SurgeError::Update("The external finalizer could not find the updating worker to take over".to_string())
+        })?;
+        if existing.pid != expected_pid
+            || existing.process_start_time != Some(expected_start_time)
+            || existing.app_id != app_id
+            || existing.target_version != target_version
+            || !matches!(probe_worker_liveness(&existing), PidLiveness::Alive)
+        {
+            return Err(SurgeError::Update(
+                "Update worker ownership changed before the external finalizer took over".to_string(),
+            ));
+        }
+
+        write_owned_worker(install_dir, &lock_path, app_id, target_version)
     }
 }
 
 impl Drop for UpdateWorkerGuard {
     fn drop(&mut self) {
+        let Ok(_lock) = acquire_worker_lock(&self.lock_path) else {
+            return;
+        };
         let Ok(raw) = std::fs::read(&self.path) else {
             return;
         };
         let Ok(record) = serde_json::from_slice::<UpdateWorkerRecord>(&raw) else {
             return;
         };
-        if record.pid == self.pid && record.app_id == self.app_id && record.target_version == self.target_version {
+        if record.owner_id == self.owner_id {
             let _ = std::fs::remove_file(&self.path);
         }
     }
+}
+
+fn write_owned_worker(
+    install_dir: &Path,
+    lock_path: &Path,
+    app_id: &str,
+    target_version: &str,
+) -> Result<UpdateWorkerGuard> {
+    let pid = current_pid();
+    let process_start_time = process_start_time(pid).ok_or_else(|| {
+        SurgeError::Platform(format!(
+            "Could not read start-time identity for update worker process {pid}"
+        ))
+    })?;
+    let record = UpdateWorkerRecord {
+        pid,
+        app_id: app_id.to_string(),
+        target_version: target_version.to_string(),
+        started_at_utc: now_utc_rfc3339(),
+        process_start_time: Some(process_start_time),
+        owner_id: Uuid::new_v4().to_string(),
+    };
+    let path = update_worker_path(install_dir);
+    let json = serde_json::to_vec_pretty(&record)
+        .map_err(|e| SurgeError::Config(format!("Failed to encode update worker marker: {e}")))?;
+    write_file_atomic(&path, &json)?;
+    Ok(UpdateWorkerGuard {
+        path,
+        lock_path: lock_path.to_path_buf(),
+        owner_id: record.owner_id,
+    })
+}
+
+fn acquire_worker_lock(path: &Path) -> Result<File> {
+    let file = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(path)?;
+    FileExt::lock_exclusive(&file)?;
+    Ok(file)
+}
+
+fn probe_worker_liveness(worker: &UpdateWorkerRecord) -> PidLiveness {
+    worker.process_start_time.map_or(PidLiveness::Unknown, |start_time| {
+        probe_process_identity(worker.pid, start_time)
+    })
+}
+
+fn worker_blocks_new_attempt(install_dir: &Path, worker: &UpdateWorkerRecord) -> Result<bool> {
+    if worker.process_start_time.is_some() {
+        return Ok(!matches!(probe_worker_liveness(worker), PidLiveness::Dead));
+    }
+
+    if let Some(status) = read_update_status(install_dir)?
+        && status.app_id == worker.app_id
+        && status.target_version == worker.target_version
+    {
+        return Ok(status.state == UpdateConvergenceState::InProgress);
+    }
+
+    let started_at = chrono::DateTime::parse_from_rfc3339(&worker.started_at_utc)
+        .ok()
+        .map(|timestamp| timestamp.with_timezone(&chrono::Utc));
+    Ok(started_at.is_some_and(|started_at| {
+        let age = chrono::Utc::now().signed_duration_since(started_at);
+        chrono::Duration::from_std(LEGACY_WORKER_MARKER_GRACE).is_ok_and(|grace| age < grace)
+    }))
 }
 
 pub fn fail_abandoned_in_progress_update(
@@ -158,10 +257,7 @@ fn fail_abandoned_in_progress_update_at(
         return Ok(Some(failed));
     };
 
-    let worker_liveness = worker.process_start_time.map_or_else(
-        || probe_pid_liveness(worker.pid),
-        |start_time| probe_process_identity(worker.pid, start_time),
-    );
+    let worker_liveness = probe_worker_liveness(&worker);
 
     if worker.process_start_time.is_some()
         && worker.pid == std::process::id()
@@ -307,6 +403,11 @@ fn update_worker_path(install_dir: &Path) -> PathBuf {
     install_dir.join(UPDATE_WORKER_FILE_NAME)
 }
 
+#[must_use]
+fn update_worker_lock_path(install_dir: &Path) -> PathBuf {
+    install_dir.join(UPDATE_WORKER_LOCK_FILE_NAME)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -420,7 +521,8 @@ mod tests {
             "2026-05-15T20:09:45Z".to_string(),
         );
         write_update_status(dir.path(), &record).unwrap();
-        write_worker_file(dir.path(), dead_helper_pid(), "demo-app", "9999.0.0");
+        let (pid, start_time) = dead_helper_identity();
+        write_worker_file_with_start_time(dir.path(), pid, "demo-app", "9999.0.0", Some(start_time));
 
         let failed = fail_abandoned_in_progress_update_at(
             dir.path(),
@@ -570,27 +672,39 @@ mod tests {
     }
 
     fn write_worker_file(dir: &Path, pid: u32, app_id: &str, target_version: &str) {
+        write_worker_file_with_start_time(dir, pid, app_id, target_version, process_start_time(pid));
+    }
+
+    fn write_worker_file_with_start_time(
+        dir: &Path,
+        pid: u32,
+        app_id: &str,
+        target_version: &str,
+        process_start_time: Option<u64>,
+    ) {
         let record = UpdateWorkerRecord {
             pid,
             app_id: app_id.to_string(),
             target_version: target_version.to_string(),
             started_at_utc: now_utc_rfc3339(),
-            process_start_time: process_start_time(pid),
+            process_start_time,
+            owner_id: String::new(),
         };
         let json = serde_json::to_vec_pretty(&record).unwrap();
         write_file_atomic(&update_worker_path(dir), &json).unwrap();
     }
 
-    fn dead_helper_pid() -> u32 {
-        let mut child = spawn_helper(false);
+    fn dead_helper_identity() -> (u32, u64) {
+        let (pid, mut child) = live_helper_pid();
+        let start_time = process_start_time(pid).expect("live helper start time");
+        let _ = child.kill();
         let _ = child.wait();
-        let pid = child.id();
         let deadline = Instant::now() + Duration::from_secs(5);
         while is_pid_alive(pid) && Instant::now() < deadline {
             std::thread::sleep(Duration::from_millis(50));
         }
         assert!(!is_pid_alive(pid), "helper pid {pid} should be dead before the test");
-        pid
+        (pid, start_time)
     }
 
     fn live_helper_pid() -> (u32, std::process::Child) {
@@ -686,6 +800,7 @@ mod tests {
             target_version: "9999.0.0".to_string(),
             started_at_utc: now_utc_rfc3339(),
             process_start_time: Some(actual_start_time ^ 1),
+            owner_id: "stale-owner".to_string(),
         };
         let json = serde_json::to_vec_pretty(&worker).unwrap();
         write_file_atomic(&update_worker_path(dir.path()), &json).unwrap();
@@ -706,5 +821,35 @@ mod tests {
 
         assert_eq!(failed.state, UpdateConvergenceState::Failed);
         assert!(failed.reason.as_deref().unwrap().contains("exited without completing"));
+    }
+
+    #[test]
+    fn live_worker_excludes_a_second_update_attempt() {
+        let dir = tempfile::tempdir().unwrap();
+        let first = UpdateWorkerGuard::record(dir.path(), "demo-app", "9999.0.0").unwrap();
+
+        let Err(error) = UpdateWorkerGuard::record(dir.path(), "demo-app", "9999.0.0") else {
+            panic!("a live worker must keep exclusive ownership");
+        };
+
+        assert!(error.to_string().contains("already owns"));
+        drop(first);
+        assert!(UpdateWorkerGuard::record(dir.path(), "demo-app", "9999.0.0").is_ok());
+    }
+
+    #[test]
+    fn external_helper_takeover_survives_parent_guard_drop() {
+        let dir = tempfile::tempdir().unwrap();
+        let parent = UpdateWorkerGuard::record(dir.path(), "demo-app", "9999.0.0").unwrap();
+        let pid = current_pid();
+        let start_time = process_start_time(pid).unwrap();
+        let helper = UpdateWorkerGuard::take_over(dir.path(), "demo-app", "9999.0.0", pid, start_time).unwrap();
+
+        drop(parent);
+
+        let persisted = read_update_worker(dir.path()).unwrap().unwrap();
+        assert_eq!(persisted.owner_id, helper.owner_id);
+        drop(helper);
+        assert!(read_update_worker(dir.path()).unwrap().is_none());
     }
 }

--- a/crates/surge-ffi/src/shared.rs
+++ b/crates/surge-ffi/src/shared.rs
@@ -14,6 +14,7 @@ use crate::handles::{SurgeContextHandle, SurgeErrorOwned};
 use crate::utils::lock_recover;
 
 pub(crate) const SURGE_OK: i32 = 0;
+pub(crate) const SURGE_UPDATE_SCHEDULED: i32 = 1;
 pub(crate) const SURGE_ERROR: i32 = -1;
 pub(crate) const SURGE_CANCELLED: i32 = -2;
 pub(crate) const SURGE_NOT_FOUND: i32 = -3;

--- a/crates/surge-ffi/src/update.rs
+++ b/crates/surge-ffi/src/update.rs
@@ -4,12 +4,12 @@ use std::time::Duration;
 
 use surge_core::config::manifest::{InstallArtifactCachePolicy, InstallArtifactCacheRetention};
 use surge_core::error::SurgeError;
-use surge_core::update::manager::{ProgressInfo, UpdateManager};
+use surge_core::update::manager::{ProgressInfo, UpdateApplyOutcome, UpdateManager};
 
 use crate::handles::{ReleaseEntryFfi, SurgeReleasesInfoHandle, SurgeUpdateManagerHandle};
 use crate::shared::{
-    ProgressBridge, SURGE_CANCELLED, SURGE_ERROR, SURGE_NOT_FOUND, SURGE_OK, SurgeProgressCallback, catch_ffi,
-    clear_shared_error, cstr_to_string, ffi_trace, set_ctx_error, set_shared_error,
+    ProgressBridge, SURGE_CANCELLED, SURGE_ERROR, SURGE_NOT_FOUND, SURGE_OK, SURGE_UPDATE_SCHEDULED,
+    SurgeProgressCallback, catch_ffi, clear_shared_error, cstr_to_string, ffi_trace, set_ctx_error, set_shared_error,
 };
 
 const DEFAULT_UPDATE_CHECK_TIMEOUT: Duration = Duration::from_mins(1);
@@ -439,7 +439,8 @@ pub unsafe extern "C" fn surge_update_download_and_apply(
         };
 
         match result {
-            Ok(()) => SURGE_OK,
+            Ok(UpdateApplyOutcome::Finalized) => SURGE_OK,
+            Ok(UpdateApplyOutcome::ExternalFinalizeScheduled) => SURGE_UPDATE_SCHEDULED,
             Err(e) => set_shared_error(&mgr_ref.ctx, &mgr_ref.last_error, &e),
         }
     }))

--- a/crates/surge-supervisor/Cargo.toml
+++ b/crates/surge-supervisor/Cargo.toml
@@ -16,7 +16,8 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 clap = { workspace = true }
 thiserror = { workspace = true }
-sysinfo = "0.39.3"
+tokio = { workspace = true }
+sysinfo = { workspace = true }
 signal-hook = "0.4.4"
 
 [target.'cfg(unix)'.dependencies]

--- a/crates/surge-supervisor/src/main.rs
+++ b/crates/surge-supervisor/src/main.rs
@@ -97,6 +97,18 @@ enum Commands {
         verbose: bool,
     },
 
+    /// Finalize a staged supervised update after the updating child exits
+    #[command(hide = true)]
+    FinalizeUpdate {
+        /// Path to the armed external-finalizer plan
+        #[arg(long)]
+        plan: PathBuf,
+
+        /// Enable verbose logging
+        #[arg(long, short = 'v')]
+        verbose: bool,
+    },
+
     /// Print SHA-256 hash of a file
     #[command(name = "sha256")]
     Sha256 {
@@ -200,6 +212,23 @@ fn main() -> ExitCode {
                 return ExitCode::FAILURE;
             }
             ExitCode::SUCCESS
+        }
+        Commands::FinalizeUpdate { plan, verbose } => {
+            init_tracing(verbose);
+            let runtime = match tokio::runtime::Builder::new_current_thread().enable_all().build() {
+                Ok(runtime) => runtime,
+                Err(error) => {
+                    tracing::error!(%error, "Failed to create external finalizer runtime");
+                    return ExitCode::FAILURE;
+                }
+            };
+            match runtime.block_on(surge_core::update::manager::run_external_finalize(&plan)) {
+                Ok(()) => ExitCode::SUCCESS,
+                Err(error) => {
+                    tracing::error!(%error, "External update finalization failed");
+                    ExitCode::FAILURE
+                }
+            }
         }
         Commands::Sha256 { file } => match surge_core::crypto::sha256::sha256_hex_file(&file) {
             Ok(hash) => {

--- a/include/surge/surge_api.h
+++ b/include/surge/surge_api.h
@@ -67,7 +67,13 @@ typedef struct surge_pack_context surge_pack_context;
 /* -------------------------------------------------------------------------- */
 
 /** Result codes returned by most API functions. */
-typedef enum surge_result { SURGE_OK = 0, SURGE_ERROR = -1, SURGE_CANCELLED = -2, SURGE_NOT_FOUND = -3 } surge_result;
+typedef enum surge_result {
+    SURGE_OK = 0,
+    SURGE_UPDATE_SCHEDULED = 1,
+    SURGE_ERROR = -1,
+    SURGE_CANCELLED = -2,
+    SURGE_NOT_FOUND = -3
+} surge_result;
 
 /** Phases reported through progress callbacks. */
 typedef enum surge_progress_phase {
@@ -278,12 +284,10 @@ SURGE_API surge_result SURGE_CALL surge_update_manager_set_release_retention_lim
  * Allow the running application to swap its own active directory during apply.
  *
  * `allow` is treated as a boolean: zero disables (the default), non-zero
- * enables. When disabled, an updater running from the active application
- * executable refuses the swap and expects an external Surge updater. A
- * self-hosted application that updates in-process (calling
- * `surge_update_download_and_apply` from inside the installed app) must
- * enable this to keep self-updating; other processes running the active
- * executable are still quiesced before the swap.
+ * enables. When disabled, an updater running from a supervised stable `app`
+ * directory transfers finalization to an external helper. Other self-hosted
+ * layouts refuse the swap. Enabling this restores the legacy in-process swap;
+ * other processes running the active executable are still quiesced first.
  *
  * `mgr` must be a valid update manager handle or NULL.
  */
@@ -315,7 +319,15 @@ SURGE_API surge_result SURGE_CALL surge_update_check(surge_update_manager* mgr, 
  * @param info        Release information from surge_update_check().
  * @param progress_cb Optional progress callback (may be NULL).
  * @param user_data   Opaque pointer forwarded to @p progress_cb.
- * @return SURGE_OK on success.
+ *
+ * A self-hosted supervised updater normally returns before the active
+ * application directory is changed. SURGE_UPDATE_SCHEDULED means a stable
+ * helper accepted ownership and is waiting for the calling application to
+ * exit. The caller must exit promptly, then inspect persisted update status
+ * after restart; scheduling alone is not installation success.
+ *
+ * @return SURGE_OK when finalization completed in this call;
+ *         SURGE_UPDATE_SCHEDULED when external finalization was accepted.
  */
 SURGE_API surge_result SURGE_CALL surge_update_download_and_apply(surge_update_manager* mgr,
                                                                   const surge_releases_info* info,


### PR DESCRIPTION
## Summary

- stage supervised self-updates and transfer finalization to a stable helper outside `app`
- use a ready, armed, and accepted handshake plus transactional worker ownership
- quiesce the exact running application before swapping the stable directory
- preserve terminal status ordering, exact rollback bits, restart arguments, environment, and bounded retry evidence

## Stack

1. #294: process-identity foundation
2. This PR (#295): external finalizer and recovery
3. #296: consumer outcome and end-to-end smoke

Base: #294. Review and merge after the first PR.

## Scope controls

- requires both current and target releases to be supervised
- rejects unsupported self-hosted layouts
- persists no storage access key or secret key in the handoff plan
- fails before acceptance when the helper cannot detach safely

## Validation

- `cargo test -p surge-core`
- `cargo test -p surge-supervisor`
- cumulative workspace, Clippy, and managed gates are exercised by the top PR

Refs #292
