### PR TITLE
Expose supervised update handoff to consumers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3309,6 +3309,7 @@ dependencies = [
  "signal-hook",
  "surge-core",
  "sysinfo",
+ "tempfile",
  "thiserror 2.0.20",
  "tokio",
  "tracing",

--- a/README.md
+++ b/README.md
@@ -230,19 +230,29 @@ explicit SSH identity, pass `--node-user <account>` (or set `--node <account>@<n
 **.NET**
 ```csharp
 using var mgr = new SurgeUpdateManager();
-await mgr.UpdateToLatestReleaseAsync(
+var result = await mgr.UpdateToLatestReleaseAsync(
     onUpdatesAvailable: releases =>
         Console.WriteLine($"{releases.Count} update(s), latest: {releases.Latest?.Version}"),
     onAfterApplyUpdate: release =>
         Console.WriteLine($"Updated to {release.Version}")
 );
+if (result?.IsUpdateFinalizationScheduled == true)
+{
+    return;
+}
 ```
 
 **Rust**
 ```rust
 let mut mgr = UpdateManager::new(ctx, "my-app", "1.0.0", "stable", install_dir)?;
 if let Some(info) = mgr.check_for_updates().await? {
-    mgr.download_and_apply(&info, None::<fn(_)>).await?;
+    let outcome = mgr.download_and_apply(&info, None::<fn(_)>).await?;
+    if matches!(
+        outcome,
+        surge_core::update::manager::UpdateApplyOutcome::ExternalFinalizeScheduled
+    ) {
+        return Ok(());
+    }
 }
 ```
 
@@ -250,13 +260,21 @@ if let Some(info) = mgr.check_for_updates().await? {
 ```c
 surge_update_manager* mgr = surge_update_manager_create(ctx, "my-app", "1.0.0", "stable", dir);
 surge_releases_info* info = NULL;
+surge_result apply_result = SURGE_OK;
 if (surge_update_check(mgr, &info) == SURGE_OK) {
-    surge_update_download_and_apply(mgr, info, progress_cb, NULL);
+    apply_result = surge_update_download_and_apply(mgr, info, progress_cb, NULL);
     surge_releases_destroy(info);
 }
 surge_update_manager_destroy(mgr);
 surge_context_destroy(ctx);
+if (apply_result == SURGE_UPDATE_SCHEDULED) {
+    return 0;
+}
 ```
+
+`ExternalFinalizeScheduled` / `IsUpdateFinalizationScheduled` / `SURGE_UPDATE_SCHEDULED`
+means the helper accepted the remaining work, not that installation finished. Stop application
+work and exit promptly, then verify the persisted convergence status after restart.
 
 ## CI/CD Integration
 

--- a/crates/surge-bench/src/runner/update.rs
+++ b/crates/surge-bench/src/runner/update.rs
@@ -13,7 +13,7 @@ use surge_core::install::{InstallProfile, RuntimeManifestMetadata, write_runtime
 use surge_core::pack::builder::{PackBuilder, TimedArtifact};
 use surge_core::platform::detect::current_rid;
 use surge_core::releases::delta::SparseTreeReuse;
-use surge_core::update::manager::{ApplyStrategy, ProgressInfo, UpdateManager};
+use surge_core::update::manager::{ApplyStrategy, ProgressInfo, UpdateApplyOutcome, UpdateManager};
 
 use crate::payload::{PayloadTemplate, ScenarioProfile};
 use crate::report::BenchmarkResult;
@@ -377,7 +377,7 @@ pub async fn run_update_scenario(
     let t0 = apply_started;
     let last_items = std::sync::Arc::new(std::sync::atomic::AtomicI64::new(-1));
     let li = last_items.clone();
-    update_manager
+    let outcome = update_manager
         .download_and_apply(
             &info,
             Some(move |p: ProgressInfo| {
@@ -394,6 +394,11 @@ pub async fn run_update_scenario(
             }),
         )
         .await?;
+    if outcome == UpdateApplyOutcome::ExternalFinalizeScheduled {
+        return Err(SurgeError::Update(
+            "Benchmark update unexpectedly required external finalization".to_string(),
+        ));
+    }
     let apply_duration = apply_started.elapsed();
     assert_directories_match(&install_dir.join("app"), &artifacts_dir)?;
     results.push(BenchmarkResult {

--- a/crates/surge-cli/src/commands/setup/convergence.rs
+++ b/crates/surge-cli/src/commands/setup/convergence.rs
@@ -9,7 +9,7 @@ use surge_core::error::{Result, SurgeError};
 use surge_core::install::{self as core_install, InstallProfile};
 use surge_core::releases::version::compare_versions;
 use surge_core::storage_config::build_storage_config_from_installer_manifest;
-use surge_core::update::manager::{ApplyStrategy, ProgressInfo, UpdateInfo, UpdateManager};
+use surge_core::update::manager::{ApplyStrategy, ProgressInfo, UpdateApplyOutcome, UpdateInfo, UpdateManager};
 
 #[derive(Debug, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -120,7 +120,7 @@ async fn update_existing_install(
     apply_installer_runtime_environment(&mut update, manifest);
 
     let update_progress = Mutex::new(ProgressReporter::new("Applying update..."));
-    manager
+    let outcome = manager
         .download_and_apply(
             &update,
             Some(|progress: ProgressInfo| {
@@ -133,6 +133,12 @@ async fn update_existing_install(
             }),
         )
         .await?;
+    if outcome == UpdateApplyOutcome::ExternalFinalizeScheduled {
+        return Err(SurgeError::Update(
+            "Installer convergence unexpectedly required external finalization; exit before verifying the installed version"
+                .to_string(),
+        ));
+    }
 
     repair_runtime_metadata(manifest, install_root)?;
     logline::success(&format!(

--- a/crates/surge-core/src/update/manager/external_finalize/quiesce.rs
+++ b/crates/surge-core/src/update/manager/external_finalize/quiesce.rs
@@ -295,7 +295,7 @@ mod tests {
             child.id(),
             start_time,
             &executable,
-            Duration::ZERO,
+            Duration::from_millis(500),
             Duration::from_secs(2),
             Duration::from_secs(1),
         )

--- a/crates/surge-ffi/src/update.rs
+++ b/crates/surge-ffi/src/update.rs
@@ -176,12 +176,10 @@ pub unsafe extern "C" fn surge_update_manager_set_release_retention_limit(
 /// Allow the running application to swap its own active directory during apply.
 ///
 /// `allow` is treated as a boolean: zero disables (the default), non-zero
-/// enables. When disabled, an updater running from the active application
-/// executable refuses the swap and expects an external Surge updater. A
-/// self-hosted application that updates in-process (calling
-/// `surge_update_download_and_apply` from inside the installed app) must
-/// enable this to keep self-updating; other processes running the active
-/// executable are still quiesced before the swap.
+/// enables. When disabled, an updater running from a supervised stable `app`
+/// directory transfers finalization to an external helper. Other self-hosted
+/// layouts refuse the swap. Enabling this restores the legacy in-process swap;
+/// other processes running the active executable are still quiesced first.
 ///
 /// # Safety
 ///

--- a/crates/surge-supervisor/Cargo.toml
+++ b/crates/surge-supervisor/Cargo.toml
@@ -10,6 +10,11 @@ description = "Process supervisor for the Surge update framework"
 name = "surge-supervisor"
 path = "src/main.rs"
 
+[[test]]
+name = "external_finalize"
+path = "tests/external_finalize.rs"
+harness = false
+
 [dependencies]
 surge-core = { workspace = true }
 tracing = { workspace = true }
@@ -22,6 +27,9 @@ signal-hook = "0.4.4"
 
 [target.'cfg(unix)'.dependencies]
 nix = { version = "0.31", features = ["signal", "process"] }
+
+[dev-dependencies]
+tempfile = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/surge-supervisor/tests/external_finalize.rs
+++ b/crates/surge-supervisor/tests/external_finalize.rs
@@ -1,0 +1,442 @@
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use surge_core::archive::packer::ArchivePacker;
+use surge_core::config::constants::{DEFAULT_ZSTD_LEVEL, RELEASES_FILE_COMPRESSED};
+use surge_core::context::{Context, StorageProvider};
+use surge_core::crypto::sha256::sha256_hex_file;
+use surge_core::install::{InstallProfile, RuntimeManifestMetadata, write_runtime_manifest};
+use surge_core::platform::detect::current_rid;
+use surge_core::platform::process::supervisor_binary_name;
+use surge_core::releases::manifest::{ReleaseEntry, ReleaseIndex, compress_release_index};
+use surge_core::supervisor::state::write_restart_args;
+use surge_core::update::manager::{ProgressInfo, UpdateApplyOutcome, UpdateManager};
+use surge_core::update::status::{UpdateConvergenceState, read_update_status};
+
+const APP_ID: &str = "external-finalizer-fixture";
+const SUPERVISOR_ID: &str = "external-finalizer-supervisor";
+const CURRENT_VERSION: &str = "1.0.0";
+const TARGET_VERSION: &str = "2.0.0";
+const MODE_ENV: &str = "SURGE_EXTERNAL_FINALIZE_MODE";
+const UPDATER_MODE: &str = "updater";
+const TARGET_MODE: &str = "target";
+const TARGET_ENV_VALUE: &str = "target-environment-preserved";
+const RESTART_ARGS: [&str; 2] = ["--fixture-restart", "value with spaces"];
+
+#[cfg(windows)]
+const UPDATER_EXE: &str = "fixture-updater.exe";
+#[cfg(not(windows))]
+const UPDATER_EXE: &str = "fixture-updater";
+#[cfg(windows)]
+const TARGET_EXE: &str = "fixture-target.exe";
+#[cfg(not(windows))]
+const TARGET_EXE: &str = "fixture-target";
+
+fn main() {
+    match std::env::var(MODE_ENV).as_deref() {
+        Ok(UPDATER_MODE) => run_self_update(),
+        Ok(TARGET_MODE) => run_target(),
+        _ => verify_self_hosted_update(),
+    }
+}
+
+fn run_self_update() {
+    let store_root = required_path("SURGE_EXTERNAL_FINALIZE_STORE");
+    let install_root = required_path("SURGE_EXTERNAL_FINALIZE_INSTALL");
+    let returned_marker = required_path("SURGE_EXTERNAL_FINALIZE_RETURNED");
+    let allow_exit_marker = required_path("SURGE_EXTERNAL_FINALIZE_ALLOW_EXIT");
+    let context = Arc::new(Context::new());
+    context.set_storage(
+        StorageProvider::Filesystem,
+        store_root.to_str().unwrap(),
+        "",
+        "",
+        "",
+        "",
+    );
+    let mut manager =
+        UpdateManager::new(context, APP_ID, CURRENT_VERSION, "test", install_root.to_str().unwrap()).unwrap();
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    runtime.block_on(async move {
+        let update = manager.check_for_updates().await.unwrap().unwrap();
+        let outcome = manager
+            .download_and_apply(&update, None::<fn(ProgressInfo)>)
+            .await
+            .unwrap();
+        assert_eq!(outcome, UpdateApplyOutcome::ExternalFinalizeScheduled);
+    });
+    std::fs::write(returned_marker, "scheduled").unwrap();
+    assert!(wait_until(Duration::from_secs(10), || allow_exit_marker.is_file()));
+}
+
+fn run_target() {
+    let install_root = required_path("SURGE_EXTERNAL_FINALIZE_INSTALL");
+    let args = std::env::args().skip(1).collect::<Vec<_>>();
+    let status = read_update_status(&install_root)
+        .unwrap()
+        .expect("target must observe update status");
+    let observed_status = format!(
+        "{}\n{}\n{}\n",
+        status.state.as_str(),
+        status.installed_version,
+        status.target_version
+    );
+
+    if args
+        .iter()
+        .any(|arg| arg == "--surge-updated" || arg.starts_with("--surge-updated="))
+    {
+        std::fs::write(
+            required_path("SURGE_EXTERNAL_FINALIZE_TARGET_HOOK_STATUS"),
+            observed_status,
+        )
+        .unwrap();
+        return;
+    }
+
+    let started_marker = required_path("SURGE_EXTERNAL_FINALIZE_TARGET_STARTED");
+    let status_marker = required_path("SURGE_EXTERNAL_FINALIZE_TARGET_STATUS");
+    let args_marker = required_path("SURGE_EXTERNAL_FINALIZE_TARGET_ARGS");
+    let environment_marker = required_path("SURGE_EXTERNAL_FINALIZE_TARGET_ENVIRONMENT");
+    let executable_marker = required_path("SURGE_EXTERNAL_FINALIZE_TARGET_EXECUTABLE");
+    let pid_path = required_path("SURGE_EXTERNAL_FINALIZE_TARGET_PID");
+    let stop_path = required_path("SURGE_EXTERNAL_FINALIZE_TARGET_STOP");
+
+    std::fs::write(status_marker, observed_status).unwrap();
+    std::fs::write(args_marker, args.join("\n")).unwrap();
+    std::fs::write(
+        environment_marker,
+        std::env::var("SURGE_EXTERNAL_FINALIZE_TARGET_VALUE").unwrap_or_default(),
+    )
+    .unwrap();
+    std::fs::write(
+        executable_marker,
+        std::fs::canonicalize(std::env::current_exe().unwrap())
+            .unwrap()
+            .to_string_lossy()
+            .as_bytes(),
+    )
+    .unwrap();
+    std::fs::write(pid_path, std::process::id().to_string()).unwrap();
+    std::fs::write(started_marker, "started").unwrap();
+    assert!(wait_until(Duration::from_mins(1), || stop_path.is_file()));
+}
+
+fn verify_self_hosted_update() {
+    #[cfg(windows)]
+    if !detached_helper_launch_is_supported() {
+        return;
+    }
+
+    let temp = tempfile::tempdir().unwrap();
+    let store_root = temp.path().join("store");
+    let install_root = temp.path().join("install");
+    let active_app_dir = install_root.join("app");
+    let updater_path = active_app_dir.join(UPDATER_EXE);
+    let returned_marker = temp.path().join("update-returned");
+    let allow_exit_marker = temp.path().join("allow-updater-exit");
+    let target_started_marker = temp.path().join("target-started");
+    let target_hook_status_marker = temp.path().join("target-hook-status");
+    let target_status_marker = temp.path().join("target-status");
+    let target_args_marker = temp.path().join("target-args");
+    let target_environment_marker = temp.path().join("target-environment");
+    let target_executable_marker = temp.path().join("target-executable");
+    let target_pid_path = temp.path().join("target.pid");
+    let target_stop_path = temp.path().join("target.stop");
+    std::fs::create_dir_all(&active_app_dir).unwrap();
+
+    let fixture_exe = std::env::current_exe().unwrap();
+    std::fs::copy(&fixture_exe, &updater_path).unwrap();
+    make_executable(&updater_path);
+    std::fs::copy(
+        Path::new(env!("CARGO_BIN_EXE_surge-supervisor")),
+        active_app_dir.join(supervisor_binary_name()),
+    )
+    .unwrap();
+    make_executable(&active_app_dir.join(supervisor_binary_name()));
+    write_current_runtime_manifest(&active_app_dir);
+    write_restart_args(
+        &install_root,
+        SUPERVISOR_ID,
+        &RESTART_ARGS.iter().map(ToString::to_string).collect::<Vec<_>>(),
+    )
+    .unwrap();
+    write_target_release(
+        &store_root,
+        &fixture_exe,
+        &install_root,
+        &target_started_marker,
+        &target_hook_status_marker,
+        &target_status_marker,
+        &target_args_marker,
+        &target_environment_marker,
+        &target_executable_marker,
+        &target_pid_path,
+        &target_stop_path,
+    );
+
+    let mut updater = std::process::Command::new(&updater_path)
+        .env(MODE_ENV, UPDATER_MODE)
+        .env("SURGE_EXTERNAL_FINALIZE_STORE", &store_root)
+        .env("SURGE_EXTERNAL_FINALIZE_INSTALL", &install_root)
+        .env("SURGE_EXTERNAL_FINALIZE_RETURNED", &returned_marker)
+        .env("SURGE_EXTERNAL_FINALIZE_ALLOW_EXIT", &allow_exit_marker)
+        .spawn()
+        .unwrap();
+
+    assert!(wait_until(Duration::from_secs(20), || returned_marker.is_file()));
+    assert!(updater.try_wait().unwrap().is_none());
+    assert!(active_app_dir.join(UPDATER_EXE).is_file());
+    assert!(!active_app_dir.join(TARGET_EXE).exists());
+    assert!(!target_started_marker.exists());
+
+    std::fs::write(&allow_exit_marker, "exit").unwrap();
+    assert!(
+        updater.wait().unwrap().success(),
+        "self-hosted updater should hand off successfully"
+    );
+    assert!(
+        wait_until(Duration::from_secs(20), || target_started_marker.is_file()),
+        "target did not start; status: {:?}; active entries: {:?}",
+        read_update_status(&install_root),
+        std::fs::read_dir(&active_app_dir).map(|entries| entries
+            .filter_map(std::result::Result::ok)
+            .map(|entry| entry.file_name())
+            .collect::<Vec<_>>()),
+    );
+
+    assert_eq!(
+        std::fs::read_to_string(&target_hook_status_marker).unwrap(),
+        "pending_restart\n2.0.0\n2.0.0\n"
+    );
+    assert_eq!(
+        std::fs::read_to_string(&target_status_marker).unwrap(),
+        "pending_restart\n2.0.0\n2.0.0\n"
+    );
+    assert_eq!(
+        std::fs::read_to_string(&target_args_marker).unwrap(),
+        RESTART_ARGS.join("\n")
+    );
+    assert_eq!(
+        std::fs::read_to_string(&target_environment_marker).unwrap(),
+        TARGET_ENV_VALUE
+    );
+    assert_eq!(
+        PathBuf::from(std::fs::read_to_string(&target_executable_marker).unwrap()),
+        std::fs::canonicalize(active_app_dir.join(TARGET_EXE)).unwrap()
+    );
+
+    assert!(wait_until(Duration::from_secs(15), || {
+        read_update_status(&install_root).ok().flatten().is_some_and(|status| {
+            status.state == UpdateConvergenceState::Converged
+                && status.installed_version == TARGET_VERSION
+                && status.supervisor_restart_confirmed
+        })
+    }));
+    assert!(
+        install_root
+            .join(format!("app-{CURRENT_VERSION}"))
+            .join(UPDATER_EXE)
+            .is_file()
+    );
+    assert!(
+        install_root
+            .join(".surge-tools")
+            .join(supervisor_binary_name())
+            .is_file()
+    );
+    assert_eq!(
+        surge_core::install::read_runtime_manifest_version(&active_app_dir)
+            .unwrap()
+            .as_deref(),
+        Some(TARGET_VERSION)
+    );
+
+    stop_fixture_processes(&install_root, &target_stop_path, &target_pid_path);
+}
+
+#[cfg(windows)]
+fn detached_helper_launch_is_supported() -> bool {
+    let environment = BTreeMap::new();
+    let mut probe = match surge_core::platform::process::spawn_detached(
+        Path::new("cmd.exe"),
+        &["/d", "/c", "exit", "0"],
+        None,
+        &environment,
+    ) {
+        Ok(probe) => probe,
+        Err(error) if error.to_string().contains("Access is denied") => {
+            eprintln!("Windows job denied safe helper breakaway; Surge failed closed before handoff");
+            return false;
+        }
+        Err(error) => panic!("detached helper capability probe failed unexpectedly: {error}"),
+    };
+    assert_eq!(probe.wait().unwrap().exit_code, 0);
+    true
+}
+
+fn required_path(name: &str) -> PathBuf {
+    PathBuf::from(std::env::var_os(name).unwrap_or_else(|| panic!("missing {name}")))
+}
+
+fn write_current_runtime_manifest(active_app_dir: &Path) {
+    let shortcuts = [];
+    let persistent_assets = [];
+    let environment = BTreeMap::new();
+    let profile = InstallProfile::new(
+        APP_ID,
+        "External finalizer fixture",
+        UPDATER_EXE,
+        APP_ID,
+        SUPERVISOR_ID,
+        "",
+        &shortcuts,
+        &persistent_assets,
+        &environment,
+    );
+    let metadata = RuntimeManifestMetadata::new(CURRENT_VERSION, "test", "filesystem", ".", "", "");
+    write_runtime_manifest(active_app_dir, &profile, &metadata).unwrap();
+}
+
+#[allow(clippy::too_many_arguments)]
+fn write_target_release(
+    store_root: &Path,
+    fixture_exe: &Path,
+    install_root: &Path,
+    target_started_marker: &Path,
+    target_hook_status_marker: &Path,
+    target_status_marker: &Path,
+    target_args_marker: &Path,
+    target_environment_marker: &Path,
+    target_executable_marker: &Path,
+    target_pid_path: &Path,
+    target_stop_path: &Path,
+) {
+    let app_store = store_root.join(APP_ID);
+    std::fs::create_dir_all(&app_store).unwrap();
+    let full_filename = format!("{APP_ID}-{TARGET_VERSION}-full.tar.zst");
+    let full_path = app_store.join(&full_filename);
+    let mut packer = ArchivePacker::new(DEFAULT_ZSTD_LEVEL).unwrap();
+    packer.add_file(fixture_exe, TARGET_EXE).unwrap();
+    packer
+        .add_file(
+            Path::new(env!("CARGO_BIN_EXE_surge-supervisor")),
+            supervisor_binary_name(),
+        )
+        .unwrap();
+    packer.finalize_to_file(&full_path).unwrap();
+
+    let environment = BTreeMap::from([
+        (MODE_ENV.to_string(), TARGET_MODE.to_string()),
+        (
+            "SURGE_EXTERNAL_FINALIZE_INSTALL".to_string(),
+            install_root.to_string_lossy().into_owned(),
+        ),
+        (
+            "SURGE_EXTERNAL_FINALIZE_TARGET_STARTED".to_string(),
+            target_started_marker.to_string_lossy().into_owned(),
+        ),
+        (
+            "SURGE_EXTERNAL_FINALIZE_TARGET_HOOK_STATUS".to_string(),
+            target_hook_status_marker.to_string_lossy().into_owned(),
+        ),
+        (
+            "SURGE_EXTERNAL_FINALIZE_TARGET_STATUS".to_string(),
+            target_status_marker.to_string_lossy().into_owned(),
+        ),
+        (
+            "SURGE_EXTERNAL_FINALIZE_TARGET_ARGS".to_string(),
+            target_args_marker.to_string_lossy().into_owned(),
+        ),
+        (
+            "SURGE_EXTERNAL_FINALIZE_TARGET_ENVIRONMENT".to_string(),
+            target_environment_marker.to_string_lossy().into_owned(),
+        ),
+        (
+            "SURGE_EXTERNAL_FINALIZE_TARGET_EXECUTABLE".to_string(),
+            target_executable_marker.to_string_lossy().into_owned(),
+        ),
+        (
+            "SURGE_EXTERNAL_FINALIZE_TARGET_PID".to_string(),
+            target_pid_path.to_string_lossy().into_owned(),
+        ),
+        (
+            "SURGE_EXTERNAL_FINALIZE_TARGET_STOP".to_string(),
+            target_stop_path.to_string_lossy().into_owned(),
+        ),
+        (
+            "SURGE_EXTERNAL_FINALIZE_TARGET_VALUE".to_string(),
+            TARGET_ENV_VALUE.to_string(),
+        ),
+    ]);
+    let release = ReleaseEntry {
+        version: TARGET_VERSION.to_string(),
+        channels: vec!["test".to_string()],
+        rid: current_rid(),
+        is_genesis: true,
+        full_filename,
+        full_size: i64::try_from(std::fs::metadata(&full_path).unwrap().len()).unwrap(),
+        full_sha256: sha256_hex_file(&full_path).unwrap(),
+        name: "External finalizer fixture".to_string(),
+        main_exe: TARGET_EXE.to_string(),
+        install_directory: APP_ID.to_string(),
+        supervisor_id: SUPERVISOR_ID.to_string(),
+        environment,
+        ..ReleaseEntry::default()
+    };
+    let index = ReleaseIndex {
+        app_id: APP_ID.to_string(),
+        releases: vec![release],
+        ..ReleaseIndex::default()
+    };
+    std::fs::write(
+        app_store.join(RELEASES_FILE_COMPRESSED),
+        compress_release_index(&index, DEFAULT_ZSTD_LEVEL).unwrap(),
+    )
+    .unwrap();
+}
+
+#[cfg(unix)]
+fn make_executable(path: &Path) {
+    use std::os::unix::fs::PermissionsExt;
+
+    let mut permissions = std::fs::metadata(path).unwrap().permissions();
+    permissions.set_mode(permissions.mode() | 0o111);
+    std::fs::set_permissions(path, permissions).unwrap();
+}
+
+#[cfg(not(unix))]
+fn make_executable(_path: &Path) {}
+
+fn wait_until(timeout: Duration, mut condition: impl FnMut() -> bool) -> bool {
+    let deadline = Instant::now() + timeout;
+    while Instant::now() < deadline {
+        if condition() {
+            return true;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    condition()
+}
+
+fn stop_fixture_processes(install_root: &Path, target_stop_path: &Path, target_pid_path: &Path) {
+    let supervisor_stop = install_root.join(format!(".surge-supervisor-{SUPERVISOR_ID}.stop"));
+    let supervisor_pid = install_root.join(format!(".surge-supervisor-{SUPERVISOR_ID}.pid"));
+    std::fs::write(&supervisor_stop, "test cleanup").unwrap();
+    assert!(wait_until(Duration::from_secs(5), || !supervisor_pid.exists()));
+    std::fs::write(target_stop_path, "stop").unwrap();
+
+    let target_pid = std::fs::read_to_string(target_pid_path)
+        .unwrap()
+        .trim()
+        .parse::<u32>()
+        .unwrap();
+    assert!(wait_until(Duration::from_secs(5), || {
+        !surge_core::platform::process::is_pid_alive(target_pid)
+    }));
+}

--- a/demoapp/Program.cs
+++ b/demoapp/Program.cs
@@ -109,6 +109,13 @@ internal static class Program
 
             Console.WriteLine();
 
+            if (result?.IsUpdateFinalizationScheduled == true)
+            {
+                Console.WriteLine(
+                    $"[Update] Finalization of v{result.PendingUpdateVersion} was handed off; exiting now.");
+                return 0;
+            }
+
             if (result != null)
             {
                 Console.WriteLine($"[Update] Updated to v{result.Version}.");

--- a/docs/integrating-surge.md
+++ b/docs/integrating-surge.md
@@ -197,6 +197,10 @@ At minimum, a green smoke should prove:
 - the update applies successfully
 - the app relaunches successfully after update
 
+For a self-hosted app, an external-finalization result is only an accepted
+handoff. The app must exit promptly, and the smoke must verify a terminal
+persisted status after restart before calling the update successful.
+
 If the app only implements prompt-first UX instead of `download_and_apply()`, the repo should still have one helper that exercises the lower-level apply path during smoke.
 
 If the app ships `online` or `online-gui` installers, include one additional clean-install check:

--- a/dotnet/Surge.NET.Tests/SurgeTests.cs
+++ b/dotnet/Surge.NET.Tests/SurgeTests.cs
@@ -186,6 +186,8 @@ namespace Surge.Tests
             Assert.Equal("", info.StorageRegion);
             Assert.Equal("", info.StorageEndpoint);
             Assert.False(info.IsSupervisorRunning);
+            Assert.False(info.IsUpdateFinalizationScheduled);
+            Assert.Equal("", info.PendingUpdateVersion);
         }
 
         [Fact]
@@ -201,7 +203,9 @@ namespace Surge.Tests
                 StorageProvider = "filesystem",
                 StorageBucket = "/tmp/releases",
                 StorageRegion = "us-east-1",
-                StorageEndpoint = "http://localhost:9000"
+                StorageEndpoint = "http://localhost:9000",
+                IsUpdateFinalizationScheduled = true,
+                PendingUpdateVersion = "1.2.4"
             };
 
             Assert.Equal("myapp", info.Id);
@@ -213,6 +217,8 @@ namespace Surge.Tests
             Assert.Equal("/tmp/releases", info.StorageBucket);
             Assert.Equal("us-east-1", info.StorageRegion);
             Assert.Equal("http://localhost:9000", info.StorageEndpoint);
+            Assert.True(info.IsUpdateFinalizationScheduled);
+            Assert.Equal("1.2.4", info.PendingUpdateVersion);
         }
     }
 
@@ -260,6 +266,30 @@ namespace Surge.Tests
 
             Assert.Throws<OperationCanceledException>(
                 () => SurgeUpdateManager.HandleNativeCancellation(-2, source.Token));
+        }
+
+        [Fact]
+        public void ScheduledUpdateInfo_KeepsInstalledVersionAndExposesTarget()
+        {
+            var current = new SurgeAppInfo
+            {
+                Id = "demo",
+                Version = "1.2.3",
+                Channel = "beta",
+                InstallDirectory = "/opt/demo",
+                SupervisorId = "demo-supervisor",
+                StorageProvider = "filesystem",
+                StorageBucket = "/tmp/releases"
+            };
+            var release = new SurgeRelease { Version = "1.2.4", Channel = "beta" };
+
+            var result = SurgeUpdateManager.CreateScheduledUpdateInfo(current, "0.0.0", release);
+
+            Assert.Equal("1.2.3", result.Version);
+            Assert.Equal("1.2.4", result.PendingUpdateVersion);
+            Assert.True(result.IsUpdateFinalizationScheduled);
+            Assert.Equal(current.InstallDirectory, result.InstallDirectory);
+            Assert.Equal(current.StorageBucket, result.StorageBucket);
         }
     }
 

--- a/dotnet/Surge.NET/NativeMethods.cs
+++ b/dotnet/Surge.NET/NativeMethods.cs
@@ -58,6 +58,7 @@ namespace Surge
     internal static partial class NativeMethods
     {
         private const string LibName = "surge";
+        internal const int UpdateScheduled = 1;
 
 #if NET10_0_OR_GREATER
         // --- Lifecycle ---

--- a/dotnet/Surge.NET/README.md
+++ b/dotnet/Surge.NET/README.md
@@ -23,6 +23,15 @@ await mgr.UpdateToLatestReleaseAsync(
 
 One call that checks for updates, downloads the smallest available patch, verifies integrity, extracts, and applies — with progress callbacks and cancellation support.
 
+When the running application updates itself, the call returns after a stable
+helper accepts finalization and before the active `app` directory is swapped.
+The returned `SurgeAppInfo` keeps `Version` at the currently installed version,
+sets `IsUpdateFinalizationScheduled`, and exposes the target through
+`PendingUpdateVersion`. Stop new work and exit promptly, then read
+`SurgeApp.LastUpdateStatus` after restart for the terminal `Converged`,
+`PendingRestart`, or `Failed` result. `onAfterApplyUpdate` is not invoked for
+the scheduled handoff.
+
 ## Key Features
 
 - **Zero managed dependencies** — no external NuGet packages are required

--- a/dotnet/Surge.NET/SurgeAppInfo.cs
+++ b/dotnet/Surge.NET/SurgeAppInfo.cs
@@ -31,6 +31,18 @@ namespace Surge
         public string SupervisorId { get; init; } = "";
 
         /// <summary>
+        /// Whether an external helper accepted this update and is waiting for
+        /// the current application process to exit before finalizing it.
+        /// </summary>
+        public bool IsUpdateFinalizationScheduled { get; init; }
+
+        /// <summary>
+        /// Target version awaiting external finalization. Empty unless
+        /// <see cref="IsUpdateFinalizationScheduled"/> is true.
+        /// </summary>
+        public string PendingUpdateVersion { get; init; } = "";
+
+        /// <summary>
         /// Storage provider used for updates (filesystem, s3, azure, gcs, github_releases).
         /// </summary>
         public string StorageProvider { get; init; } = "";

--- a/dotnet/Surge.NET/SurgeUpdateManager.cs
+++ b/dotnet/Surge.NET/SurgeUpdateManager.cs
@@ -65,9 +65,9 @@ namespace Surge
         /// <summary>
         /// Allow this process to swap its own active application directory during an update.
         /// Defaults to <c>false</c>, in which case an updater running from the active application
-        /// executable refuses the swap and expects an external Surge updater. A self-hosted
-        /// application that updates in-process must enable this to keep self-updating; other
-        /// processes running the active executable are still stopped before the swap.
+        /// executable transfers finalization to a stable helper that waits for the caller to exit.
+        /// Enabling this restores the legacy in-process swap; other processes running the active
+        /// executable are still stopped before the swap.
         /// </summary>
         public bool AllowInProcessSwap { get; set; }
 
@@ -243,14 +243,22 @@ namespace Surge
         /// <param name="progressSource">Optional progress source for receiving update progress.</param>
         /// <param name="onUpdatesAvailable">Called when updates are found, before applying.</param>
         /// <param name="onBeforeApplyUpdate">Called before applying a specific release.</param>
-        /// <param name="onAfterApplyUpdate">Called after successfully applying a release.</param>
+        /// <param name="onAfterApplyUpdate">
+        /// Called after a release is fully applied before this method returns.
+        /// It is not called when external finalization is scheduled.
+        /// </param>
         /// <param name="onApplyUpdateException">Called when applying a release fails.</param>
         /// <param name="cancellationToken">Token to cancel the operation.</param>
         /// <returns>
-        /// The <see cref="SurgeAppInfo"/> for the newly installed version,
-        /// or null if no updates were available, native cancellation occurred
-        /// without the supplied token being cancelled, or a previous
-        /// retry-safe failure is still inside its retry-backoff window.
+        /// The <see cref="SurgeAppInfo"/> for the newly installed version. For
+        /// a self-hosted update, returns the current installed version with
+        /// <see cref="SurgeAppInfo.IsUpdateFinalizationScheduled"/> set and
+        /// <see cref="SurgeAppInfo.PendingUpdateVersion"/> identifying the
+        /// target. The caller must then exit promptly and inspect the persisted
+        /// convergence status after restart. Returns null if no updates were
+        /// available, native cancellation occurred without the supplied token
+        /// being cancelled, or a previous retry-safe failure is still inside
+        /// its retry-backoff window.
         /// </returns>
         /// <exception cref="OperationCanceledException">
         /// The supplied cancellation token was cancelled.
@@ -400,13 +408,17 @@ namespace Surge
                             if (HandleNativeCancellation(applyResult, cancellationToken))
                                 return null;
 
-                            if (applyResult != 0)
+                            bool finalizationScheduled = applyResult == NativeMethods.UpdateScheduled;
+                            if (applyResult != 0 && !finalizationScheduled)
                             {
                                 var errorMsg = GetLastError();
                                 var ex = new SurgeException(applyResult, errorMsg ?? "Update apply failed.");
                                 onApplyUpdateException?.Invoke(latestRelease, ex);
                                 throw ex;
                             }
+
+                            if (finalizationScheduled)
+                                return CreateScheduledUpdateInfo(SurgeApp.Current, _currentVersion, latestRelease);
 
                             onAfterApplyUpdate?.Invoke(latestRelease);
                             SetCurrentVersionInternal(latestRelease.Version);
@@ -462,6 +474,28 @@ namespace Surge
                     }
                 }
             }, CancellationToken.None);
+        }
+
+        internal static SurgeAppInfo CreateScheduledUpdateInfo(
+            SurgeAppInfo? currentApp,
+            string currentVersion,
+            SurgeRelease latestRelease)
+        {
+            return new SurgeAppInfo
+            {
+                Id = currentApp?.Id ?? "",
+                Version = currentApp?.Version ?? currentVersion,
+                Channel = latestRelease.Channel,
+                InstallDirectory = currentApp?.InstallDirectory ?? "",
+                SupervisorId = currentApp?.SupervisorId ?? "",
+                StorageProvider = currentApp?.StorageProvider ?? "",
+                StorageBucket = currentApp?.StorageBucket ?? "",
+                StorageRegion = currentApp?.StorageRegion ?? "",
+                StorageEndpoint = currentApp?.StorageEndpoint ?? "",
+                IsSupervisorRunning = currentApp?.IsSupervisorRunning ?? false,
+                IsUpdateFinalizationScheduled = true,
+                PendingUpdateVersion = latestRelease.Version
+            };
         }
 
         private static int ParseStorageProvider(string provider)


### PR DESCRIPTION
## Summary

- expose an explicit scheduled-finalization outcome through Rust, C, and .NET without claiming the target is already installed
- update managed and internal consumers to exit or reject premature convergence checks correctly
- document the handoff contract and add a cross-platform supervised process fixture

## Stack

1. #294 merged: process-identity foundation
2. #295 merged: external finalizer and recovery
3. This PR (#296): consumer outcome and end-to-end smoke

Base: current `main` after the first two stack PRs and their post-merge CI passed.

## End-to-end proof

The fixture runs from the stable `app` path, schedules the helper, proves the old updater remains alive until explicitly released, then verifies:

- no target starts before the old process exits
- the lifecycle hook and target observe handoff-safe `pending_restart`, never `in_progress`
- the target runs from the same stable `app` directory
- environment and restart arguments survive the handoff
- supervisor startup converges after its stability window
- the exact previous application snapshot is retained

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `RUSTFLAGS="-D warnings" cargo test --release -p surge-supervisor --test external_finalize`
- `dotnet format dotnet/Surge.slnx --verify-no-changes --verbosity diagnostic`
- `dotnet test dotnet/Surge.slnx --configuration Release --no-restore` (59 passed)
- post-merge `main` CI for #295 passed across Linux, Windows, macOS Intel, macOS Apple Silicon, .NET, policy checks, and artifacts

## Remaining issue gate

The two-hop consumer release proof from acceptance criteria 4 and 5 follows this merge. Issue #292 remains open until that release and convergence proof is complete.

Refs #292