### PR TITLE
fix(core): land the two-pass in-place digest verify (review fix from #298 was lost)

### DIFF
--- a/README.md
+++ b/README.md
@@ -647,7 +647,7 @@ pack:                             # optional; omitted uses built-in defaults
   delta:
     strategy: sparse-file-ops
     max_chain_length: 8
-    chunked_patch_format: 1       # 1 = readable by every client (default); 2 = identity-chunk bitset, needs clients that know format 2
+    chunked_patch_format: 1       # 1 = readable by every client (default); 2 = identity-chunk bitset; 3 = per-chunk target digests (each needs clients that know its format)
   compression:
     format: zstd
     level: 3

--- a/crates/surge-bench/src/runner/manifest.rs
+++ b/crates/surge-bench/src/runner/manifest.rs
@@ -79,9 +79,11 @@ storage:
 pack:
   delta:
     strategy: {pack_strategy}
-    # Format version 2 (identity-chunk bitset) keeps the canonical update
-    # baseline on the identity-chunk apply path; 1 is the safe default for
-    # fleets with pre-v2 readers (surge-core #267).
+    # Format version 3 (identity-chunk bitset + per-chunk target digests)
+    # keeps the canonical update baseline on the digest-verified in-place
+    # apply path; 2 keeps the full-read verify, 1 the legacy payloads.
+    # Publishing v3 requires clients that understand it (fleet gate, same
+    # pattern as the v1 -> v2 cut, surge-core #267).
     chunked_patch_format: 3
   compression:
     format: zstd

--- a/crates/surge-core/src/config/manifest/types.rs
+++ b/crates/surge-core/src/config/manifest/types.rs
@@ -43,8 +43,9 @@ pub struct PackDeltaManifestConfig {
     pub strategy: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub max_chain_length: Option<u32>,
-    /// Chunked patch format version to publish: `1` (default, readable by every client) or `2`
-    /// (identity-chunk bitset; requires clients that understand format version 2).
+    /// Chunked patch format version to publish: `1` (default, readable by every client),
+    /// `2` (identity-chunk bitset; requires clients that understand format version 2), or
+    /// `3` (per-chunk target digests; requires clients that understand format version 3).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub chunked_patch_format: Option<u8>,
 }

--- a/crates/surge-core/src/diff/chunked/bspatch.rs
+++ b/crates/surge-core/src/diff/chunked/bspatch.rs
@@ -65,14 +65,23 @@ pub struct ChunkedBspatchResult {
     pub chunk_hashes_verified: bool,
 }
 
-/// Like `chunked_bspatch_file_with_progress_and_sha256`, but first attempts
-/// an in-place patch: when the patch uses the format version 2 identity
-/// bitset and the reconstructed file has the same size as the source, the
-/// unchanged chunks are left untouched and only changed chunks are rewritten
-/// at their existing offsets (chunk boundaries align 1:1 at equal sizes).
-/// The target hash is then computed with one full read of the patched file.
-/// When in-place is not possible the standard write-to-`output_path` flow
-/// runs instead.
+/// Like `chunked_bspatch_file_with_progress_and_sha256`, but first
+/// attempts an in-place patch: when the patch uses an identity-bitset
+/// format (version 2 or 3) and the reconstructed file has the same size
+/// as the source, the unchanged chunks are left untouched and only
+/// changed chunks are rewritten at their existing offsets (chunk
+/// boundaries align 1:1 at equal sizes).
+///
+/// Target verification depends on the format: for version 3, every
+/// changed chunk is derived and verified against its recorded target
+/// digest **before the first write**, so a stale digest fails with the
+/// target untouched; `target_hash` is `None` and `chunk_hashes_verified`
+/// is `true`, and the caller pins the file via the per-chunk digests plus
+/// the verified basis hash. For version 2 (no digests) the target is
+/// computed with one full read of the patched file and returned as
+/// `target_hash`. When in-place is not possible the standard
+/// write-to-`output_path` flow runs instead (always with a `Some` target
+/// hash).
 pub fn chunked_bspatch_file_with_progress_and_sha256_in_place(
     target_path: &Path,
     patch: &[u8],
@@ -194,10 +203,10 @@ fn bspatch_file(
     Ok((false, false))
 }
 
-/// Rewrite the changed chunks in place. Returns
-/// `(changed_written, changed_verified)`: every rewritten chunk counts as
-/// written, and as verified when it also matched the patch's recorded
-/// target digest (format version 3).
+/// Rewrite the changed chunks in place, in two passes: first derive and
+/// digest-check **every** changed chunk (no writes), then re-derive and
+/// write them. A stale digest therefore never leaves the target partially
+/// patched. Returns `(changed_written, changed_verified)`.
 fn bspatch_file_in_place(
     path: &Path,
     old_size: usize,
@@ -209,45 +218,49 @@ fn bspatch_file_in_place(
     progress: Option<&ByteProgress<'_>>,
 ) -> Result<(usize, usize)> {
     let mut file = fs::OpenOptions::new().read(true).write(true).open(path)?;
-    let mut offset = 0usize;
-    let mut changed_written = 0usize;
+
+    // Pass 1: read + patch + digest-check every changed chunk without
+    // writing anything, so a digest failure fails closed before the first
+    // byte of the target is modified.
     let mut changed_verified = 0usize;
+    let mut offset = 0usize;
     for (idx, chunk_patch) in chunks.iter().enumerate() {
         let chunk_len = chunk_len_for_index(old_size, idx, chunk_size);
-        let new_chunk = if identity[idx] {
-            None
-        } else if chunk_len == 0 {
-            if !chunk_patch.is_empty() {
-                return Err(SurgeError::Diff(
-                    "in-place patch carries a payload for an empty chunk".into(),
-                ));
-            }
-            Some(Vec::new())
-        } else {
-            file.seek(SeekFrom::Start(usize_to_u64_saturating(offset)))?;
-            let mut old_chunk = vec![0u8; chunk_len];
-            file.read_exact(&mut old_chunk)?;
-            Some(if chunk_patch.is_empty() {
-                Vec::new()
-            } else {
-                wrapper::bspatch_buffers(&old_chunk, chunk_patch)?
-            })
-        };
-        if let Some(bytes) = &new_chunk {
-            if let Some(recorded) = chunk_hashes.and_then(|hashes| hashes[idx]).as_ref() {
-                let actual: [u8; 32] = sha256_raw(bytes)
-                    .try_into()
-                    .map_err(|_| SurgeError::Diff(format!("chunk {idx} target digest has an invalid length")))?;
-                if actual != *recorded {
-                    return Err(SurgeError::Diff(format!(
-                        "chunk {idx} target digest mismatch: patch records a stale digest"
-                    )));
-                }
+        if !identity[idx] {
+            let (_, verified) = read_patched_chunk(
+                &mut file,
+                idx,
+                offset,
+                chunk_len,
+                chunk_patch,
+                chunk_hashes.and_then(|hashes| hashes[idx]),
+            )?;
+            if verified {
                 changed_verified += 1;
             }
+        }
+        offset = offset.saturating_add(chunk_len);
+    }
+
+    // Pass 2: re-derive and write every changed chunk. bspatch is a pure
+    // function of the old chunk and the patch, so the bytes written are
+    // exactly the bytes pass 1 verified.
+    let mut changed_written = 0usize;
+    offset = 0usize;
+    for (idx, chunk_patch) in chunks.iter().enumerate() {
+        let chunk_len = chunk_len_for_index(old_size, idx, chunk_size);
+        if !identity[idx] {
+            let (new_chunk, _) = read_patched_chunk(
+                &mut file,
+                idx,
+                offset,
+                chunk_len,
+                chunk_patch,
+                chunk_hashes.and_then(|hashes| hashes[idx]),
+            )?;
             changed_written += 1;
             file.seek(SeekFrom::Start(usize_to_u64_saturating(offset)))?;
-            file.write_all(bytes)?;
+            file.write_all(&new_chunk)?;
         }
         offset = offset.saturating_add(chunk_len);
         if let Some(cb) = progress {
@@ -256,6 +269,48 @@ fn bspatch_file_in_place(
     }
     file.flush()?;
     Ok((changed_written, changed_verified))
+}
+
+/// Read the old chunk at `offset`, apply its patch, and verify the result
+/// against the patch's recorded target digest when one is present. Returns
+/// the new chunk and whether a recorded digest was verified.
+fn read_patched_chunk(
+    file: &mut fs::File,
+    idx: usize,
+    offset: usize,
+    chunk_len: usize,
+    chunk_patch: &[u8],
+    recorded: Option<[u8; 32]>,
+) -> Result<(Vec<u8>, bool)> {
+    if chunk_len == 0 {
+        if !chunk_patch.is_empty() {
+            return Err(SurgeError::Diff(
+                "in-place patch carries a payload for an empty chunk".into(),
+            ));
+        }
+        return Ok((Vec::new(), recorded.is_some()));
+    }
+    if chunk_patch.is_empty() {
+        return Ok((Vec::new(), recorded.is_some()));
+    }
+    file.seek(SeekFrom::Start(usize_to_u64_saturating(offset)))?;
+    let mut old_chunk = vec![0u8; chunk_len];
+    file.read_exact(&mut old_chunk)?;
+    let new_chunk = wrapper::bspatch_buffers(&old_chunk, chunk_patch)?;
+    let verified = if let Some(expected) = recorded {
+        let actual: [u8; 32] = sha256_raw(&new_chunk)
+            .try_into()
+            .map_err(|_| SurgeError::Diff("chunk target digest has an invalid length".into()))?;
+        if actual != expected {
+            return Err(SurgeError::Diff(format!(
+                "chunk {idx} target digest mismatch: patch records a stale digest"
+            )));
+        }
+        true
+    } else {
+        false
+    };
+    Ok((new_chunk, verified))
 }
 
 fn hash_entire_file_into(path: &Path, hasher: &mut Sha256) -> Result<()> {

--- a/crates/surge-core/src/diff/chunked/bspatch.rs
+++ b/crates/surge-core/src/diff/chunked/bspatch.rs
@@ -288,10 +288,10 @@ fn read_patched_chunk(
                 "in-place patch carries a payload for an empty chunk".into(),
             ));
         }
-        return Ok((Vec::new(), recorded.is_some()));
+        return verify_empty_target(idx, recorded);
     }
     if chunk_patch.is_empty() {
-        return Ok((Vec::new(), recorded.is_some()));
+        return verify_empty_target(idx, recorded);
     }
     file.seek(SeekFrom::Start(usize_to_u64_saturating(offset)))?;
     let mut old_chunk = vec![0u8; chunk_len];
@@ -311,6 +311,23 @@ fn read_patched_chunk(
         false
     };
     Ok((new_chunk, verified))
+}
+
+/// An empty target chunk (trailing chunk or empty patch payload) must
+/// match the recorded empty digest when one is present.
+fn verify_empty_target(idx: usize, recorded: Option<[u8; 32]>) -> Result<(Vec<u8>, bool)> {
+    if let Some(expected) = recorded {
+        let actual: [u8; 32] = sha256_raw(b"")
+            .try_into()
+            .map_err(|_| SurgeError::Diff("chunk target digest has an invalid length".into()))?;
+        if actual != expected {
+            return Err(SurgeError::Diff(format!(
+                "chunk {idx} target digest mismatch: patch records a stale digest"
+            )));
+        }
+        return Ok((Vec::new(), true));
+    }
+    Ok((Vec::new(), false))
 }
 
 fn hash_entire_file_into(path: &Path, hasher: &mut Sha256) -> Result<()> {

--- a/crates/surge-core/src/diff/chunked/mod.rs
+++ b/crates/surge-core/src/diff/chunked/mod.rs
@@ -690,7 +690,7 @@ mod tests {
 
         let old = vec![11u8; 1024 * 1024];
         let mut new = old.clone();
-        new[70_000] = 200; // inside the second 256 KiB chunk
+        new[70_000] = 200; // inside the first 256 KiB chunk
         std::fs::write(&old_path, &old).expect("write target");
         std::fs::write(&new_path, &new).expect("write new");
 
@@ -829,7 +829,7 @@ mod tests {
 
         let old = vec![11u8; 1024 * 1024];
         let mut new = old.clone();
-        new[70_000] = 200; // inside the second 256 KiB chunk
+        new[70_000] = 200; // inside the first 256 KiB chunk
 
         std::fs::write(&old_path, &old).expect("write target");
         std::fs::write(&new_path, &new).expect("write new");
@@ -882,5 +882,68 @@ mod tests {
             "failed apply must leave the target untouched"
         );
         let _ = sha256_hex(&old);
+    }
+
+    #[test]
+    fn in_place_bspatch_v3_multi_chunk_tamper_leaves_target_untouched() {
+        // Two changed chunks with a stale digest on the SECOND one: the
+        // first chunk must not have been written when the failure trips
+        // (two-pass verify-before-write).
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let old_path = tmp.path().join("target.bin");
+        let new_path = tmp.path().join("new.bin");
+        let unused_output = tmp.path().join("unused.bin");
+
+        let chunk = 256 * 1024usize;
+        let old: Vec<u8> = (0..(4 * chunk)).map(|i| (i % 251) as u8).collect();
+        let mut new = old.clone();
+        new[chunk / 2] = 0xAA; // changed chunk 1
+        new[3 * chunk + 5] = 0xBB; // changed chunk 3
+        std::fs::write(&old_path, &old).expect("write target");
+        std::fs::write(&new_path, &new).expect("write new");
+
+        let patch = chunked_bsdiff_files(
+            &old_path,
+            &new_path,
+            &ChunkedDiffOptions {
+                chunk_size: chunk,
+                max_threads: 1,
+                format: ChunkedPatchFormat::IdentityChunksWithTargetHashes,
+            },
+        )
+        .expect("build patch");
+
+        // Walk the patch to the second changed chunk's digest (it follows
+        // that chunk's payload; identity chunks carry an empty payload and
+        // no digest).
+        let decoded = super::format::deserialize_patch(&patch).expect("decode");
+        let header = 4 + 1 + 8 + 8 + 8 + 4;
+        let bitset = decoded.chunks.len().div_ceil(8);
+        let mut off = header + bitset;
+        let mut seen_changed = 0usize;
+        let mut target_off = None;
+        for idx in 0..decoded.chunks.len() {
+            let len = u64::from_le_bytes(patch[off..off + 8].try_into().unwrap()) as usize;
+            off += 8 + len;
+            if !decoded.identity[idx] {
+                seen_changed += 1;
+                if seen_changed == 2 {
+                    target_off = Some(off);
+                }
+                off += 32;
+            }
+        }
+        let target_off = target_off.expect("second changed chunk digest");
+        let mut tampered = patch.clone();
+        tampered[target_off] ^= 0xFF;
+
+        let err = chunked_bspatch_file_with_progress_and_sha256_in_place(&old_path, &tampered, &unused_output, None)
+            .unwrap_err();
+        assert!(err.to_string().contains("target digest mismatch"), "{err}");
+        assert_eq!(
+            std::fs::read(&old_path).expect("read target"),
+            old,
+            "a stale digest on a later chunk must leave the target untouched"
+        );
     }
 }

--- a/docs/performance/pack-policy.md
+++ b/docs/performance/pack-policy.md
@@ -80,7 +80,7 @@ Accepted but not yet auto-tuned:
 
 - `pack.delta.max_chain_length`
 - `pack.retention.keep_latest_fulls`
-- `pack.delta.chunked_patch_format` — `1` (default) writes chunked patches every fielded client can read; `2` enables the identity-chunk bitset (unchanged chunks carry no payload — far cheaper for large files with small edits) but clients older than the reader that introduced it reject such patches, so switch only after the whole fleet runs a client that understands version 2.
+- `pack.delta.chunked_patch_format` — `1` (default) writes chunked patches every fielded client can read; `2` enables the identity-chunk bitset (unchanged chunks carry no payload — far cheaper for large files with small edits); `3` adds a SHA-256 target digest per changed chunk so the in-place applier verifies rewritten chunks in memory and skips the full-file target re-read. Versions 2 and 3 are rejected by older readers via the format version check, so switch only after the whole fleet runs a client that understands the target version.
 - `pack.retention.checkpoint_every`
 
 Not allowed in the manifest:

--- a/docs/performance/update-chains.md
+++ b/docs/performance/update-chains.md
@@ -74,8 +74,10 @@ Large anonymized profile, `sdk_only`, `100` deltas, `sparse-file-ops`
   scale 1.0). Chunked patch format v3 records a SHA-256 target digest
   for every changed chunk (identity chunks carry none — they are
   delimited by the v2 bitset and pinned by the verified basis hash).
-  The in-place applier verifies each rewritten chunk **in memory**
-  right after patching it (zero extra I/O) and skips the full read;
+  The in-place applier verifies each changed chunk **before the first
+  write** (two passes: derive + digest-check every changed chunk, then
+  re-derive and write; the extra pass is one read + bspatch per changed
+  chunk) and skips the full read;
   `target_hash` comes back `None` + `chunk_hashes_verified = true`
   and the caller pins the file via the per-chunk digests plus the
   basis hash, with the chain's final step still passing the


### PR DESCRIPTION
## Purpose
Follow-up to #298 (CSDF v3 chunk-target digests), fixing a **process
failure found in a post-merge audit**.

#298's review-fix commit (`60479a0`) did not contain the code its
message described: the correction script died on a stale text match
(the file had been reflowed by `cargo fmt` between the review and the
fix) and only a `results.tsv` line landed. The in-place apply in main
was therefore still **single-pass**: a stale digest on a later changed
chunk leaves the target partially patched (earlier chunks already
written) — exactly the fail-closed gap the Copilot thread on #298
described. The single-chunk tamper test passed either way (its only
changed chunk fails before any write), so CI stayed green.

This PR implements the fix for real, against the current source, and
adds a regression test that fails on the old code.

## Behavior impact
- `bspatch_file_in_place` is now two-phase: **pass 1** reads, patches,
  and digest-checks every changed chunk without writing anything;
  **pass 2** re-derives and writes (bspatch is a pure function of the
  old chunk and the patch, so pass 2 writes exactly the bytes pass 1
  verified). A stale digest now fails closed with the target
  byte-identical to the old file.
- Verified/changed counts are tracked separately: v2 patches (no
  digests) keep the full-read verify path. (The first draft of this
  fix conflated the two counts, which silently skipped the v2 full
  read — the pre-existing v2 test now asserts `target_hash` is `Some`
  and caught it.)
- Docs that were lost with the fix: public in-place API contract
  (v2 full-read vs v3 digest-verified), manifest
  `chunked_patch_format` docs include value 3, bench manifest comment
  describes the v3 target-digest baseline + fleet gate, "second" →
  "first" 256 KiB chunk test comment (two places).
- No performance change expected: the two-pass cost is one extra
  read+bsdiff per changed chunk (4 MiB at the canonical auto-sized
  chunk).

## Test evidence
- `cargo test --workspace`: all green (325 surge-core tests, 0
  failed), including the new
  `in_place_bspatch_v3_multi_chunk_tamper_leaves_target_untouched`
  (two changed chunks, tampered **second** digest → error + target
  untouched; fails on the pre-fix code).
- Clippy strict (`-D warnings -D clippy::unwrap_used -D
  clippy::expect_used`) + pedantic + rustfmt: 0 issues.
- Vendor sync, version sync, maintainability: pass.
- Same-session A/B vs `b641bf6`: 100-delta apply 10,227/9,384 vs
  8,951/11,948 ms, 10-delta 6,384/5,783 vs 5,228/6,147 ms — within
  host-load noise (the base-to-base spread alone is 33%); install
  tree byte-identical in every run (1,214,024,073 B at 100 deltas);
  delta pack build flat (1,336/1,300 vs 1,345/1,337 ms).

## Notes
Accountability: the #298 PR body and the resolved Copilot thread claim
"two-phase verify" which main does not have; this PR is what that
claim referred to. The audit finding (post-merge `git show` of the
fix commit) is recorded in `auto/update/program.md` history via this
PR's commit message.