### PR TITLE
Document release gates, executable mode and two-wave update proof

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,6 +118,10 @@ If the local environment cannot run a listed command, document the exact gap in 
 - App repos should expose wrapper scripts for local filesystem smoke and Windows Azure smoke. Agents should use those wrappers instead of ad hoc `surge pack` / `surge push` commands.
 - If a Rust app temporarily overrides `surge-core`, prefer a local `file://` Git source pinned to the exact Surge commit instead of a raw crate path. This preserves workspace dependency resolution in clean and cross-platform smoke runs.
 - If a failure is in Surge itself, fix it upstream in this repo first, release a new tag, then update the app repo. Do not normalize long-lived downstream patches.
+- Treat release workflow success, NuGet availability, crates.io availability, downloadable artifacts/checksums, downstream dependency restore, and live update convergence as separate gates. Report the exact last completed gate; a tag alone is not a consumable release.
+- Artifact transport can discard Unix mode bits. Pack/install changes must verify executable mode after download/extraction and prove the installed application and supervisor actually launch; successful archive extraction is not sufficient.
+- A cache hit must restore both the CLI files and their directory on `PATH`. `chmod +x` makes a file executable but does not make `surge` discoverable by later matrix steps.
+- When a change is specifically meant to prove Surge can update itself, use two complete downstream test waves across the agreed app set. Wave 2 starts only after every Wave 1 target reports the expected installed/runtime version, fresh readiness, converged update state, correct supervisor/runtime, and no release-caused restart candidate. Stable publishing, each test dispatch, and production promotion remain separately authorized actions.
 
 ## CLI Logging Output
 - For `surge-cli` command output (including progress/status updates), use the existing `logline` facility in `crates/surge-cli/src/logline.rs`.


### PR DESCRIPTION
## Purpose

Records four durable rules in the **Integrating Surge Into Other App Repos** section of `AGENTS.md`. Each corresponds to a way a release or an update-self proof has been reported as finished before it actually was.

## What this adds

- **Separate the release gates.** Release workflow success, NuGet availability, crates.io availability, downloadable artifacts and checksums, downstream dependency restore, and live update convergence are independent. Report the exact last completed gate; a tag alone is not a consumable release.
- **Artifact transport can discard Unix mode bits.** Pack and install changes must verify executable mode after download and extraction, and prove the installed application and supervisor actually launch. Successful archive extraction is not sufficient.
- **A cache hit must restore both the CLI files and their directory on `PATH`.** `chmod +x` makes a file executable but does not make `surge` discoverable by later matrix steps.
- **Proving Surge can update itself takes two complete downstream waves.** Wave 2 starts only after every Wave 1 target reports the expected installed and runtime version, fresh readiness, converged update state, correct supervisor and runtime, and no release-caused restart candidate. Stable publishing, each test dispatch, and production promotion remain separately authorized actions.

## Behavior impact

None. Documentation-only: no crate, FFI, CLI, workflow or manifest changes.

## Test evidence

No code changed, so the Rust and .NET quality gates are unaffected by this diff. `git diff --check` is clean.

## Anonymization

The added text uses neutral wording throughout — `<app>`, "downstream production node", "the agreed app set". No customer or site names, hostnames, app ids, package paths, fleet counts, downstream version numbers or credentials were introduced, consistent with the repository's anonymization policy.
